### PR TITLE
Adding a general interface for N-dimensional gridded data

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -44,7 +44,7 @@ class Columns(Element):
     of aggregating or collapsing the data with a supplied function.
     """
 
-    datatype = param.List(['array', 'dataframe', 'dictionary', 'ndelement'],
+    datatype = param.List(['array', 'dataframe', 'dictionary', 'grid', 'ndelement'],
         doc=""" A priority list of the data types to be used for storage
         on the .data attribute. If the input supplied to the element
         constructor cannot be put into the requested format, the next

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -858,7 +858,7 @@ class DFColumns(DataColumns):
 
 
     @classmethod
-    def values(cls, columns, dim, expanded, flat):
+    def values(cls, columns, dim, expanded=True, flat=True):
         data = columns.data[dim]
         if util.dd and isinstance(data, util.dd.Series):
             data = data.compute()
@@ -986,7 +986,7 @@ class ArrayColumns(DataColumns):
 
 
     @classmethod
-    def values(cls, columns, dim, expanded, flat):
+    def values(cls, columns, dim, expanded=True, flat=True):
         data = columns.data
         dim_idx = columns.get_dimension_index(dim)
         if data.ndim == 1:
@@ -1238,7 +1238,7 @@ class DictColumns(DataColumns):
         return OrderedDict([(d, v[sorting]) for d, v in columns.data.items()])
 
     @classmethod
-    def values(cls, columns, dim, expanded, flat):
+    def values(cls, columns, dim, expanded=True, flat=True):
         values = np.array(columns.data.get(columns.get_dimension(dim).name))
         if not expanded:
             return util.unique_array(values)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -442,7 +442,7 @@ class DataColumns(param.Parameterized):
         # Iterate over interfaces until one can interpret the input
         for interface in prioritized:
             try:
-                (data, kdims, vdims) = interface.reshape(eltype, data, kdims, vdims)
+                (data, kdims, vdims) = interface.init(eltype, data, kdims, vdims)
                 break
             except:
                 pass
@@ -583,7 +583,7 @@ class NdColumns(DataColumns):
     datatype = 'ndelement'
 
     @classmethod
-    def reshape(cls, eltype, data, kdims, vdims):
+    def init(cls, eltype, data, kdims, vdims):
         if isinstance(data, NdElement):
             kdims = [d for d in kdims if d != 'Index']
         else:
@@ -712,7 +712,7 @@ class DFColumns(DataColumns):
         return columns.data.dtypes[idx].type
 
     @classmethod
-    def reshape(cls, eltype, data, kdims, vdims):
+    def init(cls, eltype, data, kdims, vdims):
         element_params = eltype.params()
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
@@ -908,7 +908,7 @@ class ArrayColumns(DataColumns):
         return columns.data.dtype.type
 
     @classmethod
-    def reshape(cls, eltype, data, kdims, vdims):
+    def init(cls, eltype, data, kdims, vdims):
         if kdims is None:
             kdims = eltype.kdims
         if vdims is None:
@@ -1127,7 +1127,7 @@ class DictColumns(DataColumns):
         return columns.data[name].dtype.type
 
     @classmethod
-    def reshape(cls, eltype, data, kdims, vdims):
+    def init(cls, eltype, data, kdims, vdims):
         odict_types = (OrderedDict, cyODict)
         if kdims is None:
             kdims = eltype.kdims
@@ -1346,7 +1346,7 @@ class GridColumns(DictColumns):
     datatype = 'grid'
 
     @classmethod
-    def reshape(cls, eltype, data, kdims, vdims):
+    def init(cls, eltype, data, kdims, vdims):
         if kdims is None:
             kdims = eltype.kdims
         if vdims is None:

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1330,7 +1330,7 @@ class DictColumns(DataColumns):
 
 
 
-class NdArrayColumns(DictColumns):
+class GridColumns(DictColumns):
     """
     Interface for simple dictionary-based columns format. The dictionary
     keys correspond to the column (i.e dimension) names and the values
@@ -1339,9 +1339,7 @@ class NdArrayColumns(DictColumns):
 
     types = (dict, OrderedDict, cyODict)
 
-    datatype = 'ndarray'
-
-    dense = True
+    datatype = 'grid'
 
     @classmethod
     def reshape(cls, eltype, data, kdims, vdims):
@@ -1573,6 +1571,6 @@ class NdArrayColumns(DictColumns):
 DataColumns.register(DictColumns)
 DataColumns.register(ArrayColumns)
 DataColumns.register(NdColumns)
-DataColumns.register(NdArrayColumns)
+DataColumns.register(GridColumns)
 if pd:
     DataColumns.register(DFColumns)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1341,9 +1341,18 @@ class DictColumns(DataColumns):
 
 class GridColumns(DictColumns):
     """
-    Interface for simple dictionary-based columns format. The dictionary
-    keys correspond to the column (i.e dimension) names and the values
-    are collections representing the values in that column.
+    Interface for simple dictionary-based columns format using a
+    compressed representation that uses the cartesian product between
+    key dimensions. As with DictColumns, the dictionary keys correspond
+    to the column (i.e dimension) names and the values are NumPy arrays
+    representing the values in that column.
+
+    To use this compressed format, the key dimensions must be orthogonal
+    to one another with each key dimension specifiying an axis of the
+    multidimensional space occupied by the value dimension data. For
+    instance, given an temperature recordings sampled regularly across
+    the earth surface, a list of N unique latitudes and M unique
+    longitudes can specify the position of NxM temperature samples.
     """
 
     types = (dict, OrderedDict, cyODict)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1591,11 +1591,6 @@ class GridColumns(DictColumns):
 
     @classmethod
     def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
-        raise NotImplementedError
-
-
-    @classmethod
-    def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
         if not vdim:
             raise Exception("Cannot add key dimension to a dense representation.")
         dim = dimension.name if isinstance(dimension, Dimension) else dimension

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1159,6 +1159,17 @@ class DictColumns(DataColumns):
 
 
     @classmethod
+    def validate(cls, columns):
+        dimensions = columns.dimensions(label=True)
+        not_found = [d for d in dimensions if d not in columns.data]
+        if not_found:
+            raise ValueError('Following dimensions not found in data: %s' % not_found)
+        lengths = [len(columns.data[dim]) for dim in dimensions]
+        if len({l for l in lengths if l > 1}) > 1:
+            raise ValueError('Length of columns do not match')
+
+
+    @classmethod
     def unpack_scalar(cls, columns, data):
         """
         Given a columns object and data in the appropriate format for

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1537,6 +1537,11 @@ class GridColumns(DictColumns):
         dimensions = columns.dimensions(label=True)
         arrays = [columns.data[vdim.name] for vdim in columns.vdims]
         data = defaultdict(list)
+
+        first_sample = util.wrap_tuple(samples[0])
+        if any(len(util.wrap_tuple(s)) != len(first_sample) for s in samples):
+            raise IndexError('Sample coordinates must all be of the same length.')
+
         for sample in samples:
             if np.isscalar(sample): sample = [sample]
             if len(sample) != ndims:

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -929,6 +929,7 @@ class ArrayColumns(DataColumns):
                             for k, v in data.items()))
             data = np.column_stack(columns)
         elif isinstance(data, tuple):
+            data = [d if isinstance(d, np.ndarray) else np.array(d) for d in data]
             if cls.expanded_format(data):
                 data = np.column_stack(data)
             else:

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1367,12 +1367,6 @@ class GridColumns(DictColumns):
             raise ValueError('GridColumns must be instantiated as a '
                              'dictionary or tuple')
 
-        if 'vdims' in data:
-            vdim_array = data.pop('vdims')
-            for i, vdim in enumerate(vdims):
-                name = vdim.name if isinstance(vdim, Dimension) else vdim
-                data[name] = vdim_array[..., i]
-
         for dim in kdims+vdims:
             name = dim.name if isinstance(dim, Dimension) else dim
             if name not in data:

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1562,8 +1562,9 @@ class GridColumns(DictColumns):
         axes = tuple(columns.get_dimension_index(kdim) for kdim in columns.kdims
                     if kdim not in kdims)
         for vdim in columns.vdims:
-            data[vdim.name] = function(columns.data[vdim.name],
-                                       axis=axes, **kwargs)
+            data[vdim.name] = np.atleast_1d(function(columns.data[vdim.name],
+                                                     axis=axes, **kwargs))
+
         return data
 
 

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1425,7 +1425,9 @@ class GridColumns(DictColumns):
                 return columns.data[dim]
             prod = util.cartesian_product([columns.data[d.name] for d in columns.kdims])
             idx = columns.get_dimension_index(dim)
-            return prod[:, idx]
+            values = prod[:, idx]
+            shape = tuple(len(columns.data[d]) for d in columns.dimensions('key', True))
+            return values if flat else values.reshape(shape)
         else:
             dim = columns.get_dimension(dim)
             values = columns.data.get(dim.name)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -3,7 +3,7 @@ The data module provides utility classes to interface with various data
 backends.
 """
 
-import sys, warnings
+import sys
 from distutils.version import LooseVersion
 from collections import OrderedDict, defaultdict
 from itertools import compress, cycle
@@ -254,7 +254,7 @@ class Columns(Element):
         matching the key dimensions, returning a new object containing
         just the selected samples.
         """
-        return self.clone(self.interface.sample(self, samples))
+        return self.clone(self.interface.sample(self, samples), dense=False)
 
 
     def reduce(self, dimensions=[], function=None, spreadfn=None, **reduce_map):
@@ -715,7 +715,6 @@ class DFColumns(DataColumns):
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
         if util.is_dataframe(data):
-            columns = data.columns
             ndim = len(kdim_param.default) if kdim_param.default else None
             if kdims and vdims is None:
                 vdims = [c for c in data.columns if c not in kdims]
@@ -761,7 +760,7 @@ class DFColumns(DataColumns):
         column = columns.data[columns.get_dimension(dimension).name]
         if column.dtype.kind == 'O':
             if (not isinstance(columns.data, pd.DataFrame) or
-                LooseVersion(pd.__version__) < '0.17.0'):
+                        LooseVersion(pd.__version__) < '0.17.0'):
                 column = column.sort(inplace=False)
             else:
                 column = column.sort_values()
@@ -1459,7 +1458,7 @@ class GridColumns(DictColumns):
                 mask &= arr < ind.stop
         elif isinstance(ind, (set, list)):
             iter_slcs = []
-            for ik in k:
+            for ik in ind:
                 iter_slcs.append(arr == ik)
             mask = np.logical_or.reduce(iter_slcs)
         elif ind is None:

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1499,6 +1499,8 @@ class GridColumns(DictColumns):
         if val_dims:
             raise IndexError('Cannot slice value dimensions on dense '
                              'data, convert to sparse format first')
+
+        indexed = cls.indexed(columns, selection)
         selection = [(d, selection.get(d)) for d in dimensions]
         data = {}
         value_select = []
@@ -1516,6 +1518,10 @@ class GridColumns(DictColumns):
                          for ind in int_inds])
         for vdim in columns.vdims:
             data[vdim.name] = columns.data[vdim.name][index]
+
+        if indexed and len(data[columns.vdims[0].name]) == 1:
+            return data[columns.vdims[0].name][0]
+
         return data
 
 

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1595,8 +1595,20 @@ class GridColumns(DictColumns):
 
 
     @classmethod
+    def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
+        if not vdim:
+            raise Exception("Cannot add key dimension to a dense representation.")
+        dim = dimension.name if isinstance(dimension, Dimension) else dimension
+        return dict(columns.data, **{dim: values})
+
+
+    @classmethod
     def sort(cls, columns, by=[]):
-        return columns.data
+        if not by or by in [columns.kdims, columns.dimensions()]:
+            return columns.data
+        else:
+            raise Exception('Dense representation cannot be sorted, either instantiate '
+                            'in the desired order or use a sparse format.')
 
 
 

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1497,8 +1497,8 @@ class GridColumns(DictColumns):
         dimensions = columns.dimensions('key', label=True)
         val_dims = [vdim for vdim in columns.vdims if vdim in selection]
         if val_dims:
-            raise IndexError('Cannot slice value dimensions on dense '
-                             'data, convert to sparse format first')
+            raise IndexError('Cannot slice value dimensions in compressed format, '
+                             'convert to expanded format before slicing.')
 
         indexed = cls.indexed(columns, selection)
         selection = [(d, selection.get(d)) for d in dimensions]

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -6,7 +6,7 @@ backends.
 import sys
 from distutils.version import LooseVersion
 from collections import OrderedDict
-from itertools import compress
+from itertools import compress, cycle
 
 try:
     import itertools.izip as zip
@@ -1253,12 +1253,14 @@ class DictColumns(DataColumns):
         group_kwargs.update(kwargs)
 
         # Find all the keys along supplied dimensions
-        keys = [tuple(columns.data[d.name][i] for d in dimensions)
-                for i in range(len(columns))]
+        key_data = []
+        for d in dimensions:
+            data = columns.data[d.name]
+            key_data.append(cycle([data[0]]) if len(data) == 1 else data)
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
-        for unique_key in util.unique_iterator(keys):
+        for unique_key in util.unique_iterator(zip(key_data)):
             mask = cls.select_mask(columns, dict(zip(dimensions, unique_key)))
             group_data = OrderedDict(((d.name, columns[d.name][mask]) for d in kdims+vdims))
             group_data = group_type(group_data, **group_kwargs)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1268,14 +1268,12 @@ class DictColumns(DataColumns):
         group_kwargs.update(kwargs)
 
         # Find all the keys along supplied dimensions
-        key_data = []
-        for d in dimensions:
-            data = columns.data[d.name]
-            key_data.append(cycle([data[0]]) if len(data) == 1 else data)
+        keys = [tuple(columns.data[d.name][i] for d in dimensions)
+                for i in range(len(columns))]
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
-        for unique_key in util.unique_iterator(zip(key_data)):
+        for unique_key in util.unique_iterator(keys):
             mask = cls.select_mask(columns, dict(zip(dimensions, unique_key)))
             group_data = OrderedDict(((d.name, columns[d.name][mask]) for d in kdims+vdims))
             group_data = group_type(group_data, **group_kwargs)

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -654,8 +654,8 @@ class NdColumns(DataColumns):
         return columns.data.sort(by)
 
     @classmethod
-    def values(cls, columns, dim, expanded, flat):
-        values = columns.data.dimension_values(dim)
+    def values(cls, columns, dim, expanded=True, flat=True):
+        values = columns.data.dimension_values(dim, expanded, flat)
         if not expanded:
             return util.unique_array(values)
         return values

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -609,13 +609,14 @@ class NdColumns(DataColumns):
 
         if not isinstance(data, (NdElement, dict)):
             # If ndim > 2 data is assumed to be a mapping
+
             if (isinstance(data[0], tuple) and any(isinstance(d, tuple) for d in data[0])):
                 pass
             else:
-                data = [np.array(d) if not isinstance(d, np.ndarray) else d for d in data]
-                if not self.expanded_format(data):
-                    raise ValueError('NdColumns expects data to be of uniform shape')
                 if isinstance(data, tuple):
+                    data = tuple(np.array(d) if not isinstance(d, np.ndarray) else d for d in data)
+                    if not cls.expanded_format(data):
+                        raise ValueError('NdColumns expects data to be of uniform shape')
                     data = zip(*data)
                 ndims = len(kdims)
                 data = [(tuple(row[:ndims]), tuple(row[ndims:]))
@@ -750,11 +751,11 @@ class DFColumns(DataColumns):
                     else:
                         data = (range(len(data)), data)
                 else:
-                    data = tuple(data[:, i]  for i in range(data.shape[1]))
+                    data = tuple(data[:, i] for i in range(data.shape[1]))
 
             if isinstance(data, tuple):
                 data = [np.array(d) if not isinstance(d, np.ndarray) else d for d in data]
-                if cls.expanded_format(data):
+                if not cls.expanded_format(data):
                     raise ValueError('DFColumns expects data to be of uniform shape.')
                 data = pd.DataFrame.from_items([(c, d) for c, d in
                                                 zip(columns, data)])

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1617,8 +1617,8 @@ class GridColumns(DictColumns):
         if not by or by in [columns.kdims, columns.dimensions()]:
             return columns.data
         else:
-            raise Exception('Dense representation cannot be sorted, either instantiate '
-                            'in the desired order or use a sparse format.')
+            raise Exception('Compressed format cannot be sorted, either instantiate '
+                            'in the desired order or use the expanded format.')
 
 
 

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -464,7 +464,7 @@ class DataColumns(param.Parameterized):
 
 
     @classmethod
-    def expanded_format(cls, arrays):
+    def expanded(cls, arrays):
         return not any(array.shape not in [arrays[0].shape, (1,)] for array in arrays[1:])
 
 
@@ -615,7 +615,7 @@ class NdColumns(DataColumns):
             else:
                 if isinstance(data, tuple):
                     data = tuple(np.array(d) if not isinstance(d, np.ndarray) else d for d in data)
-                    if not cls.expanded_format(data):
+                    if not cls.expanded(data):
                         raise ValueError('NdColumns expects data to be of uniform shape')
                     data = zip(*data)
                 ndims = len(kdims)
@@ -755,7 +755,7 @@ class DFColumns(DataColumns):
 
             if isinstance(data, tuple):
                 data = [np.array(d) if not isinstance(d, np.ndarray) else d for d in data]
-                if not cls.expanded_format(data):
+                if not cls.expanded(data):
                     raise ValueError('DFColumns expects data to be of uniform shape.')
                 data = pd.DataFrame.from_items([(c, d) for c, d in
                                                 zip(columns, data)])
@@ -930,7 +930,7 @@ class ArrayColumns(DataColumns):
             data = np.column_stack(columns)
         elif isinstance(data, tuple):
             data = [d if isinstance(d, np.ndarray) else np.array(d) for d in data]
-            if cls.expanded_format(data):
+            if cls.expanded(data):
                 data = np.column_stack(data)
             else:
                 raise ValueError('ArrayColumns expects data to be of uniform shape.')
@@ -1166,7 +1166,7 @@ class DictColumns(DataColumns):
             raise ValueError("DictColumns interface couldn't convert data.""")
         elif isinstance(data, dict):
             unpacked = [(d, np.array(data[d])) for d in data]
-            if not cls.expanded_format([d[1] for d in unpacked]):
+            if not cls.expanded([d[1] for d in unpacked]):
                 raise ValueError('DictColumns expects data to be of uniform shape.')
             if isinstance(data, odict_types):
                 data.update(unpacked)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -754,7 +754,7 @@ class Dimensioned(LabelledData):
         return selection
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         """
         Returns the values along the specified dimension. This method
         must be implemented for all Dimensioned type.

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -488,7 +488,7 @@ class NdElement(NdMapping, Tabular):
         if dim.name in value_dims:
             index = value_dims.index(dim.name)
             vals = np.array([v[index] for v in self.data.values()])
-            return vals if not expanded else unique_array(vals)
+            return vals if expanded else unique_array(vals)
         else:
             return NdMapping.dimension_values(self, dim.name,
                                               expanded, flat)

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -482,15 +482,16 @@ class NdElement(NdMapping, Tabular):
         return self.clone(rows, kdims=grouped.kdims)
 
 
-    def dimension_values(self, dim, unique=False):
+    def dimension_values(self, dim, expanded=True, flat=True):
         dim = self.get_dimension(dim, strict=True)
         value_dims = self.dimensions('value', label=True)
         if dim.name in value_dims:
             index = value_dims.index(dim.name)
             vals = np.array([v[index] for v in self.data.values()])
-            return unique_array(vals) if unique else vals
+            return vals if not expanded else unique_array(vals)
         else:
-            return NdMapping.dimension_values(self, dim.name, unique)
+            return NdMapping.dimension_values(self, dim.name,
+                                              expanded, flat)
 
 
     def values(self):

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -126,9 +126,9 @@ class AdjointLayout(Dimensioned):
         return self.data[key] if key in self.data else default
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         dimension = self.get_dimension(dimension, strict=True).name
-        return self.main.dimension_values(dimension, unique)
+        return self.main.dimension_values(dimension, expanded, flat)
 
 
     def __getitem__(self, key):
@@ -433,7 +433,7 @@ class Layout(AttrTree, Dimensioned):
         return clone
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         "Returns the values along the specified dimension."
         dimension = self.get_dimension(dimension, strict=True).name
         all_dims = self.traverse(lambda x: [d.name for d in x.dimensions()])
@@ -441,9 +441,10 @@ class Layout(AttrTree, Dimensioned):
             values = [el.dimension_values(dimension) for el in self
                       if dimension in el.dimensions(label=True)]
             vals = np.concatenate(values)
-            return unique_array(vals) if unique else vals
+            return vals if expanded else unique_array(vals)
         else:
-            return super(Layout, self).dimension_values(dimension, unique)
+            return super(Layout, self).dimension_values(dimension,
+                                                        expanded, flat)
 
 
     def cols(self, ncols):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -343,7 +343,7 @@ class MultiDimensionalMapping(Dimensioned):
                           kdims=dims)
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         "Returns the values along the specified dimension."
         dimension = self.get_dimension(dimension, strict=True).name
         if dimension in self.kdims:
@@ -352,9 +352,9 @@ class MultiDimensionalMapping(Dimensioned):
             values = [el.dimension_values(dimension) for el in self
                       if dimension in el.dimensions()]
             vals = np.concatenate(values)
-            return util.unique_array(vals) if unique else vals
+            return vals if expanded else util.unique_array(vals)
         else:
-            return super(MultiDimensionalMapping, self).dimension_values(dimension, unique)
+            return super(MultiDimensionalMapping, self).dimension_values(dimension, expanded, flat)
 
 
     def reindex(self, kdims=[], force=False):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -65,7 +65,7 @@ class CompositeOverlay(ViewableElement, Composable):
         return layout
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         values = []
         found = False
         for el in self:
@@ -73,12 +73,12 @@ class CompositeOverlay(ViewableElement, Composable):
                 values.append(el.dimension_values(dimension))
                 found = True
         if not found:
-            return super(CompositeOverlay, self).dimension_values(dimension, unique)
+            return super(CompositeOverlay, self).dimension_values(dimension, expanded, flat)
         values = [v for v in values if v is not None and len(v)]
         if not values:
             return np.array()
         vals = np.concatenate(values)
-        return unique_array(vals) if unique else vals
+        return vals if expanded else unique_array(vals)
 
 
 class Overlay(Layout, CompositeOverlay):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -861,3 +861,16 @@ class ndmapping_groupby(param.ParameterizedFunction):
         return container_type(groups, kdims=dimensions)
 
 
+def cartesian_product(arrays):
+    """
+    Computes the cartesian product of a list of arrays.
+    """
+    broadcastable = np.ix_(*arrays)
+    broadcasted = np.broadcast_arrays(*broadcastable)
+    rows, cols = reduce(np.multiply, broadcasted[0].shape), len(broadcasted)
+    out = np.empty(rows * cols, dtype=broadcasted[0].dtype)
+    start, end = 0, rows
+    for a in broadcasted:
+        out[start:end] = a.reshape(-1)
+        start, end = end, end + rows
+    return out.reshape(cols, rows).T

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -4,6 +4,7 @@ import itertools
 import string, fnmatch
 import unicodedata
 from collections import defaultdict
+from functools import reduce
 
 import numpy as np
 import param

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -616,7 +616,7 @@ class Image(SheetCoordinateSystem, Raster):
             d1lin = np.linspace(l+d1_half_unit, r-d1_half_unit, dim1)
             d2lin = np.linspace(b+d2_half_unit, t-d2_half_unit, dim2)
             if expanded:
-                values = np.meshgrid(d2lin, d1lin)[dim_idx]
+                values = np.meshgrid(d2lin, d1lin)[abs(dim_idx-1)]
                 return values.flatten() if flat else values
             else:
                 return d2lin if dim_idx else d1lin

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -621,6 +621,8 @@ class Image(SheetCoordinateSystem, Raster):
             else:
                 return d2lin if dim_idx else d1lin
         elif dim_idx == 2:
+            # Raster arrays are stored with different orientation
+            # than expanded column format, reorient before expanding
             data = np.flipud(self.data).T
             return data.flatten() if flat else data
         else:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -174,8 +174,8 @@ class Raster(Element2D):
         elif not expanded and dim_idx == 1:
             return np.array(range(self.data.shape[0]))
         elif dim_idx in [0, 1]:
-            D1, D2 = np.mgrid[0:self.data.shape[1], 0:self.data.shape[0]]
-            return D1.flatten() if dim_idx == 0 else D2.flatten()
+            values = np.mgrid[0:self.data.shape[1], 0:self.data.shape[0]][dim_idx]
+            return values.flatten() if flat else values
         elif dim_idx == 2:
             return toarray(self.data.T).flatten()
         else:
@@ -616,8 +616,8 @@ class Image(SheetCoordinateSystem, Raster):
             d1lin = np.linspace(l+d1_half_unit, r-d1_half_unit, dim1)
             d2lin = np.linspace(b+d2_half_unit, t-d2_half_unit, dim2)
             if expanded:
-                Y, X = np.meshgrid(d2lin, d1lin)
-                return Y.flatten() if dim_idx else X.flatten()
+                values = np.meshgrid(d2lin, d1lin)[dim_idx]
+                return values.flatten() if flat else values
             else:
                 return d2lin if dim_idx else d1lin
         elif dim_idx == 2:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -129,7 +129,7 @@ class Raster(Element2D):
             sample[sample_ind] = self._coord2matrix(coord_fn(sample_coord))[abs(sample_ind-1)]
 
             # Sample data
-            x_vals = self.dimension_values(other_dimension[0].name, unique=True)
+            x_vals = self.dimension_values(other_dimension[0].name, False)
             ydata = self._zdata[sample[::-1]]
             if hasattr(self, 'bounds') and sample_ind == 0: ydata = ydata[::-1]
             data = list(zip(x_vals, ydata))
@@ -154,7 +154,7 @@ class Raster(Element2D):
             dimension = dims[0]
             other_dimension = [d for d in self.kdims if d.name != dimension]
             oidx = self.get_dimension_index(other_dimension[0])
-            x_vals = self.dimension_values(other_dimension[0].name, unique=True)
+            x_vals = self.dimension_values(other_dimension[0].name, False)
             reduced = function(self._zdata, axis=oidx)
             data = zip(x_vals, reduced if not oidx else reduced[::-1])
             params = dict(dict(self.get_param_values(onlychanged=True)),
@@ -164,14 +164,14 @@ class Raster(Element2D):
             return Table(data, **params)
 
 
-    def dimension_values(self, dim, unique=False):
+    def dimension_values(self, dim, expanded=True, flat=True):
         """
         The set of samples available along a particular dimension.
         """
         dim_idx = self.get_dimension_index(dim)
-        if unique and dim_idx == 0:
+        if not expanded and dim_idx == 0:
             return np.array(range(self.data.shape[1]))
-        elif unique and dim_idx == 1:
+        elif not expanded and dim_idx == 1:
             return np.array(range(self.data.shape[0]))
         elif dim_idx in [0, 1]:
             D1, D2 = np.mgrid[0:self.data.shape[1], 0:self.data.shape[0]]
@@ -338,20 +338,20 @@ class QuadMesh(Raster):
         super(QuadMesh, self).range(dimension)
 
 
-    def dimension_values(self, dimension, unique=False):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         idx = self.get_dimension_index(dimension)
         data = self.data[idx]
         if idx in [0, 1]:
             if not self._grid:
                 return data.flatten()
-            odim = 1 if unique else self.data[2].shape[idx]
+            odim = self.data[2].shape[idx] if expanded else 1
             vals = np.tile(np.convolve(data, np.ones((2,))/2, mode='valid'), odim)
             if idx:
                 return np.sort(vals)
             else:
                 return vals
         elif idx == 2:
-            return data.flatten()
+            return data.flatten() if flat else data
         else:
             return super(QuadMesh, self).dimension_values(idx)
 
@@ -388,8 +388,8 @@ class HeatMap(Columns, Element2D):
 
 
     def _compute_raster(self):
-        d1keys = self.dimension_values(0, True)
-        d2keys = self.dimension_values(1, True)
+        d1keys = self.dimension_values(0, False)
+        d2keys = self.dimension_values(1, False)
         coords = [(d1, d2, np.NaN) for d1 in d1keys for d2 in d2keys]
         dtype = 'dataframe' if pd else 'dictionary'
         dense_data = Columns(coords, kdims=self.kdims, vdims=self.vdims, datatype=[dtype])
@@ -438,8 +438,8 @@ class HeatMap(Columns, Element2D):
         super(HeatMap, self).__setstate__(state)
 
     def dense_keys(self):
-        d1keys = self.dimension_values(0, True)
-        d2keys = self.dimension_values(1, True)
+        d1keys = self.dimension_values(0, False)
+        d2keys = self.dimension_values(1, False)
         return list(zip(*[(d1, d2) for d1 in d1keys for d2 in d2keys]))
 
 
@@ -603,7 +603,7 @@ class Image(SheetCoordinateSystem, Raster):
         return self.sheet2matrixidx(*coord)
 
 
-    def dimension_values(self, dim, unique=False):
+    def dimension_values(self, dim, expanded=True, flat=True):
         """
         The set of samples available along a particular dimension.
         """
@@ -615,13 +615,14 @@ class Image(SheetCoordinateSystem, Raster):
             d2_half_unit = (t - b)/dim2/2.
             d1lin = np.linspace(l+d1_half_unit, r-d1_half_unit, dim1)
             d2lin = np.linspace(b+d2_half_unit, t-d2_half_unit, dim2)
-            if unique:
-                return d2lin if dim_idx else d1lin
-            else:
+            if expanded:
                 Y, X = np.meshgrid(d2lin, d1lin)
                 return Y.flatten() if dim_idx else X.flatten()
+            else:
+                return d2lin if dim_idx else d1lin
         elif dim_idx == 2:
-            return np.flipud(self.data).T.flatten()
+            data = np.flipud(self.data).T
+            return data.flatten() if flat else data
         else:
             super(Image, self).dimension_values(dim)
 
@@ -703,14 +704,15 @@ class RGB(Image):
         return rgb
 
 
-    def dimension_values(self, dim, unique=False):
+    def dimension_values(self, dim, expanded=True, flat=True):
         """
         The set of samples available along a particular dimension.
         """
         dim_idx = self.get_dimension_index(dim)
         if self.ndims <= dim_idx < len(self.dimensions()):
-            return np.flipud(self.data[:,:,dim_idx-self.ndims]).T.flatten()
-        return super(RGB, self).dimension_values(dim, unique=True)
+            data = np.flipud(self.data[:,:,dim_idx-self.ndims]).T
+            return data.flatten() if flat else data
+        return super(RGB, self).dimension_values(dim, expanded, flat)
 
 
     def __init__(self, data, **params):

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -71,7 +71,7 @@ class ItemTable(Element):
         return OrderedDict(zip(data[0].keys(), function(groups, axis=-1, **kwargs)))
 
 
-    def dimension_values(self, dimension):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         dimension = self.get_dimension(dimension, strict=True).name
         if dimension in self.dimensions('value', label=True):
             return np.array([self.data.get(dimension, np.NaN)])

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -428,8 +428,8 @@ class contours(ElementOperation):
             data = [element.data]
         
         elif isinstance(element, QuadMesh):
-            data = (element.dimension_values(0, True),
-                    element.dimension_values(1, True),
+            data = (element.dimension_values(0, False),
+                    element.dimension_values(1, False),
                     element.data[2])
         contour_set = contour_fn(*data, extent=extent,
                                  levels=self.p.levels)

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -111,7 +111,7 @@ class HeatMapPlot(RasterPlot):
     def _annotate_values(self, element):
         val_dim = element.vdims[0]
         vals = np.rot90(element.raster, 3).flatten()
-        d1uniq, d2uniq = [np.unique(element.dimension_values(i)) for i in range(2)]
+        d1uniq, d2uniq = [element.dimension_values(i, False) for i in range(2)]
         num_x, num_y = len(d1uniq), len(d2uniq)
         xstep, ystep = 1.0/num_x, 1.0/num_y
         xpos = np.linspace(xstep/2., 1.0-xstep/2., num_x)
@@ -127,7 +127,7 @@ class HeatMapPlot(RasterPlot):
 
     def _compute_ticks(self, element, ranges):
         xdim, ydim = element.kdims
-        dim1_keys, dim2_keys = [element.dimension_values(i, True)
+        dim1_keys, dim2_keys = [element.dimension_values(i, False)
                                 for i in range(2)]
         num_x, num_y = len(dim1_keys), len(dim2_keys)
         x0, y0, x1, y1 = element.extents

--- a/tests/testcolumns.py
+++ b/tests/testcolumns.py
@@ -399,3 +399,78 @@ class NdColumnsTest(HeterogeneousColumnTypes, ComparisonTestCase):
                           kdims=self.kdims, vdims=self.vdims)
         self.assertTrue(isinstance(columns.data, NdElement))
 
+
+class GridColumnsTest(HomogeneousColumnTypes, ComparisonTestCase):
+    """
+    Test of the NdColumns interface (mostly for backwards compatibility)
+    """
+
+    def setUp(self):
+        self.restore_datatype = Columns.datatype
+        Columns.datatype = ['grid']
+        self.data_instance_type = dict
+        self.init_data()
+
+    def init_data(self):
+        self.xs = range(11)
+        self.xs_2 = [el**2 for el in self.xs]
+
+        self.y_ints = [i*2 for i in range(11)]
+        self.columns_hm = Columns((self.xs, self.y_ints),
+                                  kdims=['x'], vdims=['y'])
+
+    def test_columns_array_init_hm(self):
+        "Tests support for arrays (homogeneous)"
+        exception = "None of the available storage backends "\
+         "were able to support the supplied data format."
+        with self.assertRaisesRegexp(Exception, exception):
+            Columns(np.column_stack([self.xs, self.xs_2]),
+                    kdims=['x'], vdims=['x2'])
+
+    def test_columns_dataframe_init_hm(self):
+        "Tests support for homogeneous DataFrames"
+        if pd is None:
+            raise SkipTest("Pandas not available")
+        exception = "None of the available storage backends "\
+         "were able to support the supplied data format."
+        with self.assertRaisesRegexp(Exception, exception):
+            Columns(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
+                    kdims=['x'], vdims=['x2'])
+
+    def test_columns_ndelement_init_hm(self):
+        "Tests support for homogeneous NdElement (backwards compatibility)"
+        exception = "None of the available storage backends "\
+         "were able to support the supplied data format."
+        with self.assertRaisesRegexp(Exception, exception):
+            Columns(NdElement(zip(self.xs, self.xs_2),
+                              kdims=['x'], vdims=['x2']))
+
+    def test_columns_2D_aggregate_partial_hm(self):
+        array = np.random.rand(11, 11)
+        columns = Columns({'x':self.xs, 'y':self.y_ints, 'z': array},
+                          kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(columns.aggregate(['x'], np.mean),
+                         Columns({'x':self.xs, 'z': np.mean(array, axis=1)},
+                                 kdims=['x'], vdims=['z']))
+
+    def test_columns_2D_reduce_hm(self):
+        array = np.random.rand(11, 11)
+        columns = Columns({'x':self.xs, 'y':self.y_ints, 'z': array},
+                          kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(np.array(columns.reduce(['x', 'y'], np.mean)),
+                         np.mean(array))
+
+    def test_columns_add_dimensions_value_hm(self):
+        with self.assertRaisesRegexp(Exception, 'Cannot add key dimension to a dense representation.'):
+            self.columns_hm.add_dimension('z', 1, 0)
+
+    def test_columns_add_dimensions_values_hm(self):
+        table =  self.columns_hm.add_dimension('z', 1, range(1,12), vdim=True)
+        self.assertEqual(table.vdims[1], 'z')
+        self.compare_arrays(table.dimension_values('z'), np.array(list(range(1,12))))
+
+    def test_columns_sort_vdim_hm(self):
+        exception = 'Dense representation cannot be sorted, either instantiate '\
+                    'in the desired order or use a sparse format.'
+        with self.assertRaisesRegexp(Exception, exception):
+            self.columns_hm.sort('y')

--- a/tests/testcolumns.py
+++ b/tests/testcolumns.py
@@ -470,7 +470,8 @@ class GridColumnsTest(HomogeneousColumnTypes, ComparisonTestCase):
         self.compare_arrays(table.dimension_values('z'), np.array(list(range(1,12))))
 
     def test_columns_sort_vdim_hm(self):
-        exception = 'Dense representation cannot be sorted, either instantiate '\
-                    'in the desired order or use a sparse format.'
+        exception = ('Compressed format cannot be sorted, either instantiate '
+                     'in the desired order or use the expanded format.')
         with self.assertRaisesRegexp(Exception, exception):
             self.columns_hm.sort('y')
+

--- a/tests/testcolumns.py
+++ b/tests/testcolumns.py
@@ -176,8 +176,8 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
 
     # Test literal formats
 
-    def test_columns_uniq_dimvals_ht(self):
-        self.assertEqual(self.table.dimension_values('Gender', unique=True),
+    def test_columns_expanded_dimvals_ht(self):
+        self.assertEqual(self.table.dimension_values('Gender', expanded=False),
                          np.array(['M', 'F']))
 
     def test_columns_implicit_indexing_init(self):


### PR DESCRIPTION
In HoloViews we now have an interface to hold data in a columnar format. This is provides a very powerful interface for some kinds of data, however when exploring dense high-dimensional arrays it is wasteful because it expands the coordinates of the key dimensions. An alternative format used by xarray, iris and in some limited ways pandas, stores the index values or coordinates (as they are sometimes called) separately from the value dimension data, which is stored as an n-dimensional array.

Instead of storing the cartesian product of all key dimension values we store only the outer indices. Often working in a Columnar format is a lot easier because merging or adding new or derived dimensions is considerably easier, however it is not only inefficient in terms of space but is also considerably slower for various operations, particularly for groupby, aggregation and reduce operations.

### The proposal

The HoloViews Columns interface actually provides a very general interface to work with structured data and in theory it does not actually restrict the format of the data. In this notebook I will outline a suggestion to add additional interfaces for the Columns type, which works with N-D gridded from hereon referred to as dense data. I will set out to show that not only is this format more efficient for various operations but the implementation is actually fairly simple and fits into our current system.

##### The datastructure

The current Columns interfaces already have different datastructures, which all fundamentally represent an array of the shape``Row x Column``, where the rows represent the total number of samples and the columns the combined key and value dimensions, this is fundamentally no different to the COO (Coordinate) sparse matrix format (except the r, c indices are actually values). The new format would provide a dense equivalent and would differ from these existing implementations in the following ways:

1) The data would clearly distinguish between key dimensions, which provide the indices/coordinates to index into the value dimensions, and how the actual value dimensions are stored, some example data would look like this:

```python
hv.Table({'x': range(10), 'y': range(100), 'z': np.random.rand(10, 100)},
         kdims=['x', 'y'], vdims=['z'])
```

Here the x and y arrays provide the indexes along the first and second axis of the z-array. Using the current formats this would have to be specified as:

```python
xs, ys = np.meshgrid(range(10), range(100))
hv.Table({'x': xs, 'y': ys, 'z': np.random.rand(10, 100)}, kdims=['x', 'y'], vdims=['z'])
```

Instead of storing the cartesian product as computed by meshgrid, the internal representation stores just the outer indices. The interface then expands these indices if required (which would generally be pretty rare).

2) There are two possible ways to represent value dimensions, either we can have one array for all value dimensions which simply stacks the arrays or we can expand the value dimensions out into the separate arrays, i.e. multiple value dimensions could be specified like this:

```python
hv.Table({'x': range(10), 'y': range(100), 'array': np.random.rand(10, 100, 2)}, kdims=['x', 'y'], vdims=['a', 'b'])
```

or like this:

```python
hv.Table({'x': range(10), 'y': range(100), 'a': np.random.rand(10, 100), 'b': np.random.rand(10, 100)},
         kdims=['x', 'y'], vdims=['a', 'b'])
```

This comes down to whether the interface should support heterogeneous value dimension types. The current proposal works on the first suggestion but it would be trivial to automatically expand the first format into the second format and store the value dimensions separately internally.


## Pros vs Cons

Pros:

+ More memory efficient
+ Considerably faster for gridded data
+ Columns and Raster types would share the same interface, the only other data structures required would be for Annotations and Paths.
+ Avoids having two completely separate implementations for gridded data and columnar data, which is important because even our current Chart types could sometimes benefit from a denser representation.
+ Provides a template for further interfaces based on xarray and iris Cubes.

Cons:

- Requires some changes to existing interfaces to access both the expanded and compressed formats easily.
- Columns becomes a misnomer (not a major obstacle since renaming baseclasses is easy).
- Gridded data is more restricted than columnar data, so value dimension indexing and swapping key and value dimensions is not directly supported.


## Obstacles/Problems

* Need to establish clear interfaces to access the dimension values both in the expanded cartesian product format and in the dense format. I would propose that ``dimension_values`` accepts a ``product`` argument (or similar) that defaults to ``False`` returning the full cartesian product by default. Additionally it would also support a ``flat`` argument defaulting to ``True`` to retain a consistent backward compatible interface. 
* Consider how to deal with Raster and Image types where the key dimension values are implicit. My current suggestion would be either to generate the coordinates in the constructor or to introduce proxy objects, which lazily compute the indexes, e.g. to describe an Image you could do something like:

```python
hv.Image({'x': BoundCoords(-0.5, 0.5, 100), 'y': BoundCoords(-0.5, 0.5, 100), 'z': np.random.rand(100, 100)})
```

* Gridded data would be more restricted than Columnar data, e.g. before slicing value dimensions or reindexing the Element it would first have to be converted to the expanded format.
* Since the sparse and dense representation have potentially overlapping signatures I believe it should be a parameter on the Columns object, you should explicitly declare that the data you are passing in is dense and the dense backends will try to parse that data.
* We can have ``as_dense`` and ``as_sparse`` methods that convert between dense and sparse representations. The as_sparse representation is obviously very straightforward as it's just the cartesian product of the dense representation. The ``as_dense`` implementation requires that the data has been aggregated already. After that it's most easily implemented by combining the sparse columns with a cartesian product of the key dimensions inserting NaNs for all values, aggregating, sorting and reshaping.
* Certain methods when applied to a dense Element return a sparse representation (currently only sample would do so).

To-do list:

- [x] Establish API for accessing data in column based and array based formats using ``dimension_values`` (interface proposed in #541 postponed).
- [x] Complete the interface by deciding whether to support sorting or whether dense sorting should be fixed. (Require sorted key data in constructor for now)
- [x] Adapt HeatMap to support both formats (postponed)
- [x] Decide what to do about Raster and Image key dimensions values (postponed).
- [x] Decide whether to implement Histogram and QuadMesh using the interface (postponed).
- [x] Add unit tests
- [x] Update docstrings

[Notebook with examples and profiling](https://github.com/ioam/holoviews/issues/541)