### PR TITLE
Open Dynamic and Scrubber fixes

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -488,7 +488,7 @@ class DynamicMap(HoloMap):
 
         if isinstance(retval, tuple):
             self._validate_key(retval[0]) # Validated output key
-            return self._style(retval)
+            return (retval[0], self._style(retval[1]))
         else:
             self._validate_key((self.counter,))
             return (self.counter, self._style(retval))

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -204,7 +204,7 @@ class MPLRenderer(Renderer):
         if extra_args != []:
             anim_kwargs = dict(anim_kwargs, extra_args=extra_args)
 
-        if self.fps is not None: anim_kwargs['fps'] = self.fps
+        if self.fps is not None: anim_kwargs['fps'] = max(int(self.fps), 1)
         if self.dpi is not None: anim_kwargs['dpi'] = self.dpi
         if not hasattr(anim, '_encoded_video'):
             with NamedTemporaryFile(suffix='.%s' % fmt) as f:

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -204,7 +204,7 @@ class MPLRenderer(Renderer):
         if extra_args != []:
             anim_kwargs = dict(anim_kwargs, extra_args=extra_args)
 
-        if self.fps is not None: anim_kwargs['fps'] = max(int(self.fps), 1)
+        if self.fps is not None: anim_kwargs['fps'] = max([int(self.fps), 1])
         if self.dpi is not None: anim_kwargs['dpi'] = self.dpi
         if not hasattr(anim, '_encoded_video'):
             with NamedTemporaryFile(suffix='.%s' % fmt) as f:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -520,11 +520,14 @@ class GenericElementPlot(DimensionedPlot):
                         if d in self.hmap.kdims}
                 frame = self.hmap.select([DynamicMap], **dims)
             elif key < self.hmap.counter:
-                key = self.hmap.keys()[key]
+                key_offset = max([key-self.hmap.cache_size, 0])
+                key = self.hmap.keys()[min([key-key_offset, len(self.hmap)-1])]
                 frame = self.hmap[key]
             elif key >= self.hmap.counter:
                 frame = next(self.hmap)
                 key = self.hmap.keys()[-1]
+            else:
+                frame = None
             if not isinstance(key, tuple): key = (key,)
             if not key in self.keys:
                 self.keys.append(key)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -88,7 +88,7 @@ class Renderer(Exporter):
         Output render format for static figures. If None, no figure
         rendering will occur. """)
 
-    fps=param.Integer(20, doc="""
+    fps=param.Number(20, doc="""
         Rendered fps (frames per second) for animated formats.""")
 
     holomap = param.ObjectSelector(default='auto',

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -199,7 +199,7 @@ class Renderer(Exporter):
                 fmt = holomap_formats[0] if self.holomap=='auto' else self.holomap
 
         if fmt in self.widgets:
-            plot = self.get_widget(plot, fmt)
+            plot = self.get_widget(plot, fmt, display_options={'fps': self.fps})
             fmt = 'html'
 
         all_formats = set(fig_formats + holomap_formats)

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -153,7 +153,12 @@ ScrubberWidget.prototype = new HoloViewsWidget;
 
 ScrubberWidget.prototype.set_frame = function(frame){
     this.current_frame = frame;
-    document.getElementById(this.slider_id).value = this.current_frame;
+    widget = document.getElementById(this.slider_id);
+    if (widget === null) {
+        this.pause_animation();
+        return
+    }
+    widget.value = this.current_frame;
     if(this.cached) {
         this.update(frame)
     } else {


### PR DESCRIPTION
This issue fixes various bugs when in DynamicMap ``open`` mode, ensuring that events stop when the cell is deleted and ensuring that the correct frame is accessed when individual callbacks fail and when frames are dropped out of the cache. Also allows non-integer ``fps`` values for widgets for infrequent polling.