### PR TITLE
Speed up NdMapping.groupby

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -6,17 +6,12 @@ baseclass for classes that accept Dimension values.
 import re
 from operator import itemgetter
 
-try:
-    from cyordereddict import OrderedDict
-except:
-    from collections import OrderedDict
-
 import numpy as np
 import param
 
 from ..core.util import (basestring, sanitize_identifier,
                          group_sanitizer, label_sanitizer, max_range,
-                         find_range, dimension_sanitizer)
+                         find_range, dimension_sanitizer, OrderedDict)
 from .options import Store, StoreOptions
 from .pprint import PrettyPrinter
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -284,13 +284,17 @@ class NdElement(NdMapping, Tabular):
         if isinstance(data, list) and all(np.isscalar(el) for el in data):
             data = (((k,), (v,)) for k, v in enumerate(data))
 
-        if not isinstance(data, NdElement) and isinstance(data, Element):
-            mapping = data.mapping()
+        if isinstance(data, Element):
+            params = dict(get_param_values(data), **params)
+            if isinstance(data, NdElement):
+                mapping = data.mapping()
+                data = mapping.data
+            else:
+                data = data.data
             if 'kdims' not in params:
                 params['kdims'] = mapping.kdims
             if 'vdims' not in params:
                 params['vdims'] = mapping.vdims
-            data = mapping.data
 
         kdims = params.get('kdims', self.kdims)
         if (data is not None and not isinstance(data, NdMapping)

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -348,8 +348,11 @@ class NdElement(NdMapping, Tabular):
 
 
     def _add_item(self, key, value, sort=True, update=True):
-        value = (value,) if np.isscalar(value) else tuple(value)
-        if len(value) != len(self.vdims):
+        if np.isscalar(value):
+            value = (value,)
+        elif not isinstance(value, NdElement):
+            value = tuple(value)
+        if len(value) != len(self.vdims) and not isinstance(value, NdElement):
             raise ValueError("%s values must match value dimensions"
                              % type(self).__name__)
         super(NdElement, self)._add_item(key, value, sort, update)
@@ -458,14 +461,6 @@ class NdElement(NdMapping, Tabular):
         return self.clone(sample_data)
 
 
-    def _item_check(self, dim_vals, data):
-        if isinstance(data, tuple):
-            for el in data:
-                self._item_check(dim_vals, el)
-            return
-        super(NdElement, self)._item_check(dim_vals, data)
-
-
     def aggregate(self, dimensions, function, **kwargs):
         """
         Allows aggregating.
@@ -474,7 +469,7 @@ class NdElement(NdMapping, Tabular):
         grouped = self.groupby(dimensions) if len(dimensions) else HoloMap({(): self}, kdims=[])
         for k, group in grouped.data.items():
             reduced = []
-            for vdim in group.vdims:
+            for vdim in self.vdims:
                 data = group[vdim.name]
                 if isinstance(function, np.ufunc):
                     reduced.append(function.reduce(data, **kwargs))

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -279,8 +279,9 @@ class MultiDimensionalMapping(Dimensioned):
         group_type = group_type if group_type else type(self)
         dimensions = [self.get_dimension(d) for d in dimensions]
         sort = not self._sorted
-        return util.ndmapping_groupby(self, dimensions, container_type,
-                                      group_type, sort=sort, **kwargs)
+        with item_check(False):
+            return util.ndmapping_groupby(self, dimensions, container_type,
+                                          group_type, sort=sort, **kwargs)
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -278,7 +278,9 @@ class MultiDimensionalMapping(Dimensioned):
         container_type = container_type if container_type else type(self)
         group_type = group_type if group_type else type(self)
         dimensions = [self.get_dimension(d) for d in dimensions]
-        return util.ndmapping_groupby(self, dimensions, container_type, group_type, **kwargs)
+        sort = not self._sorted
+        return util.ndmapping_groupby(self, dimensions, container_type,
+                                      group_type, sort=sort, **kwargs)
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -737,8 +737,11 @@ def unpack_group(group, getter):
 
 def ndmapping_groupby_pandas(ndmapping, dimensions, container_type,
                              group_type, sort=False, **kwargs):
-    idims = [dim for dim in ndmapping.kdims if dim not in dimensions
-             and dim != 'Index']
+    if 'kdims' in kwargs:
+        idims = [ndmapping.get_dimension(d) for d in kwargs['kdims']]
+    else:
+        idims = [dim for dim in ndmapping.kdims if dim not in dimensions]
+
     all_dims = [d.name for d in ndmapping.kdims]
     inds = [ndmapping.get_dimension_index(dim) for dim in idims]
     getter = operator.itemgetter(*inds) if inds else lambda x: tuple()

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -9,6 +9,11 @@ import numpy as np
 import param
 
 try:
+    from cyordereddict import OrderedDict
+except:
+    from collections import OrderedDict
+
+try:
     import pandas as pd
 except ImportError:
     pd = None

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -756,7 +756,8 @@ def ndmapping_groupby_pandas(ndmapping, dimensions, container_type,
     return container_type(groups, kdims=dimensions)
 
 
-def ndmapping_groupby_python(ndmapping, dimensions, container_type, group_type, **kwargs):
+def ndmapping_groupby_python(ndmapping, dimensions, container_type,
+                             group_type, sort=False, **kwargs):
     idims = [dim for dim in ndmapping.kdims if dim not in dimensions]
     dim_names = [dim.name for dim in dimensions]
     selects = get_unique_keys(ndmapping, dimensions)


### PR DESCRIPTION
This PR refactors the NdMapping.groupby operation into a separate function and provides an alternative implementation based on Pandas, which is significantly faster for large datasets. You can see the linear performance scaling by the old implementation and might just make out the sublinear performance of pandas, which becomes very significant for large datasets >10000 items. This is a temporary workaround until we come up with a general solution data API for NdMapping types that's being discussed in #347.

![image](https://cloud.githubusercontent.com/assets/1550771/11735982/d2604474-9fbf-11e5-833d-4299f5daebd7.png)

