### PR TITLE
Added strict checking of dimensions on Columns.groupby

### DIFF
--- a/holoviews/core/data.py
+++ b/holoviews/core/data.py
@@ -314,7 +314,7 @@ class Columns(Element):
         if not len(dimensions): dimensions = self.dimensions('key', True)
         if group_type is None: group_type = type(self)
 
-        dimensions = [self.get_dimension(d).name for d in dimensions]
+        dimensions = [self.get_dimension(d, strict=True).name for d in dimensions]
         invalid_dims = list(set(dimensions) - set(self.dimensions('key', True)))
         if invalid_dims:
             raise Exception('Following dimensions could not be found:\n%s.'


### PR DESCRIPTION
As the title says this makes Columns.groupby use strict checking when looking up dimensions, ensuring that proper exception messages are raised.