### PR TITLE
NdMapping.__setitem__ now replaces rather than updates

### DIFF
--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -342,12 +342,12 @@ class NdElement(NdMapping, Tabular):
         return reindexed
 
 
-    def _add_item(self, key, value, sort=True):
+    def _add_item(self, key, value, sort=True, update=True):
         value = (value,) if np.isscalar(value) else tuple(value)
         if len(value) != len(self.vdims):
             raise ValueError("%s values must match value dimensions"
                              % type(self).__name__)
-        super(NdElement, self)._add_item(key, value, sort)
+        super(NdElement, self)._add_item(key, value, sort, update)
 
 
     def _filter_columns(self, index, col_names):
@@ -598,8 +598,8 @@ class Collator(NdElement):
         return accumulator
 
 
-    def _add_item(self, key, value, sort=True):
-        NdMapping._add_item(self, key, value, sort)
+    def _add_item(self, key, value, sort=True, update=True):
+        NdMapping._add_item(self, key, value, sort, update)
 
 
     @property

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -145,7 +145,7 @@ class MultiDimensionalMapping(Dimensioned):
             raise KeyError('Key has to match number of dimensions.')
 
 
-    def _add_item(self, dim_vals, data, sort=True):
+    def _add_item(self, dim_vals, data, sort=True, update=True):
         """
         Adds item to the data, applying dimension types and ensuring
         key conforms to Dimension type and values.
@@ -176,7 +176,7 @@ class MultiDimensionalMapping(Dimensioned):
                                ' specified dimension values.' % (dim, repr(val)))
 
         # Updates nested data structures rather than simply overriding them.
-        if ((dim_vals in self.data)
+        if (update and (dim_vals in self.data)
             and isinstance(self.data[dim_vals], (NdMapping, OrderedDict))):
             self.data[dim_vals].update(data)
         else:
@@ -529,7 +529,7 @@ class MultiDimensionalMapping(Dimensioned):
 
 
     def __setitem__(self, key, value):
-        self._add_item(key, value)
+        self._add_item(key, value, update=False)
 
 
     def __str__(self):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -177,7 +177,7 @@ class MultiDimensionalMapping(Dimensioned):
 
         # Updates nested data structures rather than simply overriding them.
         if (update and (dim_vals in self.data)
-            and isinstance(self.data[dim_vals], (NdMapping, OrderedDict))):
+            and isinstance(self.data[dim_vals], (MultiDimensionalMapping, OrderedDict))):
             self.data[dim_vals].update(data)
         else:
             self.data[dim_vals] = data

--- a/tests/testndmapping.py
+++ b/tests/testndmapping.py
@@ -110,6 +110,22 @@ class NdIndexableMappingTest(ComparisonTestCase):
 
         self.assertEqual(list(ndmap.keys()), [0, 1])
 
+    def test_setitem_nested(self):
+        nested1 = MultiDimensionalMapping([('B', 1)])
+        ndmap = MultiDimensionalMapping([('A', nested1)])
+        nested2 = MultiDimensionalMapping([('B', 2)])
+        ndmap['A'] = nested2
+        self.assertEqual(ndmap['A'], nested2)
+
+    def test_setitem_nested(self):
+        nested1 = MultiDimensionalMapping([('B', 1)])
+        ndmap = MultiDimensionalMapping([('A', nested1)])
+        nested2 = MultiDimensionalMapping([('C', 2)])
+        nested_clone = nested1.clone()
+        nested_clone.update(nested2)
+        ndmap.update({'A': nested2})
+        self.assertEqual(ndmap['A'].data, nested_clone.data)
+
 
 class HoloMapTest(ComparisonTestCase):
 


### PR DESCRIPTION
As the title says this commit makes sure that when assigning to an NdMapping using ``__setitem__`` it should replace rather than update the existing entry. It may be he case that some machinery relies on the old behavior so this isn't ready for merge until some testing has been done.