### PR TITLE
Allow specific underscore attributes to be ignored in AttrTree

### DIFF
--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -19,6 +19,8 @@ class AttrTree(object):
     >>> t.Example.Path                             #doctest: +ELLIPSIS
     1
     """
+    _disabled_prefixes = [] # Underscore attributes that should be
+                            # ignored instead of escaped.
 
     @classmethod
     def merge(cls, trees):
@@ -201,8 +203,13 @@ class AttrTree(object):
         # Attributes starting with __ get name mangled
         if identifier.startswith('_' + type(self).__name__) or identifier.startswith('__'):
             raise AttributeError('Attribute %s not found.' % identifier)
-        elif self.fixed==True:           raise AttributeError(self._fixed_error % identifier)
-        identifier = util.sanitize_identifier(identifier, escape=False)
+        elif self.fixed==True:
+            raise AttributeError(self._fixed_error % identifier)
+
+
+        if not any(identifier.startswith(prefix)
+                   for prefix in type(self)._disabled_prefixes):
+            identifier = util.sanitize_identifier(identifier, escape=False)
 
         if identifier in self.children:
             return self.__dict__[identifier]

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -8,6 +8,7 @@ import holoviews
 from param import ipython as param_ext
 from IPython.display import HTML
 
+from ..core.tree import AttrTree
 from ..core.options import Store, Cycle, Palette
 from ..element.comparison import ComparisonTestCase
 from ..interface.collector import Collector
@@ -37,7 +38,7 @@ except ImportError:
 
 
 Collector.interval_hook = RunProgress
-
+AttrTree._disabled_prefixes = ['_repr_']
 
 def show_traceback():
     """


### PR DESCRIPTION
The underscore was checked after santizing the identifier, allowed ``A_repr_html`` to make an unwelcome reappearance.