### PR TITLE
Fixes and improvements for 3d plots

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -403,7 +403,7 @@ def max_extents(extents, zrange=False):
     """
     if zrange:
         num = 6
-        inds = [(0, 2), (1, 3)]
+        inds = [(0, 3), (1, 4), (2, 5)]
         extents = [e if len(e) == 6 else (e[0], e[1], None,
                                           e[2], e[3], None)
                    for e in extents]

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -4,8 +4,8 @@ from bokeh.models import Circle, GlyphRenderer, ColumnDataSource, Range1d
 import param
 
 from ...element import Raster, Points, Polygons, Spikes
-from ...core.util import max_range, basestring, map_colors
-from ..util import compute_sizes, get_sideplot_ranges, match_spec
+from ...core.util import max_range, basestring
+from ..util import compute_sizes, get_sideplot_ranges, match_spec, map_colors
 from .element import ElementPlot, line_properties, fill_properties
 from .path import PathPlot, PolygonPlot
 from .util import get_cmap, mpl_to_bokeh, update_plot

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -4,11 +4,11 @@ from bokeh.models import Circle, GlyphRenderer, ColumnDataSource, Range1d
 import param
 
 from ...element import Raster, Points, Polygons, Spikes
-from ...core.util import max_range, basestring
+from ...core.util import max_range, basestring, map_colors
 from ..util import compute_sizes, get_sideplot_ranges, match_spec
 from .element import ElementPlot, line_properties, fill_properties
 from .path import PathPlot, PolygonPlot
-from .util import map_colors, get_cmap, mpl_to_bokeh, update_plot
+from .util import get_cmap, mpl_to_bokeh, update_plot
 
 
 class PointPlot(ElementPlot):

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -1,8 +1,9 @@
 import numpy as np
 import param
 
+from ..util import map_colors
 from .element import ElementPlot, line_properties, fill_properties
-from .util import get_cmap, map_colors
+from .util import get_cmap
 
 
 class PathPlot(ElementPlot):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -4,8 +4,9 @@ import param
 from bokeh.models.mappers import LinearColorMapper
 
 from ...element import Image, Raster, RGB
+from ..util import map_colors
 from .element import ElementPlot, line_properties, fill_properties
-from .util import mplcmap_to_palette, map_colors, get_cmap, hsv_to_rgb
+from .util import mplcmap_to_palette, get_cmap, hsv_to_rgb
 
 
 class RasterPlot(ElementPlot):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -53,22 +53,6 @@ def get_cmap(cmap):
     return cm.get_cmap(cmap)
 
 
-def map_colors(arr, crange, cmap):
-    """
-    Maps an array of values to RGB hex strings, given
-    a color range and colormap.
-    """
-    if crange:
-        cmin, cmax = crange
-    else:
-        cmin, cmax = np.nanmin(arr), np.nanmax(arr)
-    arr = (arr - cmin) / (cmax-cmin)
-    arr = np.ma.array(arr, mask=np.logical_not(np.isfinite(arr)))
-    arr = cmap(arr)*255
-    return ["#{0:02x}{1:02x}{2:02x}".format(*(int(v) for v in c[:-1]))
-            for c in arr]
-
-
 def mpl_to_bokeh(properties):
     """
     Utility to process style properties converting any

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -119,7 +119,7 @@ class Scatter3DPlot(Plot3D, PointPlot):
 
         style = self.style[self.cyclic_index]
         cdim = points.get_dimension(self.color_index)
-        if cdim:
+        if cdim and 'cmap' in style:
             cs = points.dimension_values(self.color_index)
             style['c'] = cs
             if 'clim' not in style:

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -76,16 +76,6 @@ class Plot3D(ColorbarPlot):
         return super(Plot3D, self)._finalize_axis(key, **kwargs)
 
 
-    def update_frame(self, *args, **kwargs):
-        """
-        If on the bottom Layer, clear plot before drawing each frame.
-        """
-        if not self.subplot or self.zorder == 0:
-            self.handles['axis'].cla()
-
-        super(Plot3D, self).update_frame(*args, **kwargs)
-
-
     def _draw_colorbar(self, artist, element, dim=None):
         fig = self.handles['fig']
         ax = self.handles['axis']
@@ -180,6 +170,8 @@ class SurfacePlot(Plot3D):
 
 
     def update_handles(self, axis, element, key, ranges=None):
+        if 'artist' in self.handles:
+            self.handles['axis'].collections.remove(self.handles['artist'])
         mat = element.data
         rn, cn = mat.shape
         l, b, zmin, r, t, zmax = self.get_extents(element, ranges)
@@ -221,6 +213,8 @@ class TrisurfacePlot(Plot3D):
 
 
     def update_handles(self, axis, element, key, ranges=None):
+        if 'artist' in self.handles:
+            self.handles['axis'].collections.remove(self.handles['artist'])
         style_opts = self.style[self.cyclic_index]
         dims = element.dimensions(label=True)
         vrange = ranges[dims[2]]

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -49,7 +49,7 @@ class Plot3D(ColorbarPlot):
                                  objects=['fixed', None], doc="""
         Whether and where to display the yaxis.""")
 
-    def _finalize_axis(self, key, zlabel=None, zticks=None, **kwargs):
+    def _finalize_axis(self, key, **kwargs):
         """
         Extends the ElementPlot _finalize_axis method to set appropriate
         labels, and axes options for 3D Plots.

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -186,9 +186,13 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             if self.apply_ticks:
                 self._finalize_ticks(axis, element, xticks, yticks, zticks)
 
+
             if self.show_title and title is not None:
-                self.handles['title'] = axis.set_title(title,
-                                                **self._fontsize('title'))
+                if 'title' in self.handles:
+                    self.handles['title'].set_text(title)
+                else:
+                    self.handles['title'] = axis.set_title(title,
+                                                           **self._fontsize('title'))
         # Always called to ensure log and inverted axes are applied
         self._finalize_axes(axis)
         if not self.overlaid and not self.drawn:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -680,9 +680,6 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
 
     def update_frame(self, key, ranges=None, element=None):
         axis = self.handles['axis']
-        if self.projection == '3d':
-            axis.clear()
-
         if element is None:
             element = self._get_frame(key)
         else:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1,3 +1,4 @@
+import numpy as np
 import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
@@ -239,3 +240,22 @@ def closest_match(match, specs, depth=0):
         else:
             return sorted(match_lengths, key=lambda x: -x[1])[0][0]
 
+
+def map_colors(arr, crange, cmap, hex=True):
+    """
+    Maps an array of values to RGB hex strings, given
+    a color range and colormap.
+    """
+    if crange:
+        cmin, cmax = crange
+    else:
+        cmin, cmax = np.nanmin(arr), np.nanmax(arr)
+    arr = (arr - cmin) / (cmax-cmin)
+    arr = np.ma.array(arr, mask=np.logical_not(np.isfinite(arr)))
+    arr = cmap(arr)
+    if hex:
+        arr *= 255
+        return ["#{0:02x}{1:02x}{2:02x}".format(*(int(v) for v in c[:-1]))
+                for c in arr]
+    else:
+        return arr


### PR DESCRIPTION
This PR implements various fixes for 3d plots fixing various bugs when updating them. Rather than clearing the axis on each frame the specific artist is now removed and replaced. Scatter3D plots are now implemented by actually updating the data on an existing plot. Also makes some other fixes.

Bugs fixed by this PR:

* 3d plots zticks can now be set
* Overlays of 3d Elements now animate correctly
* Extents of 3d plots are now correctly computed

Addresses issues #503 and #504.