### PR TITLE
Support for multiple display output formats in the notebook

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -769,6 +769,10 @@ class Store(object):
     # types grouped by the backend. Set using the register method.
     registry = {}
 
+    # A list of formats to be published for display on the frontend (e.g
+    # IPython Notebook or a GUI application)
+    display_formats = ['html']
+
     # Once register_plotting_classes is called, this OptionTree is
     # populated for the given backend.
     _options = {}

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -105,6 +105,16 @@ class notebook_extension(param.ParameterizedFunction):
     width = param.Number(default=None, bounds=(0, 100), doc="""
         Width of the notebook as a percentage of the browser screen window width.""")
 
+    display_formats = param.List(default=['html'], doc="""
+        A list of formats that are rendered to the notebook where
+        multiple formats may be selected at once (although only one
+        format will be displayed).
+
+        Although the 'html' format is supported across backends, other
+        formats supported by the current backend (e.g 'png' and 'svg'
+        using the matplotlib backend) may be used. This may be useful to
+        export figures to other formats such as PDF with nbconvert. """)
+
     ip = param.Parameter(default=None, doc="IPython kernel instance")
 
     _loaded = False
@@ -113,6 +123,13 @@ class notebook_extension(param.ParameterizedFunction):
         resources = self._get_resources(params)
         ip = params.pop('ip', None)
         p = param.ParamOverrides(self, params)
+        Store.display_formats = p.display_formats
+
+        if 'html' not in p.display_formats and len(p.display_formats) > 1:
+            msg = ('Output magic unable to control displayed format '
+                   'as IPython notebook uses fixed precedence '
+                   'between %r' % p.display_formats)
+            display(HTML('<b>Warning</b>: %s' % msg))
 
         if notebook_extension._loaded == False:
             ip = get_ipython() if ip is None else ip

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -188,11 +188,57 @@ def display(obj, raw=False, **kwargs):
 
 
 def pprint_display(obj):
-    # If pretty printing is off, return None (will fallback to repr)
+    if 'html' not in Store.display_formats:
+        return None
+
+    # If pretty printing is off, return None (fallback to next display format)
     ip = get_ipython()  #  # pyflakes:ignore (in IPython namespace)
     if not ip.display_formatter.formatters['text/plain'].pprint:
         return None
     return display(obj, raw=True)
+
+
+@display_hook
+def element_png_display(element, max_frames, max_branches):
+    """
+    Used to render elements to PNG if requested in the display formats.
+    """
+    if 'png' not in Store.display_formats:
+        return None
+    info = process_object(element)
+    if info: return info
+
+    backend = Store.current_backend
+    if type(element) not in Store.registry[backend]:
+        return None
+    renderer = Store.renderers[backend]
+    # Current renderer does not support PNG
+    if 'png' not in renderer.params('fig').objects:
+        return None
+
+    data, info = renderer(element, fmt='png')
+    return data
+
+
+@display_hook
+def element_svg_display(element, max_frames, max_branches):
+    """
+    Used to render elements to SVG if requested in the display formats.
+    """
+    if 'svg' not in Store.display_formats:
+        return None
+    info = process_object(element)
+    if info: return info
+
+    backend = Store.current_backend
+    if type(element) not in Store.registry[backend]:
+        return None
+    renderer = Store.renderers[backend]
+    # Current renderer does not support SVG
+    if 'svg' not in renderer.params('fig').objects:
+        return None
+    data, info = renderer(element, fmt='svg')
+    return data
 
 
 # display_video output by default, but may be set to first_frame,
@@ -205,3 +251,9 @@ def set_display_hooks(ip):
     html_formatter.for_type(UniformNdMapping, pprint_display)
     html_formatter.for_type(AdjointLayout, pprint_display)
     html_formatter.for_type(Layout, pprint_display)
+
+    png_formatter = ip.display_formatter.formatters['image/png']
+    png_formatter.for_type(ViewableElement, element_png_display)
+
+    svg_formatter = ip.display_formatter.formatters['image/svg+xml']
+    svg_formatter.for_type(ViewableElement, element_svg_display)

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -60,6 +60,7 @@ class OptionsMagic(Magics):
         Allows updating options depending on class attributes
         and unvalidated options.
         """
+        pass
 
     @classmethod
     def get_options(cls, line, options, linemagic):
@@ -98,10 +99,10 @@ class OptionsMagic(Magics):
                         raise ValueError("Value %r for key %r not between %s and %s" % info)
                 options[keyword] = value
 
-        return cls._validate(options, linemagic)
+        return cls._validate(options, items, linemagic)
 
     @classmethod
-    def _validate(cls, options, linemagic):
+    def _validate(cls, options, items, linemagic):
         "Allows subclasses to check options are valid."
         raise NotImplementedError("OptionsMagic is an abstract base class.")
 
@@ -303,8 +304,16 @@ class OutputMagic(OptionsMagic):
 
 
     @classmethod
-    def _validate(cls, options, linemagic):
+    def _validate(cls, options, items, linemagic):
         "Validation of edge cases and incompatible options"
+
+        if 'html' in Store.display_formats:
+            pass
+        elif 'fig' in items and items['fig'] not in Store.display_formats:
+            msg = ("Output magic requesting figure format %r " % items['fig']
+                   + "not in display formats %r" % Store.display_formats)
+            display(HTML("<b>Warning:</b> %s" % msg))
+
         backend = Store.current_backend
         return Store.renderers[backend].validate(options)
 


### PR DESCRIPTION
This PR address issue #351 and makes our display system even more flexible.

You can now enable multiple display formats simultaneously (default is HTML only as before). For instance, you can now set:

```python
hv.notebook_extension(display_formats=['html','png'])
```

This will display everything as normal, but also render and save PNG data (for elements) into the notebook so that it can be used by nbconvert. As extra rendering is done, running the notebook is slower and of course HoloMaps cannot be exported as PNG unless you select a single frame to display.

You can also do:

```python
hv.notebook_extension(display_formats=['png'])
```

Which will force you to address HoloMaps for nbconvert and will also be faster to render. That said, your output will no longer be nicely centered due to how IPython displays images (out of our control).

The 'html' format is supported by everything but any other format is backend dependent. For instance, if you switch to Bokeh and ask for PNGs, you'll get text reprs instead (Bokeh currently doesn't export to PNG).

