### PR TITLE
Fixes to Columns indexing

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -229,11 +229,10 @@ class Columns(Element):
             selection = dict(zip(self.dimensions(label=True), slices))
         data = self.select(**selection)
         if value_select:
-            values = data.dimension_values(value_select)
-            if len(values) > 1:
-                return values
+            if len(data) == 1:
+                return data[value_select][0]
             else:
-                return values[0]
+                return data.reindex(vdims=[value_select])
         return data
 
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -392,10 +392,10 @@ class NdElement(NdMapping, Tabular):
         In addition to usual NdMapping indexing, NdElements can be indexed
         by column name (or a slice over column names)
         """
-        if args in self.dimensions():
-            return self.dimension_values(args)
         if isinstance(args, np.ndarray) and args.dtype.kind == 'b':
             return NdMapping.__getitem__(self, args)
+        elif args in self.dimensions():
+            return self.dimension_values(args)
         if not isinstance(args, tuple): args = (args,)
         ndmap_index = args[:self.ndims]
         val_index = args[self.ndims:]

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -572,13 +572,13 @@ class NdMapping(MultiDimensionalMapping):
         data elements, otherwise it will return the requested slice of
         the data.
         """
-        if indexslice in [Ellipsis, ()]:
-            return self
-        elif isinstance(indexslice, np.ndarray) and indexslice.dtype.kind == 'b':
+        if isinstance(indexslice, np.ndarray) and indexslice.dtype.kind == 'b':
             if not len(indexslice) == len(self):
                 raise IndexError("Boolean index must match length of sliced object")
             selection = zip(indexslice, self.data.items())
             return self.clone([item for c, item in selection if c])
+        elif indexslice in [Ellipsis, ()]:
+            return self
 
         map_slice, data_slice = self._split_index(indexslice)
         map_slice = self._transform_indices(map_slice)

--- a/tests/testcolumns.py
+++ b/tests/testcolumns.py
@@ -311,6 +311,24 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
     def test_columns_index_column_ht(self):
         self.compare_arrays(self.columns_ht['y'], self.ys)
 
+    def test_columns_boolean_index(self):
+        row = self.table[np.array([True, True, False])]
+        indexed = Columns({'Gender':['M','M'],'Age':[10,16],
+                           'Weight':[15,18], 'Height':[0.8,0.6]},
+                          kdims=self.kdims, vdims=self.vdims)
+        self.assertEquals(row, indexed)
+
+    def test_columns_value_dim_index(self):
+        row = self.table[:, :, 'Weight']
+        indexed = Columns({'Gender':['M','M','F'],'Age':[10,16, 12],
+                           'Weight':[15,18, 10]},
+                          kdims=self.kdims, vdims=self.vdims[:1])
+        self.assertEquals(row, indexed)
+
+    def test_columns_value_dim_scalar_index(self):
+        row = self.table['M', 10, 'Weight']
+        self.assertEquals(row, 15)
+
     # Casting
 
     def test_columns_array_ht(self):


### PR DESCRIPTION
There were two bugs in the ``__getitem__`` method:

1) Indexing a value dimension by name would return that column as an array.

2) Boolean slicing was not working across backends.

I've fixed these issues and added some unit tests.