### PR TITLE
Fix to nbagg widgets ensuring that tight fig_inches are applied

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -148,6 +148,8 @@ class MPLRenderer(Renderer):
         """
         fig = plot.state
         if self.mode == 'nbagg':
+            bbox = self._compute_bbox(fig, dict(bbox_inches=bbox_inches))
+            fig.set_size_inches(bbox['bbox_inches'].get_points()[1])
             manager = self.get_figure_manager(plot)
             if manager is None: return ''
             self.counter += 1


### PR DESCRIPTION
While the nbagg backend works fairly well it does not seem to take into account the ``tight`` bbox_inches property, which means that a lot of whitespace is left over when plotting anything that is non-square. Since we already have a function to determine the tight bounding box we can simply apply that manually to avoid large white margins.

Ready to merge as soon as tests pass.