### PR TITLE
Fixed outdated instructions on disabling pickle export

### DIFF
--- a/doc/Tutorials/Exporting.ipynb
+++ b/doc/Tutorials/Exporting.ipynb
@@ -443,12 +443,13 @@
    "source": [
     "Given the ``Image``, you can also access the underlying array data, because HoloViews objects are simply containers for your data and associated metadata. This means that years from now, as long as you can still run HoloViews, you can now easily re-load and explore your data, plotting it entirely different ways or running different analyses, even if you no longer have any of the original code you used to generate the data.  All you need is HoloViews, which is permanently archived on GitHub and is fully open source and thus should always remain available.  Because the data is stored conveniently in the archive alongside the figure that was published, you can see immediately which file corresponds to the data underlying any given plot in your paper, and immediately start working with the data, rather than laboriously trying to reconstruct the data from a saved figure.\n",
     "\n",
-    "If you do not want the pickle files, you can of course turn them off if you prefer, by changing ``holoviews.archive.auto()`` to:\n",
+    "If you do not want the pickle files, you can of course turn them off if you prefer, by changing ``hv.archive.auto()`` to:\n",
     "\n",
     "```python\n",
-    "from holoviews import Store\n",
-    "holoviews.archive.auto(exporters=[Store.PlotRenderer.instance(holomap=None)])\n",
-    "```"
+    "hv.archive.auto(exporters=[hv.Store.renderers['matplotlib'].instance(holomap=None)])\n",
+    "```\n",
+    "\n",
+    "This sets the default exporters list explictly which contains the ``Pickler`` exporter by default."
    ]
   },
   {


### PR DESCRIPTION
Fixed outdated instructions in order to address #468.