### PR TITLE
Let GridColumns.reindex expand format as required

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -1589,11 +1589,10 @@ class GridColumns(DictColumns):
     @classmethod
     def reindex(cls, columns, kdims, vdims):
         dropped_kdims = [kd for kd in columns.kdims if kd not in kdims]
-        if dropped_kdims and any(len(columns.data[kd.name]) > 1 for kd in dropped_kdims):
-            raise ValueError('Compressed format does not allow dropping key dimensions '
-                             'which are not constant.')
-        if (any(kd for kd in kdims if kd not in columns.kdims) or
-            any(vd for vd in vdims if vd not in columns.vdims)):
+        if dropped_kdims and all(len(columns.data[kd.name]) == 1 for kd in dropped_kdims):
+            pass
+        elif (any(kd for kd in kdims if kd not in columns.kdims) or
+            any(vd for vd in vdims if vd not in columns.vdims)) or dropped_kdims:
             return columns.clone(columns.columns()).reindex(kdims, vdims)
         dropped_vdims = ([vdim for vdim in columns.vdims
                           if vdim not in vdims] if vdims else [])


### PR DESCRIPTION
Currently the newly added ``GridColumns`` interface restricts how the data can be reindexed, ensuring that you're not dropping non-redundant dimensions. This is because gridded data requires unique indices for each position in the grid. This is not an issue when working with the expanded format because individual samples do not have to be unique. For full generality reindex on GridColumns and other grid based interfaces should allow any requested reindexing even if it requires falling back to the expanded format (which is now very cheap because the expansion uses striding tricks).