### PR TITLE
Fixed bug in bokeh hover tool for unsanitized dimensions

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -77,9 +77,7 @@ class PointPlot(ElementPlot):
 
         data[dims[0]] = [] if empty else element.dimension_values(0)
         data[dims[1]] = [] if empty else element.dimension_values(1)
-        if 'hover' in self.tools+self.default_tools:
-            for d in dims:
-                data[d] = [] if empty else element.dimension_values(d)
+        self._get_hover_data(data, element, empty)
         return data, mapping
 
 
@@ -178,10 +176,7 @@ class HistogramPlot(ElementPlot):
         else:
             data = dict(top=element.values, left=element.edges[:-1],
                         right=element.edges[1:])
-
-        if 'hover' in self.default_tools + self.tools:
-            data.update({d: [] if empty else element.dimension_values(d)
-                         for d in element.dimensions(label=True)})
+        self._get_hover_data(data, element, empty)
         return (data, mapping)
 
 
@@ -221,10 +216,7 @@ class SideHistogramPlot(HistogramPlot):
             cmap = get_cmap(style.get('cmap', style.get('palette', None)))
             data['color'] = [] if empty else map_colors(vals, main_range, cmap)
             mapping['fill_color'] = 'color'
-
-        if 'hover' in self.default_tools + self.tools:
-            data.update({d: [] if empty else element.dimension_values(d)
-                         for d in element.dimensions(label=True)})
+        self._get_hover_data(data, element, empty)
         return (data, mapping)
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -160,9 +160,21 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         tools = self.default_tools + self.tools
         if 'hover' in tools:
-            tooltips = [(d, '@'+d) for d in element.dimensions(label=True)]
+            tooltips = [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
+                        for d in element.dimensions()]
             tools[tools.index('hover')] = HoverTool(tooltips=tooltips)
         return tools
+
+
+    def _get_hover_data(self, data, element, empty=False):
+        """
+        Initializes hover data based on Element dimension values.
+        If empty initializes with no data.
+        """
+        if 'hover' in self.default_tools + self.tools:
+            for d in element.dimensions(label=True):
+                sanitized = dimension_sanitizer(d)
+                data[sanitized] = [] if empty else element.dimension_values(d)
 
 
     def _axes_props(self, plots, subplots, element, ranges):


### PR DESCRIPTION
The bokeh hover tool currently breaks if a dimension contains a space or other special character, the PR adds a small method to generate the hover data correctly.