### PR TITLE
Made color handling for all matplotlib plots consistent

### DIFF
--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -134,7 +134,7 @@ class Scatter3DPlot(Plot3D, PointPlot):
         artist._offsets3d, style, _ = self.get_data(element, ranges, style)
         cdim = element.get_dimension(self.color_index)
         if cdim and 'cmap' in style:
-            clim = style['clim'] if 'clim' in style else ranges[cdim.name]
+            clim = style['vmin'], style['vmax']
             cmap = cm.get_cmap(style['cmap'])
             artist._facecolor3d = map_colors(style['c'], clim, cmap, hex=False)
         if element.get_dimension(self.size_index):
@@ -176,8 +176,7 @@ class SurfacePlot(Plot3D):
         rn, cn = mat.shape
         l, b, zmin, r, t, zmax = self.get_extents(element, ranges)
         r, c = np.mgrid[l:r:(r-l)/float(rn), b:t:(t-b)/float(cn)]
-        style['vmin'] = zmin
-        style['vmax'] = zmax
+        self._norm_kwargs(element, ranges, style, element.vdims[0])
         return (r, c, mat), style, {}
             
 
@@ -194,10 +193,8 @@ class TrisurfacePlot(Plot3D):
     style_opts = ['cmap', 'color', 'shade', 'linewidth', 'edgecolor']
 
     def get_data(self, element, ranges, style):
-        dims = element.dimensions(label=True)
-        vrange = ranges[dims[2]]
-        style['vmin'] = vrange[0]
-        style['vmax'] = vrange[1]
+        dims = element.dimensions()
+        self._norm_kwargs(element, ranges, style, dims[2])
         x, y, z = [element.dimension_values(d) for d in dims]
         return (x, y, z), style, {}
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -571,16 +571,14 @@ class ColorbarPlot(ElementPlot):
 
 
 
-    def _norm_kwargs(self, element, ranges, opts):
+    def _norm_kwargs(self, element, ranges, opts, vdim):
         """
         Returns valid color normalization kwargs
         to be passed to matplotlib plot function.
         """
-        norm = None
         clim = opts.pop('clims', None)
         if clim is None:
-            val_dim = [d.name for d in element.vdims][0]
-            clim = ranges.get(val_dim)
+            clim = ranges.get(vdim.name)
             if self.symmetric:
                 clim = -np.abs(clim).max(), np.abs(clim).max()
         if self.logz:
@@ -590,8 +588,8 @@ class ColorbarPlot(ElementPlot):
             else:
                 norm = colors.LogNorm(vmin=clim[0], vmax=clim[1])
             opts['norm'] = norm
-        opts['clim'] = clim
-
+        opts['vmin'] = clim[0]
+        opts['vmax'] = clim[1]
 
 
 class LegendPlot(ElementPlot):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -496,6 +496,9 @@ class ColorbarPlot(ElementPlot):
         set to None default matplotlib ticking behavior is
         applied.""")
 
+    symmetric = param.Boolean(default=False, doc="""
+        Whether to make the colormap symmetric around zero.""")
+
     _colorbars = {}
 
     def _adjust_cbar(self, cbar, label, dim):

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -27,9 +27,6 @@ class RasterPlot(ColorbarPlot):
     situate_axes = param.Boolean(default=False, doc="""
         Whether to situate the image relative to other plots. """)
 
-    symmetric = param.Boolean(default=False, doc="""
-        Whether to make the colormap symmetric around zero.""")
-
     style_opts = ['alpha', 'cmap', 'interpolation', 'visible',
                   'filterrad', 'clims', 'norm']
 
@@ -189,9 +186,6 @@ class HeatMapPlot(RasterPlot):
 
 
 class QuadMeshPlot(ColorbarPlot):
-
-    symmetric = param.Boolean(default=False, doc="""
-        Whether to make the colormap symmetric around zero.""")
 
     style_opts = ['alpha', 'cmap', 'clim', 'edgecolors', 'norm', 'shading',
                   'linestyles', 'linewidths', 'hatch', 'visible']

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -68,7 +68,8 @@ class RasterPlot(ColorbarPlot):
 
         if isinstance(element, RGB):
             data = element.rgb.data
-        self._norm_kwargs(element, ranges, style)
+        vdim = element.vdims[0]
+        self._norm_kwargs(element, ranges, style, vdim)
         style['extent'] = [l, r, b, t]
 
         return [data], style, {'xticks': xticks, 'yticks': yticks}
@@ -85,7 +86,7 @@ class RasterPlot(ColorbarPlot):
         l, r, b, t = style['extent']
         im.set_data(data[0])
         im.set_extent((l, r, b, t))
-        im.set_clim(style['clim'])
+        im.set_clim((style['vmin'], style['vmax']))
         if 'norm' in style:
             im.norm = style['norm']
 
@@ -168,7 +169,7 @@ class HeatMapPlot(RasterPlot):
         l, r, b, t = style['extent']
         im.set_data(data[0])
         im.set_extent((l, r, b, t))
-        im.set_clim(style['clim'])
+        im.set_clim((style['vmin'], style['vmax']))
         if 'norm' in style:
             im.norm = style['norm']
 
@@ -195,7 +196,8 @@ class QuadMeshPlot(ColorbarPlot):
                            mask=np.logical_not(np.isfinite(element.data[2])))
         cmesh_data = list(element.data[:2]) + [data]
         style['locs'] = np.concatenate(element.data[:2])
-        self._norm_kwargs(element, ranges, style)
+        vdim = element.vdims[0]
+        self._norm_kwargs(element, ranges, style, vdim)
         return tuple(cmesh_data), style, {}
 
 
@@ -215,7 +217,7 @@ class QuadMeshPlot(ColorbarPlot):
         else:
             data, style, axis_kwargs = self.get_data(element, ranges, style)
             cmesh.set_array(data[-1])
-            cmesh.set_clim(style['clim'])
+            im.set_clim((style['vmin'], style['vmax']))
             if 'norm' in style:
                 cmesh.norm = style['norm']
             return axis_kwargs


### PR DESCRIPTION
Small fix for ColorbarPlots, moving ``symmetric`` plot option to the base class where it is used.