### PR TITLE
Fixed dimension escaping and bug setting dynamic widget labels

### DIFF
--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -322,13 +322,14 @@ class SelectionWidget(NdWidget):
 
             visibility = '' if visible else 'display: none'
             dim_str = safe_unicode(dim.name)
-            widget_data = dict(dim=dimension_sanitizer(dim_str), dim_label=dim_str,
+            escaped_dim = dimension_sanitizer(dim_str)
+            widget_data = dict(dim=escaped_dim, dim_label=dim_str,
                                dim_idx=idx, vals=dim_vals, type=widget_type,
                                visibility=visibility, step=step, next_dim=next_dim,
                                next_vals=next_vals, labels=value_labels)
 
             widgets.append(widget_data)
-            dimensions.append(dim_str)
+            dimensions.append(escaped_dim)
         init_dim_vals = escape_list(escape_vals(init_dim_vals, not self.plot.dynamic))
         return widgets, dimensions, init_dim_vals
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -268,12 +268,17 @@ class SelectionWidget(NdWidget):
                     if all(isnumeric(v) for v in dim.values):
                         dim_vals = {i: v for i, v in enumerate(dim.values)}
                         widget_type = 'slider'
+                        value_labels = escape_list(escape_vals([dim.pprint_value(v)
+                                                                for v in dim.values]))
                     else:
                         dim_vals = escape_list(escape_vals(dim.values))
+                        value_labels = escape_list(escape_vals([dim.pprint_value(v)
+                                                                for v in dim_vals]))
                         widget_type = 'dropdown'
                     init_dim_vals.append(dim_vals[0])
                 else:
                     widget_type = 'slider'
+                    value_labels = []
                     dim_vals = [dim.soft_range[0] if dim.soft_range[0] else dim.range[0],
                                 dim.soft_range[1] if dim.soft_range[1] else dim.range[1]]
                     dim_range = dim_vals[1] - dim_vals[0]

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -73,12 +73,12 @@
         require(["jQueryUI", "underscore"], function(jUI, _){
             if (noConflict) $.noConflict(true);
             var vals = {{ widget_data['vals'] }};
-            var labels = {{ widget_data['labels'] }};
             var next_vals = {{ widget_data['next_vals'] }};
             if ({{ dynamic }} && vals.constructor === Array) {
                 var min = parseFloat(vals[0]);
                 var max = parseFloat(vals[vals.length-1]);
                 var step = {{ widget_data['step'] }};
+                var labels = [min];
             } else {
                 var min = 0;
                 if ({{ dynamic }}) {
@@ -87,6 +87,7 @@
                     var max = vals.length - 1;
                 }
                 var step = 1;
+				var labels = {{ widget_data['labels'] }};
             }
 			function adjustFontSize(text) {
 				var width_ratio = (text.parent().width()/8)/text.val().length;
@@ -109,11 +110,13 @@
                     var labels = slider.slider("option", "dim_labels");
                     if ({{ dynamic }} && vals.constructor === Array) {
                         var dim_val = ui.value;
+						var label = ui.value;
                     } else {
                         var dim_val = vals[ui.value];
+						var label = labels[ui.value];
                     }
 					var text = $('#textInput{{ id }}_{{ widget_data['dim'] }}');
-					text.val(labels[ui.value]);
+					text.val(label);
 					adjustFontSize(text);
                     anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
                     if (Object.keys(next_vals).length > 0) {


### PR DESCRIPTION
When implementing improved widget value formatting in #562 I didn't handle the dynamic widget case causing some issues as described in #571 and partially fixed in #572. I've also included another fix for escaping dimension names that was overlooked previously and partially fixed in #574.