### PR TITLE
Various small fixes for GridColumns

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1390,9 +1390,9 @@ class GridColumns(DictColumns):
         for vdim in vdim_names:
             shape = data[vdim].shape
             if shape != tuple(expected):
-                raise ValueError('Key dimension values and value array %s'
+                raise ValueError('Key dimension values and value array %s '
                                  'shape do not match. Expected shape %s, '
-                                 'actual shape: %s' % (expected, vdim, shape))
+                                 'actual shape: %s' % (vdim, expected, shape))
         return data, kdims, vdims
 
 

--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1456,7 +1456,7 @@ class GridColumns(DictColumns):
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
-        for unique_key in zip(util.cartesian_product(keys)):
+        for unique_key in zip(*util.cartesian_product(keys)):
             group_data = cls.select(columns, **dict(zip(dim_names, unique_key)))
             for vdim in columns.vdims:
                 group_data[vdim.name] = np.squeeze(group_data[vdim.name])

--- a/tests/testcolumns.py
+++ b/tests/testcolumns.py
@@ -475,3 +475,6 @@ class GridColumnsTest(HomogeneousColumnTypes, ComparisonTestCase):
         with self.assertRaisesRegexp(Exception, exception):
             self.columns_hm.sort('y')
 
+
+    def test_columns_groupby(self):
+        self.assertEqual(self.columns_hm.groupby('x').keys(), list(self.xs))


### PR DESCRIPTION
Some small bugs snuck in when I was cleaning up GridColumns before it was merged in #542. I've addressed those bugs, improved error handling and added a unit test for groupby operations. I've also made sure that the GridColumns interface handles 0D or scalar data to ensure that groupby operations work even one a 1D GridColumns object.