### PR TITLE
Added support for dynamic operations and overlaying

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -106,7 +106,6 @@ class DynamicOperation(Operation):
                 el = map_obj[key]
             elif key >= map_obj.counter:
                 el = next(map_obj)
-                key = map_obj.keys()[-1]
             return function(el, **kwargs)
 
         return dynamic_operation

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -97,15 +97,7 @@ class DynamicOperation(Operation):
 
         def dynamic_operation(*key):
             key = key[0] if map_obj.mode == 'open' else key
-            if isinstance(key, tuple):
-                el = map_obj[key]
-            elif key < map_obj.counter:
-                key_offset = max([key-map_obj.cache_size, 0])
-                key = map_obj.keys()[min([key-key_offset,
-                                          len(map_obj)-1])]
-                el = map_obj[key]
-            elif key >= map_obj.counter:
-                el = next(map_obj)
+            _, el = util.get_dynamic_item(map_obj, map_obj.kdims, key)
             return function(el, **kwargs)
 
         return dynamic_operation

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -23,6 +23,11 @@ class Overlayable(object):
     """
 
     def __mul__(self, other):
+        if hasattr(other, 'call_mode'):
+            from .operation import DynamicOperation
+            def dynamic_mul(element):
+                return self * element
+            return DynamicOperation(other, dynamic_mul)
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -23,7 +23,7 @@ class Overlayable(object):
     """
 
     def __mul__(self, other):
-        if hasattr(other, 'call_mode'):
+        if type(other).__name__ == 'DynamicMap':
             from .operation import DynamicOperation
             def dynamic_mul(element):
                 return self * element

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,10 +24,10 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .operation import DynamicOperation
+            from .operation import DynamicFunction
             def dynamic_mul(element):
                 return self * element
-            return DynamicOperation(other, dynamic_mul)
+            return DynamicFunction(other, function=dynamic_mul)
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -112,12 +112,14 @@ class HoloMap(UniformNdMapping):
             layers = []
             try:
                 _, self_el = util.get_dynamic_item(self, dimensions, key)
-                layers.append(self_el)
+                if self_el is not None:
+                    layers.append(self_el)
             except KeyError:
                 pass
             try:
                 _, other_el = util.get_dynamic_item(other, dimensions, key)
-                layers.append(other_el)
+                if other_el is not None:
+                    layers.append(other_el)
             except KeyError:
                 pass
             return Overlay(layers)
@@ -145,6 +147,7 @@ class HoloMap(UniformNdMapping):
             self_in_other = self_set.issubset(other_set)
             other_in_self = other_set.issubset(self_set)
             dimensions = self.kdims
+
             if self_in_other and other_in_self: # superset of each other
                 super_keys = sorted(set(self._dimension_keys() + other._dimension_keys()))
             elif self_in_other: # self is superset
@@ -155,7 +158,7 @@ class HoloMap(UniformNdMapping):
             else: # neither is superset
                 raise Exception('One set of keys needs to be a strict subset of the other.')
 
-            if isinstance(self, DynamicMap) or (other, DynamicMap):
+            if isinstance(self, DynamicMap) or isinstance(other, DynamicMap):
                 return self._dynamic_mul(dimensions, other)
 
             items = []

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -203,10 +203,10 @@ class HoloMap(UniformNdMapping):
             return self.clone(items, kdims=dimensions, label=self._label, group=self._group)
         elif isinstance(other, self.data_type):
             if isinstance(self, DynamicMap):
-                from .operation import DynamicOperation
+                from .operation import DynamicFunction
                 def dynamic_mul(element):
                     return element * other
-                return DynamicOperation(self, dynamic_mul)
+                return DynamicFunction(self, function=dynamic_mul)
             items = [(k, v * other) for (k, v) in self.data.items()]
             return self.clone(items, label=self._label, group=self._group)
         else:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -109,41 +109,18 @@ class HoloMap(UniformNdMapping):
         map_obj = self if isinstance(self, DynamicMap) else other
         def dynamic_mul(*key):
             key = key[0] if map_obj.mode == 'open' else key
-            if isinstance(key, tuple):
-                # Handles bounded or sampled case
-                self_key = tuple(k for p, k in sorted(
-                    [(self.get_dimension_index(dim), v) for dim, v in
-                     zip(dimensions, key) if dim in self.kdims]))
-                other_key = tuple(k for p, k in sorted(
-                    [(other.get_dimension_index(dim), v)
-                     for dim, v in zip(dimensions, key) if dim in other.kdims]))
-                layers = []
-                try:
-                    layers.append(self[self_key])
-                except:
-                    pass
-                try:
-                    layers.append(other[other_key])
-                except:
-                    pass
-                return Overlay(layers)
-            else:
-                # Handles open mode case
-                if key < self.counter:
-                    key_offset = max([key-self.cache_size, 0])
-                    key = self.keys()[min([key-key_offset,
-                                           len(self)-1])]
-                    self_el = self[key]
-                elif key >= self.counter:
-                    self_el = next(self)
-                if key < other.counter:
-                    key_offset = max([key-other.cache_size, 0])
-                    key = other.keys()[min([key-key_offset,
-                                            len(other)-1])]
-                    other_el = other[key]
-                elif key >= other.counter:
-                    other_el = next(other)
-                return Overlay([self_el, other_el])
+            layers = []
+            try:
+                _, self_el = util.get_dynamic_item(self, dimensions, key)
+                layers.append(self_el)
+            except KeyError:
+                pass
+            try:
+                _, other_el = util.get_dynamic_item(other, dimensions, key)
+                layers.append(other_el)
+            except KeyError:
+                pass
+            return Overlay(layers)
         return map_obj.clone(callback=dynamic_mul, shared_data=False,
                              kdims=dimensions)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -897,7 +897,8 @@ def get_dynamic_item(map_obj, dimensions, key):
         dims = {d.name: k for d, k in zip(dimensions, key)
                 if d in map_obj.kdims}
         key = tuple(dims.get(d.name) for d in map_obj.kdims)
-        el = map_obj.select([lambda x: hasattr(x, 'call_mode')], **dims)
+        el = map_obj.select([lambda x: type(x).__name__ == 'DynamicMap'],
+                            **dims)
     elif key < map_obj.counter:
         key_offset = max([key-map_obj.cache_size, 0])
         key = map_obj.keys()[min([key-key_offset,

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -886,3 +886,26 @@ def arglexsort(arrays):
         recarray['f%s' % i] = array
     return recarray.argsort()
 
+
+def get_dynamic_item(map_obj, dimensions, key):
+    """
+    Looks up an item in a DynamicMap given a list of dimensions
+    and a corresponding key. The dimensions must be a subset
+    of the map_obj key dimensions.
+    """
+    if isinstance(key, tuple):
+        dims = {d.name: k for d, k in zip(dimensions, key)
+                if d in map_obj.kdims}
+        key = tuple(dims.get(d.name) for d in map_obj.kdims)
+        el = map_obj.select([lambda x: hasattr(x, 'call_mode')], **dims)
+    elif key < map_obj.counter:
+        key_offset = max([key-map_obj.cache_size, 0])
+        key = map_obj.keys()[min([key-key_offset,
+                                  len(map_obj)-1])]
+        el = map_obj[key]
+    elif key >= map_obj.counter:
+        el = next(map_obj)
+        key = list(map_obj.keys())[-1]
+    else:
+        el = None
+    return key, el

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -515,19 +515,7 @@ class GenericElementPlot(DimensionedPlot):
             self.current_key = key
             return self.current_frame
         elif self.dynamic:
-            if isinstance(key, tuple):
-                dims = {d.name: k for d, k in zip(self.dimensions, key)
-                        if d in self.hmap.kdims}
-                frame = self.hmap.select([DynamicMap], **dims)
-            elif key < self.hmap.counter:
-                key_offset = max([key-self.hmap.cache_size, 0])
-                key = self.hmap.keys()[min([key-key_offset, len(self.hmap)-1])]
-                frame = self.hmap[key]
-            elif key >= self.hmap.counter:
-                frame = next(self.hmap)
-                key = self.hmap.keys()[-1]
-            else:
-                frame = None
+            key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
             if not isinstance(key, tuple): key = (key,)
             if not key in self.keys:
                 self.keys.append(key)

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -1,5 +1,6 @@
 import numpy as np
 from holoviews import Dimension, DynamicMap, Image, HoloMap
+from holoviews.core.operation import DynamicOperation
 from holoviews.element.comparison import ComparisonTestCase
 
 frequencies =  np.linspace(0.5,2.0,5)
@@ -77,6 +78,25 @@ class DynamicTestSampledBounded(ComparisonTestCase):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, sampled=True)
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
+
+
+class DynamicTestOperation(ComparisonTestCase):
+
+    def test_dynamic_function(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        dmap_with_fn = DynamicOperation(dmap, lambda x: x.clone(x.data*2))
+        self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
+
+
+    def test_dynamic_function_with_kwargs(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        def fn(x, multiplier=2):
+            return x.clone(x.data*multiplier)
+        dmap_with_fn = DynamicOperation(dmap, fn, multiplier=3)
+        self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*3))
+
 
 
 class DynamicTestOverlay(ComparisonTestCase):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -1,6 +1,6 @@
 import numpy as np
 from holoviews import Dimension, DynamicMap, Image, HoloMap
-from holoviews.core.operation import DynamicOperation
+from holoviews.core.operation import DynamicFunction
 from holoviews.element.comparison import ComparisonTestCase
 
 frequencies =  np.linspace(0.5,2.0,5)
@@ -85,7 +85,7 @@ class DynamicTestOperation(ComparisonTestCase):
     def test_dynamic_function(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, sampled=True)
-        dmap_with_fn = DynamicOperation(dmap, lambda x: x.clone(x.data*2))
+        dmap_with_fn = DynamicFunction(dmap, function=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
 
@@ -94,7 +94,7 @@ class DynamicTestOperation(ComparisonTestCase):
         dmap=DynamicMap(fn, sampled=True)
         def fn(x, multiplier=2):
             return x.clone(x.data*multiplier)
-        dmap_with_fn = DynamicOperation(dmap, fn, multiplier=3)
+        dmap_with_fn = DynamicFunction(dmap, function=fn, kwargs=dict(multiplier=3))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*3))
 
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -1,5 +1,5 @@
 import numpy as np
-from holoviews import Dimension, DynamicMap, Image
+from holoviews import Dimension, DynamicMap, Image, HoloMap
 from holoviews.element.comparison import ComparisonTestCase
 
 frequencies =  np.linspace(0.5,2.0,5)
@@ -78,3 +78,36 @@ class DynamicTestSampledBounded(ComparisonTestCase):
         dmap=DynamicMap(fn, sampled=True)
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
 
+
+class DynamicTestOverlay(ComparisonTestCase):
+
+    def test_dynamic_element_overlay(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        dynamic_overlay = dmap * Image(sine_array(0,10))
+        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        self.assertEqual(dynamic_overlay[5], overlaid)
+
+    def test_dynamic_element_underlay(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        dynamic_overlay = Image(sine_array(0,10)) * dmap
+        overlaid = Image(sine_array(0,10)) * Image(sine_array(0,5))
+        self.assertEqual(dynamic_overlay[5], overlaid)
+
+    def test_dynamic_dynamicmap_overlay(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, sampled=True)
+        fn2 = lambda i: Image(sine_array(0,i*2))
+        dmap2=DynamicMap(fn2, sampled=True)
+        dynamic_overlay = dmap * dmap2
+        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        self.assertEqual(dynamic_overlay[5], overlaid)
+
+    def test_dynamic_holomap_overlay(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap = DynamicMap(fn, sampled=True)
+        hmap = HoloMap({i: Image(sine_array(0,i*2)) for i in range(10)})
+        dynamic_overlay = dmap * hmap
+        overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
+        self.assertEqual(dynamic_overlay[5], overlaid)


### PR DESCRIPTION
As the title says, this adds a ``dynamic`` parameter to the ``ElementOperation`` class, which let's the user apply lazy analyses to a HoloMap (or GridSpace of HoloMaps), which will only be evaluated when the user requests a specific key. This makes it trivial to apply complex analyses to large datasets without having to apply the analysis everywhere at once and avoids having to manually wrap the analysis in a dynamic callback.