### PR TITLE
Always apply tick rotation even if no explicit ticks are supplied

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -391,9 +391,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             axis.set_ticks(ticks)
             if labels:
                 axis.set_ticklabels(labels)
-        if ticks:
-            for tick in axis.get_ticklabels():
-                tick.set_rotation(rotation)
+        for tick in axis.get_ticklabels():
+            tick.set_rotation(rotation)
 
 
     def update_frame(self, key, ranges=None, element=None):


### PR DESCRIPTION
As the title says, in a recent refactor I only applied tick rotations if the ticks have been supplied explicitly, this always applies the rotation.