### PR TITLE
Added dynamic throttling of events to live/dynamic widgets

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -45,12 +45,6 @@ var BokehMethods = {
 		if (current === undefined) {
 			return
 		}
-		if (this.time === undefined) {
-			// Do nothing the first time
-		} else if (this.timer === undefined | ((this.time + this.timer) > Date.now())) {
-			this.queue.push(current);
-			return
-		}
 		this.time = Date.now()
 		if(this.dynamic) {
 			current = JSON.stringify(current);
@@ -64,16 +58,19 @@ var BokehMethods = {
 			if (msg.msg_type != "execute_result") {
 				console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
 				this.time = undefined;
+				this.wait = false;
 				return
 			}
-			this.timer = Date.now() - this.time;
+			this.timed = (Date.now() - this.time) * 1.1;
 			if (msg.msg_type == "execute_result") {
 				if (msg.content.data['text/plain'] === "'Complete'") {
-				   if (this.queue.length > 0) {
+					if (this.wait !== undefined) {
+						this.wait = false;
+					} else if (this.queue.length > 0) {
 					   this.dynamic_update(this.queue[this.queue.length-1]);
 					   this.queue = [];
-				   }
-				   return
+					}
+					return
 			    }
 				var data = msg.content.data['text/plain'].slice(1, -1);
 				this.frames[current] = JSON.parse(data);

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -45,7 +45,6 @@ var BokehMethods = {
 		if (current === undefined) {
 			return
 		}
-		this.time = Date.now()
 		if(this.dynamic) {
 			current = JSON.stringify(current);
 		}
@@ -64,9 +63,8 @@ var BokehMethods = {
 			this.timed = (Date.now() - this.time) * 1.1;
 			if (msg.msg_type == "execute_result") {
 				if (msg.content.data['text/plain'] === "'Complete'") {
-					if (this.wait !== undefined) {
-						this.wait = false;
-					} else if (this.queue.length > 0) {
+					this.wait = false;
+					if (this.queue.length > 0) {
 					   this.dynamic_update(this.queue[this.queue.length-1]);
 					   this.queue = [];
 					}

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -65,8 +65,9 @@ var BokehMethods = {
 				if (msg.content.data['text/plain'] === "'Complete'") {
 					this.wait = false;
 					if (this.queue.length > 0) {
-					   this.dynamic_update(this.queue[this.queue.length-1]);
-					   this.queue = [];
+						this.time = Date.now();
+						this.dynamic_update(this.queue[this.queue.length-1]);
+						this.queue = [];
 					}
 					return
 			    }

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -66,6 +66,7 @@ class BokehWidget(NdWidget):
             else:
                 handle._json = to_json
             handle.comms.send(json.dumps(msg))
+            return 'Complete'
 
 
 class BokehSelectionWidget(BokehWidget, SelectionWidget):

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -36,13 +36,6 @@ var MPLMethods = {
 		}
 	},
 	dynamic_update : function(current){
-		if (this.time === undefined) {
-			// Do nothing the first time
-		} else if (this.timer === undefined | ((this.time + this.timer) > Date.now())) {
-			this.queue.push(current);
-			return
-		}
-		this.time = Date.now()
 		if (this.dynamic) {
 			current = JSON.stringify(current);
 		}
@@ -57,7 +50,6 @@ var MPLMethods = {
 				this.time = undefined;
 				return
 			}
-			this.timer = Date.now() - this.time;
 			if (!(this.mode == 'nbagg')) {
 				if(!(current in this.cache)) {
 					var data = msg.content.data['text/plain'].slice(1, -1);
@@ -69,7 +61,10 @@ var MPLMethods = {
 				}
 				this.update(current);
 			}
-			if (this.queue.length > 0) {
+			this.timed = (Date.now() - this.time) * 1.5;
+			if (this.wait !== undefined) {
+				this.wait = false;
+			} else if (this.queue.length > 0) {
 				this.dynamic_update(this.queue[this.queue.length-1]);
 				this.queue = [];
 			}

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -62,10 +62,10 @@ var MPLMethods = {
 				this.update(current);
 			}
 			this.timed = (Date.now() - this.time) * 1.5;
-			if (this.wait !== undefined) {
-				this.wait = false;
-			} else if (this.queue.length > 0) {
-				this.dynamic_update(this.queue[this.queue.length-1]);
+			this.wait = false;
+			if (this.queue.length > 0) {
+				var current_vals = this.queue[this.queue.length-1];
+				this.dynamic_update(current_vals);
 				this.queue = [];
 			}
 		}

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -36,6 +36,13 @@ var MPLMethods = {
 		}
 	},
 	dynamic_update : function(current){
+		if (this.time === undefined) {
+			// Do nothing the first time
+		} else if (this.timer === undefined | ((this.time + this.timer) > Date.now())) {
+			this.queue.push(current);
+			return
+		}
+		this.time = Date.now()
 		if (this.dynamic) {
 			current = JSON.stringify(current);
 		}
@@ -47,8 +54,10 @@ var MPLMethods = {
 			}
 			if (msg.msg_type != "execute_result") {
 				console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
+				this.time = undefined;
 				return
 			}
+			this.timer = Date.now() - this.time;
 			if (!(this.mode == 'nbagg')) {
 				if(!(current in this.cache)) {
 					var data = msg.content.data['text/plain'].slice(1, -1);
@@ -59,6 +68,10 @@ var MPLMethods = {
 					this.update_cache();
 				}
 				this.update(current);
+			}
+			if (this.queue.length > 0) {
+				this.dynamic_update(this.queue[this.queue.length-1]);
+				this.queue = [];
 			}
 		}
 		var kernel = IPython.notebook.kernel;

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -65,6 +65,7 @@ var MPLMethods = {
 			this.wait = false;
 			if (this.queue.length > 0) {
 				var current_vals = this.queue[this.queue.length-1];
+				this.time = Date.now();
 				this.dynamic_update(current_vals);
 				this.queue = [];
 			}

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -104,7 +104,7 @@
                 dim_vals: vals,
                 dim_labels: labels,
                 next_vals: next_vals,
-                slide: _.throttle(function(event, ui) {
+                slide: function(event, ui) {
                     var vals = slider.slider("option", "dim_vals");
                     var next_vals = slider.slider("option", "next_vals");
                     var labels = slider.slider("option", "dim_labels");
@@ -124,7 +124,7 @@
                         var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
                         update_widget(next_widget, new_vals);
                     }
-                }, {{ throttle }})
+                }
             });
             slider.keypress(function(event) {
                 if (event.which == 80 || event.which == 112) {

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -120,15 +120,17 @@ SelectionWidget.prototype.get_key = function(current_vals) {
 
 SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
 	this.current_vals[dim_idx] = dim_val;
-	if (this.time === undefined) {
-		// Do nothing the first time
-	} else if ((this.timed === undefined) | ((this.time + this.timed) > Date.now())) {
-		var key = this.current_vals;
-		if (!this.dynamic) {
-			key = this.get_key(key);
+	if (this.dynamic || !this.cached) {
+		if (this.time === undefined) {
+			// Do nothing the first time
+		} else if ((this.timed === undefined) | ((this.time + this.timed) > Date.now())) {
+			var key = this.current_vals;
+			if (!this.dynamic) {
+				key = this.get_key(key);
+			}
+			this.queue.push(key);
+			return
 		}
-		this.queue.push(key);
-		return
 	}
 	this.time = Date.now();
     if(this.dynamic) {

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -92,6 +92,7 @@ function SelectionWidget(frames, id, slider_ids, keyMap, dim_vals, notFound, loa
     this.cache = {};
 	this.json_path = json_path;
     this.init_slider(this.current_vals[0]);
+	this.queue = [];
 }
 
 SelectionWidget.prototype = new HoloViewsWidget;
@@ -147,6 +148,7 @@ function ScrubberWidget(frames, num_frames, id, interval, load_json, mode, cache
 	this.json_path = json_path;
     document.getElementById(this.slider_id).max = this.length - 1;
     this.init_slider(0);
+	this.queue = [];
 }
 
 ScrubberWidget.prototype = new HoloViewsWidget;

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -123,7 +123,7 @@ SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
 	if (this.dynamic || !this.cached) {
 		if (this.time === undefined) {
 			// Do nothing the first time
-		} else if ((this.timed === undefined) | ((this.time + this.timed) > Date.now())) {
+		} else if ((this.timed === undefined) || ((this.time + this.timed) > Date.now())) {
 			var key = this.current_vals;
 			if (!this.dynamic) {
 				key = this.get_key(key);
@@ -132,6 +132,7 @@ SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
 			return
 		}
 	}
+	this.queue = [];
 	this.time = Date.now();
     if(this.dynamic) {
         this.dynamic_update(this.current_vals)


### PR DESCRIPTION
This PR adds dynamic throttling of events to the widgets. The first time a widget dynamically requests a frame from the Python kernel it will instantiate ``this.time``, which will then be used to calculate the time taken to generate that frame. Each subsequent time a new frame is requested the dynamic_update method will first check whether sufficient time has passed since the last frame was requested, if not it will queue the event. Whenever a callback completes it will execute the last queued event if there is any. This approach ensures that events generated faster than they can be processed are thrown away, while still ensuring that the last event that the user generated is processed, which means that the slider and the plot stay in sync.

Here's what I used for testing:

```python
def a(i):
    time.sleep(1)
    return hv.Image(np.random.rand(10,10))

hv.DynamicMap(a, kdims=[hv.Dimension('x', range=(0, 1.))])
```

This also let me measure the speed of plotting of updates for the first time. For this example, if you disable the sleep, I'm getting ~30 ms per frame in matplotlib and ~35ms per frame using bokeh.