### PR TITLE
Matplotlib now supports custom projections as plot option

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -340,6 +340,17 @@ group_sanitizer = sanitize_identifier_fn.instance()
 label_sanitizer = sanitize_identifier_fn.instance()
 dimension_sanitizer = sanitize_identifier_fn.instance(capitalize=False)
 
+
+def isnumeric(val):
+    if isinstance(val, (basestring, bool, np.bool_)):
+        return False
+    try:
+        float(val)
+        return True
+    except:
+        return False
+
+
 def find_minmax(lims, olims):
     """
     Takes (a1, a2) and (b1, b2) as input and returns

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -30,7 +30,7 @@ class Plot3D(ColorbarPlot):
     bgcolor = param.String(default='white', doc="""
         Background color of the axis.""")
 
-    projection = param.ObjectSelector(default='3d', doc="""
+    projection = param.ObjectSelector(default='3d', objects=['3d'], doc="""
         The projection of the matplotlib axis.""")
 
     show_frame = param.Boolean(default=False, doc="""

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -641,11 +641,11 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:
-            projs = self._deep_options(overlay, 'plot', ['projection'],
-                                       [Element])['projection']
+            projs = self._traverse_options(overlay, 'plot', ['projection'],
+                                           [Element])['projection']
             if len(set(projs)) > 1:
                 raise Exception("A single axis may only be assigned one projection type")
-            else:
+            elif len(projs):
                 params['projection'] = projs[0]
         super(OverlayPlot, self).__init__(overlay, ranges=ranges, **params)
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -640,8 +640,13 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
     _passed_handles = ['fig', 'axis']
 
     def __init__(self, overlay, ranges=None, **params):
-        if overlay.traverse(lambda x: x, (Element3D,)):
-            params['projection'] = '3d'
+        if 'projection' not in params:
+            projs = self._deep_options(overlay, 'plot', ['projection'],
+                                       [Element])['projection']
+            if len(set(projs)) > 1:
+                raise Exception("A single axis may only be assigned one projection type")
+            else:
+                params['projection'] = projs[0]
         super(OverlayPlot, self).__init__(overlay, ranges=ranges, **params)
 
     def _finalize_artist(self, key):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -641,13 +641,9 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:
-            projs = self._traverse_options(overlay, 'plot', ['projection'],
-                                           [Element])['projection']
-            if len(set(projs)) > 1:
-                raise Exception("A single axis may only be assigned one projection type")
-            elif len(projs):
-                params['projection'] = projs[0]
+            params['projection'] = self._get_projection(overlay)
         super(OverlayPlot, self).__init__(overlay, ranges=ranges, **params)
+
 
     def _finalize_artist(self, key):
         for subplot in self.subplots.values():

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -232,28 +232,36 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         extents = self.get_extents(view, ranges)
         if extents and not self.overlaid:
             coords = [coord if np.isreal(coord) else np.NaN for coord in extents]
+            valid_lim = lambda c: util.isnumeric(c) and not np.isnan(c)
             if isinstance(view, Element3D) or self.projection == '3d':
                 l, b, zmin, r, t, zmax = coords
                 zmin, zmax = (c if util.isnumeric(c) and not np.isnan(c) else None
                               for c in (zmin, zmax))
-                if not zmin == zmax:
-                    axis.set_zlim((zmin, zmax))
+                if zmin != zmax:
+                    if valid_lim(zmin):
+                        axis.set_zlim(bottom=zmin)
+                    if valid_lim(zmax):
+                        axis.set_zlim(top=zmax)
             else:
                 l, b, r, t = [coord if np.isreal(coord) else np.NaN for coord in extents]
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
-            l, r = (c if util.isnumeric(c) and not np.isnan(c) else None
-                    for c in (l, r))
+
             if self.invert_xaxis or any(p.invert_xaxis for p in subplots):
                 r, l = l, r
-            if not (l is None and r is None) and not l == r:
-                axis.set_xlim((l, r))
-            b, t = (c if util.isnumeric(c) and not np.isnan(c) else None
-                    for c in (b, t))
+            if l != r:
+                if valid_lim(l):
+                    axis.set_xlim(left=l)
+                if valid_lim(r):
+                    axis.set_xlim(right=r)
+
             if self.invert_yaxis or any(p.invert_yaxis for p in subplots):
                 t, b = b, t
-            if not (b is None and t is None) and not b == t:
-                axis.set_ylim((b, t))
+            if b != t:
+                if valid_lim(b):
+                    axis.set_ylim(bottom=b)
+                if valid_lim(t):
+                    axis.set_ylim(top=t)
 
 
     def _finalize_axes(self, axis):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -234,22 +234,25 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             coords = [coord if np.isreal(coord) else np.NaN for coord in extents]
             if isinstance(view, Element3D) or self.projection == '3d':
                 l, b, zmin, r, t, zmax = coords
-                zmin, zmax = (c if np.isfinite(c) else None for c in (zmin, zmax))
+                zmin, zmax = (c if util.isnumeric(c) and not np.isnan(c) else None
+                              for c in (zmin, zmax))
                 if not zmin == zmax:
                     axis.set_zlim((zmin, zmax))
             else:
                 l, b, r, t = [coord if np.isreal(coord) else np.NaN for coord in extents]
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
-            l, r = (c if np.isfinite(c) else None for c in (l, r))
+            l, r = (c if util.isnumeric(c) and not np.isnan(c) else None
+                    for c in (l, r))
             if self.invert_xaxis or any(p.invert_xaxis for p in subplots):
                 r, l = l, r
-            if not l == r:
+            if not (l is None and r is None) and not l == r:
                 axis.set_xlim((l, r))
-            b, t = (c if np.isfinite(c) else None for c in (b, t))
+            b, t = (c if util.isnumeric(c) and not np.isnan(c) else None
+                    for c in (b, t))
             if self.invert_yaxis or any(p.invert_yaxis for p in subplots):
                 t, b = b, t
-            if not b == t:
+            if not (b is None and t is None) and not b == t:
                 axis.set_ylim((b, t))
 
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -8,7 +8,7 @@ import param
 
 from ...core import util
 from ...core import (OrderedDict, Collator, NdOverlay, HoloMap, DynamicMap,
-                     CompositeOverlay, Element3D, Columns, NdElement)
+                     CompositeOverlay, Element3D, Columns, NdElement, Element)
 from ...element import Table, ItemTable
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -82,7 +82,7 @@ class MPLPlot(DimensionedPlot):
     sublabel_size = param.Number(default=18, doc="""
          Size of optional subfigure label.""")
 
-    projection = param.ClassSelector(default=None, doc="""
+    projection = param.Parameter(default=None, doc="""
         The projection of the plot axis, default of None is equivalent to
         2D plot, '3d' and 'polar' are also supported by matplotlib by default.
         May also supply a custom projection that is either a matplotlib

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -352,9 +352,10 @@ class GridPlot(CompositePlot):
             # Create axes
             kwargs = {}
             if create_axes:
-                threed = issubclass(vtype, Element3D)
-                subax = plt.subplot(self._layoutspec[r, c],
-                                    projection='3d' if threed else None)
+                opts = self._deep_options(view, 'plot', ['projection'], [Element])
+                if len(set(opts['projection'])) > 1:
+                    raise Exception("A single axis may only be assigned one projection type")
+                subax = plt.subplot(self._layoutspec[r, c], projection=opts['projection'][0])
 
                 if not axiswise and self.shared_xaxis and self.xaxis is not None:
                     self.xaxis = 'top'
@@ -961,11 +962,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                 continue
 
             # Determine projection type for plot
-            components = view.traverse(lambda x: x)
-            projs = ['3d' if isinstance(c, Element3D) else
-                     self.lookup_options(c, 'plot').options.get('projection', None)
-                     for c in components]
-            projs = [p for p in projs if p is not None]
+            projs = self._deep_options(view, 'plot', ['projection'],
+                                       [Element])['projection']
             if len(set(projs)) > 1:
                 raise Exception("A single axis may only be assigned one projection type")
             elif projs:

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -329,7 +329,7 @@ class GridPlot(CompositePlot):
     def _create_subplots(self, layout, axis, ranges, create_axes):
         layout = layout.map(Compositor.collapse_element, [CompositeOverlay],
                             clone=False)
-        norm_opts = self._deep_options(layout, 'norm', ['axiswise'], [Element])
+        norm_opts = self._traverse_options(layout, 'norm', ['axiswise'], [Element])
         axiswise = all(norm_opts['axiswise'])
         if not ranges:
             self.handles['fig'].set_size_inches(self.fig_inches)
@@ -352,12 +352,8 @@ class GridPlot(CompositePlot):
             # Create axes
             kwargs = {}
             if create_axes:
-                opts = self._deep_options(view, 'plot', ['projection'], [CompositeOverlay])
-                if not opts:
-                    opts = self._deep_options(view, 'plot', ['projection'], [Element])
-                if len(set(opts['projection'])) > 1:
-                    raise Exception("A single axis may only be assigned one projection type")
-                subax = plt.subplot(self._layoutspec[r, c], projection=opts['projection'][0])
+                projection = self._get_projection(view)
+                subax = plt.subplot(self._layoutspec[r, c], projection=projection)
 
                 if not axiswise and self.shared_xaxis and self.xaxis is not None:
                     self.xaxis = 'top'
@@ -964,17 +960,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                 continue
 
             # Determine projection type for plot
-            projs = self._deep_options(view, 'plot', ['projection'],
-                                      [CompositeOverlay])['projection']
-            if projs:
-                projs = self._deep_options(view, 'plot', ['projection'],
-                                           [Element])['projection']
-            if len(set(projs)) > 1:
-                raise Exception("A single axis may only be assigned one projection type")
-            elif projs:
-                projections.append(projs[0])
-            else:
-                projections.append(None)
+            projections.append(self._get_projection(view))
 
             if not create:
                 continue

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -82,8 +82,7 @@ class MPLPlot(DimensionedPlot):
     sublabel_size = param.Number(default=18, doc="""
          Size of optional subfigure label.""")
 
-    projection = param.ObjectSelector(default=None,
-                                      objects=['3d', 'polar', None], doc="""
+    projection = param.Parameter(default=None, doc="""
         The projection of the plot axis, default of None is equivalent to
         2D plot, '3d' and 'polar' are also supported.""")
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -352,7 +352,9 @@ class GridPlot(CompositePlot):
             # Create axes
             kwargs = {}
             if create_axes:
-                opts = self._deep_options(view, 'plot', ['projection'], [Element])
+                opts = self._deep_options(view, 'plot', ['projection'], [CompositeOverlay])
+                if not opts:
+                    opts = self._deep_options(view, 'plot', ['projection'], [Element])
                 if len(set(opts['projection'])) > 1:
                     raise Exception("A single axis may only be assigned one projection type")
                 subax = plt.subplot(self._layoutspec[r, c], projection=opts['projection'][0])
@@ -963,7 +965,10 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
 
             # Determine projection type for plot
             projs = self._deep_options(view, 'plot', ['projection'],
-                                       [Element])['projection']
+                                      [CompositeOverlay])['projection']
+            if projs:
+                projs = self._deep_options(view, 'plot', ['projection'],
+                                           [Element])['projection']
             if len(set(projs)) > 1:
                 raise Exception("A single axis may only be assigned one projection type")
             elif projs:

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -82,9 +82,11 @@ class MPLPlot(DimensionedPlot):
     sublabel_size = param.Number(default=18, doc="""
          Size of optional subfigure label.""")
 
-    projection = param.Parameter(default=None, doc="""
+    projection = param.ClassSelector(default=None, doc="""
         The projection of the plot axis, default of None is equivalent to
-        2D plot, '3d' and 'polar' are also supported.""")
+        2D plot, '3d' and 'polar' are also supported by matplotlib by default.
+        May also supply a custom projection that is either a matplotlib
+        projection type or implements the `_as_mpl_axes` method.""")
 
     show_frame = param.Boolean(default=True, doc="""
         Whether or not to show a complete frame around the plot.""")

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -330,8 +330,7 @@ class GridPlot(CompositePlot):
         layout = layout.map(Compositor.collapse_element, [CompositeOverlay],
                             clone=False)
         norm_opts = self._deep_options(layout, 'norm', ['axiswise'], [Element])
-        axiswise = all(v.get('axiswise', False) for v in norm_opts.values())
-
+        axiswise = all(norm_opts['axiswise'])
         if not ranges:
             self.handles['fig'].set_size_inches(self.fig_inches)
         subplots, subaxes = OrderedDict(), OrderedDict()

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -166,7 +166,9 @@ class DimensionedPlot(Plot):
         of plotting. Allows selecting normalization at different levels
         for nested data containers.""")
 
-    projection = param.ObjectSelector(default=None)
+    projection = param.Parameter(default=None, doc="""
+        Allows supplying a custom projection to transform the axis
+        coordinates during display""")
 
     def __init__(self, keys=None, dimensions=None, layout_dimensions=None,
                  uniform=True, subplot=False, adjoined=None, layout_num=0,

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -580,7 +580,10 @@ class GenericElementPlot(DimensionedPlot):
                 else:
                     y0, y1 = (np.NaN, np.NaN)
                 if self.projection == '3d':
-                    z0, z1 = ranges[dims[2].name]
+                    if len(dims) > 2:
+                        z0, z1 = ranges[dims[2].name]
+                    else:
+                        z0, z1 = np.NaN, np.NaN
             else:
                 x0, x1 = view.range(0)
                 y0, y1 = view.range(1) if ndims > 1 else (np.NaN, np.NaN)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -5,7 +5,7 @@ of this Plot baseclass.
 """
 
 from itertools import groupby, product
-from collections import Counter
+from collections import Counter, defaultdict
 
 import numpy as np
 import param
@@ -400,10 +400,15 @@ class DimensionedPlot(Plot):
         Traverses the supplied object getting all options
         in opts for the specified opt_type and specs
         """
-        lookup = lambda x: ((type(x).__name__, x.group, x.label),
-                            {o: cls.lookup_options(x, opt_type).options.get(o, None)
-                             for o in opts})
-        return dict(obj.traverse(lookup, specs))
+        def lookup(x):
+            options = cls.lookup_options(x, opt_type)
+            return {o: options.options.get(o, None)
+                    for o in opts}
+        options = defaultdict(list)
+        for opts in obj.traverse(lookup, specs):
+            for opt, v in opts.items():
+                options[opt].append(v)
+        return options
 
 
     def update(self, key):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -395,10 +395,16 @@ class DimensionedPlot(Plot):
 
 
     @classmethod
-    def _traverse_options(cls, obj, opt_type, opts, specs=None, keyfn=None, defaults=False):
+    def _traverse_options(cls, obj, opt_type, opts,
+                          specs=None, keyfn=None, defaults=False):
         """
         Traverses the supplied object getting all options
-        in opts for the specified opt_type and specs
+        in opts for the specified opt_type and specs. If
+        a keyfn is supplied the returned options will be
+        nested by the returned key. If defaults is True
+        it will also look up the default plot options
+        specified on the matching plot type, appending
+        the default values with ``_default``.
         """
         def lookup(x):
             options = cls.lookup_options(x, opt_type)
@@ -432,9 +438,10 @@ class DimensionedPlot(Plot):
         """
         Uses traversal to find the appropriate projection
         for a nested object. Respects projections set on
-        Overlays before considering Element based settings.
-        If more than one non-None projection type is found
-        an exception is raised.
+        Overlays before considering Element based settings,
+        before finally looking up the default projection on
+        the plot type. If more than one non-None projection
+        type is found an exception is raised.
         """
         isoverlay = lambda x: isinstance(x, CompositeOverlay)
         opts = cls._traverse_options(obj, 'plot', ['projection'],

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -168,7 +168,9 @@ class DimensionedPlot(Plot):
 
     projection = param.Parameter(default=None, doc="""
         Allows supplying a custom projection to transform the axis
-        coordinates during display""")
+        coordinates during display. Example projections include '3d'
+        and 'polar' projections supported by some backends. Depending
+        on the backend custom projection objects may be supplied.""")
 
     def __init__(self, keys=None, dimensions=None, layout_dimensions=None,
                  uniform=True, subplot=False, adjoined=None, layout_num=0,

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -8,17 +8,8 @@ import param
 from ...core import OrderedDict, NdMapping
 from ...core.options import Store
 from ...core.util import (dimension_sanitizer, safe_unicode, basestring,
-                          unique_iterator, unicode)
+                          unique_iterator, unicode, isnumeric)
 from ...core.traversal import hierarchical
-
-def isnumeric(val):
-    if isinstance(val, (basestring, bool, np.bool_)):
-        return False
-    try:
-        float(val)
-        return True
-    except:
-        return False
 
 def escape_vals(vals, escape_numerics=True):
     """


### PR DESCRIPTION
This PR allows custom projections to be specified on an Element. Also includes a number of fixes to ensure that extents are computed correctly in those cases.