### PR TITLE
Added support for setting the legend font size

### DIFF
--- a/doc/Tutorials/Options.ipynb
+++ b/doc/Tutorials/Options.ipynb
@@ -543,7 +543,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The color of the curve has been changed to red and the fontsizes of the x-axis label and all the tick labels has been modified. The ``fontsize`` is an important plot option and you can find more information about the available options in the ``fontsize`` documentation above.\n",
+    "The color of the curve has been changed to red and the fontsizes of the x-axis label and all the tick labels have been modified. The ``fontsize`` is an important plot option and you can find more information about the available options in the ``fontsize`` documentation above.\n",
     "\n",
     "The ``%%opts`` magic is designed to allow incremental customization which explains why the curve in the cell above has retained the increased thickness specified earlier. To reset all the customizations that have been applied to an object, you can create a fresh, uncustomized copy as follows:"
    ]

--- a/doc/Tutorials/Options.ipynb
+++ b/doc/Tutorials/Options.ipynb
@@ -228,7 +228,8 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -523,6 +524,45 @@
     "\n",
     "Here parentheses indicate style options, square brackets indicate plot options, and curly brackets indicate norm options (with ``+axiswise`` and ``+framewise`` indicating True for those values, and ``-axiswise`` and ``-framewise`` indicating False).  Additional *target-specification*s and associated options of each type for that *target-specification* can be supplied at the end of this line.  This ultra-concise syntax is used throughout the other tutorials, because it helps minimize the code needed to specify the plotting options, and helps make it very clear that these options are handled separately from the actual data.\n",
     "\n",
+    "Here we demonstrate the concise syntax by customizing the style and plot options of the ``Curve`` in the layout:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Curve (color='r') [fontsize={'xlabel':15, 'ticks':8}] \n",
+    "layout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The color of the curve has been changed to red and the fontsizes of the x-axis label and all the tick labels has been modified. The ``fontsize`` is an important plot option and you can find more information about the available options in the ``fontsize`` documentation above.\n",
+    "\n",
+    "The ``%%opts`` magic is designed to allow incremental customization which explains why the curve in the cell above has retained the increased thickness specified earlier. To reset all the customizations that have been applied to an object, you can create a fresh, uncustomized copy as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "layout()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "The ``%opts`` \"line\" magic (with one ``%``) works just the same as the ``%%opts`` \"cell\" magic, but it changes the global default options for all future cells, allowing you to choose a new default colormap, line width, etc.\n",
     "\n",
     "Apart from its brevity, a big benefit of using the IPython magic syntax ``%%opts`` or ``%opts`` is that it is fully tab-completable.  Each of the options that is currently available will be listed if you press ``<TAB>`` when you are ready to write it, which makes it much easier to find the right parameter.  Of course, you will still need to consult the full ``holoviews.help`` documentation (described above) to see the type, allowable values, and documentation for each option, but the tab completion should at least get you started and is great for helping you remember the list of options and see which options are available.\n",
@@ -600,7 +640,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -611,6 +611,10 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         if not plot.legend:
             return
         plot.legend[0].set(**options)
+        legend_fontsize = self._fontsize('legend', 'size').get('size',False)
+        if legend_fontsize:
+            plot.legend[0].label_text_font_size = legend_fontsize
+
         plot.legend.orientation = self.legend_position
         legends = plot.legend[0].legends
         new_legends = []

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -646,7 +646,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             if self.legend_cols: leg_spec['ncol'] = self.legend_cols
             leg = axis.legend(data.keys(), data.values(),
                               title=title, scatterpoints=1,
-                              **leg_spec)
+                              **dict(leg_spec, **self._fontsize('legend')))
             frame = leg.get_frame()
             frame.set_facecolor('1.0')
             frame.set_edgecolor('0.0')

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -647,6 +647,9 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             leg = axis.legend(data.keys(), data.values(),
                               title=title, scatterpoints=1,
                               **dict(leg_spec, **self._fontsize('legend')))
+            title_fontsize = self._fontsize('legend_title')
+            if title_fontsize:
+                leg.get_title().set_fontsize(title_fontsize['fontsize'])
             frame = leg.get_frame()
             frame.set_facecolor('1.0')
             frame.set_edgecolor('0.0')

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -135,7 +135,7 @@ class DimensionedPlot(Plot):
        Finer control is available by supplying a dictionary where any
        unmentioned keys reverts to the default sizes, e.g:
 
-          {'ticks':20, 'title':15, 'ylabel':5, 'xlabel':5}
+          {'ticks':20, 'title':15, 'ylabel':5, 'xlabel':5, 'legend':8}
 
        You can set the fontsize of both 'ylabel' and 'xlabel' together
        using the 'labels' key.""")

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -135,7 +135,9 @@ class DimensionedPlot(Plot):
        Finer control is available by supplying a dictionary where any
        unmentioned keys reverts to the default sizes, e.g:
 
-          {'ticks':20, 'title':15, 'ylabel':5, 'xlabel':5, 'legend':8}
+          {'ticks':20, 'title':15,
+           'ylabel':5, 'xlabel':5,
+           'legend':8, 'legend_title':13}
 
        You can set the fontsize of both 'ylabel' and 'xlabel' together
        using the 'labels' key.""")


### PR DESCRIPTION
This PR adds support for setting the fontsize in legends, addressing issue #353.

It uses the same system as everything else, i.e:

```python
%%opts NdOverlay [fontsize={'legend':14}]
hv.NdOverlay({i:hv.Curve(np.random.rand(10,2)) for i in range(3)})
```
![image](https://cloud.githubusercontent.com/assets/890576/11762927/c524d1fa-a0ee-11e5-9595-40d3c040bc42.png)
