### PR TITLE
Layout templates

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -789,6 +789,9 @@ class GenericLayoutPlot(GenericCompositePlot):
     """
     A GenericLayoutPlot accepts either a Layout or a NdLayout and
     displays the elements in a cartesian grid in scanline order.
+
+    The positioning of the elements of the layout can be customized
+    with a layout template.
     """
 
     def __init__(self, layout, **params):


### PR DESCRIPTION
This PR is designed to address the difficulties we have with customizing Layouts, e.g setting non-square aspects, positioning subfigures and insets. What is proposed here was first suggested on Gitter.

The basic idea is that HoloViews makes visualizing things easy. So why not use our existing elements and operators to define a 'layout template'? We already have a ``Bounds`` element that is pretty ideal for this:

```python
hv.Bounds((0.05, 0.3, 0.9, 0.95), extents=(0, 0, 2, 1)) *\
hv.Bounds((0.05, 0.05, 0.9, 0.25)) *\
hv.Bounds((1.05, 0.3, 1.9, 0.95)) *\
hv.Bounds((1.05, 0.05, 1.9, .25))
```

![image](https://cloud.githubusercontent.com/assets/890576/12821530/b1db3f34-cb5b-11e5-9191-7ae82290e479.png)

The idea is that the overlay order defines the subfigure ordering. This would let us do insets as well as you could position these anywhere you like. We might want a special layout template element/object that could do something like this but number the subfigures.

There isn't much here yet as we will need to discuss this proposal carefully before much code is written. Discussing this with Philipp, it sounds like this would be feasible to support in the plotting code.