### PR TITLE
Fixed matplotlib Point clims and sizes

### DIFF
--- a/doc/Tutorials/Sampling_Data.ipynb
+++ b/doc/Tutorials/Sampling_Data.ipynb
@@ -47,7 +47,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "hv.notebook_extension()\n",
-    "%opts Layout [fig_size=125] Points (s=50)\n",
+    "%opts Layout [fig_size=125] Points [size_index=None] (s=50) Scatter3D [size_index=None]\n",
     "%opts Bounds (linewidth=2 color='k') {+axiswise} Text (fontsize=16 color='k') Image (cmap='Reds')"
    ]
   },

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -594,7 +594,9 @@ class PointPlot(ChartPlot, ColorbarPlot):
         if cdim:
             cs = points.dimension_values(self.color_index)
             style['c'] = cs
-            style['clim'] = ranges.get(cdim.name)
+            if 'clim' not in style:
+                clims = ranges[cdim.name]
+                style.update(vmin=clims[0], vmax=clims[1])
         else:
             style['c'] = color
         edgecolor = style.pop('edgecolors', style.pop('edgecolor', 'none'))

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -109,10 +109,12 @@ class Scatter3DPlot(Plot3D, PointPlot):
     onto a particular Dimension of the data.
     """
 
-    color_index = param.ClassSelector(default=4, class_=(basestring, int), doc="""
+    color_index = param.ClassSelector(default=4, class_=(basestring, int),
+                                      allow_None=True, doc="""
       Index of the dimension from which the color will the drawn""")
 
-    size_index = param.ClassSelector(default=3, class_=(basestring, int), doc="""
+    size_index = param.ClassSelector(default=3, class_=(basestring, int),
+                                     allow_None=True, doc="""
       Index of the dimension from which the sizes will the drawn.""")
 
     def initialize_plot(self, ranges=None):


### PR DESCRIPTION
Title says it all. Simple fix, turns out plt.scatter accepts clim but really expects the ranges to be set via vmin and vmax.