### PR TITLE
Add ArchiveComparison, allowing two archives to be compared.

### DIFF
--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 
 import re, os, time, string, zipfile, tarfile, shutil, itertools, pickle
 from collections import defaultdict
+from cStringIO import StringIO # CEBALERT
 
 from io import BytesIO
 from hashlib import sha256
@@ -840,3 +841,101 @@ class FileArchive(Archive):
     def listing(self):
         "Return a list of filename entries currently in the archive"
         return ['.'.join([f,ext]) if ext else f for (f,ext) in self._files.keys()]
+
+
+
+class ArchiveReader(object):
+    """
+    ArchiveReaders abstract operations over different archive formats,
+    e.g. directory vs. zip file.
+    """
+    def __init__(self,archive):
+        self.archive_location = archive
+        self.root,self.archive_name=os.path.split(self.archive_location)
+
+    def open_member(self,name):
+        raise NotImplementedError
+
+    def member_exists(self,name):
+        raise NotImplementedError
+
+    def list_members(self):
+        raise NotImplementedError
+
+
+
+class Directory(ArchiveReader):
+    
+    def __init__(self,archive):
+        super(Directory,self).__init__(archive)        
+        if not os.path.isdir(self.archive_location):
+            raise ValueError("Directory archive not found at %s"%self.archive_location)
+        self.archive=self.archive_location
+
+    def list_members(self):
+        return os.listdir(self.archive)
+
+    def open_member(self,name):
+        return open(self._fullname(name),'r')
+
+    def member_exists(self,name):
+        return os.path.exists(self._fullname(name))
+
+    def _fullname(self,name):
+        return os.path.join(self.archive,name)
+
+
+
+class ZipFile(ArchiveReader):
+
+    def __init__(self,archive):
+        super(ZipFile,self).__init__(archive)
+        self.archive = zipfile.ZipFile(self.archive_location,'r')
+        self.archive_name=os.path.splitext(self.archive_name)[0] # drop .zip
+    
+    def list_members(self):
+        return [self._name(member) for member in self.archive.namelist()]
+
+    def open_member(self,name):        
+        # ZipFile().open() returns a file-like object that's not
+        # file-like enough for ZipFile.open() :( See
+        # e.g. http://stackoverflow.com/a/12025492
+        return StringIO(self.archive.read(self._fullname(name))) # CEBALERT: python3
+
+    def member_exists(self,name):
+        return name in self.list_members()
+
+    def _fullname(self,name):
+        return self.archive_name + '/' + name
+
+    def _name(self,fullname):
+        return fullname.split(self.archive_name+'/',1).pop()
+
+
+
+class TarFile(ArchiveReader):
+
+    def __init__(self,archive):
+        super(TarFile,self).__init__(archive)
+        self.archive = tarfile.open(self.archive_location,'r')
+        self.archive_name=os.path.splitext(self.archive_name)[0] # drop .tar
+
+    def list_members(self):
+        return [self._name(member) for member in self.archive.getnames()]
+
+    def open_member(self,name):
+        return self.archive.extractfile(self._fullname(name))
+    
+    def member_exists(self,name):
+        try:
+            self.archive.getmember(self._fullname(name))
+        except KeyError:
+            return False
+        else:
+            return True
+
+    def _fullname(self,name):
+        return self.archive_name + '/' + name
+
+    def _name(self,fullname):
+        return fullname.split(self.archive_name+'/',1).pop()

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -17,15 +17,23 @@ methods on all objects as comparison opertors only return Booleans and
 thus would not supply any information regarding *why* two elements are
 considered different.
 """
+
+import traceback
+import os
+from collections import defaultdict, namedtuple
+
 import numpy as np
 from unittest.util import safe_repr
 from unittest import TestCase
 from numpy.testing import assert_array_equal, assert_array_almost_equal
+import param
 
 from . import *    # pyflakes:ignore (All Elements need to support comparison)
 from ..core import Element, Empty, AdjointLayout, Overlay, Dimension, HoloMap, \
                    Dimensioned, Layout, NdLayout, NdOverlay, GridSpace
 from ..core.options import Options, Cycle
+from ..core.io import Unpickler, Directory, TarFile, ZipFile
+from ..core.dimension import OrderedDict
 from ..interface.pandas import DFrame as PandasDFrame
 from ..interface.pandas import DataFrameView
 from ..interface.seaborn import DFrame, Bivariate, Distribution, \
@@ -648,3 +656,140 @@ class ComparisonTestCase(Comparison, TestCase):
         registry = Comparison.register()
         for k, v in registry.items():
             self.addTypeEqualityFunc(k, v)
+
+
+
+
+############################################################
+# Archive comparison
+
+ComparisonResult = namedtuple('ComparisonResult', ['ref_archive', 'test_archive', 'ref_member', 'match', 'msg'])
+
+def loadpickle(x):
+    return Unpickler.load(x)
+
+def read(x):
+    return x.read()
+
+# CEBALERT
+Comparison.register()
+
+
+
+def match_by_name(ref_reader, test_reader):
+    """
+    Given reference and test archive readers, match up
+    their contents by name and return in sorted order.
+    Data that exists in test but not ref is returned in extra.
+    """
+    ref_files = sorted(ref_reader.list_members())
+
+    matches = OrderedDict()
+    for ref_file in ref_files:
+        matches[ref_file] = ref_file if test_reader.member_exists(ref_file) else None
+
+    extra = set(test_reader.list_members()) - set(ref_files)
+    return matches, extra
+
+
+class ArchiveComparison(param.Parameterized):
+    """
+    Compare a 'test' archive against a 'reference' archive.
+
+    Use equal() to find out if the archives match or not,
+    or step through comparisons() for information about
+    each comparison performed.
+
+    Specify a custom match_fn to control exactly what (and 
+    in what order) to compare.
+
+    By default, archive members will simply be opened and read for
+    comparison; specify alternatives for particular file types
+    by adding them to load_fns.
+    """
+
+    match_fn = param.Callable(default=match_by_name,doc="""
+        Function that matches up files in a 'reference' archive to
+        those in a 'test' archive.
+
+        Should accept two archive readers and return:
+
+            1. a dict-like mapping of files to compare (using a value 
+               of None to indicate missing test data);
+
+            2. a list (potentially empty) of files present in the test
+               that are not present in the reference.
+        """)
+
+    load_fns = param.Dict(default=defaultdict(lambda: read, {'.hvz': loadpickle}))
+
+    def __init__(self,ref,test,**params):
+        super(ArchiveComparison,self).__init__(**params)
+        self.ref = self._read_archive(ref)
+        self.test = self._read_archive(test)        
+
+
+    def equal(self):
+        """
+        Return True if the two archives contain the same contents,
+        otherwise False.
+        
+        Stops at first failure to match (subsequently available as
+        .first_failure).
+        """
+        for result in self.comparisons():
+            if not result.match:
+                self.first_failure = result
+                return False
+        return True
+
+
+    def comparisons(self):
+        """
+        Return a generator to allow stepping through comparisons.
+
+        Each comparison yields a ComparisonResult.
+        """
+        matches,extra = self.match_fn(self.ref,self.test)
+
+        for unused in extra:
+            yield self._result(unused,False,'Extra test member')
+        
+        for rmember in matches:
+            if matches[rmember] is None:
+                yield self._result(rmember,False,'Test is missing member')
+            else:
+                load_fn = self.load_fns[os.path.splitext(rmember)[1].lower()]
+                r = load_fn(self.ref.open_member(rmember))
+                try:
+                    t = load_fn(self.test.open_member(matches[rmember]))
+                except:
+                    yield self._result(rmember,False,'Cannot open test and ref members with same function (%s): %s'%(lf,traceback.format_exc()))
+                    continue # sorry
+                    
+                # ok finally we discovered we can actually do a comparison
+                try:
+                    Comparison.assertEqual(r,t)
+                except:
+                    yield self._result(rmember,False,traceback.format_exc())
+                else:
+                    yield self._result(rmember,True,None)
+                
+
+
+    def _read_archive(self,archive_location):
+        if not os.path.exists(archive_location):
+            raise IOError("Cannot find archive %s"%archive_location)
+
+        if os.path.isdir(archive_location):
+            return Directory(archive_location)
+        elif os.path.splitext(archive_location)[1].lower()=='.zip':
+            return ZipFile(archive_location)
+        elif os.path.splitext(archive_location)[1].lower()=='.tar':
+            return TarFile(archive_location)
+        else:
+            raise IOError('Do not know how to read %s'%archive)
+
+
+    def _result(self,rmember,match,msg):
+        return ComparisonResult(self.ref.archive_location,self.test.archive_location,rmember,match,msg)

--- a/tests/testarchivecomparison.py
+++ b/tests/testarchivecomparison.py
@@ -1,0 +1,128 @@
+"""
+Unit test of ArchiveComparison.
+"""
+
+import os
+import shutil
+from collections import namedtuple
+
+from unittest import TestCase
+
+import numpy as np
+
+from holoviews import Image
+from holoviews.core.io import FileArchive
+from holoviews.element.comparison import ArchiveComparison
+
+# TODO:
+# * test the actual comparison information (rather than just match or not)
+# * test single file archive
+# * test different matching functions
+
+
+fspec = namedtuple('fspec',('name','contents'))
+
+
+class TestArchiveComparison(TestCase):
+
+    archive_format = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = '_testarchivecomp'
+
+        for f in os.listdir('.'):
+            if f.startswith(cls.root):
+                # CEBALERT: can't remember how to indicate test error (not error with stuff being tested)
+                raise AssertionError('%s already exists: move away'%f)
+
+        cls.image1 = Image(np.array([[1,2],[4,5]]), group='Group1', label='Im1')
+        cls.image2 = Image(np.array([[5,4],[3,2]]), group='Group2', label='Im1')
+        cls.image3 = Image(np.array([[6,7],[9,8]]), group='Group3', label='Im1')
+        cls.export_name = 'test'
+
+        cls.fa_opts = {}
+        if cls.archive_format is not None:
+            cls.fa_opts['pack']=True
+            cls.fa_opts['archive_format']=cls.archive_format
+        else:
+            cls.fa_opts['pack']=False
+        cls.ext = '.%s'%cls.archive_format if cls.archive_format else ''
+
+
+    def setUp(self):
+        os.mkdir(self.root)
+
+ 
+    def tearDown(self):
+        for f in os.listdir('.'):
+            if os.path.isdir(f) and f.startswith(self.root):
+                shutil.rmtree(f)
+
+       
+    def _compare_archives(self,fspec1,fspec2,match=True):
+        self._make_archive(fspec1)
+        self._make_archive(fspec2)
+
+        a = ArchiveComparison(os.path.join(self.root,fspec1.name)+self.ext,
+                              os.path.join(self.root,fspec2.name)+self.ext)
+
+        if match:
+            if not a.equal():
+                raise AssertionError(a.fails)
+        else:
+            self.assertFalse(a.equal())
+
+
+    def _make_archive(self,fspec):
+        a = FileArchive(root=self.root,export_name=fspec.name,**self.fa_opts)
+        for x in fspec.contents:
+            a.add(x)
+        a.export()
+
+
+    def test_missing_test_archive(self):
+        self._make_archive(fspec(self.export_name,(self.image1,self.image1)))
+
+        with self.assertRaises(IOError):
+            ArchiveComparison(os.path.join(self.root,self.export_name)+self.ext,
+                              os.path.join(self.root,'doesnotexist'+self.ext))
+            
+
+    def test_missing_ref_archive(self):
+        self._make_archive(fspec(self.export_name,(self.image1,self.image1)))
+
+        with self.assertRaises(IOError):
+            ArchiveComparison(os.path.join(self.root,'doesnotexist')+self.ext,
+                              os.path.join(self.root,self.export_name+self.ext))
+
+
+    def test_matching_contents(self):
+        self._compare_archives(fspec(self.export_name+'1',(self.image1,self.image2)),
+                               fspec(self.export_name+'2',(self.image1,self.image2)),
+                               match=True)
+
+    def test_nonmatching_contents(self):
+        self._compare_archives(fspec(self.export_name+'1',(self.image1,self.image2)),
+                               fspec(self.export_name+'2',(self.image1,self.image1)),
+                               match=False)
+        
+    def test_extra_data(self):
+        self._compare_archives(fspec(self.export_name+'1',(self.image1,self.image2)),
+                               fspec(self.export_name+'2',(self.image1,self.image2,self.image3)),
+                               match=False)
+
+    def test_missing_data(self):
+        self._compare_archives(fspec(self.export_name+'1',(self.image1,self.image2,self.image3)),
+                               fspec(self.export_name+'2',(self.image1,self.image2)),
+                               match=False)
+
+
+
+class TestZipArchiveComparison(TestArchiveComparison):
+    archive_format = 'zip'
+
+
+
+class TestTarArchiveComparison(TestArchiveComparison):
+    archive_format = 'tar'


### PR DESCRIPTION
I'm opening this PR to ask for general feedback (mainly from @jlstevens) on archive comparisons: does the approach make sense?

You will see some CEBALERTs in the PR, just to note minor things I haven't gotten around to sorting out yet. If possible, please ignore those for the general feedback.
## ArchiveReader
- I've abstracted some operations on zip, tar, directory with 'ArchiveReaders'. How do you feel about that? I suppose there could be ArchiveWriters as well, but it depends what you feel about the idea of the Readers.
- ArchiveReaders are not explicitly tested (although they get tested by testarchivecomparison.py)
## ArchiveComparison
- I don't really like the `load_fns`
- I don't really like `ComparisonResult`. If it's staying, probably needs to be a class and have a repr etc. (They are handy for testing notebooks cell by cell.)
- As you know, a generator being returned by comparisons() seemed like a good idea immediately when I started. Not sure how I feel about that now, though.
## Also
- I feel some general unease about what will happen with large archives, what will happen with archives that aren't on the local file system, etc.

Anyway, just so you can see what's coming, and avert a disaster before it's too late (well, it's already too late, because I re-wrote the notebook testing with it ;) )
