### PR TITLE
Improved infrastructure for notebook testing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "doc/builder"]
 	path = doc/builder
 	url = https://github.com/ioam/ioam-builder.git
-[submodule "doc/reference_data"]
-	path = doc/reference_data
-	url = https://github.com/ioam/holoviews-data.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ install:
   - pip install coveralls awscli
   - git clone https://github.com/ioam/holoviews-data.git -b reference_data ./doc/reference_data
   - cd ./doc/reference_data
-  - REF_BRANCH=${TRAVIS_PULL_REQUEST//false/master}
-  - echo "Attempting to checkout $REF_BRANCH branch"
-  - if [ $(git branch -a --list *origin/$REF_BRANCH | wc -l) -eq 1 ] ; then
-      git checkout $REF_BRANCH;
+  - REF_DATA_BRANCH=${TRAVIS_PULL_REQUEST//false/master}
+  - echo "Attempting to checkout $REF_DATA_BRANCH branch"
+  - if [ $(git branch -a --list *origin/$REF_DATA_BRANCH | wc -l) -eq 1 ] ; then
+      git checkout $REF_DATA_BRANCH;
     else
       echo "Using the master branch reference data";
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,15 @@ install:
   - pip install path.py
   - pip install coveralls awscli
   - git clone https://github.com/ioam/holoviews-data.git -b reference_data ./doc/reference_data
+  - cd ./doc/reference_data
+  - REF_BRANCH=${TRAVIS_PULL_REQUEST//false/master}
+  - echo "Attempting to checkout $REF_BRANCH branch"
+  - if [ $(git branch -a --list *origin/$REF_BRANCH | wc -l) -eq 1 ] ; then
+      git checkout $REF_BRANCH;
+    else
+      echo "Using the master branch reference data";
+    fi
+  - cd ../..
 
 before-script:
   - "echo 'backend : Agg' > $HOME/.matplotlib/matplotlibrc"

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,21 @@ install:
   - pip install git+git://github.com/ioam/param.git
   - pip install path.py
   - pip install coveralls awscli
+  - sudo apt-get -qq update
+  - sudo apt-get install -y jq
+  - if [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
+      CURRENT_BUILD=$(curl -s -X GET "https://api.travis-ci.org/repos/ioam/holoviews/builds?number=$TRAVIS_BUILD_NUMBER");
+      NEXT_BUILD=$(curl -s -X GET "https://api.travis-ci.org/repos/ioam/holoviews/builds?number=$((TRAVIS_BUILD_NUMBER + 1))");
+      MSG1=$(echo $CURRENT_BUILD | jq '.[].message' );
+      MSG2=$(echo $NEXT_BUILD | jq '.[].message' );
+      if [ "$MSG1" == "$MSG2" ] ; then
+        BUILD_ID=$(echo $NEXT_BUILD | jq .[].id);
+        TRAVIS_PULL_REQUEST=$(curl -s -X GET "https://api.travis-ci.org/repos/ioam/holoviews/builds/$BUILD_ID" | jq .compare_url | cut -d '/' -f7 | cut -d \" -f1);
+      fi
+    fi
+  - REF_DATA_BRANCH=${TRAVIS_PULL_REQUEST//false/reference_data}
   - git clone https://github.com/ioam/holoviews-data.git -b reference_data ./doc/reference_data
   - cd ./doc/reference_data
-  - REF_DATA_BRANCH=${TRAVIS_PULL_REQUEST//false/master}
   - echo "Attempting to checkout $REF_DATA_BRANCH branch"
   - if [ $(git branch -a --list *origin/$REF_DATA_BRANCH | wc -l) -eq 1 ] ; then
       git checkout $REF_DATA_BRANCH;

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ install:
   - pip install git+git://github.com/ioam/param.git
   - pip install path.py
   - pip install coveralls awscli
-  - sudo apt-get -qq update
-  - sudo apt-get install -y jq
   - if [ "$TRAVIS_PULL_REQUEST" == 'false' ]; then
       CURRENT_BUILD=$(curl -s -X GET "https://api.travis-ci.org/repos/ioam/holoviews/builds?number=$TRAVIS_BUILD_NUMBER");
       NEXT_BUILD=$(curl -s -X GET "https://api.travis-ci.org/repos/ioam/holoviews/builds?number=$((TRAVIS_BUILD_NUMBER + 1))");

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ install:
   - pip install git+git://github.com/ioam/param.git
   - pip install path.py
   - pip install coveralls awscli
+  - git clone https://github.com/ioam/holoviews-data.git -b reference_data ./doc/reference_data
 
 before-script:
   - "echo 'backend : Agg' > $HOME/.matplotlib/matplotlibrc"


### PR DESCRIPTION
I think it is safe to say that none of us are too fond of the ``reference_data`` submodule. 

In fact, I've found it a real hinderance personally:

* It bloats up any repository fast and can be a pain to simply download.
* We have far too many 'Updated reference submodule reference' commits.
* You have to download the reference data repository to do this update (non-trivial as history keeps changing to keep it squashed!).
* Anyone submitting a PR is subjected to this painful process.

However, there are a few advantages using GitHub:

* Hosting is free, unlike S3 where we would need to pay per GB downloaded.
* Integrates with Travis and PRs because you point to a particular commit SHA.

Here is the overall outline of how it will work if this PR goes to plan:

1. Submit a PR normally. Once it is done, check Travis to find the latest build number (tests will have failed due to the PR changes).
2. Go to [travis.holoviews.org](http://travis.holoviews.org/) and find the build number, check that the display data is all correct. Travis will have pushed the test data to S3 so it is available to buildbot (given a recent build number). 
3. Go to [buildbot.holoviews.org](http://buildbot.holoviews.org/) (in development), log in and supply a small amount of information (e.g the build number) and trigger the build.

This would make things a *lot* easier but the submodule reference in the current system would remain a major problem. Although we *could* automatically update the reference on *our* repository we can't help people submitting PRs to us. We don't have the credentials to push to other people's repositories. Other people would still be left with some of the nastiest steps to carry out themselves.

The proposed system is based on these ideas:

* The ``holoviews-data`` repository stays. It is no longer used as a submodule though, it is simply cloned into ``doc/reference_data`` and switched to the correct branch.
* To work with PRs, each PR will have its own branch based on the PR number. There is also a master branch.
* Commits to update reference data use ``--amend`` to keep the repository small. We can snapshot master at any time by creating a copy on a branch (e.g on release).

How will this work concretely?

1.When running notebook tests, Travis uses the ``$TRAVIS_PULL_REQUEST`` environment variable to clone the ``holoviews-data`` repository and checkout the branch called ``PR$TRAVIS_PULL_REQUEST``. If this branch doesn't exist, it backs off to the ``master branch`` to use the test data there.
2.  Once the test is finished, Travis uses the ``$TRAVIS_BUILD_NUMBER`` environment variables to create a directory in an S3 bucket to push ``test_data``. It will also write the ``$TRAVIS_PULL_REQUEST``  variable to a file called ``SOURCE``. Note, if the build is not for a PR, it dumps ````$TRAVIS_BRANCH```` into SOURCE instead. Travis is already pushing the display data to a bucket to allow review on ``travis.holoviews.org``.
2. Buildbot then needs two bits of information to operate: the PR number and the Travis build number. It can then checkout the PR by number (using a ``hub`` utility to make this easier). Buildbot can pull the test data from S3 and do a sanity check: make sure the SOURCE file matches the specified PR. Note, I could pull from S3 first, check SOURCE and automatically get the right PR, but I think I feel validation is necessary. You don't want a screw up in the build number to affect a different PRs test data.
3. Buildbot has now downloaded the test data from S3 so it can now commit it back to the ``holoviews-data`` repository on a branch based on the specified PR number (commit with ``--amend``). This means the next time Travis runs a build for the PR it will fetch the correct test data.

Advantages:

1. No more submodule or submodule reference updating commits.
2. Users never need to touch the ``holoviews-data`` repository themselves.
3. Much easier - everything is automated as much as possible. Note that you cannot skip the review process as you have to explicitly make sure the new test data is good. Then you decide to run a buildbot build (or not) to make that test data as new reference data.
3. Still works with PRs but uses GitHub to hold the reference data.

I bet it sounds complicated but if it works, it will make developing new notebooks much easier.