### PR TITLE
Fixed Timer reporting for long durations

### DIFF
--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -696,12 +696,11 @@ class TimerMagic(Magics):
 
     @staticmethod
     def elapsed_time():
-        elapsed = time.time() -  TimerMagic.start_time
-        minutes = elapsed // 60
+        seconds = time.time() -  TimerMagic.start_time
+        minutes = seconds // 60
         hours = minutes // 60
-        seconds = elapsed % 60
-        return "Timer elapsed: %02d:%02d:%02d" % (hours, minutes, seconds)
-
+        return "Timer elapsed: %02d:%02d:%02d" % (hours, minutes % 60, seconds % 60)
+                                    
     @classmethod
     def option_completer(cls, k,v):
         return ['start']


### PR DESCRIPTION
The %timer magic output is mixed up for long durations (anything over an hour).  E.g. for a 9-hour computation:

```
In [1]: %timer
Out [1]:
Timer elapsed: 08:533:41
```

Someone should check the logic in my fix, but I think it will now say ``08:53:41`` (which is how long I *think* the computation took in this case).