### PR TITLE
Removed dependency on matplotlib, nbformat and pyparsing in ipython

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -2,7 +2,7 @@ import os
 from unittest import SkipTest
 
 import param
-import jinja2
+from IPython import version_info
 from IPython.display import HTML
 
 import holoviews
@@ -11,17 +11,33 @@ from ..element.comparison import ComparisonTestCase
 from ..interface.collector import Collector
 from ..plotting.renderer import Renderer
 from ..plotting import * # noqa (API import - register plotting backends)
-from .archive import notebook_archive
 from .magics import load_magics
 from .display_hooks import display  # noqa (API import)
 from .display_hooks import set_display_hooks, OutputMagic
-from .parser import Parser
 from .widgets import RunProgress
 
 from param import ipython as param_ext
 
+try:
+    if version_info[0] >= 4:
+        import nbformat # noqa (ensures availability)
+    else:
+        from IPython import nbformat # noqa (ensures availability)
+    from .archive import notebook_archive
+    holoviews.archive = notebook_archive
+except ImportError:
+    pass
+
+try:
+    import pyparsing
+except ImportError:
+    pyparsing = None
+    # Populating the namespace for keyword evaluation
+    from ..core.options import Cycle, Palette # noqa (namespace import)
+    import numpy as np                        # noqa (namespace import)
+    Parser.namespace = {'np': np, 'Cycle': Cycle, 'Palette': Palette}
+
 Collector.interval_hook = RunProgress
-holoviews.archive = notebook_archive
 
 
 def show_traceback():
@@ -79,6 +95,7 @@ def load_hvjs(logo=False, JS=True, message='HoloViewsJS successfully loaded.'):
     """
     Displays javascript and CSS to initialize HoloViews widgets.
     """
+    import jinja2
     # Evaluate load_notebook.html template with widgetjs code
     if JS:
         widgetjs, widgetcss = Renderer.html_assets(extras=False, backends=[])
@@ -92,12 +109,6 @@ def load_hvjs(logo=False, JS=True, message='HoloViewsJS successfully loaded.'):
                                   'logo': logo,
                                   'message':message})))
 
-
-# Populating the namespace for keyword evaluation
-from ..core.options import Cycle, Palette # noqa (namespace import)
-import numpy as np                        # noqa (namespace import)
-
-Parser.namespace = {'np':np, 'Cycle':Cycle, 'Palette': Palette}
 
 class notebook_extension(param.ParameterizedFunction):
     """

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -3,10 +3,12 @@ from unittest import SkipTest
 
 import param
 from IPython import version_info
+import numpy as np
+import holoviews
+from param import ipython as param_ext
 from IPython.display import HTML
 
-import holoviews
-from ..core.options import Store
+from ..core.options import Store, Cycle, Palette
 from ..element.comparison import ComparisonTestCase
 from ..interface.collector import Collector
 from ..plotting.renderer import Renderer
@@ -15,8 +17,6 @@ from .magics import load_magics
 from .display_hooks import display  # noqa (API import)
 from .display_hooks import set_display_hooks, OutputMagic
 from .widgets import RunProgress
-
-from param import ipython as param_ext
 
 try:
     if version_info[0] >= 4:
@@ -30,12 +30,11 @@ except ImportError:
 
 try:
     import pyparsing
+    from .parser import Parser
+    Parser.namespace = {'np': np, 'Cycle': Cycle, 'Palette': Palette}
 except ImportError:
     pyparsing = None
-    # Populating the namespace for keyword evaluation
-    from ..core.options import Cycle, Palette # noqa (namespace import)
-    import numpy as np                        # noqa (namespace import)
-    Parser.namespace = {'np': np, 'Cycle': Cycle, 'Palette': Palette}
+
 
 Collector.interval_hook = RunProgress
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -7,6 +7,7 @@ import sys, traceback, inspect, io
 import IPython
 from IPython.core.ultratb import AutoFormattedTB
 
+import holoviews
 from ..core.options import Store, StoreOptions, BackendError, SkipRendering
 from ..core import (ViewableElement, UniformNdMapping,
                     HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
@@ -14,7 +15,6 @@ from ..core import (ViewableElement, UniformNdMapping,
 from ..core.traversal import unique_dimkeys
 from .magics import OutputMagic, OptsMagic
 
-from .archive import notebook_archive
 # To assist with debugging of display hooks
 FULL_TRACEBACK = None
 ABBREVIATE_TRACEBACKS = True
@@ -103,7 +103,7 @@ def display_hook(fn):
             # Only want to add to the archive for one display hook...
             disabled_suffixes = ['png_display', 'svg_display']
             if not any(fn.__name__.endswith(suffix) for suffix in disabled_suffixes):
-                notebook_archive.add(element, html=html)
+                holoviews.archive.add(element, html=html)
             filename = OutputMagic.options['filename']
             if filename:
                 Store.renderers[Store.current_backend].save(element, filename)

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -193,11 +193,15 @@ def list_formats(format_type, backend=None):
     """
     if backend is None:
         backend = Store.current_backend
-        mode = Store.renderers[backend].mode
+        mode = Store.renderers[backend].mode if backend in Store.renderers else None
     else:
         split = backend.split(':')
         backend, mode = split if len(split)==2 else (split[0], 'default')
-    return Store.renderers[backend].mode_formats[format_type][mode]
+
+    if backend in Store.renderers:
+        return Store.renderers[backend].mode_formats[format_type][mode]
+    else:
+        return []
 
 
 @magics_class


### PR DESCRIPTION
Addresses issues mentioned in #528 partially by removing all hard dependencies on notebook and matplotlib in the ipython module. This ensures holoviews can be imported in IPython even without matplotlib and the notebook.