### PR TITLE
New GeoMap Element for plotting geographical maps

### DIFF
--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -12,6 +12,7 @@ each collection of paths.
 """
 
 import numpy as np
+from geopandas import GeoDataFrame
 
 import param
 from ..core import Dimension, Element2D
@@ -128,6 +129,31 @@ class Polygons(Contours):
         Polygons optionally accept a value dimension, corresponding
         to the supplied value.""", bounds=(1,1))
 
+
+
+class GeoMap(Contours):
+    """
+    GeoMap is a Path Element which represents a geographical map consisting
+    of a collection of polygons representing geographical regions which can
+    optionally be associated with an additional value (e.g. population size,
+    region area, etc.).
+    """
+
+    group = param.String(default="GeoMap", constant=True)
+
+    vdims = param.List(default=[Dimension('Value')], doc="""
+        GeoMaps optionally accept a value dimension, corresponding
+        to the supplied value.""", bounds=(1,1))
+
+    def __init__(self, data, **params):
+        assert isinstance(data, GeoDataFrame)
+
+        def get_array_for_poly(poly):
+            xs, ys = poly.exterior.xy
+            return np.array([xs, ys]).T
+
+        data = [get_array_for_poly(poly) for poly in data.geometry]
+        super(GeoMap, self).__init__(data, **params)
 
 
 class BaseShape(Path):

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -152,7 +152,16 @@ class GeoMap(Contours):
             xs, ys = poly.exterior.xy
             return np.array([xs, ys]).T
 
-        data = [get_array_for_poly(poly) for poly in data.geometry]
+        geoms = []
+
+        for poly in data.geometry:
+            try:
+                geoms.append(get_array_for_poly(poly))
+            except AttributeError:
+                for subpoly in poly.geoms:
+                    geoms.append(get_array_for_poly(subpoly))
+
+        data = geoms
         super(GeoMap, self).__init__(data, **params)
 
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -2,7 +2,7 @@ from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
                      GridSpace, NdElement, Columns, GridMatrix, NdLayout)
 from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         RGB, Histogram, Spread, HeatMap, Contours, Bars,
-                        Box, Bounds, Ellipse, Polygons, BoxWhisker,
+                        Box, Bounds, Ellipse, Polygons, GeoMap, BoxWhisker,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
                         Table, ItemTable, Surface, Scatter3D, Trisurface)
 from ...core.options import Options, Cycle
@@ -56,6 +56,7 @@ Store.register({Overlay: OverlayPlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
                 Polygons: PolygonPlot,
+                GeoMap:   PolygonPlot,
 
                 # Annotations
                 HLine: LineAnnotationPlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -56,7 +56,7 @@ Store.register({Overlay: OverlayPlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
                 Polygons: PolygonPlot,
-                GeoMap:   PolygonPlot,
+                GeoMap:   GeoMapPlot,
 
                 # Annotations
                 HLine: LineAnnotationPlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -15,7 +15,7 @@ from .callbacks import Callbacks # noqa (API import)
 from .element import OverlayPlot, BokehMPLWrapper, BokehMPLRawWrapper
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BoxPlot, BarPlot, SpikesPlot, SideSpikesPlot)
-from .path import PathPlot, PolygonPlot
+from .path import PathPlot, PolygonPlot, GeoMapPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
 from .raster import RasterPlot, RGBPlot, HeatmapPlot
 from .renderer import BokehRenderer
@@ -127,6 +127,7 @@ options.Box = Options('style', color='black')
 options.Bounds = Options('style', color='black')
 options.Ellipse = Options('style', color='black')
 options.Polygons = Options('style', color=Cycle())
+options.GeoMap = Options('style', fill_color='white', line_color='black')
 
 # Rasters
 options.Image = Options('style', cmap='hot')

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -36,3 +36,16 @@ class PolygonPlot(PathPlot):
             data['color'] = [] if empty else list(colors)*len(element.data)
 
         return data, mapping
+
+
+class GeoMapPlot(PolygonPlot):
+    """
+    GeoMapPlot draws paths representing the region boundaries in the
+    supplied GeoMap. If the GeoMap has an associated value the color of
+    regions will be drawn from the supplied cmap, otherwise the supplied
+    facecolor will apply.
+    """
+
+    aspect = param.Parameter(default='equal', doc="""
+        GeoMap elements use an 'equal' aspect ratio by default but
+        may be set to an explicit aspect ratio or to 'square'.""")

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -1,4 +1,5 @@
 import numpy as np
+import param
 
 from .element import ElementPlot, line_properties, fill_properties
 from .util import get_cmap, map_colors
@@ -49,3 +50,6 @@ class GeoMapPlot(PolygonPlot):
     aspect = param.Parameter(default='equal', doc="""
         GeoMap elements use an 'equal' aspect ratio by default but
         may be set to an explicit aspect ratio or to 'square'.""")
+
+    bgcolor = param.Parameter(default='white', doc="""
+        Background color of the plot.""")

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -155,7 +155,8 @@ Store.register({Curve: CurvePlot,
                 Box:      PathPlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
-                Polygons: PolygonPlot}, 'matplotlib', style_aliases=style_aliases)
+                Polygons: PolygonPlot,
+                GeoMap:   PolygonPlot}, 'matplotlib', style_aliases=style_aliases)
 
 
 MPLPlot.sideplots.update({Histogram: SideHistogramPlot,

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -156,7 +156,7 @@ Store.register({Curve: CurvePlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
                 Polygons: PolygonPlot,
-                GeoMap:   PolygonPlot}, 'matplotlib', style_aliases=style_aliases)
+                GeoMap:   GeoMapPlot}, 'matplotlib', style_aliases=style_aliases)
 
 
 MPLPlot.sideplots.update({Histogram: SideHistogramPlot,
@@ -204,6 +204,7 @@ options.Arrow = Options('style', color='k', linewidth=2, fontsize=13)
 # Paths
 options.Contours = Options('style', color=Cycle())
 options.Path = Options('style', color=Cycle())
+options.GeoMap = Options('style', color=Cycle(), edgecolor='black', facecolor='none')
 options.Box = Options('style', color=Cycle())
 options.Bounds = Options('style', color=Cycle())
 options.Ellipse = Options('style', color=Cycle())

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -204,7 +204,7 @@ options.Arrow = Options('style', color='k', linewidth=2, fontsize=13)
 # Paths
 options.Contours = Options('style', color=Cycle())
 options.Path = Options('style', color=Cycle())
-options.GeoMap = Options('style', color=Cycle(), edgecolor='black', facecolor='none')
+options.GeoMap = Options('style', color=Cycle(), edgecolor='black', facecolor='white')
 options.Box = Options('style', color=Cycle())
 options.Bounds = Options('style', color=Cycle())
 options.Ellipse = Options('style', color=Cycle())

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -116,3 +116,6 @@ class GeoMapPlot(PolygonPlot):
     aspect = param.Parameter(default='equal', doc="""
         GeoMap elements use an 'equal' aspect ratio by default but
         may be set to an explicit aspect ratio or to 'square'.""")
+
+    bgcolor = param.Parameter(default='white', doc="""
+        Background color of the map.""")

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -103,3 +103,16 @@ class PolygonPlot(ColorbarPlot):
         elif value is not None and np.isfinite(value):
             collection.set_array(np.array([value]*len(element.data)))
             collection.set_clim(ranges[vdim.name])
+
+
+class GeoMapPlot(PolygonPlot):
+    """
+    GeoMapPlot draws paths representing the region boundaries in the
+    supplied GeoMap. If the GeoMap has an associated value the color of
+    regions will be drawn from the supplied cmap, otherwise the supplied
+    facecolor will apply.
+    """
+
+    aspect = param.Parameter(default='equal', doc="""
+        GeoMap elements use an 'equal' aspect ratio by default but
+        may be set to an explicit aspect ratio or to 'square'.""")

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -119,3 +119,29 @@ class GeoMapPlot(PolygonPlot):
 
     bgcolor = param.Parameter(default='white', doc="""
         Background color of the map.""")
+
+    frame = param.Boolean(default=False, doc="""
+        Whether to show the frame around the plot.""")
+
+    def initialize_plot(self, ranges=None):
+        # TODO: Most of this is copied & pasted from PolygonPlot.
+        #       How can we avoid the code duplication?!?
+        element = self.hmap.last
+        key = self.keys[-1]
+        axis = self.handles['axis']
+        ranges = self.compute_ranges(self.hmap, key, ranges)
+        ranges = match_spec(element, ranges)
+        collection, polys = self._create_polygons(element, ranges)
+        axis.add_collection(collection)
+        self.handles['polys'] = polys
+
+        axis.xaxis.set_visible(False)
+        axis.yaxis.set_visible(False)
+        axis.set_frame_on(self.frame)
+
+        if self.colorbar:
+            self._draw_colorbar(collection, element)
+
+        self.handles['artist'] = collection
+
+        return self._finalize_axis(self.keys[-1], ranges=ranges)


### PR DESCRIPTION
This PR is only intended as a basis for discussion and certainly not ready to be merged.

I'm interested in plotting geographical maps using Holoviews. This PR is a quick-and-dirty implementation to get some basic functionality working quickly. It introduces a new element called `GeoMap` which can be used as follows.
```python
import holoviews as hv
from geopandas import GeoDataFrame
hv.notebook_extension()
```
```python
!wget https://raw.githubusercontent.com/MinnPost/simple-map-d3/master/example-data/world-population.geo.json
```
```python
df = GeoDataFrame.from_file('./world-population.geo.json')
```
```python
%%opts GeoMap [fig_inches=(14, None)] (linewidth=0.5)
hv.GeoMap(df)
```
![map_of_world](https://cloud.githubusercontent.com/assets/2692805/12080285/4f5c3f3e-b256-11e5-9268-0790f7a0f63c.png)

The implementation is rather crude and I'm sure I'm doing a lot of things wrong or inefficiently. Also, there are certainly missing features. One of the key things I'd like to see is the ability to colour the regions according to the values in some column of the given GeoDataFrame (e.g. `POP2005` in this case to show population sizes), which I haven't figured out how to do yet although I'd imagine that if I subclassed the correct Holoviews element then it should just work (perhaps with minor tweaks). In the future I could also imagine support for different projection systems, adding layers from Google Maps/OpenStreetMap, etc.

I gather that @philippjfr has already done some work regarding geographical maps, so I didn't want to take this much further without feedback and opinions whether this is going in the right direction. Any comments, suggestions and criticism would be greatly appreciated. Thanks!