### PR TITLE
Reimplemented Layout aspects handling

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -752,7 +752,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                 main_aspect = np.nan if isinstance(main, Empty) else main_options.get('aspect', 1)
                 main_aspect = self.aspect_weight*main_aspect + 1-self.aspect_weight
             else:
-                main_aspect = 1
+                main_aspect = np.nan
 
             if layout_type in ['Dual', 'Triple']:
                 el = layout_view.get('right', None)
@@ -804,6 +804,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         widths = np.array([r for col in col_widthratios.values()
                            for ratios in col[1] for r in ratios])/4
 
+        hr_unnormalized = compute_ratios(row_heightratios, False)
         wr_unnormalized = compute_ratios(col_widthratios, False)
         hr_list = compute_ratios(row_heightratios)
         wr_list = compute_ratios(col_widthratios)

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -812,8 +812,12 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         # Compute the number of rows and cols
         cols, rows = len(wr_list), len(hr_list)
 
-        width = sum(wr_list)
-        yscale = width/sum([(1/v)*4 for v in wr_unnormalized])
+
+        wr_list = [r if np.isfinite(r) else 1 for r in wr_list]
+        hr_list = [r if np.isfinite(r) else 1 for r in hr_list]
+
+        width = sum([r if np.isfinite(r) else 1 for r in wr_list])
+        yscale = width/sum([(1/v)*4 if np.isfinite(v) else 4 for v in wr_unnormalized])
         if self.absolute_scaling:
             width = width*np.nanmax(widths)
 

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -39,7 +39,7 @@ def normalize_ratios(ratios):
     normalized = {}
     for i, v in enumerate(zip(*ratios.values())):
         arr = np.array(v)
-        normalized[i] = arr/np.nanmax(v)
+        normalized[i] = arr/float(np.nanmax(arr))
     return normalized
 
 def compute_ratios(ratios, normalized=True):

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -1,7 +1,10 @@
 import re
 
-from ...core.util import basestring
+import numpy as np
 from matplotlib import ticker
+
+from ...core.util import basestring
+
 
 def wrap_formatter(formatter):
     """
@@ -17,3 +20,31 @@ def wrap_formatter(formatter):
             return ticker.StrMethodFormatter(formatter)
         else:
             return ticker.FormatStrFormatter(formatter)
+
+def unpack_adjoints(ratios):
+    new_ratios = {}
+    offset = 0
+    for k, (num, ratios) in sorted(ratios.items()):
+        unpacked = [[] for _ in range(num)]
+        for r in ratios:
+            nr = len(r)
+            for i in range(num):
+                unpacked[i].append(r[i] if i < nr else np.nan)
+        for i, r in enumerate(unpacked):
+            new_ratios[k+i+offset] = r
+        offset += num-1
+    return new_ratios
+
+def normalize_ratios(ratios):
+    normalized = {}
+    for i, v in enumerate(zip(*ratios.values())):
+        arr = np.array(v)
+        normalized[i] = arr/np.nanmax(v)
+    return normalized
+
+def compute_ratios(ratios, normalized=True):
+    unpacked = unpack_adjoints(ratios)
+    if normalized:
+        unpacked = normalize_ratios(unpacked)
+    sorted_ratios = sorted(unpacked.items())
+    return np.nanmax(np.vstack([v for _, v in sorted_ratios]), axis=0)


### PR DESCRIPTION
The previous PR improved aspect handling in Layouts but did not really fix it. This new implementation actually does what it's supposed to. I'd appreciate it if you could try some complex layout arrangements and then fiddling with the aspects of the individual components.

Here's some that I've tried:

```python
%%opts Layout [aspect_weight=1.0 absolute_scaling=True] Image.A [aspect=1.5] Image.C [aspect=0.5]
np.random.seed(42)
(hv.Image(np.random.rand(25, 25), group='A') +
 hv.Image(np.random.rand(25, 25), group='B') +
 hv.Image(np.random.rand(25, 25), group='C'))
```

![image](https://cloud.githubusercontent.com/assets/1550771/12853544/908d75dc-cc2c-11e5-9c42-147f906d9914.png)

Here absolute scaling controls whether the plots are scaled in absolute or relative terms, i.e. in the example relative scaling means that plot A (aspect=1.5) is the width of a usual plot and everything else is scaled down relative to that and absolute scaling means plot A is actually 1.5 times wider than it would usually be.

A more complex example is this:

```python
%%opts Layout [aspect_weight=1 sublabel_format='']
%%opts Image [aspect=1] Area.A [invert_axes=True aspect=0.4] Area.B [aspect=3]
img_a = hv.Image(np.random.rand(25, 25), group='A')
img_b = hv.Image(np.random.rand(25, 25), group='B')
img_a.hist() + hv.Area(img_b.reduce(x=np.mean), group='A') + img_b + hv.Area(img_a.reduce(x=np.mean), group='A') +\
hv.Area(img_b.reduce(y=np.mean), group='B').hist() + hv.Empty() + hv.Area(img_b.reduce(y=np.mean), group='B') + hv.Empty()
```

![image](https://cloud.githubusercontent.com/assets/1550771/12856406/b8c86dc6-cc3c-11e5-8154-50bd726d704d.png)