### PR TITLE
Avoid passing default group in clone if new_type is supplied

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -277,6 +277,8 @@ class LabelledData(param.Parameterized):
             new_params = new_type.params()
             params = {k: v for k, v in params.items()
                       if k in new_params}
+            if params.get('group') == self.params()['group'].default:
+                params.pop('group')
         settings = dict(params, **overrides)
         if 'id' not in settings:
             settings['id'] = self.id


### PR DESCRIPTION
Avoids inheriting of default groups in clone when new_type is supplied avoiding inappropriate group labels.