### PR TITLE
Added bbox_extra_artists to improve bounding box calculation

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -563,6 +563,8 @@ class ColorbarPlot(ElementPlot):
             self._adjust_cbar(cbar, label, dim)
             self.handles['cax'] = cax
             self.handles['cbar'] = cbar
+            ylabel = cax.yaxis.get_label()
+            self.handles['bbox_extra_artists'] += [cax, ylabel]
             ax_colorbars.append((artist, cax, spec, label))
 
         for i, (artist, cax, spec, label) in enumerate(ax_colorbars[:-1]):
@@ -700,6 +702,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             frame.set_linewidth('1.0')
             leg.set_zorder(10e6)
             self.handles['legend'] = leg
+            self.handles['bbox_extra_artists'].append(leg)
         self.handles['legend_data'] = data
 
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -111,6 +111,7 @@ class MPLPlot(DimensionedPlot):
             self.warning('Set either final_hooks or deprecated '
                          'finalize_hooks, not both.')
         self.finalize_hooks = self.final_hooks
+        self.handles['bbox_extra_artists'] = []
 
 
     def _init_axis(self, fig, axis):
@@ -164,7 +165,10 @@ class MPLPlot(DimensionedPlot):
                               bbox_transform=axis.transAxes)
             at.patch.set_visible(False)
             axis.add_artist(at)
-            self.handles['sublabel'] = at.txt.get_children()[0]
+            sublabel = at.txt.get_children()[0]
+            self.handles['sublabel'] = sublabel
+            self.handles['bbox_extra_artists'] += [sublabel]
+
 
 
     def _finalize_axis(self, key):
@@ -401,7 +405,7 @@ class GridPlot(CompositePlot):
                 subplot = plotting_class(view,  **dict(opts, **dict(params, **kwargs)))
                 collapsed_layout[coord] = subplot.layout if isinstance(subplot, CompositePlot) else subplot.hmap
                 subplots[(r, c)] = subplot
-            else:
+            elif subax is not None:
                 subax.set_visible(False)
             if r != self.rows-1:
                 r += 1
@@ -1022,6 +1026,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             title = self._format_title(key)
             title = self.handles['fig'].suptitle(title, **self._fontsize('title'))
             self.handles['title'] = title
+            self.handles['bbox_extra_artists'] += [title]
 
         return self._finalize_axis(None)
 

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -118,7 +118,7 @@ class MPLWidget(NdWidget):
 
     def initialize_connection(self, plot):
         plot.update(0)
-        self.manager = self.renderer.get_figure_manager(plot)
+        self.manager = self.renderer.get_figure_manager(plot.state)
         self.comm = WidgetCommSocket(self.manager)
 
 


### PR DESCRIPTION
This PR adds a default entry to the ``MPLPlot`` handles to register any additional artists, which are not automatically tracked by the matplotlib figure. These are then taken into account when computing a tight bounding box on the renderer. This fixes various cases where colorbars, axis labels and legends were ignored and therefore completely or partially cut-off.