### PR TITLE
Ad hoc fix of the \xi bug

### DIFF
--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -272,10 +272,17 @@ class SelectionWidget(NdWidget):
                         dim_vals = escape_list(escape_vals(dim.values))
                         widget_type = 'dropdown'
                     init_dim_vals.append(dim_vals[0])
+
+                    value_labels = escape_list(escape_vals([dim.pprint_value(v)
+                                                        for v in dim.values]))
                 else:
                     widget_type = 'slider'
                     dim_vals = [dim.soft_range[0] if dim.soft_range[0] else dim.range[0],
                                 dim.soft_range[1] if dim.soft_range[1] else dim.range[1]]
+
+                    value_labels = escape_list(escape_vals([dim.pprint_value(v)
+                                                        for v in dim_vals]))
+
                     dim_range = dim_vals[1] - dim_vals[0]
                     int_type = isinstance(dim.type, type) and issubclass(dim.type, int)
                     if isinstance(dim_range, int) or int_type:

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -209,7 +209,7 @@
 	}
     var widget_ids = new Array({{ Nwidget }});
     {% for dim in dimensions %}
-    widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";
+    widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim | replace ("\\", "\\\\") }}";
     {% endfor %}
     var frame_data = {{ frames | safe }};
     var dim_vals = {{ init_dim_vals }};


### PR DESCRIPTION
By escaping backslashes in the Jinja template this fixes #573, but it would be more elegant to have a specific filter for making things JavaScript-safe.