### PR TITLE
Various plotting fixes

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -173,7 +173,7 @@ class Columns(Element):
         supplied, which will ensure the selection is only applied if the
         specs match the selected object.
         """
-        if selection_specs and not self.matches(selection_specs):
+        if selection_specs and not any(self.matches(sp) for sp in selection_specs):
             return self
 
         data = self.interface.select(self, **selection)

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -370,7 +370,8 @@ class Callbacks(param.Parameterized):
             else:
                 obj = getattr(plot.state, k)
                 obj_data = models_to_json([obj])[0]
-                data[k] = [obj_data.get(attr) for attr in v]
+                data[k] = [obj_data.get(attr, obj_data.get('data', {}).get(attr))
+                           for attr in v]
         if pycallback.cb_attributes:
             cb_data = models_to_json([pycallback.callback_obj])[0]
             data['cb_obj'] = [cb_data.get(attr) for attr in pycallback.cb_attributes]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -479,9 +479,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.current_key = key
             self.current_frame = element
 
+        glyph = self.handles['glyph']
+        if hasattr(glyph, 'visible'):
+            glyph.visible = bool(element)
         if not element:
-            source = self.handles['source']
-            source.data = {k: [] for k in source.data}
             return
 
         if isinstance(self.hmap, DynamicMap):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -253,13 +253,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return (x_axis_type, y_axis_type), (xlabel, ylabel, zlabel), plot_ranges
 
 
-    def _init_plot(self, key, plots, ranges=None):
+    def _init_plot(self, key, element, plots, ranges=None):
         """
         Initializes Bokeh figure to draw Element into and sets basic
         figure and axis attributes including axes types, labels,
         titles and plot height and width.
         """
-        element = self._get_frame(key)
         subplots = list(self.subplots.values()) if self.subplots else []
 
         axis_types, labels, plot_ranges = self._axes_props(plots, subplots, element, ranges)
@@ -437,7 +436,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         # Initialize plot, source and glyph
         if plot is None:
-            plot = self._init_plot(key, ranges=ranges, plots=plots)
+            plot = self._init_plot(key, element, ranges=ranges, plots=plots)
             self._init_axes(plot)
         self.handles['plot'] = plot
 
@@ -710,7 +709,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         element = self._get_frame(key)
         ranges = self.compute_ranges(self.hmap, key, ranges)
         if plot is None and not self.tabs:
-            plot = self._init_plot(key, ranges=ranges, plots=plots)
+            plot = self._init_plot(key, element, ranges=ranges, plots=plots)
             self._init_axes(plot)
         if plot and not self.overlaid:
             self._update_plot(key, plot, self.hmap.last)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -173,7 +173,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         if 'hover' in self.default_tools + self.tools:
             for d in element.dimensions(label=True):
-                sanitized = dimension_sanitizer(d)
+                sanitized = util.dimension_sanitizer(d)
                 data[sanitized] = [] if empty else element.dimension_values(d)
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -199,12 +199,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if plot.yaxis[0].axis_label == xlabel:
                     plot_ranges['x_range'] = plot.y_range
 
-        if element.get_dimension_type(0) is np.datetime64:
+        if el.get_dimension_type(0) is np.datetime64:
             x_axis_type = 'datetime'
         else:
             x_axis_type = 'log' if self.logx else 'auto'
 
-        if len(dims) > 1 and element.get_dimension_type(1) is np.datetime64:
+        if len(dims) > 1 and el.get_dimension_type(1) is np.datetime64:
             y_axis_type = 'datetime'
         else:
             y_axis_type = 'log' if self.logy else 'auto'

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -115,7 +115,8 @@ class HeatmapPlot(ElementPlot):
     style_opts = ['cmap', 'color'] + line_properties + fill_properties
 
     def _axes_props(self, plots, subplots, element, ranges):
-        labels = self._axis_labels(element, plots)
+        dims = element.dimensions()
+        labels = self._get_axis_labels(dims)
         xvals, yvals = [element.dimension_values(i, True)
                         for i in range(2)]
         plot_ranges = {'x_range': [str(x) for x in xvals],

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -149,11 +149,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             # Apply title
             title = None if self.zorder > 0 else self._format_title(key)
             if self.show_title and title is not None:
-                if 'title' in self.handles:
-                    self.handles['title'].set_text(title)
-                else:
-                    fontsize = self._fontsize('title')
-                    self.handles['title'] = axis.set_title(title, **fontsize)
+                fontsize = self._fontsize('title')
+                self.handles['title'] = axis.set_title(title, **fontsize)
 
             # Apply subplot label
             self._subplot_label(axis)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -518,7 +518,7 @@ class GenericElementPlot(DimensionedPlot):
             if isinstance(key, tuple):
                 dims = {d.name: k for d, k in zip(self.dimensions, key)
                         if d in self.hmap.kdims}
-                frame = self.hmap.select(**dims)
+                frame = self.hmap.select([DynamicMap], **dims)
             elif key < self.hmap.counter:
                 key = self.hmap.keys()[key]
                 frame = self.hmap[key]

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -2,12 +2,11 @@ from __future__ import unicode_literals
 
 import os, uuid, json, math
 
-import numpy as np
 import param
 
 from ...core import OrderedDict, NdMapping
 from ...core.options import Store
-from ...core.util import (dimension_sanitizer, safe_unicode, basestring,
+from ...core.util import (dimension_sanitizer, safe_unicode,
                           unique_iterator, unicode, isnumeric)
 from ...core.traversal import hierarchical
 
@@ -142,7 +141,7 @@ class NdWidget(param.Parameterized):
                      else self.json_load_path)
         if json_path and json_path[-1] != '/':
             json_path = json_path + '/'
-        dynamic = repr(self.plot.dynamic) if self.plot.dynamic else 'false'
+        dynamic = json.dumps(self.plot.dynamic) if self.plot.dynamic else 'false'
         return dict(CDN=CDN, frames=self.get_frames(), delay=delay,
                     cached=cached, load_json=load_json, mode=mode, id=self.id,
                     Nframes=len(self.plot), widget_name=name, json_path=json_path,


### PR DESCRIPTION
A number of fixes to plotting in particular for the bokeh backend. 

The fixes include:

* Empty datasources cause issues in 0.11.1, now setting the glyph invisible instead
* Datetime axes limits were being inferred incorrectly on OverlayPlots
* Fixed some outdated method signatures and unreferenced variables
* Fixed a bug with selection_specs in Columns.select that caused issues in plotting
* Fixed a bug in widget templating resulting in a unicode string with the `u` prefix being templated (causing JS syntax errors)