### PR TITLE
Fix urls in tutorials

### DIFF
--- a/doc/Tutorials/Exploring_Data.ipynb
+++ b/doc/Tutorials/Exploring_Data.ipynb
@@ -533,7 +533,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Merging multiple ``HoloMap``s in this step-by-step way would be cumbersome, and avoiding this complexity is why the ``Collator`` object (another instance of ``Dimensioned``) has been provided.  ``Collator`` will be described in the [Columnar Data](Columnar_Data) tutorial."
+    "Merging multiple ``HoloMap``s in this step-by-step way would be cumbersome, and avoiding this complexity is why the ``Collator`` object (another instance of ``Dimensioned``) has been provided.  ``Collator`` will be described in the [Columnar Data](Columnar_Data.ipynb) tutorial."
    ]
   },
   {

--- a/doc/Tutorials/Introduction.ipynb
+++ b/doc/Tutorials/Introduction.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "Welcome to HoloViews!\n",
     "\n",
-    "This tutorial explains the basics of how to use HoloViews to explore your data. If this is your first contact with HoloViews, you may want to start by looking at our [showcase](Showcase) to get a good idea of what can be achieved with HoloViews.  If this introduction does not cover the type of visualizations you need, you should check out our [Elements](Elements) and [Containers](Containers) components to see what else is available."
+    "This tutorial explains the basics of how to use HoloViews to explore your data. If this is your first contact with HoloViews, you may want to start by looking at our [showcase](Showcase.ipynb) to get a good idea of what can be achieved with HoloViews.  If this introduction does not cover the type of visualizations you need, you should check out our [Elements](Elements.ipynb) and [Containers](Containers.ipynb) components to see what else is available."
    ]
   },
   {
@@ -37,10 +37,10 @@
     "\n",
     "* ***How your data should be grouped for display***. In short, how you want your data to be organized for visualization. If you have a collection of points that was computed from an image, you can easily overlay your points over the image. As a result you have something that both displays sensibly, and is grouped together in a semantically meaningful way.\n",
     "\n",
-    "HoloViews can display your data even if it knows only the [Element](Elements) type, \n",
+    "HoloViews can display your data even if it knows only the [Element](Elements.ipynb) type, \n",
     "which lets HoloViews stay out your way when initially exploring your data, offering immediate feedback with reasonable default visualizations. As your analysis becomes more complex and your research progresses, you may offer more of the useful metadata above so that HoloViews will automatically improve your displayed figures accordingly.  Throughout, all you need to supply is this metadata plus optional and separate plotting hints (such as choosing specific colors if you like), rather than having to write cumbersome code to put figures together or having to paste bits together manually in an external drawing or plotting program.\n",
     "\n",
-    "Note that the HoloViews data components have only minimal required dependencies (Numpy and Param, both with no required dependencies of their own).  This data format can thus be integrated directly into your research or development code, for maximum convenience and flexibility (see e.g. the [ImaGen](http://ioam.github.io/imagen) library for an example).  Plotting implementations are currently provided for matplotlib and Bokeh, and other plotting packages could be used for the same data in the future if needed.  Similarly, HoloViews provides strong support for the [IPython/Jupyter notebook](http://ipython.org/notebook.html) interface, and we recommend using the notebook for building [reproducible yet interactive workflows](Exporting), but none of the components require IPython either.  Thus HoloViews is designed to fit into your existing workflow, without adding complicated dependencies."
+    "Note that the HoloViews data components have only minimal required dependencies (Numpy and Param, both with no required dependencies of their own).  This data format can thus be integrated directly into your research or development code, for maximum convenience and flexibility (see e.g. the [ImaGen](http://ioam.github.io/imagen) library for an example).  Plotting implementations are currently provided for matplotlib and Bokeh, and other plotting packages could be used for the same data in the future if needed.  Similarly, HoloViews provides strong support for the [IPython/Jupyter notebook](http://ipython.org/notebook.html) interface, and we recommend using the notebook for building [reproducible yet interactive workflows](Exporting.ipynb), but none of the components require IPython either.  Thus HoloViews is designed to fit into your existing workflow, without adding complicated dependencies."
    ]
   },
   {
@@ -112,7 +112,7 @@
     "* ``hv.help(Element, visualization=True)`` or ``hv.help(e, visualization=True)``: description of options for *visualizing* an ``Element`` or the specific object ``e``, not the options for the object itself\n",
     "* ``%%output info=True`` on an IPython/Jupyter notebook cell or ``%output info=True`` on the whole notebook: show ``hv.help(o, visualization=True)`` for every HoloViews object ``o`` as it is returned in a cell.\n",
     "\n",
-    "Lastly, you can tab-complete nearly all arguments to HoloViews classes, so if you try ``Element(vd<TAB>``, you will see the available keyword arguments (``vdims`` in this case).  All of these forms of help are described in detail in the [Options](options) tutorial."
+    "Lastly, you can tab-complete nearly all arguments to HoloViews classes, so if you try ``Element(vd<TAB>``, you will see the available keyword arguments (``vdims`` in this case).  All of these forms of help are described in detail in the [options](Options.ipynb) tutorial."
    ]
   },
   {
@@ -126,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To begin, let's see how HoloViews stays out your way when initially exploring some data. Let's view an image, selecting the appropriate [RGB Element](Elements#RGB). Now, although we could immediately load our image into the ``RGB`` object, we will first load it into a raw Numpy array (by specifying ``array=True``):"
+    "To begin, let's see how HoloViews stays out your way when initially exploring some data. Let's view an image, selecting the appropriate [RGB Element](Elements.ipynb#RGB). Now, although we could immediately load our image into the ``RGB`` object, we will first load it into a raw Numpy array (by specifying ``array=True``):"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here ``rgb_parrot`` is an ``RGB`` HoloViews element, which requires 3 or 4 dimensional data and can store an associated label.  ``rgb_parrot`` is *not* a plot -- it is just a data structure with some metadata.  The ``holoviews.ipython`` extension, in turn, makes sure that any ``RGB`` element is displayed appropriately, i.e. as a color image with an associated optional title, plotted using matplotlib.  But the ``RGB`` object itself does not have any connection to the plotting library, and stores no data about the plot, just its own data, which is sufficient for the external plotting routines to visualize the data usefully and meaningfully.  And the same plot can be [generated outside of IPython](Options) just as easily, e.g. to save as a ``.png`` or ``.svg`` file.\n",
+    "Here ``rgb_parrot`` is an ``RGB`` HoloViews element, which requires 3 or 4 dimensional data and can store an associated label.  ``rgb_parrot`` is *not* a plot -- it is just a data structure with some metadata.  The ``holoviews.ipython`` extension, in turn, makes sure that any ``RGB`` element is displayed appropriately, i.e. as a color image with an associated optional title, plotted using matplotlib.  But the ``RGB`` object itself does not have any connection to the plotting library, and stores no data about the plot, just its own data, which is sufficient for the external plotting routines to visualize the data usefully and meaningfully.  And the same plot can be [generated outside of IPython](Options.ipynb) just as easily, e.g. to save as a ``.png`` or ``.svg`` file.\n",
     "\n",
     "Because ``rgb_parrot`` is just our actual data, it can be composed with other objects, pickled, and analyzed as-is.  For instance, we can still access the underlying Numpy array easily via the ``.data`` attribute, and can verify that it is indeed our actual data:"
    ]
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For some image analysis purposes, working in RGB colour space is too limiting. It is often more flexible to work with a single N&times;M array at a time and visualize the data in each channel using a colormap. To do this we need the [Image](Elements#Image) ``Element`` instead of the ``RGB`` ``Element``.\n",
+    "For some image analysis purposes, working in RGB colour space is too limiting. It is often more flexible to work with a single N&times;M array at a time and visualize the data in each channel using a colormap. To do this we need the [Image](Elements.ipynb#Image) ``Element`` instead of the ``RGB`` ``Element``.\n",
     "\n",
     "To illustrate, let's start by visualizing the total luminance across all the channels of the parrot image, choosing a specific colormap using the HoloViews ``%%opts`` IPython [cell magic](http://ipython.org/ipython-doc/dev/interactive/tutorial.html#magic-functions).  ``%%opts Image`` allows us to pass plotting hints to the underlying visualization code for ``Image`` objects:"
    ]
@@ -222,7 +222,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As described in the [Options](Options) tutorial, the same options can also be specified in pure Python, though not quite as succinctly.\n",
+    "As described in the [Options](Options.ipynb) tutorial, the same options can also be specified in pure Python, though not quite as succinctly.\n",
     "\n",
     "The resulting plot is what we would expect: dark areas are shown in blue and bright areas are shown in red. Notice how the plotting hints (your desired colormap in this case) are kept entirely separate from your actual data, so that the Image data structure contains only your actual data and the metadata that describes it, not incidental information like matplotlib or Bokeh options.  We will now set the default colormap to grayscale for all subsequent cells using the ``%opt`` command, and look at a single color channel by building an appropriate ``Image`` element:"
    ]
@@ -323,7 +323,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice how the labels we have set are useful for both the titles and for the indexing, and are thus not simply plotting-specific details -- they are semantically meaningful metadata describing this data. There are also sublabels **A** and **B** generated automatically for each subfigure; these can be [changed or disabled](Containers#subfigure-labels) if you prefer."
+    "Notice how the labels we have set are useful for both the titles and for the indexing, and are thus not simply plotting-specific details -- they are semantically meaningful metadata describing this data. There are also sublabels **A** and **B** generated automatically for each subfigure; these can be [changed or disabled](Containers.ipynb#subfigure-labels) if you prefer."
    ]
   },
   {
@@ -349,7 +349,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You may wonder what the \"``.Image``\" is doing in the middle of the indexing above. This is the **``group``** name which, even though we haven't set it directly in this case, is as important a concept as the label.  All HoloViews objects come with both ``group`` and a ``label``, which allows you to specify both what *kind* of thing the object is (its ``group``), and which specific one it is (the ``label``). These values will be used to construct subfigure titles, to allow you to access the object by name in containers, and to allow you to set [options](Options) for specific objects or for groups of them.\n",
+    "You may wonder what the \"``.Image``\" is doing in the middle of the indexing above. This is the **``group``** name which, even though we haven't set it directly in this case, is as important a concept as the label.  All HoloViews objects come with both ``group`` and a ``label``, which allows you to specify both what *kind* of thing the object is (its ``group``), and which specific one it is (the ``label``). These values will be used to construct subfigure titles, to allow you to access the object by name in containers, and to allow you to set [options](Options.ipynb) for specific objects or for groups of them.\n",
     "  \n",
     "``Group``s and ``label``s can both be set to any Python string, including spaces and special characters.  The ``label`` is an arbitrary name you can use for this data item.  The ``group`` is meant to describe the category or the semantic type of the data. By default, the group is the same as the name of the HoloViews element type, in this case ``Image``:"
    ]
@@ -573,7 +573,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Putting two components ([Elements](Elements) or [Containers](Containers)) side by side into a ``Layout`` using ``+`` is one of the most common operations in HoloViews, and works with any possible component type.  But there is another compositional operator ``*`` that is also very useful for creating complex visualizations, by overlaying components on top of each other.  Nearly all components can be overlaid as well, except for a ``Layout``; a ``Layout`` can contain ``Overlays``, but never the other way around."
+    "Putting two components ([Elements](Elements.ipynb) or [Containers](Containers.ipynb)) side by side into a ``Layout`` using ``+`` is one of the most common operations in HoloViews, and works with any possible component type.  But there is another compositional operator ``*`` that is also very useful for creating complex visualizations, by overlaying components on top of each other.  Nearly all components can be overlaid as well, except for a ``Layout``; a ``Layout`` can contain ``Overlays``, but never the other way around."
    ]
   },
   {
@@ -588,7 +588,7 @@
    "metadata": {},
    "source": [
     "\n",
-    "One type of element designed specifically for overlaying is the [annotation](Elements#Annotations). Here we use the [Arrow Element](Elements#Arrow) to label our parrot using the original ``RGB`` object with the overlay (``*``) operator:"
+    "One type of element designed specifically for overlaying is the [annotation](Elements.ipynb#Annotations). Here we use the [Arrow Element](Elements.ipynb#Arrow) to label our parrot using the original ``RGB`` object with the overlay (``*``) operator:"
    ]
   },
   {
@@ -640,7 +640,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Overlays may be simple annotations as demonstrated above, but often they can contain significant volumes of important data. To demonstrate, we will introduce the concept of **operations** and the [``Contours``](Elements#Contours) ``Element``:"
+    "Overlays may be simple annotations as demonstrated above, but often they can contain significant volumes of important data. To demonstrate, we will introduce the concept of **operations** and the [``Contours``](Elements.ipynb#Contours) ``Element``:"
    ]
   },
   {
@@ -683,7 +683,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The final topic for the introduction is animations.  Animation relies on a powerful multidimensional data container called a ``HoloMap``, which is described in detail in the [Exploring Data](Exploring_Data) tutorial.  Here, as a brief illustration, we show how to construct three ``HoloMap``s from sets of ``Images`` with ``Contours``, constructed using a list of different threshold levels for the above image.\n",
+    "The final topic for the introduction is animations.  Animation relies on a powerful multidimensional data container called a ``HoloMap``, which is described in detail in the [Exploring Data](Exploring_Data.ipynb) tutorial.  Here, as a brief illustration, we show how to construct three ``HoloMap``s from sets of ``Images`` with ``Contours``, constructed using a list of different threshold levels for the above image.\n",
     "\n",
     "As you can see in the above plot, having a large number of threshold levels would be very difficult to include in a single plot.  In such a case, one could lay them all out side by side, but here we show how to combine them into three ``HoloMap`` objects that support animation, whether viewed separately or as part of the same ``Layout``:"
    ]
@@ -728,7 +728,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Hopefully you now understand the basic concepts of HoloViews. It's now worth checking out the full features of the [HoloMap](Exploring_Data) component, as well as all the other types of [elements](Elements) and [containers](Containers).  Have fun!"
+    "Hopefully you now understand the basic concepts of HoloViews. It's now worth checking out the full features of the [HoloMap](Exploring_Data.ipynb) component, as well as all the other types of [elements](Elements.ipynb) and [containers](Containers.ipynb).  Have fun!"
    ]
   }
  ],

--- a/doc/Tutorials/Showcase.ipynb
+++ b/doc/Tutorials/Showcase.ipynb
@@ -168,7 +168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we create a high-dimensional [``HoloMap``](Exploring_Data) to explore: The tuple keys are the points in the parameter space, and the values are the corresponding ``Image`` objects:"
+    "Now we create a high-dimensional [``HoloMap``](Exploring_Data.ipynb) to explore: The tuple keys are the points in the parameter space, and the values are the corresponding ``Image`` objects:"
    ]
   },
   {
@@ -326,7 +326,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For convenience, the IPython-magic syntax for [setting options](Options) like ``%%opts`` is used throughout these tutorials.  However, you can use pure Python code to control the options in a similar way, e.g. from within an external non-IPython program where you want to render a HoloViews plot straight to a file, though it requires a few more curly brackets and quote marks:"
+    "For convenience, the IPython-magic syntax for [setting options](Options.ipynb) like ``%%opts`` is used throughout these tutorials.  However, you can use pure Python code to control the options in a similar way, e.g. from within an external non-IPython program where you want to render a HoloViews plot straight to a file, though it requires a few more curly brackets and quote marks:"
    ]
   },
   {


### PR DESCRIPTION
Pretty much every URL in the Introduction Tutorial was broken due to missing a .html suffix on http://holoviews.org/Tutorials/Introduction.html, which I believe corresponds to missing .ipynb in the notebook.

I also fixed some URLs in Showcase and Exploring_Data, where most URLs were correct.

Other Tutorial pages may still have problems.