### PR TITLE
DictColumns validation and fixes

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1159,6 +1159,17 @@ class DictColumns(DataColumns):
 
 
     @classmethod
+    def validate(cls, columns):
+        dimensions = columns.dimensions(label=True)
+        not_found = [d for d in dimensions if d not in columns.data]
+        if not_found:
+            raise ValueError('Following dimensions not found in data: %s' % not_found)
+        lengths = [len(columns.data[dim]) for dim in dimensions]
+        if len({l for l in lengths if l > 1}) > 1:
+            raise ValueError('Length of columns do not match')
+
+
+    @classmethod
     def unpack_scalar(cls, columns, data):
         """
         Given a columns object and data in the appropriate format for

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -6,7 +6,7 @@ backends.
 import sys
 from distutils.version import LooseVersion
 from collections import OrderedDict
-from itertools import compress
+from itertools import compress, cycle
 
 try:
     import itertools.izip as zip
@@ -1253,12 +1253,14 @@ class DictColumns(DataColumns):
         group_kwargs.update(kwargs)
 
         # Find all the keys along supplied dimensions
-        keys = [tuple(columns.data[d.name][i] for d in dimensions)
-                for i in range(len(columns))]
+        key_data = []
+        for d in dimensions:
+            data = columns.data[d.name]
+            key_data.append(cycle([data[0]]) if len(data) == 1 else data)
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
-        for unique_key in util.unique_iterator(keys):
+        for unique_key in util.unique_iterator(zip(key_data)):
             mask = cls.select_mask(columns, dict(zip(dimensions, unique_key)))
             group_data = OrderedDict(((d.name, columns[d.name][mask]) for d in kdims+vdims))
             group_data = group_type(group_data, **group_kwargs)


### PR DESCRIPTION
Currently the DictColumns interfaces is lacking any validation which means it's easy to construct invalid Columns types, which won't be detected until the object is accessed or plotted. This adds a validation method to the interface and ensures that scalar columns are supported.

Will add unit tests before merging.