### PR TITLE
Added initial_hook and renamed finalize_hook to final_hook

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -115,6 +115,12 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         if isinstance(check, Element3D):
             self.projection = '3d'
 
+        for hook in self.initial_hooks:
+            try:
+                hook(self, element)
+            except Exception as e:
+                self.warning("Plotting hook %r could not be applied:\n\n %s" % (hook, e))
+
 
     def _finalize_axis(self, key, title=None, ranges=None, xticks=None, yticks=None,
                        zticks=None, xlabel=None, ylabel=None, zlabel=None):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -59,19 +59,19 @@ class MPLPlot(DimensionedPlot):
         Size relative to the supplied overall fig_inches in percent.""")
 
     initial_hooks = param.HookList(default=[], doc="""
-        Optional list of hooks called when finalizing an axis.
-        The hook is passed the full set of plot handles and the
-        displayed object.""")
+        Optional list of hooks called before plotting the data onto
+        the axis. The hook is passed the plot object and the displayed
+        object, other plotting handles can be accessed via plot.handles.""")
 
     final_hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing an axis.
-        The hook is passed the full set of plot handles and the
-        displayed object.""")
+        The hook is passed the plot object and the displayed
+        object, other plotting handles can be accessed via plot.handles.""")
 
     finalize_hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing an axis.
-        The hook is passed the full set of plot handles and the
-        displayed object.""")
+        The hook is passed the plot object and the displayed
+        object, other plotting handles can be accessed via plot.handles.""")
 
     sublabel_format = param.String(default=None, allow_None=True, doc="""
         Allows labeling the subaxes in each plot with various formatters

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -58,6 +58,16 @@ class MPLPlot(DimensionedPlot):
     fig_size = param.Integer(default=100, bounds=(1, None), doc="""
         Size relative to the supplied overall fig_inches in percent.""")
 
+    initial_hooks = param.HookList(default=[], doc="""
+        Optional list of hooks called when finalizing an axis.
+        The hook is passed the full set of plot handles and the
+        displayed object.""")
+
+    final_hooks = param.HookList(default=[], doc="""
+        Optional list of hooks called when finalizing an axis.
+        The hook is passed the full set of plot handles and the
+        displayed object.""")
+
     finalize_hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing an axis.
         The hook is passed the full set of plot handles and the
@@ -96,6 +106,14 @@ class MPLPlot(DimensionedPlot):
         fig, axis = self._init_axis(fig, axis)
         self.handles['fig'] = fig
         self.handles['axis'] = axis
+
+        if not self.final_hooks and self.finalize_hooks:
+            self.warning('Using deprecated finalize_hooks options, '
+                         'use final_hooks instead')
+            self.final_hooks = self.finalize_hooks
+        elif self.final_hooks and self.finalize_hooks:
+            raise ValueError('Set either final_hooks or deprecated '
+                             'finalize_hooks, not both.')
 
 
     def _init_axis(self, fig, axis):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -107,13 +107,10 @@ class MPLPlot(DimensionedPlot):
         self.handles['fig'] = fig
         self.handles['axis'] = axis
 
-        if not self.final_hooks and self.finalize_hooks:
-            self.warning('Using deprecated finalize_hooks options, '
-                         'use final_hooks instead')
-            self.final_hooks = self.finalize_hooks
-        elif self.final_hooks and self.finalize_hooks:
-            raise ValueError('Set either final_hooks or deprecated '
-                             'finalize_hooks, not both.')
+        if self.final_hooks and self.finalize_hooks:
+            self.warning('Set either final_hooks or deprecated '
+                         'finalize_hooks, not both.')
+        self.finalize_hooks = self.final_hooks
 
 
     def _init_axis(self, fig, axis):


### PR DESCRIPTION
This PR implements the suggestion made in #396 to add an ``initial_hook`` and rename ``finalize_hook`` to ``final_hook``.