### PR TITLE
Fixed for matplotlib ColorbarPlot with no solids

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -505,7 +505,8 @@ class ColorbarPlot(ElementPlot):
     _colorbars = {}
 
     def _adjust_cbar(self, cbar, label, dim):
-        if math.floor(self.style[self.cyclic_index].get('alpha', 1)) == 1:
+        noalpha = math.floor(self.style[self.cyclic_index].get('alpha', 1)) == 1
+        if (cbar.solids and noalpha):
             cbar.solids.set_edgecolor("face")
         cbar.set_label(label)
         if isinstance(self.cbar_ticks, ticker.Locator):


### PR DESCRIPTION
Some plot types have only discrete colors, which means the colorbar has no solids. This ensures that the solid edgecolor is only set if there is actually a ``cbar.solids`` object to set it on.