### PR TITLE
Fixing constant dimensions

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -508,7 +508,7 @@ class Dimensioned(LabelledData):
 
     __abstract = True
     _sorted = False
-    _dim_groups = ['kdims', 'vdims', 'ddims']
+    _dim_groups = ['kdims', 'vdims', 'cdims', 'ddims']
     _dim_aliases = dict(key_dimensions='kdims', value_dimensions='vdims',
                         constant_dimensions='cdims', deep_dimensions='ddims')
 
@@ -528,7 +528,7 @@ class Dimensioned(LabelledData):
     def deep_dimensions(self): return self.ddims
 
     def __init__(self, data, **params):
-        for group in self._dim_groups+['cdims']+list(self._dim_aliases.keys()):
+        for group in self._dim_groups+list(self._dim_aliases.keys()):
             if group in ['deep_dimensions', 'ddims']: continue
             if group in params:
                 if group in self._dim_aliases:
@@ -587,7 +587,8 @@ class Dimensioned(LabelledData):
                    'c': (lambda x: x.cdims, {})}
         aliases = {'key': 'k', 'value': 'v', 'constant': 'c'}
         if selection == 'all':
-            dims = [dim for group in self._dim_groups
+            groups = [d for d in self._dim_groups if d != 'cdims']
+            dims = [dim for group in groups
                     for dim in getattr(self, group)]
         elif isinstance(selection, list):
             dims =  [dim for group in selection

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -508,7 +508,7 @@ class Dimensioned(LabelledData):
 
     __abstract = True
     _sorted = False
-    _dim_groups = ['kdims', 'vdims', 'cdims', 'ddims']
+    _dim_groups = ['kdims', 'vdims', 'ddims']
     _dim_aliases = dict(key_dimensions='kdims', value_dimensions='vdims',
                         constant_dimensions='cdims', deep_dimensions='ddims')
 
@@ -528,7 +528,7 @@ class Dimensioned(LabelledData):
     def deep_dimensions(self): return self.ddims
 
     def __init__(self, data, **params):
-        for group in self._dim_groups+list(self._dim_aliases.keys()):
+        for group in self._dim_groups+['cdims']+list(self._dim_aliases.keys()):
             if group in ['deep_dimensions', 'ddims']: continue
             if group in params:
                 if group in self._dim_aliases:


### PR DESCRIPTION
This PR fixes various issues with constant dimensions, in particular it ensures the the default call to .dimensions no longer returns the constant dimensions, which caused a wide range of issues.