### PR TITLE
MPLWidgets now always display first frame from cache

### DIFF
--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -14,15 +14,10 @@ MPLScrubberWidget.prototype = Object.create(ScrubberWidget.prototype);
 // Define methods to override on widgets
 var MPLMethods = {
 	init_slider : function(init_val){
+		this.update_cache();
+		this.update(0);
 		if(this.mode == 'nbagg') {
-			this.update_cache();
-			this.update(0);
 			this.set_frame(init_val, 0);
-		} else if(this.cached) {
-			this.update_cache();
-			this.update(0);
-		} else {
-			this.dynamic_update(0);
 		}
 	},
 	populate_cache : function(idx){


### PR DESCRIPTION
As the title says the matplotlib widgets now display the first frame from the cache even in dynamic/live mode. This allows exported examples of DynamicMaps to at least display the initial image.