### PR TITLE
Improved exception for control codes

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -246,7 +246,14 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
         (as a list of tokens) by applying the eliminations,
         substitutions and transforms.
         """
-        name = unicodedata.name(c).lower()
+        ccmap = {'\a':unicodedata.name(u'a')}
+        if unicodedata.category(c) == 'Cc': # Handle control codes
+            invalid = {'\a':'a','\b':'b','\v':'v','\f':'f','\r':'r'}
+            if c in invalid:
+                raise Exception("Please use a raw string or escape control code '\%s'"
+                                % invalid[c])
+        else:
+            name = unicodedata.name(c).lower()
         # Filtering
         for elim in eliminations:
             name = name.replace(elim, '')

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -246,15 +246,7 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
         (as a list of tokens) by applying the eliminations,
         substitutions and transforms.
         """
-        if unicodedata.category(c) == 'Cc': # Handle control codes
-            # Note, \v, \f and \r already removed by split call in sanitize.
-            # Splitting without losing escape codes is non-trivial
-            invalid = {'\a':'a','\b':'b'}
-            if c in invalid:
-                raise Exception("Please use a raw string or escape control code '\%s'"
-                                % invalid[c])
-        else:
-            name = unicodedata.name(c).lower()
+        name = unicodedata.name(c).lower()
         # Filtering
         for elim in eliminations:
             name = name.replace(elim, '')
@@ -320,6 +312,10 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
 
     def sanitize(self, name, valid_fn):
         "Accumulate blocks of hex and separate blocks by underscores"
+        invalid = {'\a':'a','\b':'b', '\v':'v','\f':'f','\r':'r'}
+        for cc in filter(lambda el: el in name, invalid.keys()):
+            raise Exception("Please use a raw string or escape control code '\%s'"
+                            % invalid[cc])
         sanitized, chars = [], ''
         for split in name.split():
             for c in split:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -246,7 +246,6 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
         (as a list of tokens) by applying the eliminations,
         substitutions and transforms.
         """
-        ccmap = {'\a':unicodedata.name(u'a')}
         if unicodedata.category(c) == 'Cc': # Handle control codes
             invalid = {'\a':'a','\b':'b','\v':'v','\f':'f','\r':'r'}
             if c in invalid:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -247,7 +247,9 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
         substitutions and transforms.
         """
         if unicodedata.category(c) == 'Cc': # Handle control codes
-            invalid = {'\a':'a','\b':'b','\v':'v','\f':'f','\r':'r'}
+            # Note, \v, \f and \r already removed by split call in sanitize.
+            # Splitting without losing escape codes is non-trivial
+            invalid = {'\a':'a','\b':'b'}
             if c in invalid:
                 raise Exception("Please use a raw string or escape control code '\%s'"
                                 % invalid[c])


### PR DESCRIPTION
This PR aims to address issue #473 by raising an exception early if any of the '\a','\b','\v','\f' or '\v' control codes are detected. These control codes are almost never used and cause errors in matplotlib/holoviews when users try using something simple like ``'$\alpha$'`` or ``'$\beta$'``.