### PR TITLE
Correctly sort heterogeneous types in DictColumns

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -873,3 +873,16 @@ def cartesian_product(arrays):
     supplied dimensions.
     """
     return np.broadcast_arrays(*np.ix_(*arrays))
+
+
+def arglexsort(arrays):
+    """
+    Returns the indices of the lexicographical sorting
+    order of the supplied arrays.
+    """
+    dtypes = ','.join(array.dtype.str for array in arrays)
+    recarray = np.empty(len(arrays[0]), dtype=dtypes)
+    for i, array in enumerate(arrays):
+        recarray['f%s' % i] = array
+    return recarray.argsort()
+


### PR DESCRIPTION
As suggested in #580 this replaces the lexicographical sorting implemented on ArrayColumns and DictColumns with more useful general sorting as is already in place on the DFColumns and NdColumns interfaces. In the case of ArrayColumns we can simply create a record array view into the actual array, which we can apply the sorting to. For DictColumns we need to actually construct a record array but this shouldn't be any more expensive than the existing implementation, which already creates an intermediate array to compute the sort order on.

This should be ready to merge once the tests pass.