### PR TITLE
Unifying live widgets and adding nbagg support

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -20,7 +20,7 @@ holoviews.archive = notebook_archive
 
 def supported_formats(optional_formats):
     "Optional formats that are actually supported"
-    supported = ['nbagg']
+    supported = []
     for fmt in optional_formats:
         try:
             anim = animation.FuncAnimation(plt.figure(),

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -20,7 +20,7 @@ holoviews.archive = notebook_archive
 
 def supported_formats(optional_formats):
     "Optional formats that are actually supported"
-    supported = []
+    supported = ['nbagg']
     for fmt in optional_formats:
         try:
             anim = animation.FuncAnimation(plt.figure(),

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -16,6 +16,11 @@ try:
 except:
     mpld3 = None
 
+try:
+    from matplotlib.backends.backend_nbagg import new_figure_manager_given_figure
+except:
+    new_figure_manager_given_figure = None
+
 import param
 
 from ..core.options import Store
@@ -143,10 +148,8 @@ def display_figure(fig, message=None, max_width='100%'):
     dpi = OutputMagic.options['dpi']
     backend = OutputMagic.options['backend']
 
-    if backend == 'nbagg':
-        import numpy as np
-        from matplotlib.backends.backend_nbagg import FigureManagerNbAgg, new_figure_manager_given_figure
         manager = new_figure_manager_given_figure(np.random.randint(10**8), fig)
+    if backend == 'nbagg' and new_figure_manager_given_figure is not None:
         manager.show()
         return ''
     elif backend == 'd3' and mpld3:

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -135,6 +135,8 @@ def display_widgets(plot):
         return ScrubberWidget(plot)()
     if widget_mode == 'embed':
         return SelectionWidget(plot)()
+    elif widget_mode == 'live':
+        return SelectionWidget(plot, embed=False)()
 
 
 def display_figure(fig, message=None, max_width='100%'):

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -148,8 +148,9 @@ def display_figure(fig, message=None, max_width='100%'):
     dpi = OutputMagic.options['dpi']
     backend = OutputMagic.options['backend']
 
-        manager = new_figure_manager_given_figure(np.random.randint(10**8), fig)
     if backend == 'nbagg' and new_figure_manager_given_figure is not None:
+        manager = new_figure_manager_given_figure(OutputMagic.nbagg_counter, fig)
+        OutputMagic.nbagg_counter += 1
         manager.show()
         return ''
     elif backend == 'd3' and mpld3:

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -42,10 +42,6 @@ ENABLE_TRACEBACKS=True
 
 
 def animate(anim, dpi, writer, fmt, anim_kwargs, extra_args):
-    if OutputMagic.options['holomap'] == "nbagg":
-        plt.show()
-        return ''
-
     if extra_args != []:
         anim_kwargs = dict(anim_kwargs, extra_args=extra_args)
 
@@ -64,7 +60,7 @@ def HTML_video(plot):
     writers = animation.writers.avail
     current_format = OutputMagic.options['holomap']
     for fmt in [current_format] + list(OutputMagic.ANIMATION_OPTS.keys()):
-        if fmt == 'nbagg' or OutputMagic.ANIMATION_OPTS[fmt][0] in writers:
+        if OutputMagic.ANIMATION_OPTS[fmt][0] in writers:
             try:
                 return animate(anim, dpi, *OutputMagic.ANIMATION_OPTS[fmt])
             except: pass

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -42,6 +42,10 @@ ENABLE_TRACEBACKS=True
 
 
 def animate(anim, dpi, writer, fmt, anim_kwargs, extra_args):
+    if OutputMagic.options['holomap'] == "nbagg":
+        plt.show()
+        return ''
+
     if extra_args != []:
         anim_kwargs = dict(anim_kwargs, extra_args=extra_args)
 
@@ -60,7 +64,7 @@ def HTML_video(plot):
     writers = animation.writers.avail
     current_format = OutputMagic.options['holomap']
     for fmt in [current_format] + list(OutputMagic.ANIMATION_OPTS.keys()):
-        if OutputMagic.ANIMATION_OPTS[fmt][0] in writers:
+        if fmt == 'nbagg' or OutputMagic.ANIMATION_OPTS[fmt][0] in writers:
             try:
                 return animate(anim, dpi, *OutputMagic.ANIMATION_OPTS[fmt])
             except: pass
@@ -146,7 +150,13 @@ def display_figure(fig, message=None, max_width='100%'):
     dpi = OutputMagic.options['dpi']
     backend = OutputMagic.options['backend']
 
-    if backend == 'd3' and mpld3:
+    if backend == 'nbagg':
+        import numpy as np
+        from matplotlib.backends.backend_nbagg import FigureManagerNbAgg, new_figure_manager_given_figure
+        manager = new_figure_manager_given_figure(np.random.randint(10**8), fig)
+        manager.show()
+        return ''
+    elif backend == 'd3' and mpld3:
         fig.dpi = dpi
         mpld3.plugins.connect(fig, mpld3.plugins.MousePosition(fontsize=14))
         html = "<center>" + mpld3.fig_to_html(fig) + "<center/>"

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -26,7 +26,7 @@ from ..element import Raster
 from ..plotting import LayoutPlot, GridPlot, RasterGridPlot
 from ..plotting import ANIMATION_OPTS, HTML_TAGS, opts, get_plot_size
 from .magics import OutputMagic, OptsMagic
-from .widgets import IPySelectionWidget, SelectionWidget, ScrubberWidget
+from .widgets import SelectionWidget, ScrubberWidget
 
 from .archive import notebook_archive
 
@@ -121,7 +121,6 @@ def display_widgets(plot):
     widget_format = OutputMagic.options['holomap']
     assert widget_mode is not None, "Mistaken call to display_widgets method"
 
-
     isuniform = plot.uniform
     islinear = bijective(plot.keys)
     if not isuniform and widget_format == 'widgets':
@@ -136,10 +135,6 @@ def display_widgets(plot):
         return ScrubberWidget(plot)()
     if widget_mode == 'embed':
         return SelectionWidget(plot)()
-    elif widget_mode == 'cached':
-        return IPySelectionWidget(plot, cached=True)()
-    else:
-        return IPySelectionWidget(plot, cached=False)()
 
 
 def display_figure(fig, message=None, max_width='100%'):

--- a/holoviews/ipython/jsslider.jinja
+++ b/holoviews/ipython/jsslider.jinja
@@ -4,6 +4,7 @@
         this.frames = frames;
         this.fig_id = "fig_" + id;
         this.img_id = "_anim_img" + id;
+        this.id = id;
         this.slider_ids = slider_ids;
         this.keyMap = keyMap
         this.current_frame = 0;
@@ -81,7 +82,7 @@
 		}
 	    }
 	    callbacks = {iopub: {output: $.proxy(callback, this)}};
-	    var cmd = "holoviews.ipython.widgets.SelectionWidget.widgets['{{ id }}'].update(" + this.keyMap[key] + ")";
+	    var cmd = "holoviews.ipython.widgets.SelectionWidget.widgets['" + this.id + "'].update(" + this.keyMap[key] + ")";
             kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
 	}
     }

--- a/holoviews/ipython/jsslider.jinja
+++ b/holoviews/ipython/jsslider.jinja
@@ -71,6 +71,8 @@
 		function callback(msg) { }
 	    } else {
 		function callback(msg){
+		    /* This callback receives data from Python as a string
+		       in order to parse it correctly quotes are sliced off*/
 		    var data = msg.content.data['text/plain'].slice(1, -1);
 		    if(this.mpld3){
 			data = JSON.parse(data);
@@ -83,7 +85,7 @@
 	    }
 	    callbacks = {iopub: {output: $.proxy(callback, this)}};
 	    var cmd = "holoviews.ipython.widgets.SelectionWidget.widgets['" + this.id + "'].update(" + this.keyMap[key] + ")";
-            kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
+	    kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
 	}
     }
 </script>

--- a/holoviews/ipython/jsslider.jinja
+++ b/holoviews/ipython/jsslider.jinja
@@ -1,6 +1,6 @@
 <script language="javascript">
     /* Define the NDSlider class */
-    function NDSlider(frames, id, slider_ids, keyMap, dim_vals, notFound, load_json, mpld3){
+    function NDSlider(frames, id, slider_ids, keyMap, dim_vals, notFound, load_json, mpld3, nbagg, cached){
         this.frames = frames;
         this.fig_id = "fig_" + id;
         this.img_id = "_anim_img" + id;
@@ -10,9 +10,38 @@
         this.current_vals = dim_vals;
         this.load_json = load_json;
         this.mpld3 = mpld3;
+	this.nbagg = nbagg;
         this.notFound = notFound;
+	this.cached = cached;
+	this.update();
+	if(this.nbagg) {
+            this.set_frame(this.current_vals[0], 0);
+	}
+    }
 
-        this.set_frame(this.current_vals[0], 0);
+    NDSlider.prototype.update = function(){
+	if(this.current_frame == undefined) {
+            $("#" + this.img_id).html(this.notFound);
+        } else if(this.load_json) {
+            var data_url = "{{ server }}/" + this.fig_id + "/" + this.current_frame;
+	    if(this.mpld3) {
+                d3.select("#"+this.img_id).selectAll("*").remove();
+		$.getJSON(data_url, (function(img_id) {
+		    return function(data) {
+                        mpld3.draw_figure(img_id, data);
+			};
+		}(this.img_id)));
+	    } else {
+                $("#" + this.img_id).load("{{ server }}/" + this.fig_id + "/" + this.current_frame);
+            }
+	} else {
+	    if(this.mpld3) {
+                d3.select("#" + this.img_id).selectAll("*").remove();
+                mpld3.draw_figure(this.img_id, this.frames[this.current_frame]);
+            } else {
+                $("#" + this.img_id).html(this.frames[this.current_frame]);
+            }
+        }
     }
 
     NDSlider.prototype.set_frame = function(dim_val, dim_idx){
@@ -32,31 +61,29 @@
             else if(this.slider_ids.length == 1) { key += ',';}
         }
         key += ")";
-        this.current_frame = this.keyMap[key];
-        if(this.current_frame == undefined) {
-            $("#" + this.img_id).html(this.notFound);
-        } else if(this.load_json) {
-            var data_url = "{{ server }}/" + this.fig_id + "/" + this.current_frame;
-		    if(this.mpld3) {
-                d3.select("#"+this.img_id).selectAll("*").remove();
-				$.getJSON(data_url,
-                    (function(img_id) {
-					     return function(data) {
-                             mpld3.draw_figure(img_id, data);
-					     };
-				     }(this.img_id))
-				);
-			} else {
-                $("#" + this.img_id).load("{{ server }}/" + this.fig_id + "/" + this.current_frame);
-            }
-		}else {
-		    if(this.mpld3) {
-                d3.select("#" + this.img_id).selectAll("*").remove();
-                mpld3.draw_figure(this.img_id, this.frames[this.current_frame]);
-            }else {
-                $("#" + this.img_id).html(this.frames[this.current_frame]);
-            }
-        }
+	if(this.cached) {
+	    this.current_frame = this.keyMap[key];
+            this.update()
+	} else {
+	    var kernel = IPython.notebook.kernel;
+	    if(this.nbagg) {
+		function callback(msg) { }
+	    } else {
+		function callback(msg){
+		    var data = msg.content.data['text/plain'].slice(1, -1);
+		    if(this.mpld3){
+			data = JSON.parse(data);
+		    } else {
+			data = {0: data};
+		    }
+		    this.frames = data;
+		    this.update()
+		}
+	    }
+	    callbacks = {iopub: {output: $.proxy(callback, this)}};
+	    var cmd = "holoviews.ipython.widgets.SelectionWidget.widgets['{{ id }}'].update(" + this.keyMap[key] + ")";
+            kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
+	}
     }
 </script>
 
@@ -224,12 +251,12 @@
     	function create_widget() {
             setTimeout(function() {
 	            anim{{ id }} = new NDSlider(frame_data, "{{ id }}", widget_ids,
-                        keyMap, dim_vals, notFound, {{ load_json }}, {{ mpld3 }});
+                        keyMap, dim_vals, notFound, {{ load_json }}, {{ mpld3 }}, {{ nbagg }}, {{ cached }});
 	        }, 0);
 	    }
 
 	    {% if mpld3 %}
-        if(typeof(window.mpld3) !== "undefined" && window.mpld3._mpld3IsLoaded){
+        if(typeof(window.mpld3) !== 'undefined' && window.mpld3._mpld3IsLoaded){
 	        create_widget();
         }else {
 	        var d3_require = {paths: {"d3" : "{{ d3_url }}"}}

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -147,7 +147,7 @@ class OutputMagic(OptionsMagic):
     # Formats that are always available
     inbuilt_formats= ['auto', 'widgets', 'scrubber', 'repr']
     # Codec or system-dependent format options
-    optional_formats = ['webm','mp4', 'gif', 'nbagg']
+    optional_formats = ['webm','mp4', 'gif']
 
     # Lists: strict options, Set: suggested options, Tuple: numeric bounds.
     allowed = {'backend'     : ['mpl','d3', 'nbagg'],

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -181,6 +181,9 @@ class OutputMagic(OptionsMagic):
     # Used to disable info output in testing
     _disable_info_output = False
 
+    # Counter for nbagg figures
+    nbagg_counter = 0
+
     def __init__(self, *args, **kwargs):
         super(OutputMagic, self).__init__(*args, **kwargs)
         self.output.__func__.__doc__ = self._generate_docstring()

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -147,10 +147,10 @@ class OutputMagic(OptionsMagic):
     # Formats that are always available
     inbuilt_formats= ['auto', 'widgets', 'scrubber', 'repr']
     # Codec or system-dependent format options
-    optional_formats = ['webm','mp4', 'gif']
+    optional_formats = ['webm','mp4', 'gif', 'nbagg']
 
     # Lists: strict options, Set: suggested options, Tuple: numeric bounds.
-    allowed = {'backend'     : ['mpl','d3'],
+    allowed = {'backend'     : ['mpl','d3', 'nbagg'],
                'fig'         : ['svg', 'png', 'repr'],
                'holomap'     : inbuilt_formats,
                'widgets'     : ['embed', 'live', 'cached'],

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -153,7 +153,7 @@ class OutputMagic(OptionsMagic):
     allowed = {'backend'     : ['mpl','d3', 'nbagg'],
                'fig'         : ['svg', 'png', 'repr'],
                'holomap'     : inbuilt_formats,
-               'widgets'     : ['embed', 'live', 'cached'],
+               'widgets'     : ['embed', 'live'],
                'fps'         : (0, float('inf')),
                'max_frames'  : (0, float('inf')),
                'max_branches': (0, float('inf')),

--- a/holoviews/ipython/widgets.py
+++ b/holoviews/ipython/widgets.py
@@ -250,6 +250,7 @@ class NdWidget(param.Parameterized):
 
     def __init__(self, plot, **params):
         super(NdWidget, self).__init__(**params)
+        self.id = uuid.uuid4().hex
         self.plot = plot
         self.dimensions = plot.dimensions
         self.keys = plot.keys
@@ -401,7 +402,6 @@ class SelectionWidget(NdWidget):
 
     def __init__(self, plot, **params):
         NdWidget.__init__(self, plot, **params)
-        self.id = uuid.uuid4().hex
         self.nbagg = OutputMagic.options['backend'] == 'nbagg'
         self.frames = {}
         if self.embed:

--- a/holoviews/ipython/widgets.py
+++ b/holoviews/ipython/widgets.py
@@ -500,7 +500,6 @@ class SelectionWidget(NdWidget):
                 self.frames.popitem(last=False)
             frame = self._plot_figure(n)
             if self.mpld3: frame = self.encode_frames({0: frame})
-            SelectionWidget.updates[n] = frame
             self.frames[n] = frame
         return self.frames[n]
 

--- a/holoviews/ipython/widgets.py
+++ b/holoviews/ipython/widgets.py
@@ -412,7 +412,8 @@ class SelectionWidget(NdWidget):
             self.frames = self.encode_frames(frames)
         elif self.nbagg:
             fig = self.plot[0]
-            self.manager = new_figure_manager_given_figure(np.random.randint(10**8), fig)
+            self.manager = new_figure_manager_given_figure(OutputMagic.nbagg_counter, fig)
+            OutputMagic.nbagg_counter += 1
             self.comm = CustomCommSocket(self.manager)
 
         SelectionWidget.widgets[self.id] = self

--- a/tests/testwidgets.py
+++ b/tests/testwidgets.py
@@ -55,7 +55,7 @@ class TestWidgets(IPTestCase):
 
     def test_selection_widget_1(self):
         html = normalize(SelectionWidget(self.plot1)())
-        self.assertEqual(digest_data(html), '46b4b1c50ae4530341b25a2f7761263413dec12ccde3e30b0210a07f841d5aaa')
+        self.assertEqual(digest_data(html), '96b80b0561553bac4b074085dabca97cde2010d68035be28d96fb2236e6887e7')
 
     def test_scrubber_widget_2(self):
         html = normalize(ScrubberWidget(self.plot2)())
@@ -63,7 +63,7 @@ class TestWidgets(IPTestCase):
 
     def test_selection_widget_2(self):
         html = normalize(SelectionWidget(self.plot2)())
-        self.assertEqual(digest_data(html), '41b4c724661eac26254c3202348d71281e1b0275421d2134e46e2ac594eeb620')
+        self.assertEqual(digest_data(html), '4039fc8103c6bf76bf882180f4387464cd02766b4b59c9f93189a52284c6bcbd')
 
 
 if __name__ == "__main__":

--- a/tests/testwidgets.py
+++ b/tests/testwidgets.py
@@ -55,7 +55,7 @@ class TestWidgets(IPTestCase):
 
     def test_selection_widget_1(self):
         html = normalize(SelectionWidget(self.plot1)())
-        self.assertEqual(digest_data(html), '96b80b0561553bac4b074085dabca97cde2010d68035be28d96fb2236e6887e7')
+        self.assertEqual(digest_data(html), 'fd292efa2e934a1b8a8b9449399b76509aa40dfabcf9e630c8222ca362e20c8d')
 
     def test_scrubber_widget_2(self):
         html = normalize(ScrubberWidget(self.plot2)())
@@ -63,7 +63,7 @@ class TestWidgets(IPTestCase):
 
     def test_selection_widget_2(self):
         html = normalize(SelectionWidget(self.plot2)())
-        self.assertEqual(digest_data(html), '4039fc8103c6bf76bf882180f4387464cd02766b4b59c9f93189a52284c6bcbd')
+        self.assertEqual(digest_data(html), '7353eaabf3481411a332b9d9c4aa591aab93f6edf72ac5b6bfbe45458e824714')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces three major changes to widgets:

* IPySelectionWidget is deprecated for a number of reasons:
   * It is based on the IPython widget system, which is still subject to change.
   * It made selection of the appropriate widget confusing.
   * It always requires a live notebook.
   * Its layout didn't look any good.

* The SelectionWidget can now render plots dynamically
   * This can be activated via %output widgets='live'
   * It supports live rendering of all current figure backends (i.e. png, svg, mpld3 and nbagg)
   * It supports dynamic caching, the size of the cache can be controlled via the SelectionWidget.cache_size parameter

* Support for nbagg
   * Can be used for static frames and widgets
   * The nbagg matplotlib backend provides widgets for zooming, panning and most interestingly resizing.
   * To use widgets with nbagg, widgets='live' must be selected.