### PR TITLE
Fixes for Image.table and regular sampling

### DIFF
--- a/doc/Tutorials/Sampling_Data.ipynb
+++ b/doc/Tutorials/Sampling_Data.ipynb
@@ -381,7 +381,7 @@
    "outputs": [],
    "source": [
     "%%opts Layout [fig_size=150] Scatter3D [color_index=3] (cmap='Reds' edgecolor='k')\n",
-    "obs_hmap.table().to.scatter3d(['Observation', 'x', 'y'], ['z']) + obs_hmap.table()"
+    "obs_hmap.table().to.scatter3d() + obs_hmap.table()"
    ]
   },
   {
@@ -542,10 +542,10 @@
    },
    "outputs": [],
    "source": [
-    "sample_style = dict(facecolors='r', edgecolors='k', alpha=1)\n",
-    "all_samples = obs_hmap.table().to.scatter3d(['Observation', 'x', 'y'], ['z'])(style=dict(alpha=0.15))\n",
+    "sample_style = dict(edgecolors='k', alpha=1)\n",
+    "all_samples = obs_hmap.table().to.scatter3d()(style=dict(alpha=0.15))\n",
     "sampled = obs_hmap.sample((3,3))\n",
-    "subsamples = sampled.to.scatter3d(['Observation', 'x', 'y'], ['z'])(style=sample_style)\n",
+    "subsamples = sampled.to.scatter3d()(style=sample_style)\n",
     "all_samples * subsamples + sampled"
    ]
   },
@@ -565,7 +565,7 @@
    "outputs": [],
    "source": [
     "sampled = obs_hmap.sample((3,3), bounds=(2,5,5,10))\n",
-    "subsamples = sampled.to.scatter3d(['Observation', 'x', 'y'], ['z'])(style=sample_style)\n",
+    "subsamples = sampled.to.scatter3d()(style=sample_style)\n",
     "all_samples * subsamples + sampled"
    ]
   },
@@ -593,9 +593,9 @@
     "curve = hv.HoloMap({(i) : hv.Curve(zip(xs, np.sin(xs)*i))\n",
     "                    for i in np.linspace(0.5, 1.5, 3)},\n",
     "                   key_dimensions=['Observation'])\n",
-    "all_samples = curve.table().to.points(['Observation', 'x'], ['y'])\n",
+    "all_samples = curve.table().to.points()\n",
     "sampled = curve.sample([0, 2, 4, 6, 8])\n",
-    "sampling = all_samples * sampled.to.points(['Observation', 'x'], ['y'], extents=extents)(style=dict(color='r'))\n",
+    "sampling = all_samples * sampled.to.points(extents=extents)(style=dict(color='r'))\n",
     "sampling + sampled"
    ]
   },
@@ -615,7 +615,7 @@
    "outputs": [],
    "source": [
     "sampled = curve.table().select(Observation=(0, 1.1), x={0, 2, 4, 6, 8})\n",
-    "sampling = all_samples * sampled.to.points(['Observation', 'x'], ['y'], extents=extents)(style=dict(color='r'))\n",
+    "sampling = all_samples * sampled.to.points(extents=extents)(style=dict(color='r'))\n",
     "sampling + sampled"
    ]
   },
@@ -643,7 +643,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.10"
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -255,13 +255,13 @@ class HoloMap(UniformNdMapping):
                 xsamples = [(lx+ux)/2.0 for lx,ux in zip(xedges[:-1], xedges[1:])]
                 ysamples = [(ly+uy)/2.0 for ly,uy in zip(yedges[:-1], yedges[1:])]
 
-                X,Y = np.meshgrid(xsamples, ysamples)
+                Y,X = np.meshgrid(ysamples, xsamples)
                 linsamples = zip(X.flat, Y.flat)
             else:
                 raise NotImplementedError("Regular sampling not implemented "
                                           "for high-dimensional Views.")
 
-            samples = set(self.last.closest(linsamples))
+            samples = list(util.unique_iterator(self.last.closest(linsamples)))
 
         sampled = self.clone([(k, view.sample(samples, **sample_values))
                               for k, view in self.data.items()])

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -616,7 +616,7 @@ class Image(SheetCoordinateSystem, Raster):
             if unique:
                 return d2lin if dim_idx else d1lin
             else:
-                X, Y = np.meshgrid(d1lin, d2lin)
+                Y, X = np.meshgrid(d2lin, d1lin)
                 return Y.flatten() if dim_idx else X.flatten()
         elif dim_idx == 2:
             return np.flipud(self.data).T.flatten()


### PR DESCRIPTION
There's a bug in Image dimension_values, which processes the meshgrid incorrectly and which means that the .table output is broken. Additionally regular sampling on Images now sorts the data correctly. I've also included some fixes/improvements for the Sampling Data Tutorial since this PR changes almost all the output there.