### PR TITLE
Implemented DynamicMap sampled mode

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -381,6 +381,12 @@ class DynamicMap(HoloMap):
        element will be cached and therefore accessible when casting to a
        HoloMap.  Applicable in open mode only.""")
 
+    sampled = param.Boolean(default=False, doc="""
+       Allows defining a DynamicMap in closed mode without defining the
+       dimension bounds or values. Useful for allowing to let a HoloMap
+       in a composite plot to define the dimension sampling.
+       """)
+
     def __init__(self, callback, initial_items=None, **params):
         super(DynamicMap, self).__init__(initial_items, callback=callback, **params)
         self.counter = 0
@@ -412,7 +418,12 @@ class DynamicMap(HoloMap):
         """
         isgenerator = isinstance(self.callback, types.GeneratorType)
         if isgenerator:
+            if self.sampled:
+                raise ValueError("Cannot set DynamicMap containing generator "
+                                 "to sampled")
             return 'generator'
+        if self.sampled:
+            return 'key'
         # Any unbounded kdim (any direction) implies open mode
         for kdim in self.kdims:
             if (kdim.values) and kdim.range != (None,None):

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -129,7 +129,7 @@ def element_display(element, max_frames, max_branches):
 @display_hook
 def map_display(vmap, max_frames, max_branches):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
-    if len(vmap) == 0 and not isinstance(vmap, DynamicMap):
+    if len(vmap) == 0 and (not isinstance(vmap, DynamicMap) or vmap.sampled):
         return sanitize_HTML(vmap)
     elif len(vmap) > max_frames:
         max_frame_warning(max_frames)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -13,7 +13,7 @@ from ...core import traversal
 from ...core.options import Compositor
 from ...core.util import basestring
 from ..plot import Plot, DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
-from ..util import get_dynamic_mode
+from ..util import get_dynamic_mode, initialize_sampled
 from .renderer import BokehRenderer
 from .util import layout_padding
 
@@ -126,7 +126,7 @@ class GridPlot(BokehPlot, GenericCompositePlot):
                  layout_num=1, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
-        dynamic = get_dynamic_mode(layout)
+
         self.layout = layout
         self.rows, self.cols = layout.shape
         self.layout_num = layout_num
@@ -135,6 +135,10 @@ class GridPlot(BokehPlot, GenericCompositePlot):
             dimensions, keys = traversal.unique_dimkeys(layout)
         if 'uniform' not in params:
             params['uniform'] = traversal.uniform(layout)
+
+        dynamic, sampled = get_dynamic_mode(layout)
+        if sampled:
+            initialize_sampled(layout, dimensions, keys[0])
 
         super(GridPlot, self).__init__(keys=keys, dimensions=dimensions,
                                        dynamic=dynamic,

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -10,12 +10,12 @@ from matplotlib import gridspec, animation
 import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Element3D,
-                     Empty, Collator)
+                     Empty, Collator, DynamicMap)
 from ...core.options import Store, Compositor
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
 from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
-from ..util import get_dynamic_mode
+from ..util import get_dynamic_mode, initialize_sampled
 from .renderer import MPLRenderer
 
 
@@ -259,7 +259,6 @@ class GridPlot(CompositePlot):
                  keys=None, dimensions=None, layout_num=1, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
-        dynamic = get_dynamic_mode(layout)
         self.layout = layout
         self.cols, self.rows = layout.shape
         self.layout_num = layout_num
@@ -268,7 +267,9 @@ class GridPlot(CompositePlot):
             dimensions, keys = traversal.unique_dimkeys(layout)
         if 'uniform' not in params:
             params['uniform'] = traversal.uniform(layout)
-
+        dynamic, sampled = get_dynamic_mode(layout)
+        if sampled:
+            initialize_sampled(layout, dimensions, keys[0])
         super(GridPlot, self).__init__(keys=keys, dimensions=dimensions,
                                        dynamic=dynamic,
                                        **dict(extra_opts, **params))

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -426,7 +426,7 @@ class GenericElementPlot(DimensionedPlot):
         keys = keys if keys else list(self.hmap.data.keys())
         plot_opts = self.lookup_options(self.hmap.last, 'plot').options
 
-        dynamic = element.mode if isinstance(element, DynamicMap) else False
+        dynamic = False if not isinstance(element, DynamicMap) or element.sampled else element.mode
         super(GenericElementPlot, self).__init__(keys=keys, dimensions=dimensions,
                                                  dynamic=dynamic,
                                                  **dict(params, **plot_opts))

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -18,7 +18,7 @@ from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor
 from ..core.spaces import HoloMap, DynamicMap
 from ..element import Table, Annotation
-from .util import get_dynamic_mode
+from .util import get_dynamic_mode, initialize_sampled
 
 
 class Plot(param.Parameterized):
@@ -797,8 +797,11 @@ class GenericLayoutPlot(GenericCompositePlot):
         self.rows, self.cols = layout.shape
         self.coords = list(product(range(self.rows),
                                    range(self.cols)))
-        dynamic = get_dynamic_mode(layout)
+        dynamic, sampled = get_dynamic_mode(layout)
         dimensions, keys = traversal.unique_dimkeys(layout)
+        if sampled:
+            initialize_sampled(layout, dimensions, keys[0])
+
         uniform = traversal.uniform(layout)
         plotopts = self.lookup_options(layout, 'plot').options
         super(GenericLayoutPlot, self).__init__(keys=keys, dimensions=dimensions,

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -148,6 +148,7 @@ class Renderer(Exporter):
         dmaps = obj.traverse(lambda x: x, specs=[DynamicMap])
         for dmap in dmaps:
             if dmap.sampled:
+                # Skip initialization until plotting code
                 continue
             if dmap.call_mode == 'key':
                 dmap[dmap._initial_key()]

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -147,6 +147,8 @@ class Renderer(Exporter):
         # Initialize DynamicMaps with first data item
         dmaps = obj.traverse(lambda x: x, specs=[DynamicMap])
         for dmap in dmaps:
+            if dmap.sampled:
+                continue
             if dmap.call_mode == 'key':
                 dmap[dmap._initial_key()]
             else:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -122,11 +122,25 @@ def get_sideplot_ranges(plot, element, main, ranges):
 
 def get_dynamic_mode(composite):
     "Returns the common mode of the dynamic maps in given composite object"
-    dynamic_modes = composite.traverse(lambda x: x.mode, [DynamicMap])
-    if dynamic_modes and not composite.traverse(lambda x: x, ['HoloMap']):
-        if len(set(dynamic_modes)) > 1:
-            raise Exception("Cannot display composites of DynamicMap objects "
-                            "with different interval modes (i.e open or closed mode).")
-        return dynamic_modes[0]
+    dynmaps = composite.traverse(lambda x: x, [DynamicMap])
+    holomaps = composite.traverse(lambda x: x, ['HoloMap'])
+    dynamic_modes = [m.call_mode for m in dynmaps]
+    dynamic_sampled = any(m.sampled for m in dynmaps)
+    if len(set(dynamic_modes)) > 1:
+        raise Exception("Cannot display composites of DynamicMap objects "
+                        "with different interval modes (i.e open or closed mode).")
+    elif dynamic_modes and not holomaps:
+        return 'closed' if dynamic_modes[0] == 'key' else 'open', dynamic_sampled
     else:
-        return None
+        return None, dynamic_sampled
+
+
+def initialize_sampled(obj, dimensions, key):
+    """
+    Initializes any DynamicMaps in sampled mode.
+    """
+    select = dict(zip([d.name for d in dimensions], key))
+    try:
+        selection = obj.select([DynamicMap], **select)
+    except KeyError:
+        pass

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -64,3 +64,17 @@ class DynamicTestCallableClosed(ComparisonTestCase):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
         self.assertEqual(dmap, dmap.clone())
+
+
+class DynamicTestSampledClosed(ComparisonTestCase):
+
+    def test_sampled_closed_init(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        self.assertEqual(dmap.mode, 'closed')
+
+    def test_sampled_closed_init(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
+

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -104,10 +104,9 @@ class MPLRendererTest(ComparisonTestCase):
         data = self.renderer.static_html(self.map1, fmt='gif')
         self.assertEqual(digest_data(data),
                          '9d43822e0f368f3c673b19aaf66d22252849947b7dc4a157306c610c42d319b5')
-
     def test_export_widgets(self):
         bytesio = BytesIO()
-        self.renderer.export_widgets(self.map1, bytesio, fmt='widgets')
+        self.renderer.export_widget(self.map1, bytesio, fmt='widgets')
         data = normalize(bytesio.read())
         self.assertEqual(digest_data(data),
                          '91bbc7b4efebd07b1ee595b902d9899b27f2c7e353dfc87c57c2dfd5d0404301')


### PR DESCRIPTION
DynamicMaps now have a sampled mode allowing defining them in closed mode without a fixed sampling. The user may sample from them explicitly or they may be displayed in a composite object containing HoloMaps that define a fixed number of samples.