### PR TITLE
Cleaned up and improved legend handling for all backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - coverage combine
 
 after_script:
-  - zip -r test_data.zip doc/test_data/
+  - zip -r test_data.zip doc/test_data/*
   - aws s3 cp --region eu-west-1 ./test_data.zip "s3://preview.holoviews.org/$TRAVIS_BUILD_NUMBER/test_data_py${TRAVIS_PYTHON_VERSION:0:1}.zip"
   - aws s3 cp --recursive --region eu-west-1 ./doc/test_html "s3://travis.holoviews.org/build_$TRAVIS_BUILD_NUMBER"
   - aws s3 rm --recursive --region eu-west-1 s3://preview.holoviews.org/$(($TRAVIS_BUILD_NUMBER - 4))

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -264,6 +264,9 @@ class SpikesPlot(PathPlot):
     position = param.Number(default=0., doc="""
       The position of the lower end of each spike.""")
 
+    show_legend = param.Boolean(default=True, doc="""
+        Whether to show legend for the plot.""")
+
     style_opts = (['color', 'cmap', 'palette'] + line_properties)
 
     def get_extents(self, element, ranges):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -85,7 +85,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     show_grid = param.Boolean(default=True, doc="""
         Whether to show a Cartesian grid on the plot.""")
 
-    show_legend = param.Boolean(default=False, doc="""
+    show_legend = param.Boolean(default=True, doc="""
         Whether to show legend for the plot.""")
 
     shared_axes = param.Boolean(default=True, doc="""
@@ -368,7 +368,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Disables legends if show_legend is disabled.
         """
-        if not self.overlaid and not self.show_legend:
+        if not self.overlaid:
             for l in self.handles['plot'].legend:
                 l.legends[:] = []
                 l.border_line_alpha = 0
@@ -387,12 +387,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _glyph_properties(self, plot, element, source, ranges):
         properties = self.style[self.cyclic_index]
 
-        if self.overlay_dims:
-            legend = ', '.join([d.pprint_value_string(v) for d, v in
-                                self.overlay_dims.items()])
-        else:
-            legend = element.label
-        properties['legend'] = legend
+        if self.show_legend:
+            if self.overlay_dims:
+                legend = ', '.join([d.pprint_value_string(v) for d, v in
+                                    self.overlay_dims.items()])
+            else:
+                legend = element.label
+            properties['legend'] = legend
         properties['source'] = source
         return properties
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -1,10 +1,14 @@
 import numpy as np
+import param
 
 from .element import ElementPlot, line_properties, fill_properties
 from .util import get_cmap, map_colors
 
 
 class PathPlot(ElementPlot):
+
+    show_legend = param.Boolean(default=False, doc="""
+        Whether to show legend for the plot.""")
 
     style_opts = ['color'] + line_properties
     _plot_method = 'multi_line'

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -1,4 +1,5 @@
 import numpy as np
+import param
 
 from bokeh.models.mappers import LinearColorMapper
 
@@ -8,6 +9,9 @@ from .util import mplcmap_to_palette, map_colors, get_cmap
 
 
 class RasterPlot(ElementPlot):
+
+    show_legend = param.Boolean(default=False, doc="""
+        Whether to show legend for the plot.""")
 
     style_opts = ['cmap']
     _plot_method = 'image'
@@ -96,6 +100,9 @@ class RGBPlot(RasterPlot):
 
 
 class HeatmapPlot(ElementPlot):
+
+    show_legend = param.Boolean(default=False, doc="""
+        Whether to show legend for the plot.""")
 
     _plot_method = 'rect'
     style_opts = ['cmap', 'color'] + line_properties + fill_properties

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -205,6 +205,7 @@ options.Text = Options('style', fontsize=13)
 options.Arrow = Options('style', color='k', linewidth=2, fontsize=13)
 # Paths
 options.Contours = Options('style', color=Cycle())
+options.Contours = Options('plot', show_legend=True)
 options.Path = Options('style', color=Cycle())
 options.Box = Options('style', color=Cycle())
 options.Bounds = Options('style', color=Cycle())

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -20,6 +20,9 @@ from .plot import AdjoinedPlot
 
 class ChartPlot(ElementPlot):
 
+    show_legend = param.Boolean(default=True, doc="""
+        Whether to show legend for the plot.""")
+
     def __init__(self, data, **params):
         super(ChartPlot, self).__init__(data, **params)
         key_dim = self.hmap.last.get_dimension(0)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -602,46 +602,39 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         for subplot in self.subplots.values():
             subplot._finalize_artist(key)
 
-    def _adjust_legend(self, axis):
+    def _adjust_legend(self, overlay, axis):
         """
         Accumulate the legend handles and labels for all subplots
         and set up the legend
         """
-
         title = ''
         legend_data = []
-        if issubclass(self.hmap.type, NdOverlay):
-            dimensions = self.hmap.last.kdims
-            for key in self.hmap.last.data.keys():
-                subplot = self.subplots[key]
+        dimensions = overlay.kdims
+        title = ', '.join([d.name for d in dimensions])
+        for key, subplot in self.subplots.items():
+            element = overlay.data.get(key, False)
+            if not subplot.show_legend or not element: continue
+            title = ', '.join([d.name for d in dimensions])
+            handle = subplot.handles.get('artist', False)
+            if isinstance(overlay, NdOverlay):
                 key = (dim.pprint_value(k) for k, dim in zip(key, dimensions))
                 label = ','.join([str(k) + dim.unit if dim.unit else str(k) for dim, k in
                                   zip(dimensions, key)])
-                handle = subplot.handles.get('artist', False)
                 if handle:
                     legend_data.append((handle, label))
-            title = ', '.join([d.name for d in dimensions])
-        else:
-            for key, subplot in self.subplots.items():
+            else:
                 if isinstance(subplot, OverlayPlot):
                     legend_data += subplot.handles.get('legend_data', {}).items()
-                else:
-                    layer = self.hmap.last.data.get(key, False)
-                    handle = subplot.handles.get('artist', False)
-                    if layer and not isinstance(layer, Raster) and layer.label and handle:
-                        legend_data.append((handle, layer.label))
-        autohandles, autolabels = axis.get_legend_handles_labels()
-        legends = list(zip(*legend_data)) if legend_data else ([], [])
-        all_handles = list(legends[0]) + list(autohandles)
-        all_labels = list(legends[1]) + list(autolabels)
+                elif element and element.label and handle:
+                    legend_data.append((handle, element.label))
+        all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
         data = OrderedDict()
-        show_legend = self.lookup_options(self.hmap.last, 'plot').options.get('show_legend', None)
         used_labels = []
         for handle, label in zip(all_handles, all_labels):
             if handle and (handle not in data) and label and label not in used_labels:
                 data[handle] = label
                 used_labels.append(label)
-        if (not len(set(data.values())) > 1 and not show_legend) or not self.show_legend:
+        if (not len(set(data.values())) > 0) or not self.show_legend:
             legend = axis.get_legend()
             if legend:
                 legend.set_visible(False)
@@ -658,6 +651,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             frame.set_facecolor('1.0')
             frame.set_edgecolor('0.0')
             frame.set_linewidth('1.0')
+            leg.set_zorder(10e6)
             self.handles['legend'] = leg
         self.handles['legend_data'] = data
 
@@ -665,18 +659,23 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
     def initialize_plot(self, ranges=None):
         axis = self.handles['axis']
         key = self.keys[-1]
+        element = self._get_frame(key)
 
         ranges = self.compute_ranges(self.hmap, key, ranges)
         for plot in self.subplots.values():
             plot.initialize_plot(ranges=ranges)
-        self._adjust_legend(axis)
+
+        if not self.show_legend:
+            return
+        self._adjust_legend(element, axis)
 
         return self._finalize_axis(key, ranges=ranges, title=self._format_title(key))
 
 
     def update_frame(self, key, ranges=None, element=None):
+        axis = self.handles['axis']
         if self.projection == '3d':
-            self.handles['axis'].clear()
+            axis.clear()
 
         if element is None:
             element = self._get_frame(key)
@@ -704,6 +703,9 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             raise Exception("Some Elements returned by the dynamic callback "
                             "were not initialized correctly and could not be "
                             "rendered.")
+
+        if self.show_legend:
+            self._adjust_legend(element, axis)
 
         self._finalize_axis(key, ranges=ranges)
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -665,9 +665,8 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         for plot in self.subplots.values():
             plot.initialize_plot(ranges=ranges)
 
-        if not self.show_legend:
-            return
-        self._adjust_legend(element, axis)
+        if self.show_legend:
+            self._adjust_legend(element, axis)
 
         return self._finalize_axis(key, ranges=ranges, title=self._format_title(key))
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -625,7 +625,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             else:
                 if isinstance(subplot, OverlayPlot):
                     legend_data += subplot.handles.get('legend_data', {}).items()
-                elif element and element.label and handle:
+                if element and element.label and handle:
                     legend_data.append((handle, element.label))
         all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
         data = OrderedDict()

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -625,7 +625,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             else:
                 if isinstance(subplot, OverlayPlot):
                     legend_data += subplot.handles.get('legend_data', {}).items()
-                if element and element.label and handle:
+                if element.label and handle:
                     legend_data.append((handle, element.label))
         all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
         data = OrderedDict()

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -673,12 +673,14 @@ class GenericOverlayPlot(GenericElementPlot):
             opts = {}
             if overlay_type == 2:
                 opts['overlay_dims'] = OrderedDict(zip(self.hmap.last.kdims, key))
+            if issubclass(plottype, GenericOverlayPlot):
+                opts['show_legend'] = self.show_legend
             style = self.lookup_options(vmap.last, 'style').max_cycles(group_length)
             plotopts = dict(opts, keys=self.keys, style=style, cyclic_index=cyclic_index,
                             zorder=self.zorder+zorder, ranges=ranges, overlaid=overlay_type,
                             layout_dimensions=self.layout_dimensions,
                             show_title=self.show_title, dimensions=self.dimensions,
-                            uniform=self.uniform, show_legend=self.show_legend,
+                            uniform=self.uniform,
                             **{k: v for k, v in self.handles.items() if k in self._passed_handles})
 
             if not isinstance(key, tuple): key = (key,)


### PR DESCRIPTION
As the title suggests this is a refactor of the legend code so that a) it behaves more similarly across backends and b) to clean up the code a little bit.

Concretely this PR addresses the following issues:

* Legends not updating per frame in mpl
* Legend zorder being too low in mpl
* Allow toggling legends consistently at the Element and Overlay level, providing finer control. Previously some Element types could be toggled others could not.