### PR TITLE
Matplotlib version compatibility fix for Scatter3D facecolors

### DIFF
--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -1,5 +1,8 @@
+from distutils.version import LooseVersion
+
 import numpy as np
 import param
+import matplotlib as mpl
 import matplotlib.cm as cm
 
 from ...core import Dimension
@@ -114,7 +117,11 @@ class Scatter3DPlot(Plot3D, PointPlot):
         self._compute_styles(element, ranges, style)
         # Temporary fix until color handling is deterministic in mpl+py3
         if not element.get_dimension(self.color_index) and 'c' in style:
-            style['color'] = style['c']
+            color = style.pop('c')
+            if LooseVersion(mpl.__version__) >= '1.5':
+                style['color'] = color
+            else:
+                style['facecolors'] = color
         return (xs, ys, zs), style, {}
 
     def init_artists(self, ax, plot_data, plot_kwargs):


### PR DESCRIPTION
Matplotlib handling of colors continues to be the bane of my life, it seems that facecolor handling for 3d scatter plots has changed between 1.4.3. and 1.5.0 and that was the source of various transients. Hoping this will finally put that issue to rest and we can remove the handling once we upgrade to 1.5 or whenever we decide to stop supporting earlier versions.