### PR TITLE
Allowed DynamicMaps to work with dimension subsets

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -460,8 +460,10 @@ class GenericElementPlot(DimensionedPlot):
             self.current_key = key
             return self.current_frame
         elif self.dynamic:
+            dims = {d.name: k for d, k in zip(self.dimensions, key)
+                    if d in self.hmap.kdims}
             if isinstance(key, tuple):
-                frame = self.hmap[key]
+                frame = self.hmap.select(**dims)
             elif key < self.hmap.counter:
                 key = self.hmap.keys()[key]
                 frame = self.hmap[key]

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -2,7 +2,8 @@ import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     GridSpace, NdLayout, Store)
-from ..core.util import match_spec, is_number, wrap_tuple, get_overlay_spec
+from ..core.util import (match_spec, is_number, wrap_tuple,
+                         get_overlay_spec, unique_iterator)
 
 
 def displayable(obj):
@@ -133,6 +134,10 @@ def get_dynamic_mode(composite):
     "Returns the common mode of the dynamic maps in given composite object"
     dynmaps = composite.traverse(lambda x: x, [DynamicMap])
     holomaps = composite.traverse(lambda x: x, ['HoloMap'])
+    holomap_kdims = unique_iterator([kd for dm in holomaps for kd in dm.kdims])
+    if holomaps and any(not set(dm.kdims) < set(holomap_kdims) for dm in dynmaps):
+        raise Exception('In sampled mode DynamicMap key dimensions must be a '
+                        'subset of dimensions of the HoloMap(s) defining the sampling.')
     dynamic_modes = [m.call_mode for m in dynmaps]
     dynamic_sampled = any(m.sampled for m in dynmaps)
     if len(set(dynamic_modes)) > 1:


### PR DESCRIPTION
Allows DynamicMaps to be used as long as their dimensions are overlapping. In sampled mode now raises exception if the DynamicMap dimensions aren't a subset of the HoloMap dimensions, which define the sampling.