### PR TITLE
Minor fixes to Exporting tutorial, including example of PNG output

### DIFF
--- a/doc/Tutorials/Exporting.ipynb
+++ b/doc/Tutorials/Exporting.ipynb
@@ -4,17 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most of the other tutorials show you how to use HoloViews for interactive, exploratory visualization of your data, while the [Options](Options.ipynb) tutorial shows how to use HoloViews completely non-interactively, generating and rendering images directly to disk.  In this notebook, we show how HoloViews works together with the IPython/Jupyter Notebook to establish a fully interactive yet *also* fully reproducible scientific or engineering workflow for generating reports or publications.  That is, as you interactively explore your data and build visualizations in the notebook, you can automatically generate and export them as figures that will feed directly into your papers or web pages, along with records of how those figures were generated and even soring the actual data involved so that it can be re-analyzed later. \n",
+    "Most of the other tutorials show you how to use HoloViews for interactive, exploratory visualization of your data, while the [Options](Options.ipynb) tutorial shows how to use HoloViews completely non-interactively, generating and rendering images directly to disk.  In this notebook, we show how HoloViews works together with the IPython/Jupyter Notebook to establish a fully interactive yet *also* fully reproducible scientific or engineering workflow for generating reports or publications.  That is, as you interactively explore your data and build visualizations in the notebook, you can automatically generate and export them as figures that will feed directly into your papers or web pages, along with records of how those figures were generated and even storing the actual data involved so that it can be re-analyzed later. \n",
     "\n",
     "## Reproducible research\n",
     "\n",
     "To understand why this capability is important, let's consider the process by which scientific results are typically generated and published without HoloViews.  Scientists and engineers use a wide variety of data-analysis tools, ranging from GUI-based programs like Excel spreadsheets, mixed GUI/command-line programs like Matlab, or purely scriptable tools like matplotlib or bokeh.  The process by which figures are created in any of these tools typically involves copying data from its original source, selecting it, transforming it, choosing portions of it to put into a figure, choosing the various plot options for a subfigure, combining different subfigures into a complete figure, generating a publishable figure file with the full figure, and then inserting that into a report or publication.  \n",
     "\n",
-    "If using GUI tools, often the final figure is the only record of that process, and even just a few weeks or months later a researcher will often be completely unable to say precisely how a given figure was generated.  Moreover, this process needs to be repeated whenever new data is collected, which is an error-prone and time-consuming process. The lack of records is a serious problem for building on past work and revisiting the assumptions involved, which greatly slows progress both for individual researchers and for the field as a whole.  Graphical environments for capturing and replaying a user's GUI-based workflow have been developed, but these have greatly restricted the process of exploration, because they only support a few of the many analyses required, and thus they have rarely been successful in practice.  With GUI tools it is also very difficult to \"curate\" the sequence of steps involved, i.e., eliminating dead ends, speculative work, and unnecessary steps to show the clear path from incoming data to a figure.\n",
+    "If using GUI tools, often the final figure is the only record of that process, and even just a few weeks or months later a researcher will often be completely unable to say precisely how a given figure was generated.  Moreover, this process needs to be repeated whenever new data is collected, which is an error-prone and time-consuming process. The lack of records is a serious problem for building on past work and revisiting the assumptions involved, which greatly slows progress both for individual researchers and for the field as a whole.  Graphical environments for capturing and replaying a user's GUI-based workflow have been developed, but these have greatly restricted the process of exploration, because they only support a few of the many analyses required, and thus they have rarely been successful in practice.  With GUI tools it is also very difficult to \"curate\" the sequence of steps involved, i.e., eliminating dead ends, speculative work, and unnecessary steps, with a goal of showing the clear path from incoming data to a final figure.\n",
     "\n",
     "In principle, using scriptable or command-line tools offers the promise of capturing the steps involved, in a form that can be curated.  In practice, however, the situation is often no better than with GUI tools, because the data is typically taken through many manual steps that culminate in a published figure, and without a laboriously manually created record of what steps are involved, the provenance of a given figure remains unknown.  Where reproducible workflows are created in this way, they tend to be \"after the fact\", as an explicit exercise to accompany a publication, and thus (a) they are rarely done, (b) they are very difficult to do if any of the steps were not recorded originally.  \n",
     "\n",
-    "An IPython/Jupyter notebook helps significantly to make the scriptable-tools approach viable, by recording both code and the resulting output, and can thus in principle act as a record for establishing the full provenance of a figure.  But because typical plotting libraries require so much plotting-specific code before any plot is visible, the notebook quickly becomes unreadable.  To make notebooks readable, researchers then typically move the plotting code for a specific figure to some external file, which then drifts out of sync with the notebook so that the notebook no longer acts as a record of the link between the original data and the resulting figure.  HoloViews provides the final missing piece in this approach, by allowing researchers to work directly with their data interactively in a notebook, using small amounts of code that focus on the data and analyses rather than plotting code, yet showing the results directly alongside the specification for generating them.  This tutorial will describe how use a Jupyter notebook with HoloViews to export your results in a way that preserves the information about how those results were generated, providing a clear chain of provenance and making reproducible research practical at last."
+    "An IPython/Jupyter notebook helps significantly to make the scriptable-tools approach viable, by recording both code and the resulting output, and can thus in principle act as a record for establishing the full provenance of a figure.  But because typical plotting libraries require so much plotting-specific code before any plot is visible, the notebook quickly becomes unreadable.  To make notebooks readable, researchers then typically move the plotting code for a specific figure to some external file, which then drifts out of sync with the notebook so that the notebook no longer acts as a record of the link between the original data and the resulting figure.  \n",
+    "\n",
+    "HoloViews provides the final missing piece in this approach, by allowing researchers to work directly with their data interactively in a notebook, using small amounts of code that focus on the data and analyses rather than plotting code, yet showing the results directly alongside the specification for generating them.  This tutorial will describe how use a Jupyter notebook with HoloViews to export your results in a way that preserves the information about how those results were generated, providing a clear chain of provenance and making reproducible research practical at last."
    ]
   },
   {
@@ -62,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This mechanism can be used to provide a clear link between the steps for generating the figure, and the file on disk.  You can now load the exported plot back into HoloViews, if you like, though the result would be a bit confusing:"
+    "This mechanism can be used to provide a clear link between the steps for generating the figure, and the file on disk.  You can now load the exported plot back into HoloViews, if you like, though the result would be a bit confusing due to the additional set of axes applied to the new plot:"
    ]
   },
   {
@@ -105,14 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Adding files to an archive"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To turn on automatic adding of your files to the export archive, run ``holoviews.archive.auto()``:"
+    "To turn on automatic adding of your files to the export archive, run ``hv.archive.auto()``:"
    ]
   },
   {
@@ -132,7 +127,21 @@
    "source": [
     "This object's behavior can be customized extensively; try pressing shift-[tab] twice within the parentheses for a list of options, which are described more fully below.\n",
     "\n",
-    "By default, the output will go into a directory with the same name as your notebook, and the names for each object will be generated from the groups and labels used by HoloViews.  Objects that contain HoloMaps are not exported by default, since those are usually rendered as animations that are not suitable for inclusion in publications, but you can change it to ``.auto(holomap='gif')`` if you want those as well.  To see how the auto-exporting works, let's define a few HoloViews objects:"
+    "By default, the output will go into a directory with the same name as your notebook, and the names for each object will be generated from the groups and labels used by HoloViews.  Objects that contain HoloMaps are not exported by default, since those are usually rendered as animations that are not suitable for inclusion in publications, but you can change it to ``.auto(holomap='gif')`` if you want those as well.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding files to an archive"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To see how the auto-exporting works, let's define a few HoloViews objects:"
    ]
   },
   {
@@ -202,7 +211,7 @@
     "\n",
     "The ``{group}-{label}`` information lists the names HoloViews uses for default titles and for attribute access for the various objects that make up a given displayed object.  E.g. the first SVG image in the list is a ``Layout`` of the three given ``Image`` objects, and the second one is an ``Overlay`` of an ``RGB`` object and an ``Arrow`` object.  This information usually helps distinguish one plot from another, because they will typically be plots of objects that have different labels.  \n",
     "\n",
-    "If the generated names are not unique, a numerical suffix will be added to make them unique.  A maximum filename length is enforced, which can be set with ``holoviews.archive.max_filename=``_num_.\n",
+    "If the generated names are not unique, a numerical suffix will be added to make them unique.  A maximum filename length is enforced, which can be set with ``hv.archive.max_filename=``_num_.\n",
     "\n",
     "If you prefer a fixed-width filename, you can use a hash for each name instead (or in addition), where ``:.8`` specifies how many characters to keep from the hash:"
    ]
@@ -314,24 +323,28 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Controlling the behavior of ``holoviews.archive``"
+    "### Controlling the behavior of ``hv.archive``"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``holoviews.archive`` object provides numerous parameters that can be changed.  You can e.g.:\n",
+    "The ``hv.archive`` object provides numerous parameters that can be changed.  You can e.g.:\n",
     "\n",
-    "- output the whole directory to a single compressed ZIP or tar archive file (e.g. ``archive.set_param(pack=False, archive_format='zip')`` or ``archive_format='tar'``)\n",
+    "- output the whole directory to a single compressed ZIP or tar archive file (e.g. ``hv.archive.set_param(pack=False, archive_format='zip')`` or ``archive_format='tar'``)\n",
     "\n",
-    "- generate a new directory or archive every time the notebook is run (``archive.uniq_name=True``); otherwise the old output directory is erased each time \n",
+    "- generate a new directory or archive every time the notebook is run (``hv.archive.uniq_name=True``); otherwise the old output directory is erased each time \n",
     "\n",
-    "- choose your own name for the output directory or archive (e.g. ``archive.export_name=\"{timestamp}\"``)\n",
+    "- choose your own name for the output directory or archive (e.g. ``hv.archive.export_name=\"{timestamp}\"``)\n",
     "\n",
     "- change the format of the optional timestamp (e.g. to retain snapshots hourly, ``archive.set_param(export_name=\"{timestamp}\", timestamp_format=\"%Y_%m_%d-%H\")``)\n",
     "\n",
-    "These options and any others listed above can all be set in the ``holoviews.archive.auto()`` call at the start, for convenience and to ensure that they apply to all of the files that are added."
+    "- select PNG output, at a specified rendering resolution:\n",
+    "```hv.archive.exporters=[hv.Store.renderers['matplotlib'].instance(size=50, fig='png', dpi=144)])\n",
+    "```\n",
+    "\n",
+    "These options and any others listed above can all be set in the ``hv.archive.auto()`` call at the start, for convenience and to ensure that they apply to all of the files that are added."
    ]
   },
   {
@@ -345,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To actually write the files you have stored in the archive to disk, you need to call ``export()`` after any cell that might contain computation-intensive code.  Usually it's best to do so as the last or nearly last cell in your notebook, though here we did it earlier because we wanted to show how to use the exported files."
+    "To actually write the files you have stored in the archive to disk, you need to call ``export()`` after any cell that might contain computation-intensive code.  Usually it's best to do so as the last or nearly last cell in your notebook, though here we do it earlier because we wanted to show how to use the exported files."
    ]
   },
   {
@@ -384,13 +397,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For technical reasons to do with how the IPython Notebook interacts with JavaScript, if you use the IPython command ``Run all``, the holoviews.archive.export() command is not actually executed when the cell with that call is encountered during the run.  Instead, the ``export()`` is queued until after the final cell in the notebook has been executed.  This asynchronous execution has several awkward but not serious consequences:\n",
+    "For technical reasons to do with how the IPython Notebook interacts with JavaScript, if you use the IPython command ``Run all``, the ``hv.archive.export()`` command is not actually executed when the cell with that call is encountered during the run.  Instead, the ``export()`` is queued until after the final cell in the notebook has been executed.  This asynchronous execution has several awkward but not serious consequences:\n",
     "\n",
-    "- It is not possible for the ``export()`` cell to show whether any errors were encountered during exporting, because these will not occur until after the notebook has completed processing.  To see any errors, you can run  ``holoviews.archive.last_export_status()`` separately, *after* the ``Run all`` has completed.  E.g. just press shift-[Enter] in the following cell, which will tell you whether the previous export was successful.\n",
+    "- It is not possible for the ``export()`` cell to show whether any errors were encountered during exporting, because these will not occur until after the notebook has completed processing.  To see any errors, you can run  ``hv.archive.last_export_status()`` separately, *after* the ``Run all`` has completed.  E.g. just press shift-[Enter] in the following cell, which will tell you whether the previous export was successful.\n",
     "\n",
     "- If you use ``Run all``, the directory listing ``os.listdir()`` above will show the results from the *previous* time this notebook was run, since it executes before the export.  Again, you can use shift-[Enter] to update the data once complete.\n",
     "\n",
-    "- The ``Export name:`` in the output of ``holoviews.archive.export()`` will not always show the actual name of the directory or archive that will be created.  In particular, it may say ``{notebook}``, which when saving will actually expand to the name of your IPython Notebook."
+    "- The ``Export name:`` in the output of ``hv.archive.export()`` will not always show the actual name of the directory or archive that will be created.  In particular, it may say ``{notebook}``, which when saving will actually expand to the name of your IPython Notebook."
    ]
   },
   {
@@ -449,7 +462,7 @@
     "hv.archive.auto(exporters=[hv.Store.renderers['matplotlib'].instance(holomap=None)])\n",
     "```\n",
     "\n",
-    "This sets the default exporters list explictly which contains the ``Pickler`` exporter by default."
+    "Here, the exporters list has been updated to include the usual default exporters *without* the `Pickler` exporter that would usually be included."
    ]
   },
   {
@@ -463,7 +476,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The export options from HoloViews help you establish a feasible workflow for doing reproducible research: starting from interactive exploration, either export specific files with ``%%output``, or enable ``holoviews.archive.auto()``, which will store a copy of your notebook and its output ready for inclusion in a document but retaining the complete recipe for reproducing the results later.  \n",
+    "The export options from HoloViews help you establish a feasible workflow for doing reproducible research: starting from interactive exploration, either export specific files with ``%%output``, or enable ``hv.archive.auto()``, which will store a copy of your notebook and its output ready for inclusion in a document but retaining the complete recipe for reproducing the results later.  \n",
     "\n",
     "HoloViews also works very well with the [Lancet](http://ioam.github.io/lancet) tool for exploring large parameter spaces, and Lancet provides an interface to HoloViews that makes Lancet output directly available for use in HoloViews.  Lancet, when used with IPython Notebook and HoloViews, makes it feasible to work with large numbers of computation-intensive processes that generate heterogeneous data that needs to be collated, analyzed, and visualized. For more background and a suggested workflow, see our [2013 paper on using Lancet](http://dx.doi.org/10.3389/fninf.2013.00044) with IPython Notebook.  Because that paper was written before the release of HoloViews, it does not discuss how HoloViews helps in this process, but that aspect is covered in our [2015 paper on using HoloViews for reproducible research](http://conference.scipy.org/proceedings/scipy2015/pdfs/jean-luc_stevens.pdf)."
    ]


### PR DESCRIPTION
There were still some confusing and outdated bits.  The number of cells might have changed, which could change the output, but the rendered images should *not* have changed.

Provides further fixes for issue #468.