### PR TITLE
Bokeh Comms

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -37,20 +37,17 @@ var BokehMethods = {
 		if (data !== undefined) {
 			if (data.root !== undefined) {
 				doc = Bokeh.index[data.root].model.document;
-				$.each(data, function(id, value) {
-					ds = doc.get_model_by_id(id);
-					if (ds != undefined) {
-						ds.set(value.data);
-					}
-				});
-			} else {
-				$.each(data, function(id, value) {
-					var ds = Bokeh.Collections(value.type).get(id);
-					if (ds != undefined) {
-						ds.set(value.data);
-					}
-				});
 			}
+			$.each(data.data, function(i, value) {
+				if (data.root !== undefined) {
+					ds = doc.get_model_by_id(value.id);
+				} else if {
+					var ds = Bokeh.Collections(value.type).get(value.id);
+				}
+				if (ds != undefined) {
+					ds.set(value.data);
+				}
+			});
 		}
 	},
 	dynamic_update : function(current){

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -41,7 +41,7 @@ var BokehMethods = {
 			$.each(data.data, function(i, value) {
 				if (data.root !== undefined) {
 					ds = doc.get_model_by_id(value.id);
-				} else if {
+				} else {
 					var ds = Bokeh.Collections(value.type).get(value.id);
 				}
 				if (ds != undefined) {

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -75,8 +75,8 @@ class Callback(param.ParameterizedFunction):
         function callback(msg){
           if (msg.msg_type == "execute_result") {
             var data = JSON.parse(msg.content.data['text/plain'].slice(1, -1));
-            $.each(data, function(id, value) {
-              var ds = Bokeh.Collections(value.type).get(id);
+            $.each(data.data, function(i, value) {
+              var ds = Bokeh.Collections(value.type).get(value.id);
                 if (ds != undefined) {
                   ds.set(value.data);
                 }
@@ -145,13 +145,14 @@ class Callback(param.ParameterizedFunction):
         """
         Serializes any Bokeh plot objects passed to it as a list.
         """
-        data = {}
+        data = dict(data=[])
         for obj in objects:
             if old_bokeh:
                 json = obj.vm_serialize(changed_only=True)
             else:
                 json = obj.to_json(False)
-            data[obj.ref['id']] = {'type': obj.ref['type'], 'data': json}
+            data['data'].append({'id': obj.ref['id'], 'type': obj.ref['type'],
+                                 'data': json})
         return serialize_json(data)
 
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -37,6 +37,12 @@ class BokehPlot(DimensionedPlot):
 
     renderer = BokehRenderer
 
+    def __init__(self, *args, **params):
+        super(BokehPlot, self).__init__(*args, **params)
+        self.document = None
+        self.root = None
+
+
     def get_data(self, element, ranges=None, empty=False):
         """
         Returns the data from an element in the appropriate format for
@@ -45,6 +51,22 @@ class BokehPlot(DimensionedPlot):
         the column in the datasource.
         """
         raise NotImplementedError
+
+
+    def set_document(self, document):
+        """
+        Sets the current document on all subplots.
+        """
+        for plot in self.traverse(lambda x: x):
+            plot.document = document
+
+
+    def set_root(self, root):
+        """
+        Sets the current document on all subplots.
+        """
+        for plot in self.traverse(lambda x: x):
+            plot.root = root
 
 
     def _init_datasource(self, data):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -75,6 +75,8 @@ class BokehRenderer(Renderer):
         if not old_bokeh:
             doc = Document()
             doc.add_root(plot.state)
+            plot.set_root(plot.state)
+            plot.set_document(doc)
         return notebook_div(plot.state)
 
 

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -57,7 +57,7 @@ class BokehRenderer(Renderer):
         elif fmt == 'json':
             plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles)
                            for h in handles]
-            data = OrderedDict()
+            data = dict(data=[])
             if not old_bokeh:
                 data['root'] = plot.state._id
             for plotobj in plotobjects:
@@ -65,8 +65,9 @@ class BokehRenderer(Renderer):
                     json = plotobj.vm_serialize(changed_only=True)
                 else:
                     json = plotobj.to_json(False)
-                data[plotobj.ref['id']] = {'type': plotobj.ref['type'],
-                                           'data': json}
+                data['data'].append({'id': plotobj.ref['id'],
+                                     'type': plotobj.ref['type'],
+                                     'data': json})
             return serialize_json(data), info
 
 


### PR DESCRIPTION
This PR fixes bokeh comms to retain the order of objects to update fixing issues with colormaps not updating correctly. Additionally the callbacks are also updated and now work with the dev release of bokeh and should be compatible with the upcoming v0.11 release.