### PR TITLE
Small Bokeh tutorial/code improvements

### DIFF
--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -7,6 +7,10 @@
     "id": "e6a399c2-931d-445e-a80a-30ea27653f27"
    },
    "source": [
+    "<div class=\"alert alert-info\" role=\"alert\">\n",
+    "    This tutorial contains a lot of bokeh plots, which may take a little while to load and render.\n",
+    "</div>\n",
+    "\n",
     "One of the major design principles of HoloViews is that the declaration of data is completely independent from the plotting implementation. This means that the visualization of HoloViews data structures can be performed by different plotting backends. As part of the 1.4 release of HoloViews, a [Bokeh](http://bokeh.pydata.org) backend was added in addition to the default ``matplotlib`` backend. Bokeh provides a powerful platform to generate interactive plots using HTML5 canvas and WebGL, and is ideally suited towards interactive exploration of data.\n",
     "\n",
     "By combining the ease of generating interactive, high-dimensional visualizations with the interactive widgets and fast rendering provided by Bokeh, HoloViews becomes even more powerful.\n",

--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -471,7 +471,7 @@
     "heatmap_data = {(chr(65+i),chr(97+j)):i*j for i in range(5) for j in range(5) if i!=j}\n",
     "data = [np.random.normal() for i in range(10000)]\n",
     "hist = np.histogram(data, 20)\n",
-    "hv.Points(error, vdims=['Error']) + hv.HeatMap(heatmap_data) + hv.Histogram(hist)"
+    "hv.Points(error) + hv.HeatMap(heatmap_data).sort() + hv.Histogram(hist)"
    ]
   },
   {
@@ -503,8 +503,8 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Points [tools=['box_select', 'lasso_select', 'poly_select']] (s=10 unselected_color='red' color='blue')\n",
-    "hv.Points(error, vdims=['Error'])"
+    "%%opts Points [tools=['box_select', 'lasso_select', 'poly_select']] (size=10 unselected_color='red' color='blue')\n",
+    "hv.Points(error)"
    ]
   },
   {

--- a/doc/Tutorials/Bokeh_Elements.ipynb
+++ b/doc/Tutorials/Bokeh_Elements.ipynb
@@ -429,25 +429,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``BoxWhisker`` Elements may also be used to represent a distribution as a marginal plot by adjoining it using ``<<``."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "points = hv.Points(np.random.randn(500, 2))\n",
-    "points << hv.BoxWhisker(points['y']) << hv.BoxWhisker(points['x'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### ``Histogram`` <a id='Histogram'></a>"
    ]
   },
@@ -716,27 +697,6 @@
    "source": [
     "%%opts VectorField.A [color_dim='angle'] VectorField.M [color_dim='magnitude']\n",
     "hv.VectorField(vector_data, group='A')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The vector fields above were sampled on a regular grid, but any collection of x,y values is allowed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "n=20\n",
-    "x=np.linspace(1,3,n)\n",
-    "y=np.sin(np.linspace(0,2*np.pi,n))/4\n",
-    "hv.VectorField([x,y,x*5,np.ones(n)]) * hv.VectorField([x,-y,x*5,np.ones(n)])"
    ]
   },
   {

--- a/doc/Tutorials/Bokeh_Elements.ipynb
+++ b/doc/Tutorials/Bokeh_Elements.ipynb
@@ -4,6 +4,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<div class=\"alert alert-info\" role=\"alert\">\n",
+    "    This tutorial contains a lot of bokeh plots, which may take a little while to load and render.\n",
+    "</div>\n",
+    "\n",
     "``Element``s are the basic building blocks for any HoloViews visualization. These are the objects that can be composed together using the various [Container](Containers.ipynb) types. \n",
     "Here in this overview, we show an example of how to build each of these ``Element``s directly out of Python or Numpy data structures.  An even more powerful way to use them is by collecting similar ``Element``s into a HoloMap, as described in [Exploring Data](Exploring_Data.ipynb), so that you can explore, select, slice, and animate them flexibly, but here we focus on having small, self-contained examples.  Complete reference material for each type can be accessed using our [documentation system](Introduction.ipynb#ParamDoc).  This tutorial uses the default matplotlib plotting backend; see the [Bokeh Elements](Bokeh_Elements.ipynb) tutorial for the corresponding bokeh plots.\n",
     "\n",

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -101,6 +101,7 @@ except ImportError:
     pass
 
 
+point_size = np.sqrt(6) # Matches matplotlib default
 Cycle.default_cycles['default_colors'] =  ['#30a2da', '#fc4f30', '#e5ae38',
                                            '#6d904f', '#8b8b8b']
 
@@ -108,11 +109,12 @@ options = Store.options(backend='bokeh')
 
 # Charts
 options.Curve = Options('style', color=Cycle(), line_width=2)
-options.Scatter = Options('style', color=Cycle(), size=np.sqrt(6))
+options.Scatter = Options('style', color=Cycle(), size=point_size)
+options.Points = Options('style', color=Cycle(), size=point_size)
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', fill_color=Cycle(), fill_alpha=0.6, line_color='black')
 options.Histogram = Options('style', fill_color="#036564", line_color="#033649")
-options.Points = Options('style', color=Cycle(), size=np.sqrt(6))
+
 options.Spikes = Options('style', color='black')
 options.Area = Options('style', color=Cycle(), line_color='black')
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -74,18 +74,8 @@ Store.register({Overlay: OverlayPlot,
                 ItemTable: TablePlot,
                 DFrame: TablePlot,
                 NdElement: TablePlot,
-                Columns: TablePlot,
+                Columns: TablePlot},
 
-                # Wrapped mpl 3d plots
-                Surface: PlotSelector(lambda x: 'bokeh',
-                                      [('mpl', SurfacePlot),
-                                       ('bokeh', BokehMPLRawWrapper)], True),
-                Scatter3D: PlotSelector(lambda x: 'bokeh',
-                                        [('mpl', Scatter3DPlot),
-                                         ('bokeh', BokehMPLRawWrapper)], True),
-                Trisurface: PlotSelector(lambda x: 'bokeh',
-                                         [('mpl', TrisurfacePlot),
-                                          ('bokeh', BokehMPLRawWrapper)], True)},
                'bokeh')
 
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -116,11 +116,11 @@ options = Store.options(backend='bokeh')
 
 # Charts
 options.Curve = Options('style', color=Cycle(), line_width=2)
-options.Scatter = Options('style', color=Cycle())
+options.Scatter = Options('style', color=Cycle(), size=np.sqrt(6))
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', fill_color=Cycle(), fill_alpha=0.6, line_color='black')
 options.Histogram = Options('style', fill_color="#036564", line_color="#033649")
-options.Points = Options('style', color=Cycle())
+options.Points = Options('style', color=Cycle(), size=np.sqrt(6))
 options.Spikes = Options('style', color='black')
 options.Area = Options('style', color=Cycle(), line_color='black')
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
                      GridSpace, NdElement, Columns, GridMatrix, NdLayout)
 from ...element import (Curve, Points, Scatter, Image, Raster, Path,

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -8,7 +8,7 @@ from ...core.util import max_range, basestring
 from ..util import compute_sizes, get_sideplot_ranges, match_spec
 from .element import ElementPlot, line_properties, fill_properties
 from .path import PathPlot, PolygonPlot
-from .util import map_colors, get_cmap, mpl_to_bokeh
+from .util import map_colors, get_cmap, mpl_to_bokeh, update_plot
 
 
 class PointPlot(ElementPlot):
@@ -416,28 +416,7 @@ class ChartPlot(ElementPlot):
     def _update_chart(self, key, element, ranges):
         new_chart = self._init_chart(element, ranges)
         old_chart = self.handles['plot']
-        old_renderers = old_chart.select(type=GlyphRenderer)
-        new_renderers = new_chart.select(type=GlyphRenderer)
-
-        old_chart.y_range.update(**new_chart.y_range.properties_with_values())
-        updated = []
-        for new_r in new_renderers:
-            for old_r in old_renderers:
-                if type(old_r.glyph) == type(new_r.glyph):
-                    old_renderers.pop(old_renderers.index(old_r))
-                    new_props = new_r.properties_with_values()
-                    source = new_props.pop('data_source')
-                    old_r.glyph.update(**new_r.glyph.properties_with_values())
-                    old_r.update(**new_props)
-                    old_r.data_source.data.update(source.data)
-                    updated.append(old_r)
-                    break
-
-        for old_r in old_renderers:
-            if old_r not in updated:
-                emptied = {k: [] for k in old_r.data_source.data}
-                old_r.data_source.data.update(emptied)
-
+        update_plot(old_chart, new_chart)
         properties = self._plot_properties(key, old_chart, element)
         old_chart.update(**properties)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -69,7 +69,7 @@ class PointPlot(ElementPlot):
             if empty:
                 data[map_key] = []
             else:
-                ms = style.get('size', 1)
+                ms = style.get('size', np.sqrt(6))**2
                 sizes = element.dimension_values(self.size_index)
                 data[map_key] = np.sqrt(compute_sizes(sizes, self.size_fn,
                                                       self.scaling_factor,

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -200,21 +200,23 @@ class GridPlot(BokehPlot, GenericCompositePlot):
             kwargs = {}
             if c == 0 and r != 0:
                 kwargs['xaxis'] = 'bottom-bare'
-                kwargs['width'] = 175
+                kwargs['width'] = 150
             if c != 0 and r == 0 and not layout.ndims == 1:
                 kwargs['yaxis'] = 'left-bare'
-                kwargs['height'] = 175
+                kwargs['height'] = 150
             if c == 0 and r == 0:
-                kwargs['width'] = 175
-                kwargs['height'] = 175
+                kwargs['width'] = 150
+                kwargs['height'] = 150
             if r != 0 and c != 0:
                 kwargs['xaxis'] = 'bottom-bare'
                 kwargs['yaxis'] = 'left-bare'
 
             if 'width' not in kwargs:
-                kwargs['width'] = 125
+                kwargs['width'] = 105
             if 'height' not in kwargs:
-                kwargs['height'] = 125
+                kwargs['height'] = 105
+            if 'border' not in kwargs:
+                kwargs['border'] = 0
 
             if isinstance(layout, GridMatrix):
                 if view.traverse(lambda x: x, [Histogram]):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -15,6 +15,8 @@ except:
     from bokeh.core.enums import Palette
     from bokeh.models.plots import Plot
     bokeh_lt_011 = False
+
+from bokeh.models import GlyphRenderer
 from bokeh.plotting import Figure
 
 # Conversion between matplotlib and bokeh markers
@@ -177,3 +179,33 @@ def hsv_to_rgb(hsv):
     rgb = clist[order[i], np.arange(np.prod(shape))[:,None]]
 
     return rgb.reshape(shape+(3,))
+
+
+def update_plot(old, new):
+    """
+    Updates an existing plot or figure with a new plot,
+    useful for bokeh charts and mpl conversions, which do
+    not allow updating an existing plot easily.
+    """
+    old_renderers = old.select(type=GlyphRenderer)
+    new_renderers = new.select(type=GlyphRenderer)
+
+    old.x_range.update(**new.x_range.properties_with_values())
+    old.y_range.update(**new.y_range.properties_with_values())
+    updated = []
+    for new_r in new_renderers:
+        for old_r in old_renderers:
+            if type(old_r.glyph) == type(new_r.glyph):
+                old_renderers.pop(old_renderers.index(old_r))
+                new_props = new_r.properties_with_values()
+                source = new_props.pop('data_source')
+                old_r.glyph.update(**new_r.glyph.properties_with_values())
+                old_r.update(**new_props)
+                old_r.data_source.data.update(source.data)
+                updated.append(old_r)
+                break
+
+    for old_r in old_renderers:
+        if old_r not in updated:
+            emptied = {k: [] for k in old_r.data_source.data}
+            old_r.data_source.data.update(emptied)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -186,6 +186,8 @@ def update_plot(old, new):
     Updates an existing plot or figure with a new plot,
     useful for bokeh charts and mpl conversions, which do
     not allow updating an existing plot easily.
+
+    ALERT: Should be replaced once bokeh supports it directly
     """
     old_renderers = old.select(type=GlyphRenderer)
     new_renderers = new.select(type=GlyphRenderer)


### PR DESCRIPTION
Minor fixes for the Bokeh tutorials removing additional Element examples, which do not yet work, i.e. sidebar of ErrorBars and overlay of VectorFields. Also added bootstrap based warning messages to warn that Tutorials can take a minute to render because there's so many plots on the page.