### PR TITLE
Widget values now use value formatter

### DIFF
--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -296,6 +296,9 @@ class SelectionWidget(NdWidget):
                 else:
                     next_vals = {}
 
+                value_labels = escape_list(escape_vals([dim.pprint_value(v)
+                                                        for v in dim_vals]))
+
                 if isnumeric(dim_vals[0]):
                     dim_vals = [round(v, 10) for v in dim_vals]
                     if next_vals:
@@ -317,7 +320,7 @@ class SelectionWidget(NdWidget):
             widget_data = dict(dim=dimension_sanitizer(dim_str), dim_label=dim_str,
                                dim_idx=idx, vals=dim_vals, type=widget_type,
                                visibility=visibility, step=step, next_dim=next_dim,
-                               next_vals=next_vals)
+                               next_vals=next_vals, labels=value_labels)
 
             widgets.append(widget_data)
             dimensions.append(dim_str)

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -7,7 +7,7 @@ import param
 from ...core import OrderedDict, NdMapping
 from ...core.options import Store
 from ...core.util import (dimension_sanitizer, safe_unicode,
-                          unique_iterator, unicode, isnumeric)
+                          unique_array, unicode, isnumeric)
 from ...core.traversal import hierarchical
 
 def escape_vals(vals, escape_numerics=True):
@@ -289,7 +289,7 @@ class SelectionWidget(NdWidget):
                     dim_vals = next_vals[init_dim_vals[idx-1]]
                 else:
                     dim_vals = (dim.values if dim.values else
-                                list(unique_iterator(self.mock_obj.dimension_values(dim.name))))
+                                list(unique_array(self.mock_obj.dimension_values(dim.name))))
                 if idx < self.mock_obj.ndims-1:
                     next_vals = hierarchy[idx]
                     next_dim = safe_unicode(self.mock_obj.kdims[idx+1])

--- a/holoviews/plotting/widgets/jsslider.css
+++ b/holoviews/plotting/widgets/jsslider.css
@@ -4,6 +4,10 @@ div.hololayout {
     margin: 0;
 }
 
+div.holoframe {
+	width: 75%;
+}
+
 div.holowell {
     display: flex;
     align-items: center;
@@ -49,4 +53,8 @@ div.hologroup {
     width: 100%;
     padding-left:  0.5em;
     padding-right: 0;
+}
+
+.ui-resizable-se {
+	visibility: hidden
 }

--- a/holoviews/plotting/widgets/jsslider.css
+++ b/holoviews/plotting/widgets/jsslider.css
@@ -26,6 +26,7 @@ form.holoform {
 
 div.holowidgets {
     padding-right: 0;
+	width: 25%;
 }
 
 div.holoslider {

--- a/holoviews/plotting/widgets/jsslider.css
+++ b/holoviews/plotting/widgets/jsslider.css
@@ -59,3 +59,7 @@ div.hologroup {
 .ui-resizable-se {
 	visibility: hidden
 }
+
+.ui-resizable-s {
+	visibility: hidden
+}

--- a/holoviews/plotting/widgets/jsslider.css
+++ b/holoviews/plotting/widgets/jsslider.css
@@ -14,7 +14,10 @@ form.holoform {
     background-color: #fafafa;
     border-radius: 5px;
     overflow: hidden;
-    padding: 0.8em;
+	padding-left: 0.8em;
+    padding-right: 0.8em;
+    padding-top: 0.4em;
+    padding-bottom: 0.4em;
 }
 
 div.holowidgets {
@@ -27,14 +30,13 @@ div.holoslider {
 }
 
 div.holoformgroup {
-    padding-right: 0.5em;
     padding-top: 0.5em;
     margin-bottom: 0.5em;
 }
 
 div.hologroup {
     padding-left: 0;
-    padding-right: 0;
+    padding-right: 0.8em;
 }
 
 .holoselect {

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -17,7 +17,7 @@
         <div class="holowell row row-fluid">
           <div class="hologroup col-xs-4 span4">
             <input type="text" class="holotext form-control input-small"
-                   id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" disabled>
+                   id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" readonly>
           </div>
           <div class="holoslider span7 offset1 col-xs-7 col-xs-offset-1"
                id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -71,6 +71,7 @@
                         require(["jQueryUI", "underscore"], function(jUI, _){
                             if (noConflict) $.noConflict(true);
                             var vals = {{ widget_data['vals'] }};
+                            var labels = {{ widget_data['labels'] }};
                             var next_vals = {{ widget_data['next_vals'] }};
                             if ({{ dynamic }} && vals.constructor === Array) {
                                 var min = parseFloat(vals[0]);
@@ -93,16 +94,18 @@
                                 step: step,
                                 value: min,
                                 dim_vals: vals,
+                                dim_labels: labels,
                                 next_vals: next_vals,
                                 slide: _.throttle(function(event, ui) {
                                     var vals = slider.slider("option", "dim_vals");
                                     var next_vals = slider.slider("option", "next_vals");
+                                    var labels = slider.slider("option", "dim_labels");
                                     if ({{ dynamic }} && vals.constructor === Array) {
                                         var dim_val = ui.value;
                                     } else {
                                         var dim_val = vals[ui.value];
                                     }
-									$('#textInput{{ id }}_{{ widget_data['dim'] }}').val((dim_val*1).toString());
+									$('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[ui.value]);
                                     anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
                                     if (Object.keys(next_vals).length > 0) {
                                         var new_vals = next_vals[dim_val];
@@ -141,7 +144,7 @@
                                     }
                                 }
                             });
-                            $('#textInput{{ id }}_{{ widget_data['dim'] }}').val((vals[0]*1).toString());
+                            $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[0]);
                         });
 						// Slider JS Block END
                     </script>
@@ -153,16 +156,18 @@
                     </div>
                     <script>
                         var vals = {{ widget_data['vals'] }};
+                        var labels = {{ widget_data['labels'] }};
                         var widget = $("#_anim_widget{{ id }}_{{ widget_data['dim'] }}");
+                        widget.data('values', vals)
                         for (var i=0; i<vals.length; i++){
                             widget.append($("<option>", {
                                 value: i,
-                                text: vals[i]
+                                text: labels[i]
                             }));
                         };
                         widget.data("next_vals", {{ widget_data['next_vals'] }});
                         widget.on('change', function(event, ui) {
-                            var dim_val = this.options[this.value].text;
+                            var dim_val = $.data(this, 'values')[this.value];
                             if(anim{{ id }}) {
                                 anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
                             }

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -88,6 +88,11 @@
                 }
                 var step = 1;
             }
+			function adjustFontSize(text) {
+				if (text.val().length > 10) {
+					text.css('font-size', 100-Math.min(text.val().length*2.4, 50)+'%');
+				}
+			}
             var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
             slider.slider({
                 animate: "fast",
@@ -107,7 +112,9 @@
                     } else {
                         var dim_val = vals[ui.value];
                     }
-                    $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[ui.value]);
+					var text = $('#textInput{{ id }}_{{ widget_data['dim'] }}');
+					text.val(labels[ui.value]);
+					adjustFontSize(text);
                     anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
                     if (Object.keys(next_vals).length > 0) {
                         var new_vals = next_vals[dim_val];
@@ -144,7 +151,9 @@
                     }
                 }
             });
-            $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[0]);
+			var textInput = $('#textInput{{ id }}_{{ widget_data['dim'] }}')
+			textInput.val(labels[0]);
+			adjustFontSize(textInput);
         });
         // Slider JS Block END
         </script>

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -1,13 +1,13 @@
 <div class="hololayout row row-fluid">
-  <div class="holoframe span9 col-xs-8 col-md-9">
+  <div class="holoframe" id="display_area{{ id }}">
     <div id="_anim_img{{ id }}">
       {% block init_frame %}
       {{ init_frame }}
       {% endblock %}
     </div>
   </div>
-  <div class="span3 col-xs-4 col-md-3">
-    <form class="holoform well">
+  <div id="widget_area{{ id }}">
+    <form class="holoform well" id="form{{ id }}">
       {% for widget_data in widgets %}
       {% if widget_data['type'] == 'slider' %}
       <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
@@ -24,6 +24,12 @@
         </div>
       </div>
 	  <script>
+        $("#display_area{{ id }}").resizable({
+		    resize: function(event, ui) {
+			    $("#widget_area{{ id }}").width($(this).parent().width()-ui.size.width);
+		    }
+	    });
+        $("#widget_area{{ id }}").resizable()
         // Slider JS Block START
         function loadcssfile(filename){
             var fileref=document.createElement("link")

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -24,12 +24,6 @@
         </div>
       </div>
 	  <script>
-        $("#display_area{{ id }}").resizable({
-		    resize: function(event, ui) {
-			    $("#widget_area{{ id }}").width($(this).parent().width()-ui.size.width);
-		    }
-	    });
-        $("#widget_area{{ id }}").resizable()
         // Slider JS Block START
         function loadcssfile(filename){
             var fileref=document.createElement("link")
@@ -205,6 +199,14 @@
 /* Instantiate the {{ widget_name }} class. */
 /* The IDs given should match those used in the template above. */
 (function() {
+	if (jQuery.ui !== undefined) {
+		$("#display_area{{ id }}").resizable({
+			resize: function(event, ui) {
+				$("#widget_area{{ id }}").width($(this).parent().width()-ui.size.width);
+			}
+		});
+		$("#widget_area{{ id }}").resizable();
+	}
     var widget_ids = new Array({{ Nwidget }});
     {% for dim in dimensions %}
     widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -15,11 +15,11 @@
           <strong>{{ widget_data['dim_label'] }}:</strong>
         </label>
         <div class="holowell row row-fluid">
-          <div class="hologroup col-xs-4 span4">
+          <div class="hologroup col-xs-5">
             <input type="text" class="holotext form-control input-small"
                    id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" readonly>
           </div>
-          <div class="holoslider span7 offset1 col-xs-7 col-xs-offset-1"
+          <div class="holoslider col-xs-7"
                id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>
         </div>
       </div>

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -6,7 +6,7 @@
       {% endblock %}
     </div>
   </div>
-  <div id="widget_area{{ id }}">
+  <div class="holowidgets" id="widget_area{{ id }}">
     <form class="holoform well" id="form{{ id }}">
       {% for widget_data in widgets %}
       {% if widget_data['type'] == 'slider' %}

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -89,9 +89,12 @@
                 var step = 1;
             }
 			function adjustFontSize(text) {
-				if (text.val().length > 10) {
-					text.css('font-size', 100-Math.min(text.val().length*2.4, 50)+'%');
+				if (text.val().length > 8) {
+				    size = 100-Math.min(text.val().length*2.5, 50)+'%';
+				} else {
+				    size= '100%';
 				}
+				text.css('font-size', size);
 			}
             var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
             slider.slider({

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -95,11 +95,8 @@
                 var step = 1;
             }
 			function adjustFontSize(text) {
-				if (text.val().length > 8) {
-				    size = 100-Math.min(text.val().length*2.5, 50)+'%';
-				} else {
-				    size= '100%';
-				}
+				var width_ratio = (text.parent().width()/8)/text.val().length;
+				var size = Math.min(0.9, Math.max(0.6, width_ratio))+'em';
 				text.css('font-size', size);
 			}
             var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -1,214 +1,212 @@
 <div class="hololayout row row-fluid">
-    <div class="holoframe span9 col-xs-8 col-md-9">
-        <div id="_anim_img{{ id }}">
-            {% block init_frame %}
-                {{ init_frame }}
-            {% endblock %}
-        </div>
+  <div class="holoframe span9 col-xs-8 col-md-9">
+    <div id="_anim_img{{ id }}">
+      {% block init_frame %}
+      {{ init_frame }}
+      {% endblock %}
     </div>
-    <div class="span3 col-xs-4 col-md-3">
-        <form class="holoform well">
-            {% for widget_data in widgets %}
-                {% if widget_data['type'] == 'slider' %}
-                    <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
-                        <label for="textInput{{ id }}_{{ widget_data['dim'] }}">
-                            <strong>{{ widget_data['dim_label'] }}:</strong>
-                        </label>
-                        <div class="holowell row row-fluid">
-                            <div class="hologroup col-xs-4 span4">
-                                <input type="text" class="holotext form-control input-small"
-                                       id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" disabled>
-                            </div>
-                            <div class="holoslider span7 offset1 col-xs-7 col-xs-offset-1"
-                                 id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>
-                        </div>
-                    </div>
-                    <script>
-                        // Slider JS Block START
-                        function loadcssfile(filename){
-                            var fileref=document.createElement("link")
-                            fileref.setAttribute("rel", "stylesheet")
-                            fileref.setAttribute("type", "text/css")
-                            fileref.setAttribute("href", filename)
-                            document.getElementsByTagName("head")[0].appendChild(fileref)
-                        }
-                        loadcssfile("https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css");
-                        /* Check if jQuery and jQueryUI have been loaded
-                         otherwise load with require.js */
-                        var jQuery = window.jQuery,
-                        // check for old versions of jQuery
-                                oldjQuery = jQuery && !!jQuery.fn.jquery.match(/^1\.[0-4](\.|$)/),
-                                jquery_path = '',
-                                paths = {},
-                                noConflict;
-                        var jQueryUI = jQuery.ui;
-                        // check for jQuery
-                        if (!jQuery || oldjQuery) {
-                            // load if it's not available or doesn't meet min standards
-                            paths.jQuery = jQuery;
-                            noConflict = !!oldjQuery;
-                        } else {
-                            // register the current jQuery
-                            define('jquery', [], function() { return jQuery; });
-                        }
-                        if (!jQueryUI) {
-                            paths.jQueryUI = "{{ CDN['jQueryUI'] }}"
-                        } else {
-                            define('jQueryUI', [], function() { return jQuery.ui; });
-                        }
-                        paths.underscore = "{{ CDN['underscore'] }}";
-                        var jquery_require = {paths: paths,
-                            shim: {
-                                "jQueryUI": {
-                                    exports:"$",
-                                    deps: ['jquery']
-                                },
-                                "underscore": {
-                                    exports: '_'
-                                }
-                            }}
-                        require.config(jquery_require);
-                        require(["jQueryUI", "underscore"], function(jUI, _){
-                            if (noConflict) $.noConflict(true);
-                            var vals = {{ widget_data['vals'] }};
-                            var labels = {{ widget_data['labels'] }};
-                            var next_vals = {{ widget_data['next_vals'] }};
-                            if ({{ dynamic }} && vals.constructor === Array) {
-                                var min = parseFloat(vals[0]);
-                                var max = parseFloat(vals[vals.length-1]);
-                                var step = {{ widget_data['step'] }};
-                            } else {
-                                var min = 0;
-								if ({{ dynamic }}) {
-                                   var max = Object.keys(vals).length - 1;
-								} else {
-								   var max = vals.length - 1;
-								}
-                                var step = 1;
-                            }
-                            var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
-                            slider.slider({
-                                animate: "fast",
-                                min: min,
-                                max: max,
-                                step: step,
-                                value: min,
-                                dim_vals: vals,
-                                dim_labels: labels,
-                                next_vals: next_vals,
-                                slide: _.throttle(function(event, ui) {
-                                    var vals = slider.slider("option", "dim_vals");
-                                    var next_vals = slider.slider("option", "next_vals");
-                                    var labels = slider.slider("option", "dim_labels");
-                                    if ({{ dynamic }} && vals.constructor === Array) {
-                                        var dim_val = ui.value;
-                                    } else {
-                                        var dim_val = vals[ui.value];
-                                    }
-									$('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[ui.value]);
-                                    anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
-                                    if (Object.keys(next_vals).length > 0) {
-                                        var new_vals = next_vals[dim_val];
-                                        var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
-                                        update_widget(next_widget, new_vals);
-									}
-                                }, {{ throttle }})
-                            });
-                            slider.keypress(function(event) {
-                                if (event.which == 80 || event.which == 112) {
-                                    var start = slider.slider("option", "value");
-                                    var stop =  slider.slider("option", "max");
-                                    for (var i=start; i<=stop; i++) {
-                                        var delay = i*{{ delay }};
-                                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
-                                            var val = {value:i};
-                                            slider.slider('value',i);
-                                            slider.slider("option", "slide")(null, val);
-                                        }, slider), delay);
-                                        }, slider)(i);
-                                    }
-                                }
-                                if (event.which == 82 || event.which == 114) {
-                                    var start = slider.slider("option", "value");
-                                    var stop =  slider.slider("option", "min");
-                                    var count = 0;
-                                    for (var i=start; i>=stop; i--) {
-                                        var delay = count*{{ delay }};
-                                        count = count + 1;
-                                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
-                                            var val = {value:i};
-                                            slider.slider('value',i);
-                                            slider.slider("option", "slide")(null, val);
-                                        }, slider), delay);
-                                        }, slider)(i);
-                                    }
-                                }
-                            });
-                            $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[0]);
-                        });
-						// Slider JS Block END
-                    </script>
-                {% elif widget_data['type']=='dropdown' %}
-                    <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
-                        <label for="textInput{{ id }}_{{ widget_data['dim'] }}"><strong>{{ widget_data['dim_label'] }}:</strong></label>
-                        <select class="holoselect form-control" id="_anim_widget{{ id }}_{{ widget_data['dim'] }}" >
-                        </select>
-                    </div>
-                    <script>
-                        var vals = {{ widget_data['vals'] }};
-                        var labels = {{ widget_data['labels'] }};
-                        var widget = $("#_anim_widget{{ id }}_{{ widget_data['dim'] }}");
-                        widget.data('values', vals)
-                        for (var i=0; i<vals.length; i++){
-                            widget.append($("<option>", {
-                                value: i,
-                                text: labels[i]
-                            }));
-                        };
-                        widget.data("next_vals", {{ widget_data['next_vals'] }});
-                        widget.on('change', function(event, ui) {
-                            var dim_val = $.data(this, 'values')[this.value];
-                            if(anim{{ id }}) {
-                                anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
-                            }
-							var next_vals = $.data(this, "next_vals");
-							if (Object.keys(next_vals).length > 0) {
-                                var new_vals = next_vals[dim_val];
-                                var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
-                                update_widget(next_widget, new_vals);
-							}
-                        });
-                    </script>
-                {% endif %}
-            {% endfor %}
+  </div>
+  <div class="span3 col-xs-4 col-md-3">
+    <form class="holoform well">
+      {% for widget_data in widgets %}
+      {% if widget_data['type'] == 'slider' %}
+      <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
+        <label for="textInput{{ id }}_{{ widget_data['dim'] }}">
+          <strong>{{ widget_data['dim_label'] }}:</strong>
+        </label>
+        <div class="holowell row row-fluid">
+          <div class="hologroup col-xs-4 span4">
+            <input type="text" class="holotext form-control input-small"
+                   id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" disabled>
+          </div>
+          <div class="holoslider span7 offset1 col-xs-7 col-xs-offset-1"
+               id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>
+        </div>
+      </div>
+	  <script>
+        // Slider JS Block START
+        function loadcssfile(filename){
+            var fileref=document.createElement("link")
+            fileref.setAttribute("rel", "stylesheet")
+            fileref.setAttribute("type", "text/css")
+            fileref.setAttribute("href", filename)
+            document.getElementsByTagName("head")[0].appendChild(fileref)
+        }
+        loadcssfile("https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css");
+        /* Check if jQuery and jQueryUI have been loaded
+           otherwise load with require.js */
+        var jQuery = window.jQuery,
+            // check for old versions of jQuery
+            oldjQuery = jQuery && !!jQuery.fn.jquery.match(/^1\.[0-4](\.|$)/),
+            jquery_path = '',
+            paths = {},
+            noConflict;
+        var jQueryUI = jQuery.ui;
+        // check for jQuery
+        if (!jQuery || oldjQuery) {
+            // load if it's not available or doesn't meet min standards
+            paths.jQuery = jQuery;
+            noConflict = !!oldjQuery;
+        } else {
+            // register the current jQuery
+            define('jquery', [], function() { return jQuery; });
+        }
+        if (!jQueryUI) {
+            paths.jQueryUI = "{{ CDN['jQueryUI'] }}"
+        } else {
+            define('jQueryUI', [], function() { return jQuery.ui; });
+        }
+        paths.underscore = "{{ CDN['underscore'] }}";
+        var jquery_require = {
+            paths: paths,
+            shim: {
+                "jQueryUI": {
+                    exports:"$",
+                    deps: ['jquery']
+                },
+                "underscore": {
+                    exports: '_'
+                }
+            }
+        }
+        require.config(jquery_require);
+        require(["jQueryUI", "underscore"], function(jUI, _){
+            if (noConflict) $.noConflict(true);
+            var vals = {{ widget_data['vals'] }};
+            var labels = {{ widget_data['labels'] }};
+            var next_vals = {{ widget_data['next_vals'] }};
+            if ({{ dynamic }} && vals.constructor === Array) {
+                var min = parseFloat(vals[0]);
+                var max = parseFloat(vals[vals.length-1]);
+                var step = {{ widget_data['step'] }};
+            } else {
+                var min = 0;
+                if ({{ dynamic }}) {
+                    var max = Object.keys(vals).length - 1;
+                } else {
+                    var max = vals.length - 1;
+                }
+                var step = 1;
+            }
+            var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
+            slider.slider({
+                animate: "fast",
+                min: min,
+                max: max,
+                step: step,
+                value: min,
+                dim_vals: vals,
+                dim_labels: labels,
+                next_vals: next_vals,
+                slide: _.throttle(function(event, ui) {
+                    var vals = slider.slider("option", "dim_vals");
+                    var next_vals = slider.slider("option", "next_vals");
+                    var labels = slider.slider("option", "dim_labels");
+                    if ({{ dynamic }} && vals.constructor === Array) {
+                        var dim_val = ui.value;
+                    } else {
+                        var dim_val = vals[ui.value];
+                    }
+                    $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[ui.value]);
+                    anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
+                    if (Object.keys(next_vals).length > 0) {
+                        var new_vals = next_vals[dim_val];
+                        var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
+                        update_widget(next_widget, new_vals);
+                    }
+                }, {{ throttle }})
+            });
+            slider.keypress(function(event) {
+                if (event.which == 80 || event.which == 112) {
+                    var start = slider.slider("option", "value");
+                    var stop =  slider.slider("option", "max");
+                    for (var i=start; i<=stop; i++) {
+                        var delay = i*{{ delay }};
+                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+                            var val = {value:i};
+                            slider.slider('value',i);
+                            slider.slider("option", "slide")(null, val);
+                        }, slider), delay);}, slider)(i);
+                    }
+                }
+                if (event.which == 82 || event.which == 114) {
+                    var start = slider.slider("option", "value");
+                    var stop =  slider.slider("option", "min");
+                    var count = 0;
+                    for (var i=start; i>=stop; i--) {
+                        var delay = count*{{ delay }};
+                        count = count + 1;
+                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+                            var val = {value:i};
+                            slider.slider('value',i);
+                            slider.slider("option", "slide")(null, val);
+                        }, slider), delay);}, slider)(i);
+                    }
+                }
+            });
+            $('#textInput{{ id }}_{{ widget_data['dim'] }}').val(labels[0]);
+        });
+        // Slider JS Block END
+        </script>
+        {% elif widget_data['type']=='dropdown' %}
+        <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
+          <label for="textInput{{ id }}_{{ widget_data['dim'] }}"><strong>{{ widget_data['dim_label'] }}:</strong></label>
+          <select class="holoselect form-control" id="_anim_widget{{ id }}_{{ widget_data['dim'] }}" >
+          </select>
+        </div>
+        <script>
+        var vals = {{ widget_data['vals'] }};
+        var labels = {{ widget_data['labels'] }};
+        var widget = $("#_anim_widget{{ id }}_{{ widget_data['dim'] }}");
+        widget.data('values', vals)
+        for (var i=0; i<vals.length; i++){
+            widget.append($("<option>", {
+                value: i,
+                text: labels[i]
+            }));
+        };
+        widget.data("next_vals", {{ widget_data['next_vals'] }});
+        widget.on('change', function(event, ui) {
+            var dim_val = $.data(this, 'values')[this.value];
+            if(anim{{ id }}) {
+                anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
+            }
+            var next_vals = $.data(this, "next_vals");
+            if (Object.keys(next_vals).length > 0) {
+                var new_vals = next_vals[dim_val];
+                var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
+                update_widget(next_widget, new_vals);
+            }
+        });
+        </script>
+        {% endif %}
+        {% endfor %}
         </form>
     </div>
 </div>
 
 
 <script language="javascript">
-    /* Instantiate the {{ widget_name }} class. */
-    /* The IDs given should match those used in the template above. */
-    (function() {
-        var widget_ids = new Array({{ Nwidget }});
-        {% for dim in dimensions %}
-            widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";
-        {% endfor %}
-        var frame_data = {{ frames | safe }};
-        var dim_vals = {{ init_dim_vals }};
-        var keyMap = {{ key_data }};
-        var notFound = "{{ notFound }}";
-
-        function create_widget() {
-            setTimeout(function() {
-                anim{{ id }} = new {{ widget_name }}(frame_data, "{{ id }}", widget_ids,
-                        keyMap, dim_vals, notFound, {{ load_json }}, {{ mode }},
-                        {{ cached }}, "{{ json_path}}", {{ dynamic }});
-            }, 0);
-        }
-
-        {% block create_widget %}
-            create_widget();
-        {% endblock %}
-    })();
+/* Instantiate the {{ widget_name }} class. */
+/* The IDs given should match those used in the template above. */
+(function() {
+    var widget_ids = new Array({{ Nwidget }});
+    {% for dim in dimensions %}
+    widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";
+    {% endfor %}
+    var frame_data = {{ frames | safe }};
+    var dim_vals = {{ init_dim_vals }};
+    var keyMap = {{ key_data }};
+    var notFound = "{{ notFound }}";
+    function create_widget() {
+        setTimeout(function() {
+            anim{{ id }} = new {{ widget_name }}(frame_data, "{{ id }}", widget_ids,
+				keyMap, dim_vals, notFound, {{ load_json }}, {{ mode }},
+				{{ cached }}, "{{ json_path}}", {{ dynamic }});
+        }, 0);
+    }
+    {% block create_widget %}
+    create_widget();
+    {% endblock %}
+})();
 </script>


### PR DESCRIPTION
Currently the values displayed in the slider widget text box and dropdown menu are derived from the raw value (with some rounding applied). However as suggested in #548 the widgets should also use the dimensions value formatter if specified. This allows timestamps to be formatted correctly, for example, ensuring that you don't get mismatching labels between the title and the widget. The only issue with this approach is that the formatted version can often be longer and therefore become unreadable. Before merging I'd like to brainstorm a little bit about what we can do for very long labels. Here is an example:

<img width="1015" alt="screen shot 2016-03-22 at 11 45 52 am" src="https://cloud.githubusercontent.com/assets/1550771/13951271/aeed4dbc-f027-11e5-8c57-469d19ca6672.png">


Note I also reindented the jinja template because it was a mess.
