### PR TITLE
Full support of the style system using DynamicMaps 

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -969,6 +969,21 @@ class StoreOptions(object):
 
 
     @classmethod
+    def tree_to_dict(cls, tree):
+        """
+        Given an OptionTree, convert it into the equivalent dictionary format.
+        """
+        specs = {}
+        for k in tree.keys():
+            spec_key = '.'.join(k)
+            specs[spec_key] = {}
+            for grp in tree[k].groups:
+                kwargs = tree[k].groups[grp].kwargs
+                if kwargs:
+                    specs[spec_key][grp] = kwargs
+        return specs
+
+    @classmethod
     def propagate_ids(cls, obj, match_id, new_id, applied_keys):
         """
         Recursively propagate an id through an object for components

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -994,8 +994,10 @@ class StoreOptions(object):
             raise AssertionError("The set_ids method requires "
                                  "Store.custom_options to contain"
                                  " a tree with id %d" % new_id)
-        obj.traverse(lambda o: setattr(o, 'id', new_id)
-                      if o.id == match_id else None, specs=set(applied_keys))
+        def propagate(o):
+            if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
+                setattr(o, 'id', new_id)
+        obj.traverse(propagate, specs=set(applied_keys) | {'DynamicMap'})
 
     @classmethod
     def capture_ids(cls, obj):


### PR DESCRIPTION
This PR fixes a major issue with ``DynamicMaps``, namely that they did not properly support styling. This is because when a ``DynamicMap`` is created it may contain *no* elements meaning that  there is nothing to propagate an ``id`` to when ``%%opts`` or ``__call__`` is used. In other words, every time a value is returned by the callback, it was too late as styling had already been applied.

The approach used here seems to work well but there are things I am not entirely happy with:

* Using ``__class__.__name__`` to check for DynamicMap. I am fairly sure I'll encounter cyclic import issues if I try to import ``DynamicMap`` into ``options.py``.
* It is a little inefficient as I'm converting from an ``OptionTree`` to dictionary format and back to an ``OptionTree`` per frame.
* This is going to generate a ludicrous number of custom ids and option trees if you use the DynamicMap much (one per frame!). Many of these will be identical as well (until the style is changed, if ever).

Hopefully, I can address these issue but I think this PR is very important for the 1.4.1 release. Styling ``DynamicMap`` as easily as ``HoloMap`` is crucial!