### PR TITLE
Options Tutorial example of customizing composite object via __call__

### DIFF
--- a/doc/Tutorials/Options.ipynb
+++ b/doc/Tutorials/Options.ipynb
@@ -411,6 +411,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "To customize options of individual components in composite objects like Overlays or Layouts you can either specify the options on each individual component or specify which object to customize using the ``{type}[.{group}[.{label}]]`` syntax."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "(image + curve)(style={'Image.Function.Sine': dict(cmap='Reds'), 'Curve': dict(color='indianred')})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Both IPython notebook and ``renderer.save()`` use the same mechanisms for keeping track of the options, so they will give the same results.  Specifically, what happens when you \"bind\" a set of options to an object is that there is an integer ID stored in the object (``green_sine`` in this case), and a corresponding entry with that ID is stored in a database of options called an ``OptionTree`` (kept in ``holoviews.core.options.Store``).  The object itself is otherwise unchanged, but then if that object is later used in another container, etc. it will retain its ID and therefore its customization.  Any customization stored in an ``OptionTree`` will override any class attribute defaults set like ``RasterGridPlot.border=5`` above. This approach lets HoloViews keep track of any customizations you want to make, without ever affecting your actual data objects.\n",
     "\n",
     "If the same object is later customized again to create a new customized object, the old customizations will be copied, and then the new customizations applied.  The new customizations will thus override the old, while retaining any previous customizations not specified in the new step.  \n",


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/495, this adds an example of specifying options on a composite object to the Options Tutorial.