### PR TITLE
Normalizing aspects when computing Layout fig_inches

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -820,6 +820,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         # Compute and set the plot size if not explicitly supplied
         col_ars = [ar for ars in col_aspect_ratios for ar in ars]
         row_ars = [ar for ars in row_aspect_ratios for ar in ars]
+        col_ars = [ar/max(col_ars) if ar else 0 for ar in col_ars]
+
         width = len(col_ars[::2]) + sum(col_ars[1::2])
         yscale = sum(col_ars)/sum(row_ars)
         xinches, yinches = None, None


### PR DESCRIPTION
This fixes a bug when adjusting aspects in a Layout and setting the aspect_weight to a non-zero value. The previous bug made it incredibly fiddly to get the plot spacing in a gridded layout with non-square aspects right. Now when setting aspect_weight=1 you should always get a plot without excessive whitespace.