### PR TITLE
Improved tracebacks

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -42,6 +42,17 @@ from .tree import AttrTree
 from .util import sanitize_identifier, group_sanitizer,label_sanitizer
 from .pprint import InfoPrinter
 
+
+class BackendError(Exception):
+    """
+    Custom exception used to generate abbreviated tracebacks when there
+    is an error in the backend. Use to suppress long tracebacks that can
+    easily be caused by the users (e.g a typo in the style options)
+    where the user would be better served by a short error message
+    rather than a long traceback.
+    """
+    pass
+
 class OptionError(Exception):
     """
     Custom exception raised when there is an attempt to apply invalid

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -14,7 +14,7 @@ from ..plotting.renderer import Renderer
 from ..plotting.widgets import NdWidget
 from .archive import notebook_archive
 from .magics import load_magics
-from .display_hooks import display      # pyflakes:ignore (API import)
+from .display_hooks import display  # pyflakes:ignore (API import)
 from .display_hooks import set_display_hooks, OutputMagic
 from .parser import Parser
 from .widgets import RunProgress
@@ -23,6 +23,14 @@ from param import ipython as param_ext
 
 Collector.interval_hook = RunProgress
 holoviews.archive = notebook_archive
+
+
+def show_traceback():
+    """
+    Display the full traceback after an abbreviated traceback has occured.
+    """
+    from .display_hooks import FULL_TRACEBACK
+    print FULL_TRACEBACK
 
 
 class IPTestCase(ComparisonTestCase):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -30,7 +30,7 @@ def show_traceback():
     Display the full traceback after an abbreviated traceback has occured.
     """
     from .display_hooks import FULL_TRACEBACK
-    print FULL_TRACEBACK
+    print(FULL_TRACEBACK)
 
 
 class IPTestCase(ComparisonTestCase):

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -2,7 +2,7 @@
 Definition and registration of display hooks for the IPython Notebook.
 """
 from functools import wraps
-import sys, traceback
+import sys, traceback, inspect
 
 import IPython
 import param
@@ -105,7 +105,12 @@ def display_hook(fn):
             return html
         except Exception as e:
             StoreOptions.state(element, state=optstate)
-            if ABBREVIATE_TRACEBACKS:
+            frame = inspect.trace()[-1]
+            mod = inspect.getmodule(frame[0])
+            module = (mod.__name__ if mod else frame[1]).split('.')[0]
+            backends = Store.renderers.keys()
+            abbreviate =  module in backends
+            if ABBREVIATE_TRACEBACKS and abbreviate:
                 info = dict(name=type(e).__name__,
                             message=str(e).replace('\n','<br>'))
                 return "<b>{name}</b><br>{message}".format(**info)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -7,7 +7,7 @@ import sys, traceback, inspect
 import IPython
 import param
 
-from ..core.options import Store, StoreOptions
+from ..core.options import Store, StoreOptions, BackendError
 from ..core import (LabelledData, Element, ViewableElement, UniformNdMapping,
                     HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
                     CompositeOverlay, DynamicMap)
@@ -109,7 +109,7 @@ def display_hook(fn):
             mod = inspect.getmodule(frame[0])
             module = (mod.__name__ if mod else frame[1]).split('.')[0]
             backends = Store.renderers.keys()
-            abbreviate =  module in backends
+            abbreviate =  isinstance(e, BackendError) or module in backends
             if ABBREVIATE_TRACEBACKS and abbreviate:
                 info = dict(name=type(e).__name__,
                             message=str(e).replace('\n','<br>'))

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -2,9 +2,10 @@
 Definition and registration of display hooks for the IPython Notebook.
 """
 from functools import wraps
-import sys, traceback, inspect
+import sys, traceback, inspect, io
 
 import IPython
+from IPython.core.ultratb import AutoFormattedTB
 import param
 
 from ..core.options import Store, StoreOptions, BackendError
@@ -16,7 +17,8 @@ from .magics import OutputMagic, OptsMagic
 
 from .archive import notebook_archive
 # To assist with debugging of display hooks
-ABBREVIATE_TRACEBACKS=True
+FULL_TRACEBACK = None
+ABBREVIATE_TRACEBACKS = True
 
 #==================#
 # Helper functions #
@@ -92,6 +94,7 @@ def last_frame(obj):
 def display_hook(fn):
     @wraps(fn)
     def wrapped(element):
+        global FULL_TRACEBACK
         optstate = StoreOptions.state(element)
         try:
             html = fn(element,
@@ -111,9 +114,15 @@ def display_hook(fn):
             backends = Store.renderers.keys()
             abbreviate =  isinstance(e, BackendError) or module in backends
             if ABBREVIATE_TRACEBACKS and abbreviate:
+                AutoTB = AutoFormattedTB(mode = 'Verbose',color_scheme='Linux')
+                buff = io.StringIO()
+                AutoTB(out=buff)
+                buff.seek(0)
+                FULL_TRACEBACK = buff.read()
                 info = dict(name=type(e).__name__,
                             message=str(e).replace('\n','<br>'))
-                return "<b>{name}</b><br>{message}".format(**info)
+                msg ='<i> [Call ipython.show_traceback() for details]</i>'
+                return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
             else:
                 traceback.print_exc()
     return wrapped


### PR DESCRIPTION
This pull request implements much nicer abbreviated traceback behavior. Abbreviated tracebacks only occur when the exception originates in a backend module (e.g matplotlib or bokeh) and not from HoloViews itself (unless a ``BackendError`` has been explicitly raised).

In addition, there is no need to worry about ``ABBREVIATE_TRACEBACKS`` anymore as you can just call ``ipython.show_traceback()`` after an abbreviated traceback has occurred in order to view the error in full (with syntax highlighting!). 

If the tests pass I'm happy to see this merged although maybe I should remove ``ABBREVIATE_TRACEBACKS`` entirely? Do we care about backward compatibility in this case?

Lastly, any feedback from anyone willing to try out this branch would be much appreciated.