### PR TITLE
Fixed hard dependencies on pandas

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -6,8 +6,7 @@ import colorsys
 import param
 
 from ..core import util
-from ..core.data import (PandasInterface, ArrayInterface, NdElementInterface,
-                         DictInterface)
+from ..core.data import (ArrayInterface, NdElementInterface, DictInterface)
 from ..core import (Dimension, NdMapping, Element2D,
                     Overlay, Element, Dataset, NdElement)
 from ..core.boundingregion import BoundingRegion, BoundingBox
@@ -16,6 +15,12 @@ from ..core.util import pd
 from .chart import Curve
 from .tabular import Table
 from .util import compute_edges, toarray
+
+try:
+    from ..core.data import PandasInterface
+except ImportError:
+    PandasInterface = None
+
 
 class Raster(Element2D):
     """

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -40,8 +40,6 @@ Store.register({Overlay: OverlayPlot,
                 ErrorBars: ErrorPlot,
                 Spread: SpreadPlot,
                 Spikes: SpikesPlot,
-                BoxWhisker: BoxPlot,
-                Bars: BarPlot,
                 Area: AreaPlot,
 
                 # Rasters
@@ -77,6 +75,13 @@ Store.register({Overlay: OverlayPlot,
 
 AdjointLayoutPlot.registry[Histogram] = SideHistogramPlot
 AdjointLayoutPlot.registry[Spikes] = SideSpikesPlot
+
+try:
+    import pandas
+    Store.register({BoxWhisker: BoxPlot,
+                    Bars: BarPlot}, 'bokeh')
+except ImportError:
+    pass
 
 try:
     from ..mpl.seaborn import TimeSeriesPlot, BivariatePlot, DistributionPlot

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1,5 +1,10 @@
 import numpy as np
-from bokeh.charts import Bar, BoxPlot as BokehBoxPlot
+
+try:
+    from bokeh.charts import Bar, BoxPlot as BokehBoxPlot
+except:
+    Bar, BokehBoxPlot = None, None
+
 from bokeh.models import Circle, GlyphRenderer, ColumnDataSource, Range1d
 import param
 


### PR DESCRIPTION
There were two hard dependencies on pandas, which are resolved by this PR. The first involved import the PandasInterface, which is not available unless pandas was installed. The other was an issue in the bokeh backend outlined in #589.