### PR TITLE
Fixed generator generator check on DataColumns

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -424,8 +424,7 @@ class DataColumns(param.Parameterized):
             data = data.data
         elif isinstance(data, Element):
             data = tuple(data.dimension_values(d) for d in kdims+vdims)
-        elif (not (util.is_dataframe(data) or isinstance(data, (tuple, dict, np.ndarray, list)))
-              and sys.version_info.major >= 3):
+        elif isinstance(data, util.generator_types):
             data = list(data)
 
         # Set interface priority order

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -30,12 +30,16 @@ except ImportError:
     bz = None
 
 # Python3 compatibility
+import types
 if sys.version_info.major == 3:
     basestring = str
     unicode = str
+    generator_types = (zip, range, types.GeneratorType)
 else:
     basestring = basestring
     unicode = unicode
+    from itertools import izip
+    generator_types = (izip, xrange, types.GeneratorType)
 
 
 def process_ellipses(obj, key, vdim_selection=False):


### PR DESCRIPTION
The check to expand ``zip``, ``range`` and generator expressions on Columns relied on excluding other types rather than checking explicitly for those types. This explicitly checks for (i)zip, (x)range and generator types across python versions.