### PR TITLE
Correctly handle empty plots in mpl GridPlot

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -349,15 +349,14 @@ class GridPlot(CompositePlot):
                 vtype = view.type if isinstance(view, HoloMap) else view.__class__
                 opts = self.lookup_options(view, 'plot').options
             else:
-                continue
+                vtype = None
 
             # Create axes
             kwargs = {}
             if create_axes:
-                threed = issubclass(vtype, Element3D)
+                threed = issubclass(vtype, Element3D) if vtype else None
                 subax = plt.subplot(self._layoutspec[r, c],
                                     projection='3d' if threed else None)
-
                 if not axiswise and self.shared_xaxis and self.xaxis is not None:
                     self.xaxis = 'top'
                 if not axiswise and self.shared_yaxis and self.yaxis is not None:
@@ -386,8 +385,8 @@ class GridPlot(CompositePlot):
                 subaxes[(r, c)] = subax
             else:
                 subax = None
-            if issubclass(vtype, CompositeOverlay) and (c == self.cols - 1 and
-                                                        r == self.rows//2):
+            if vtype and issubclass(vtype, CompositeOverlay) and (c == self.cols - 1 and
+                                                                  r == self.rows//2):
                 kwargs['show_legend'] = self.show_legend
                 kwargs['legend_position'] = 'right'
 


### PR DESCRIPTION
Fixes issues with empty plots not being handled correctly in the matplotlib backend's GridPlot. This example demonstrates the fixed behavior:

```python
def data():
    return hv.Curve(np.cumsum(np.random.normal(size=(20,))))

hmap = hv.HoloMap({
        ('dog', 'yes'): data()(style=dict(color='red')),
        ('cat', 'yes'): data()(style=dict(color='blue')),
        ('rabbit', 'yes'): data(),
        ('rabbit', 'no'): data(),
    },
    kdims=['Animal', 'Hungry']
)
hv.GridSpace(hmap)
```

![image](https://cloud.githubusercontent.com/assets/1550771/13144622/9a8da3d8-d643-11e5-8f35-66b68d69e0de.png)

On currrent master the rabbit column is empty since it simply fills plots in scanline order.