### PR TITLE
Dynamic overlay

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -611,6 +611,14 @@ def sort_topologically(graph):
                                     (names_by_level.get(i, None)
                                      for i in itertools.count())))
 
+def get_overlay_spec(o, k, v):
+    """
+    Gets the type.group.label + key spec from an Element in an Overlay.
+    """
+    k = (wrap_tuple(k),)
+    return ((type(v).__name__, v.group, v.label) + k if len(o.kdims) else
+            (type(v).__name__,) + k)
+
 
 def layer_sort(hmap):
    """
@@ -619,8 +627,7 @@ def layer_sort(hmap):
    """
    orderings = {}
    for o in hmap:
-      okeys = [(type(v).__name__, v.group, v.label) + k if len(o.kdims) else
-               (type(v).__name__,) + k for k, v in o.data.items()]
+      okeys = [get_overlay_spec(o, k, v) for k, v in o.data.items()]
       if len(okeys) == 1 and not okeys[0] in orderings:
          orderings[okeys[0]] = []
       else:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -615,7 +615,7 @@ def get_overlay_spec(o, k, v):
     """
     Gets the type.group.label + key spec from an Element in an Overlay.
     """
-    k = (wrap_tuple(k),)
+    k = wrap_tuple(k)
     return ((type(v).__name__, v.group, v.label) + k if len(o.kdims) else
             (type(v).__name__,) + k)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -18,6 +18,7 @@ from ...core import Store, HoloMap, Overlay, CompositeOverlay, DynamicMap
 from ...core import util
 from ...element import RGB
 from ..plot import GenericElementPlot, GenericOverlayPlot
+from ..util import dynamic_update
 from .callbacks import Callbacks
 from .plot import BokehPlot
 from .renderer import old_bokeh
@@ -694,9 +695,17 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         for k, subplot in self.subplots.items():
             empty = False
             if isinstance(self.hmap, DynamicMap):
-                el = self.dynamic_update(subplot, k, element, items)
-                empty = el is None
+                idx = dynamic_update(self, subplot, k, element, items)
+                empty = idx is None
+                if empty:
+                    _, el = items.pop(idx)
             subplot.update_frame(key, ranges, element=el, empty=empty)
+
+
+        if isinstance(self.hmap, DynamicMap) and items:
+            raise Exception("Some Elements returned by the dynamic callback "
+                            "were not initialized correctly and could not be "
+                            "rendered.")
 
         if not self.overlaid and not self.tabs:
             self._update_ranges(element, ranges)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -7,7 +7,7 @@ import numpy as np
 import param
 
 from ...core import util
-from ...core import (OrderedDict, Collator, NdOverlay, HoloMap,
+from ...core import (OrderedDict, Collator, NdOverlay, HoloMap, DynamicMap,
                      CompositeOverlay, Element3D, Columns, NdElement)
 from ...element import Table, ItemTable, Raster
 from ..plot import GenericElementPlot, GenericOverlayPlot
@@ -124,12 +124,12 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         When the number of the frame is supplied as n, this method looks
         up and computes the appropriate title, axis labels and axis bounds.
         """
-
+        element = self._get_frame(key)
+        self.current_frame = element
         axis = self.handles['axis']
         if self.bgcolor:
             axis.set_axis_bgcolor(self.bgcolor)
 
-        element = self._get_frame(key)
         subplots = list(self.subplots.values()) if self.subplots else []
         if self.zorder == 0 and key is not None:
             title = None if self.zorder > 0 else self._format_title(key)
@@ -391,12 +391,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         If n is greater than the number of available frames, update
         using the last available frame.
         """
-        if not element:
-            if self.dynamic and self.overlaid:
-                self.current_key = key
-                element = self.current_frame
-            else:
-                element = self._get_frame(key)
+        reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        if not reused and element is None:
+            element = self._get_frame(key)
         else:
             self.current_key = key
             self.current_frame = element
@@ -679,9 +676,16 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         else:
             self.current_frame = element
             self.current_key = key
-        ranges = self.compute_ranges(self.hmap, key, ranges)
-        for k, plot in self.subplots.items():
-            plot.update_frame(key, ranges, element.get(k, None))
+
+        range_obj = element if isinstance(self.hmap, DynamicMap) else self.hmap
+        ranges = self.compute_ranges(range_obj, key, ranges)
+
+        items = element.items()
+        for k, subplot in self.subplots.items():
+            el = element.get(k, None)
+            if isinstance(self.hmap, DynamicMap):
+                el = self.dynamic_update(subplot, k, element, items)
+            subplot.update_frame(key, ranges, el)
 
         self._finalize_axis(key, ranges=ranges)
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -11,6 +11,7 @@ from ...core import (OrderedDict, Collator, NdOverlay, HoloMap, DynamicMap,
                      CompositeOverlay, Element3D, Columns, NdElement)
 from ...element import Table, ItemTable, Raster
 from ..plot import GenericElementPlot, GenericOverlayPlot
+from ..util import dynamic_update
 from .plot import MPLPlot
 from .util import wrap_formatter
 
@@ -684,8 +685,15 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         for k, subplot in self.subplots.items():
             el = element.get(k, None)
             if isinstance(self.hmap, DynamicMap):
-                el = self.dynamic_update(subplot, k, element, items)
+                idx = dynamic_update(self, subplot, k, element, items)
+                if idx is not None:
+                    _, el = items.pop(idx)
             subplot.update_frame(key, ranges, el)
+
+        if isinstance(self.hmap, DynamicMap) and items:
+            raise Exception("Some Elements returned by the dynamic callback "
+                            "were not initialized correctly and could not be "
+                            "rendered.")
 
         self._finalize_axis(key, ranges=ranges)
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -660,10 +660,10 @@ class GenericOverlayPlot(GenericElementPlot):
                 continue
 
             if self.hmap.type == Overlay:
-                style_key = (vmap.type.__name__,) + (key,)
+                style_key = (vmap.type.__name__,) + key
             else:
                 if not isinstance(key, tuple): key = (key,)
-                style_key = group_fn(vmap) + (key,)
+                style_key = group_fn(vmap) + key
             group_key = style_key[:length]
             zorder = ordering.index(style_key) + zoffset
             cyclic_index = group_counter[group_key]
@@ -757,11 +757,13 @@ class GenericOverlayPlot(GenericElementPlot):
             if spec[0] == match[0]:
                 new_specs.append((i, spec[1:]))
             else:
-                match_length = max(i for i in range(len(match[0]))
-                                   if (isinstance(match[0], tuple)
-                                       and match[0][:i] == spec[0][:i])
-                                   or (isinstance(match[0], util.basestring)
-                                       and match[0].startswith(spec[0][:i])))
+                if util.isnumber(match[0]) and util.isnumber(spec[0]):
+                    match_length = -abs(match[0]-spec[0])
+                elif all(isinstance(s[0], basestring) for s in [spec, match]):
+                    match_length = max(i for i in range(len(match[0]))
+                                       if match[0].startswith(spec[0][:i]))
+                else:
+                    match_length = 0
                 match_lengths.append((i, match_length, spec[0]))
         if not new_specs:
             if depth == 0:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -734,51 +734,6 @@ class GenericOverlayPlot(GenericElementPlot):
             return separator.join([title, dim_title])
 
 
-    def dynamic_update(self, subplot, key, overlay, items):
-        """
-        Function to assign layers in an Overlay to a new plot.
-        """
-        layer = overlay.get(key, None)
-        if layer is None:
-            match_spec = util.get_overlay_spec(self.current_frame,
-                                               util.wrap_tuple(key),
-                                               subplot.current_frame)
-            specs = [(i, util.get_overlay_spec(overlay, util.wrap_tuple(k), el))
-                     for i, (k, el) in enumerate(items)]
-            idx = self.closest_match(match_spec, specs)
-            k, layer = items.pop(idx)
-        return layer
-
-
-    def closest_match(self, match, specs, depth=0):
-        new_specs = []
-        match_lengths = []
-        for i, spec in specs:
-            if spec[0] == match[0]:
-                new_specs.append((i, spec[1:]))
-            else:
-                if util.isnumber(match[0]) and util.isnumber(spec[0]):
-                    match_length = -abs(match[0]-spec[0])
-                elif all(isinstance(s[0], basestring) for s in [spec, match]):
-                    match_length = max(i for i in range(len(match[0]))
-                                       if match[0].startswith(spec[0][:i]))
-                else:
-                    match_length = 0
-                match_lengths.append((i, match_length, spec[0]))
-        if not new_specs:
-            if depth == 0:
-                raise Exception("No plot with matching type found, ensure "
-                                "the first frame of the DynamicMap initializes "
-                                "all required plots.")
-            else:
-                return sorted(match_lengths, key=lambda x: -x[1])[0][0]
-        elif new_specs == 1:
-            return new_specs[0][0]
-        else:
-            depth = depth+1
-            return self.closest_match(match[1:], new_specs, depth)
-
-
 
 class GenericCompositePlot(DimensionedPlot):
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -2,7 +2,7 @@ import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     GridSpace, NdLayout, Store)
-from ..core.util import match_spec
+from ..core.util import match_spec, is_number, wrap_tuple, get_overlay_spec
 
 
 def displayable(obj):
@@ -159,3 +159,49 @@ def save_frames(obj, filename, fmt=None, backend=None, options=None):
     for i in range(len(plot)):
         plot.update(i)
         renderer.save(plot, '%s_%s' % (filename, i), fmt=fmt, options=options)
+
+
+def dynamic_update(plot, subplot, key, overlay, items):
+    """
+    Given a plot, subplot and dynamically generated (Nd)Overlay
+    find the closest matching Element for that plot.
+    """
+    match_spec = get_overlay_spec(overlay,
+                                  wrap_tuple(key),
+                                  subplot.current_frame)
+    specs = [(i, get_overlay_spec(overlay, wrap_tuple(k), el))
+             for i, (k, el) in enumerate(items)]
+    return closest_match(match_spec, specs)
+
+
+def closest_match(match, specs, depth=0):
+    """
+    Recursively iterates over type, group, label and overlay key,
+    finding the closest matching spec.
+    """
+    new_specs = []
+    match_lengths = []
+    for i, spec in specs:
+        if spec[0] == match[0]:
+            new_specs.append((i, spec[1:]))
+        else:
+            if is_number(match[0]) and is_number(spec[0]):
+                match_length = -abs(match[0]-spec[0])
+            elif all(isinstance(s[0], basestring) for s in [spec, match]):
+                match_length = max(i for i in range(len(match[0]))
+                                   if match[0].startswith(spec[0][:i]))
+            else:
+                match_length = 0
+            match_lengths.append((i, match_length, spec[0]))
+
+    if len(new_specs) == 1:
+        return new_specs[0][0]
+    elif new_specs:
+        depth = depth+1
+        return closest_match(match[1:], new_specs, depth)
+    else:
+        if depth == 0 or not match_lengths:
+            return None
+        else:
+            return sorted(match_lengths, key=lambda x: -x[1])[0][0]
+


### PR DESCRIPTION
This PR makes it possible to use return Overlays with changing keys in a DynamicMap callback. It's a sensitive change, which will require some more testing.

Note that while it now displays everything certain things do not yet work:

* Legends do not yet change to reflect the new NdOverlay key or Overlay label
* In matplotlib styles will not consistently update.

And certain things cannot work:

* Cyclic styles cannot work with a DynamicMap as the total ordering is required during instantiation. Could consider raising a warning when an Element returned from a DynamicMap is given a cyclic style.
* You cannot return more Elements or different types of Elements than are supplied during instantiation.