### PR TITLE
Simplified cartesian_product utility

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1429,9 +1429,8 @@ class GridColumns(DictColumns):
                 return columns.data[dim]
             prod = util.cartesian_product([columns.data[d.name] for d in columns.kdims])
             idx = columns.get_dimension_index(dim)
-            values = prod[:, idx]
-            shape = tuple(len(columns.data[d]) for d in columns.dimensions('key', True))
-            return values if flat else values.reshape(shape)
+            values = prod[idx]
+            return values.flatten() if flat else values
         else:
             dim = columns.get_dimension(dim)
             values = columns.data.get(dim.name)
@@ -1457,7 +1456,7 @@ class GridColumns(DictColumns):
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
-        for unique_key in util.cartesian_product(keys):
+        for unique_key in zip(util.cartesian_product(keys)):
             group_data = cls.select(columns, **dict(zip(dim_names, unique_key)))
             for vdim in columns.vdims:
                 group_data[vdim.name] = np.squeeze(group_data[vdim.name])

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -868,14 +868,8 @@ class ndmapping_groupby(param.ParameterizedFunction):
 
 def cartesian_product(arrays):
     """
-    Computes the cartesian product of a list of arrays.
+    Computes the cartesian product of a list of 1D arrays
+    returning arrays matching the shape defined by all
+    supplied dimensions.
     """
-    broadcastable = np.ix_(*arrays)
-    broadcasted = np.broadcast_arrays(*broadcastable)
-    rows, cols = reduce(np.multiply, broadcasted[0].shape), len(broadcasted)
-    out = np.empty(rows * cols, dtype=broadcasted[0].dtype)
-    start, end = 0, rows
-    for a in broadcasted:
-        out[start:end] = a.reshape(-1)
-        start, end = end, end + rows
-    return out.reshape(cols, rows).T
+    return np.broadcast_arrays(*np.ix_(*arrays))


### PR DESCRIPTION
As the title says this greatly simplifies the ``cartesian_product`` utility now returning arrays for each dimension in the shape defined by the dimension values.