### PR TITLE
Replaced mailinglist with gitter channel in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ Clone holoviews directly from GitHub with::
 Please visit `our website <http://ioam.github.com/holoviews/>`_ for
 official releases, installation instructions, documentation, and examples.
 
-For general discussion, we have a mailing list on 
-`Google Groups <https://groups.google.com/forum/#!forum/holoviews>`_. In addition
+For general discussion, we have a `gitter channel https://gitter.im/ioam/holoviews`._
+In addition
 we have a `wiki page <https://github.com/ioam/holoviews/wiki/Experimental-Features>`_
 describing current work-in-progress and experimental features. If you find any bugs or 
 have any feature suggestions please file a GitHub Issue or submit a pull request.


### PR DESCRIPTION
The mailinglist is not in use anymore, while the gitter channel is.