### PR TITLE
Introduced the SkipRendering exception

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -54,6 +54,14 @@ class BackendError(Exception):
     """
     pass
 
+class SkipRendering(Exception):
+    """
+    A SkipRendering exception in the plotting code will make the display
+    hooks fall back to a text repr. Used to skip rendering of
+    DynamicMaps with exhausted element generators.
+    """
+    pass
+
 class OptionError(Exception):
     """
     Custom exception raised when there is an attempt to apply invalid

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -7,7 +7,7 @@ import sys, traceback, inspect, io
 import IPython
 from IPython.core.ultratb import AutoFormattedTB
 
-from ..core.options import Store, StoreOptions, BackendError
+from ..core.options import Store, StoreOptions, BackendError, SkipRendering
 from ..core import (ViewableElement, UniformNdMapping,
                     HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
                     CompositeOverlay, DynamicMap)
@@ -109,6 +109,9 @@ def display_hook(fn):
                 Store.renderers[Store.current_backend].save(element, filename)
 
             return html
+        except SkipRendering as e:
+            sys.stderr.write("Rendering process skipped: %s" % str(e))
+            return None
         except Exception as e:
             try:
                 StoreOptions.state(element, state=optstate)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 
 import param
 from ..core.io import Exporter
-from ..core.options import Store, StoreOptions
+from ..core.options import Store, StoreOptions, SkipRendering
 from ..core.util import find_file
 from .. import Layout, HoloMap, AdjointLayout
 from .widgets import NdWidget, ScrubberWidget, SelectionWidget
@@ -163,7 +163,10 @@ class Renderer(Exporter):
             if dmap.call_mode == 'key':
                 dmap[dmap._initial_key()]
             else:
-                next(dmap)
+                try:
+                    next(dmap)
+                except StopIteration: # Exhausted DynamicMap
+                    raise SkipRendering("DynamicMap generator exhausted.")
 
         if not isinstance(obj, Plot):
             obj = Layout.from_values(obj) if isinstance(obj, AdjointLayout) else obj


### PR DESCRIPTION
This PR introduces a new type of Exception called ``SkipRendering``.

Currently it is used to skip the rendering of an open ``DynamicMap`` that is defined by an exhausted generator.