### PR TITLE
Fixed fontsize option when supplying a single numeric value

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -274,21 +274,24 @@ class DimensionedPlot(Plot):
 
     def _fontsize(self, key, label='fontsize', common=True):
         if not self.fontsize: return {}
+
+        if not isinstance(self.fontsize, dict):
+            return {label:self.fontsize} if common else {}
+
         unknown_keys = set(self.fontsize.keys()) - set(self._fontsize_keys)
         if unknown_keys:
             msg = "Popping unknown keys %r from fontsize dictionary.\nValid keys: %r"
             self.warning(msg %  (list(unknown_keys), self._fontsize_keys))
             for key in unknown_keys: self.fontsize.pop(key, None)
 
-        if isinstance(self.fontsize, dict):
-            if key in self.fontsize:
-                return {label:self.fontsize[key]}
-            elif key in ['ylabel', 'xlabel'] and 'labels' in self.fontsize:
-                return {label:self.fontsize['labels']}
-            else:
-                return {}
+        if key in self.fontsize:
+            return {label:self.fontsize[key]}
+        elif key in ['ylabel', 'xlabel'] and 'labels' in self.fontsize:
+            return {label:self.fontsize['labels']}
+        else:
+            return {}
 
-        return {label:self.fontsize} if common else {}
+
 
 
     def compute_ranges(self, obj, key, ranges):


### PR DESCRIPTION
This PR addresses issue #590 by re-enabling numeric values for the fontsize option. It seems to be working again although I do seem to have some trouble changing the tick label fontsizes. I'll have to investigate and make sure it is hooked up properly...