### PR TITLE
Switched Bokeh LineAnnotationPlot to use Span annotation

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 import numpy as np
-from bokeh.models import BoxAnnotation
+from bokeh.models import Span
 
 from ...element import HLine, VLine
 from .element import ElementPlot, text_properties, line_properties
@@ -46,28 +46,19 @@ class LineAnnotationPlot(ElementPlot):
 
     def get_data(self, element, ranges=None, empty=False):
         data, mapping = {}, {}
-        if (isinstance(element, HLine) or
-            (isinstance(element, VLine) and self.invert_axes)):
-            mapping['bottom'] = element.data
-            mapping['top'] = element.data
-        elif (isinstance(element, VLine) or
-              (isinstance(element, HLine) and self.invert_axes)):
-            mapping['left'] = element.data
-            mapping['right'] = element.data
+        mapping['dimension'] = 'width' if isinstance(element, HLine) else 'height'
+        mapping['location'] = element.data
         return (data, mapping)
-
 
     def _init_glyph(self, plot, mapping, properties):
         """
         Returns a Bokeh glyph object.
         """
-        properties.pop('source', None)
-        properties.pop('legend', None)
-        box = BoxAnnotation(plot=plot, level='overlay',
-                            **dict(mapping, **properties))
+        properties.pop('source')
+        properties.pop('legend')
+        box = Span(level='overlay', **dict(mapping, **properties))
         plot.renderers.append(box)
         return None, box
-
 
     def get_extents(self, element, ranges=None):
         return None, None, None, None


### PR DESCRIPTION
Previously we had to use the bokeh BoxAnnotation to render VLine and HLine Elements but since 0.11 bokeh ships with a Span annotation which is more appropriate. This can be merged once https://github.com/bokeh/bokeh/issues/3993 in bokeh is fixed and 0.12 is released.