### PR TITLE
Notebook extension now switches backend automatically

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -34,6 +34,7 @@ Store:
 """
 import pickle
 from contextlib import contextmanager
+from collections import OrderedDict
 
 import numpy as np
 
@@ -774,7 +775,7 @@ class Store(object):
     object.
     """
 
-    renderers = {} # The set of available Renderers across all backends.
+    renderers = OrderedDict() # The set of available Renderers across all backends.
 
     # A mapping from ViewableElement types to their corresponding plot
     # types grouped by the backend. Set using the register method.

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -170,6 +170,10 @@ class notebook_extension(param.ParameterizedFunction):
             Store.renderers[r].load_nb()
 
 
+        if resources[-1] != 'holoviews':
+            get_ipython().magic(u"output backend=%r" % resources[-1])
+
+
     def _get_resources(self, args, params):
         """
         Finds the list of resources from the keyword parameters and pops


### PR DESCRIPTION

This PR addresses some of our later discussion in #334. Now when you use ``notebook_extension`` the backend associated with the last block of Javascript that gets loaded is activated.

The resource order is determined by the ``*args`` e.g ``hv.notebook_extension('bokeh', 'matplotlib')`` but if keywords are used, the order of the renderers registered in ``Store`` (i.e the order in which backends are registered) determines what will be activated.