### PR TITLE
python 3 compatibility fix

### DIFF
--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -111,8 +111,8 @@ def hierarchical(keys):
     ndims = len(keys[0])
     if ndims <= 1:
         return True
-    dim_vals = zip(*keys)
-    combinations = (zip(*dim_vals[i:i+2])
+    dim_vals = list(zip(*keys))
+    combinations = (list(zip(*dim_vals[i:i+2]))
                     for i in range(ndims-1))
     hierarchies = []
     for combination in combinations:

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -112,7 +112,7 @@ def hierarchical(keys):
     if ndims <= 1:
         return True
     dim_vals = list(zip(*keys))
-    combinations = (list(zip(*dim_vals[i:i+2]))
+    combinations = (zip(*dim_vals[i:i+2])
                     for i in range(ndims-1))
     hierarchies = []
     for combination in combinations:


### PR DESCRIPTION
zip returns an iterable under python 3, and so 'Showcase.ipynb' doesn't work