### PR TITLE
Avoided deep lookup on get_dimension_index

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -639,14 +639,15 @@ class Dimensioned(LabelledData):
         """
         if isinstance(dim, Dimension): dim = dim.name
         if isinstance(dim, int):
-            if dim < len(self.dimensions()):
+            if (dim < (self.ndims + len(self.vdims)) or
+                dim < len(self.dimensions())):
                 return dim
             else:
                 return IndexError('Dimension index out of bounds')
         try:
-            sanitized = {dimension_sanitizer(kd): kd
-                         for kd in self.dimensions('key', True)}
-            return [d.name for d in self.dimensions()].index(sanitized.get(dim, dim))
+            if dim in self.kdims+self.vdims:
+                return (self.kdims+self.vdims).index(dim)
+            return self.dimensions().index(dim)
         except ValueError:
             raise Exception("Dimension %s not found in %s." %
                             (dim, self.__class__.__name__))


### PR DESCRIPTION
Provides a considerable speedup for the get_dimension_index method
on deeply nested objects by avoiding looking up deep dimensions
unless necessary.

On a moderately sized GridSpace of HoloMaps plotting was sped up to 4 seconds from 21 seconds.