### PR TITLE
Renderer instances keep track of last plot

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -143,6 +143,7 @@ class Renderer(Exporter):
     backend_dependencies = {}
 
     def __init__(self, **params):
+        self.last_plot = None
         super(Renderer, self).__init__(**params)
 
 
@@ -205,6 +206,7 @@ class Renderer(Exporter):
         if fmt not in all_formats:
             raise Exception("Format %r not supported by mode %r. Allowed formats: %r"
                             % (fmt, self.mode, fig_formats + holomap_formats))
+        self.last_plot = plot
         return plot, fmt
 
 


### PR DESCRIPTION
This PR adds a ``last_plot`` attribute to ``Renderer`` instances, which let's the user easily get a handle on the last thing they plotted, which is very helpful for debugging, understanding how plots are structured, and in order to directly customize a plot, e.g. to prototype an ``initial_hook`` or ``final_hook``.