### PR TITLE
Layout, overlay and grid of a HoloMap now reduces all key dimensions by default.

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -517,9 +517,11 @@ class Dimensioned(LabelledData):
 
 
     def _valid_dimensions(self, dimensions):
-        "Validates key dimension input"
-        if not dimensions:
-            return dimensions
+        """Validates key dimension input
+        
+        Returns kdims if no dimensions are specified"""
+        if dimensions is None:
+            dimensions = self.kdims
         elif not isinstance(dimensions, list):
             dimensions = [dimensions]
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -499,9 +499,9 @@ class HoloMap(UniformNdMapping):
         """
         Splits the UniformNdMapping along a specified number of dimensions and
         overlays items in the split out Maps.
+
+        Shows all HoloMap data When no dimensions are specified.
         """
-        if dimensions is None:
-            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):
@@ -516,9 +516,9 @@ class HoloMap(UniformNdMapping):
         """
         GridSpace takes a list of one or two dimensions, and lays out the containing
         Views along these axes in a GridSpace.
+
+        Shows all HoloMap data When no dimensions are specified.
         """
-        if dimensions is None:
-            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):
@@ -530,9 +530,9 @@ class HoloMap(UniformNdMapping):
         """
         GridSpace takes a list of one or two dimensions, and lays out the containing
         Views along these axes in a GridSpace.
+
+        Shows all HoloMap data When no dimensions are specified.
         """
-        if dimensions is None:
-            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -495,11 +495,13 @@ class HoloMap(UniformNdMapping):
 
     data_type = (ViewableElement, NdMapping, Layout)
 
-    def overlay(self, dimensions, **kwargs):
+    def overlay(self, dimensions=None, **kwargs):
         """
         Splits the UniformNdMapping along a specified number of dimensions and
         overlays items in the split out Maps.
         """
+        if dimensions is None:
+            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):
@@ -510,11 +512,13 @@ class HoloMap(UniformNdMapping):
             return self.groupby(dims, group_type=NdOverlay, **kwargs)
 
 
-    def grid(self, dimensions, **kwargs):
+    def grid(self, dimensions=None, **kwargs):
         """
         GridSpace takes a list of one or two dimensions, and lays out the containing
         Views along these axes in a GridSpace.
         """
+        if dimensions is None:
+            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):
@@ -522,11 +526,13 @@ class HoloMap(UniformNdMapping):
         return self.groupby(dimensions, container_type=GridSpace, **kwargs)
 
 
-    def layout(self, dimensions, **kwargs):
+    def layout(self, dimensions=None, **kwargs):
         """
         GridSpace takes a list of one or two dimensions, and lays out the containing
         Views along these axes in a GridSpace.
         """
+        if dimensions is None:
+            dimensions = self.kdims
         dimensions = self._valid_dimensions(dimensions)
         if len(dimensions) == self.ndims:
             with item_check(False):


### PR DESCRIPTION
This makes it possible to easily get an overview of the contents of a holomap, as discussed in #254 