### PR TITLE
Element Tutorial fixes

### DIFF
--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -993,7 +993,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Like ``Raster``, a HoloViews ``Image`` allows you to view 2D arrays using an arbitrary color map. Unlike ``Raster``, an ``Image`` is associated with a [2D coordinate system in continuous space](Continuous_Coordinates.ipynb), which is appropriate for values sampled from some underlying continuous distribution (as in a photograph or other measurements from locations in real space).  Slicing, sampling, etc. on an ``Image`` all use this continuous space, whereas the corresponding operations on a ``Raster`` work on the raw array coordinates."
+    "Like ``Raster``, a HoloViews ``Image`` allows you to view 2D arrays using an arbitrary color map. Unlike ``Raster``, an ``Image`` is associated with a [2D coordinate system in continuous space](Continuous_Coordinates.ipynb), which is appropriate for values sampled from some underlying continuous distribution (as in a photograph or other measurements from locations in real space).  Slicing, sampling, etc. on an ``Image`` all use this continuous space, whereas the corresponding operations on a ``Raster`` work on the raw array coordinates.\n",
+    "\n",
+    "To make the coordinate system clear, we'll define two arrays called ``xs`` and ``ys`` with a non-square aspect and map them through a simple function that illustrate how these inputs relate to the coordinate system:"
    ]
   },
   {
@@ -1004,9 +1006,10 @@
    },
    "outputs": [],
    "source": [
-    "bounds=(-5,-5,5,5)   # Coordinate system: (left, bottom, top, right)\n",
-    "(hv.Image(np.sin(x**2+y**2),   bounds=bounds) \n",
-    " + hv.Image(np.sin(x**2+y**2), bounds=bounds)[-2.5:2.5, -2.5:2.5])"
+    "bounds=(-2,-3,5,2)   # Coordinate system: (left, bottom, top, right)\n",
+    "xs,ys = np.meshgrid(np.linspace(-2,5,50), np.linspace(2,-3, 30))\n",
+    "(hv.Image(np.sin(xs-1)+ys, bounds=bounds) \n",
+    " + hv.Image(np.sin(xs-1)+ys, bounds=bounds)[0:5, -2.5:2])"
    ]
   },
   {

--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -995,10 +995,10 @@
    "outputs": [],
    "source": [
     "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
-    "bounds=(-1,-1,1,1)   # Coordinate system: (left, bottom, top, right)\n",
+    "bounds=(-5,-5,5,5)   # Coordinate system: (left, bottom, top, right)\n",
     "\n",
     "(hv.Image(np.sin(x**2+y**2),   bounds=bounds) \n",
-    " + hv.Image(np.sin(x**2+y**2), bounds=bounds)[-0.5:0.5, -0.5:0.5])"
+    " + hv.Image(np.sin(x**2+y**2), bounds=bounds)[-2.5:2.5, -2.5:2.5])"
    ]
   },
   {

--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -690,7 +690,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y  = np.mgrid[-10:10,-10:10] * 0.25\n",
+    "y,x  = np.mgrid[-10:10,-10:10] * 0.25\n",
     "sine_rings  = np.sin(x**2+y**2)*np.pi+np.pi\n",
     "exp_falloff = 1/np.exp((x**2+y**2)/8)\n",
     "\n",
@@ -817,7 +817,7 @@
    "outputs": [],
    "source": [
     "%%opts Scatter3D [azimuth=40 elevation=20]\n",
-    "x,y = np.mgrid[-5:5, -5:5] * 0.1\n",
+    "y,x = np.mgrid[-5:5, -5:5] * 0.1\n",
     "heights = np.sin(x**2+y**2)\n",
     "hv.Scatter3D(zip(x.flat,y.flat,heights.flat))"
    ]
@@ -889,7 +889,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "hv.Raster(np.sin(x**2+y**2))"
    ]
   },
@@ -994,7 +994,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "bounds=(-5,-5,5,5)   # Coordinate system: (left, bottom, top, right)\n",
     "\n",
     "(hv.Image(np.sin(x**2+y**2),   bounds=bounds) \n",
@@ -1032,7 +1032,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "\n",
     "r = 0.5*np.sin(np.pi  +3*x**2+y**2)+0.5\n",
     "g = 0.5*np.sin(x**2+2*y**2)+0.5\n",
@@ -1109,10 +1109,10 @@
    },
    "outputs": [],
    "source": [
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "h = 0.5 + np.sin(0.2*(x**2+y**2)) / 2.0\n",
-    "s = 0.5*np.cos(y*3)+0.5\n",
-    "v = 0.5*np.cos(x*3)+0.5\n",
+    "s = 0.5*np.cos(x*3)+0.5\n",
+    "v = 0.5*np.cos(y*3)+0.5\n",
     "\n",
     "hv.HSV(np.dstack([h, s, v]))"
    ]
@@ -1412,7 +1412,7 @@
    },
    "outputs": [],
    "source": [
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "\n",
     "def circle(radius, x=0, y=0):\n",
     "    angles = np.linspace(0, 2*np.pi, 100)\n",

--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -864,7 +864,18 @@
    "source": [
     "**A collection of raster image types**\n",
     "\n",
-    "The second large class of ``Elements`` is the raster elements. Like ``Points`` and unlike the other  ``Chart`` elements, ``Raster Elements`` live in a 2D key-dimensions space. For the ``Image``, ``RGB``, and ``HSV`` elements, the coordinates of this two-dimensional key space are defined in a [continuously indexable coordinate system](Continuous_Coordinates.ipynb)."
+    "The second large class of ``Elements`` is the raster elements. Like ``Points`` and unlike the other  ``Chart`` elements, ``Raster Elements`` live in a 2D key-dimensions space. For the ``Image``, ``RGB``, and ``HSV`` elements, the coordinates of this two-dimensional key space are defined in a [continuously indexable coordinate system](Continuous_Coordinates.ipynb). We can use ``np.meshgrid`` to define the appropriate sampling along the ``x`` and ``y`` dimensions:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x,y = np.meshgrid(np.linspace(-5,5,101), np.linspace(5,-5,101))"
    ]
   },
   {
@@ -889,7 +900,6 @@
    },
    "outputs": [],
    "source": [
-    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "hv.Raster(np.sin(x**2+y**2))"
    ]
   },
@@ -994,9 +1004,7 @@
    },
    "outputs": [],
    "source": [
-    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "bounds=(-5,-5,5,5)   # Coordinate system: (left, bottom, top, right)\n",
-    "\n",
     "(hv.Image(np.sin(x**2+y**2),   bounds=bounds) \n",
     " + hv.Image(np.sin(x**2+y**2), bounds=bounds)[-2.5:2.5, -2.5:2.5])"
    ]
@@ -1032,8 +1040,6 @@
    },
    "outputs": [],
    "source": [
-    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
-    "\n",
     "r = 0.5*np.sin(np.pi  +3*x**2+y**2)+0.5\n",
     "g = 0.5*np.sin(x**2+2*y**2)+0.5\n",
     "b = 0.5*np.sin(np.pi/2+x**2+y**2)+0.5\n",
@@ -1109,7 +1115,6 @@
    },
    "outputs": [],
    "source": [
-    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "h = 0.5 + np.sin(0.2*(x**2+y**2)) / 2.0\n",
     "s = 0.5*np.cos(x*3)+0.5\n",
     "v = 0.5*np.cos(y*3)+0.5\n",
@@ -1412,8 +1417,6 @@
    },
    "outputs": [],
    "source": [
-    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
-    "\n",
     "def circle(radius, x=0, y=0):\n",
     "    angles = np.linspace(0, 2*np.pi, 100)\n",
     "    return np.array( list(zip(x+radius*np.sin(angles), y+radius*np.cos(angles))))\n",

--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -1008,8 +1008,8 @@
    "source": [
     "bounds=(-2,-3,5,2)   # Coordinate system: (left, bottom, top, right)\n",
     "xs,ys = np.meshgrid(np.linspace(-2,5,50), np.linspace(2,-3, 30))\n",
-    "(hv.Image(np.sin(xs-1)+ys, bounds=bounds) \n",
-    " + hv.Image(np.sin(xs-1)+ys, bounds=bounds)[0:5, -2.5:2])"
+    "(hv.Image(np.sin(xs)+ys, bounds=bounds) \n",
+    " + hv.Image(np.sin(xs)+ys, bounds=bounds)[0:3, -2.5:2])"
    ]
   },
   {


### PR DESCRIPTION
This PR addresses the issues raised in #516 regarding the Element tutorial, namely:

* Confusing bounds for ``Image``.
* Incorrect names for ``x`` and ``y`` generated with ``np.mgrid``

I've made the changes in such a way that I believe that most of the tests will continue to pass though ``Image`` will probably fail given the change of bounds.