### PR TITLE
Add extra hook before_display_hook to alter plotted data before display.

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -55,6 +55,11 @@ class MPLRenderer(Renderer):
          The 'mpld3' mode uses the mpld3 library whereas the 'nbagg' uses
          matplotlib's the experimental nbagg backend. """)
 
+    before_display_hooks = param.HookList(default=[], doc="""
+        Optional list of hooks called before displaying a plot.
+        The hook is passed renderer, the plot object, the binary plotted object
+        and the fmt. It can be used to alter the raw data.""")
+
 
     # <format name> : (animation writer, format,  anim_kwargs, extra_args)
     ANIMATION_OPTS = {
@@ -96,6 +101,12 @@ class MPLRenderer(Renderer):
                 raise Exception("<b>Python 3 matplotlib animation support broken &lt;= 1.3</b>")
             anim = plot.anim(fps=self.fps)
             data = self._anim_data(anim, fmt)
+
+        for hook in self.before_display_hooks:
+            try:
+                data = hook(self, obj, data, fmt)
+            except Exception as e:
+                self.warning("Displaying hook %r could not be applied:\n\n %s" % (hook, e))
 
         return data, {'file-ext':fmt,
                       'mime_type':MIME_TYPES[fmt]}


### PR DESCRIPTION
See #432 

Example to add a second SVG file to the plot:
```python
%output fig='svg'
import xml.etree.ElementTree as et
from svg_merge import remove_meta, combine

def combiner(self, obj, data, fmt):
    if fmt == 'svg':
        data = combine([et.fromstring(data), remove_meta('/tmp/b.svg')])
    return data

hv.Store.renderers['matplotlib'].before_display_hooks=[combiner]

hv.Curve(zip([0,1,2], [0,1,.5]))
```

![c](https://cloud.githubusercontent.com/assets/3776190/12747209/fb44dbb8-c9a2-11e5-92a0-db94f90ccdf1.png)
