### PR TITLE
Use requirejs.config not require.config

### DIFF
--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -69,7 +69,7 @@
                 }
             }
         }
-        require.config(jquery_require);
+        requirejs.config(jquery_require);
         require(["jQueryUI", "underscore"], function(jUI, _){
             if (noConflict) $.noConflict(true);
             var vals = {{ widget_data['vals'] }};


### PR DESCRIPTION
In some cases require.config does not seem to be available, this uses requirejs.config instead, which should always be available.