### PR TITLE
Decouple scaling method from scaling factor (as per issue #363).

### DIFF
--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -509,7 +509,7 @@
    "source": [
     "Thus the ``Scatter`` object expresses a dependent relationship between *x* and *y*, making it useful for combining with other similar ``Chart`` types, while the ``Points`` object expresses the relationship of two independent keys *x* and *y* with optional ``vdims`` (zero in this case), which makes ``Points`` objects meaningful to combine with the ``Raster`` types below.\n",
     "\n",
-    "Of course, the ``vdims`` need not be empty for ``Points``; here is an example with two additional quantities for each point, as ``value_dimension``s *z* and &alpha; visualized as the color and size of the dots, respectively:"
+    "Of course, the ``vdims`` need not be empty for ``Points``; here is an example with two additional quantities for each point, as ``value_dimension``s *z* and &alpha; visualized as the color and size of the dots, respectively. The point sizes can be tweaked using the option `scaling_factor`, which determines the amount by which each point width or area is scaled, depending on the value of `scaling_method`."
    ]
   },
   {
@@ -520,7 +520,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Points [color_index=2 size_index=3 scaling_factor=50]\n",
+    "%%opts Points [color_index=2 size_index=3 scaling_method=\"width\" scaling_factor=50]\n",
     "np.random.seed(10)\n",
     "data = np.random.rand(100,4)\n",
     "\n",

--- a/doc/Tutorials/Pandas_Conversion.ipynb
+++ b/doc/Tutorials/Pandas_Conversion.ipynb
@@ -565,7 +565,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Curve (color='k') Scatter [color_index=2 size_index=2 scaling_factor=10.0] (cmap='Blues' edgecolors='k')\n",
+    "%%opts Curve (color='k') Scatter [color_index=2 size_index=2 scaling_factor=20.0] (cmap='Blues' edgecolors='k')\n",
     "macro_overlay = gdp_curves * gdp_unem_scatter\n",
     "annotations = hv.Arrow(1973, 8, 'Oil Crisis', 'v') * hv.Arrow(1975, 6, 'Stagflation', 'v') *\\\n",
     "hv.Arrow(1979, 8, 'Energy Crisis', 'v') * hv.Arrow(1981.9, 5, 'Early Eighties\\n Recession', 'v')\n",

--- a/doc/Tutorials/Pandas_Conversion.ipynb
+++ b/doc/Tutorials/Pandas_Conversion.ipynb
@@ -519,7 +519,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Scatter [scaling_factor=1.4] (color=Palette('Set3') edgecolors='k')\n",
+    "%%opts Scatter [scaling_factor=15.0] (color=Palette('Set3') edgecolors='k')\n",
     "gdp_unem_scatter = macro.scatter('year', ['GDP Growth', 'Unemployment'])\n",
     "gdp_unem_scatter.overlay('country')"
    ]
@@ -539,7 +539,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Scatter [size_index=1 scaling_factor=1.3] (color=Palette('Dark2'))\n",
+    "%%opts Scatter [size_index=1 scaling_factor=3.0] (color=Palette('Dark2'))\n",
     "macro.scatter('GDP Growth', 'Unemployment').overlay('country')"
    ]
   },
@@ -565,7 +565,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Curve (color='k') Scatter [color_index=2 size_index=2 scaling_factor=1.4] (cmap='Blues' edgecolors='k')\n",
+    "%%opts Curve (color='k') Scatter [color_index=2 size_index=2 scaling_factor=10.0] (cmap='Blues' edgecolors='k')\n",
     "macro_overlay = gdp_curves * gdp_unem_scatter\n",
     "annotations = hv.Arrow(1973, 8, 'Oil Crisis', 'v') * hv.Arrow(1975, 6, 'Stagflation', 'v') *\\\n",
     "hv.Arrow(1979, 8, 'Energy Crisis', 'v') * hv.Arrow(1981.9, 5, 'Early Eighties\\n Recession', 'v')\n",

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -21,13 +21,15 @@ class PointPlot(ElementPlot):
     radius_index = param.Integer(default=None, doc="""
       Index of the dimension from which the sizes will the drawn.""")
 
+    scaling_method = param.ObjectSelector(default="area",
+                                          objects=["width", "area"],
+                                          doc="""
+      Determines whether the `scaling_factor` should be applied to
+      the width or area of each point (default: "area").""")
+
     scaling_factor = param.Number(default=1, bounds=(1, None), doc="""
-      If values are supplied the area of the points is computed relative
-      to the marker size. It is then multiplied by scaling_factor to the power
-      of the ratio between the smallest point and all other points.
-      For values of 1 scaling by the values is disabled, a factor of 2
-      allows for linear scaling of the area and a factor of 4 linear
-      scaling of the point width.""")
+      Scaling factor which is applied to either the width or area
+      of each point, depending on the value of `scaling_method`.""")
 
     size_fn = param.Callable(default=np.abs, doc="""
       Function applied to size values before applying scaling,
@@ -67,7 +69,7 @@ class PointPlot(ElementPlot):
                 ms = style.get('size', 1)
                 sizes = element.dimension_values(self.size_index)
                 data[map_key] = compute_sizes(sizes, self.size_fn,
-                                              self.scaling_factor, ms)
+                                    self.scaling_factor, self.scaling_method, ms)
 
         data[dims[0]] = [] if empty else element.dimension_values(0)
         data[dims[1]] = [] if empty else element.dimension_values(1)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -529,7 +529,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
       Determines whether the `scaling_factor` should be applied to
       the width or area of each point (default: "area").""")
 
-    scaling_factor = param.Number(default=1, bounds=(1, None), doc="""
+    scaling_factor = param.Number(default=1, bounds=(0, None), doc="""
       Scaling factor which is applied to either the width or area
       of each point, depending on the value of `scaling_method`.""")
 
@@ -561,7 +561,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
             cs = points.dimension_values(self.color_index)
 
         style = self.style[self.cyclic_index]
-        if self.size_index < ndims and self.scaling_factor > 1:
+        if self.size_index < ndims:
             style['s'] = self._compute_size(points, style)
 
         color = style.pop('color', None)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -523,13 +523,15 @@ class PointPlot(ChartPlot, ColorbarPlot):
     size_index = param.Integer(default=2, doc="""
       Index of the dimension from which the sizes will the drawn.""")
 
+    scaling_method = param.ObjectSelector(default="area",
+                                          objects=["width", "area"],
+                                          doc="""
+      Determines whether the `scaling_factor` should be applied to
+      the width or area of each point (default: "area").""")
+
     scaling_factor = param.Number(default=1, bounds=(1, None), doc="""
-      If values are supplied the area of the points is computed relative
-      to the marker size. It is then multiplied by scaling_factor to the power
-      of the ratio between the smallest point and all other points.
-      For values of 1 scaling by the values is disabled, a factor of 2
-      allows for linear scaling of the area and a factor of 4 linear
-      scaling of the point width.""")
+      Scaling factor which is applied to either the width or area
+      of each point, depending on the value of `scaling_method`.""")
 
     show_grid = param.Boolean(default=True, doc="""
       Whether to draw grid lines at the tick positions.""")
@@ -584,7 +586,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
     def _compute_size(self, element, opts):
         sizes = element.dimension_values(self.size_index)
         ms = opts.pop('s') if 's' in opts else plt.rcParams['lines.markersize']
-        return compute_sizes(sizes, self.size_fn, self.scaling_factor, ms)
+        return compute_sizes(sizes, self.size_fn, self.scaling_factor, self.scaling_method, ms)
 
 
     def update_handles(self, axis, element, key, ranges=None):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1,3 +1,4 @@
+import math
 import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
@@ -74,14 +75,22 @@ def undisplayable_info(obj, html=False):
             ['<b>%s</b>' % error, remedy, '<i>%s</i>' % info])))
 
 
-def compute_sizes(sizes, size_fn, scaling, base_size):
+def compute_sizes(sizes, size_fn, scaling_factor, scaling_method, base_size):
     """
     Scales point sizes according to a scaling factor,
     base size and size_fn, which will be applied before
     scaling.
     """
+    if scaling_method == 'area':
+        scaling_factor = math.sqrt(scaling_factor)
+    elif scaling_method == 'width':
+        pass  # can use scaling factor unchanged in this case
+    else:
+        raise ValueError(
+            'Invalid value for argument "scaling_method": "{}". '
+            'Valid values are: "width", "area".'.format(scaling_method))
     sizes = size_fn(sizes)
-    return (base_size*scaling**sizes)
+    return (base_size*scaling_factor*sizes)
 
 
 def get_sideplot_ranges(plot, element, main, ranges):


### PR DESCRIPTION
This PR implements a fix for #363. It introduces a new option `scaling_method` which determines whether `scaling_factor` should scale the point width or area (no other scaling methods are currently allowed, although they could certainly be added if there are other sensible alternatives).

If this PR is accepted then some of the notebooks will need updating as well (and the new option should be documented somewhere (possibly in the `Elements` notebook?). I haven't done this yet because I don't fully understand the notebook testing process and was worried that I'd break something.

Also, I couldn't find a unit test for the helper function `utils.compute_sizes()`. I'm not sure how fine-grained the unit testing process in holoviews is supposed to be so haven't added one, but let me know if you'd like me to do this.