### PR TITLE
Fixed setting of aspect on log axes

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -169,6 +169,10 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                     axis.xaxis.grid(self.show_grid)
                     axis.yaxis.grid(self.show_grid)
 
+
+                # Apply aspects
+                self._set_aspect(axis, self.aspect)
+
                 # Apply log axes
                 if self.logx:
                     axis.set_xscale('log')
@@ -182,10 +186,6 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 # Apply ticks
                 if self.apply_ticks:
                     self._finalize_ticks(axis, dimensions, xticks, yticks, zticks)
-
-            # Apply aspects
-            if not (self.logx or self.logy):
-                self._set_aspect(axis, self.aspect)
 
         if not subplots and not self.drawn:
             self._finalize_artist(key)


### PR DESCRIPTION
Previously setting of aspects on plots with log axes was not working so I just disabled it. However I just found out through an issue brought up by @basnijholt that this is merely because aspects have to be set before the axes have had log scaling applied. This PR simply changes the order in which these settings are applied.