### PR TITLE
Small fix for updating HeatMap labels

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -180,7 +180,8 @@ class HeatMapPlot(RasterPlot):
                     annotation.remove()
                 except:
                     pass
-            self._annotate_plot(axis, style['annotations'])
+            annotations = self._annotate_plot(axis, style['annotations'])
+            self.handles['annotations'] = annotations
         return axis_kwargs
 
 


### PR DESCRIPTION
The HeatMap value labels weren't correctly added to the handles which resulted in them never being cleared, resulting in drawing more and more overlapping text labels.