### PR TITLE
Added plot option to control which axis labels to display

### DIFF
--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -33,6 +33,9 @@ class Plot3D(ColorbarPlot):
     bgcolor = param.String(default='white', doc="""
         Background color of the axis.""")
 
+    labelled = param.List(default=['x', 'y', 'z'], doc="""
+        Whether to plot the 'x', 'y' and 'z' labels.""")
+
     projection = param.ObjectSelector(default='3d', objects=['3d'], doc="""
         The projection of the matplotlib axis.""")
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -45,6 +45,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
     invert_zaxis = param.Boolean(default=False, doc="""
         Whether to invert the plot z-axis.""")
 
+    labelled = param.List(default=['x', 'y'], doc="""
+        Whether to plot the 'x' and 'y' labels.""")
+
     logx = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the x-axis of the Chart.""")
 
@@ -254,9 +257,12 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         xlabel, ylabel, zlabel = self._get_axis_labels(dimensions, xlabel, ylabel, zlabel)
         if self.invert_axes:
             xlabel, ylabel = ylabel, xlabel
-        if xlabel and self.xaxis: axes.set_xlabel(xlabel, **self._fontsize('xlabel'))
-        if ylabel and self.yaxis: axes.set_ylabel(ylabel, **self._fontsize('ylabel'))
-        if zlabel and self.zaxis: axes.set_zlabel(zlabel, **self._fontsize('zlabel'))
+        if xlabel and self.xaxis and 'x' in self.labelled:
+            axes.set_xlabel(xlabel, **self._fontsize('xlabel'))
+        if ylabel and self.yaxis and 'y' in self.labelled:
+            axes.set_ylabel(ylabel, **self._fontsize('ylabel'))
+        if zlabel and self.zaxis and 'z' in self.labelled:
+            axes.set_zlabel(zlabel, **self._fontsize('zlabel'))
 
 
     def _set_axis_formatter(self, axis, dim):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -8,7 +8,7 @@ from matplotlib import gridspec, animation
 import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
-                     Collator)
+                     Collator, GridMatrix)
 from ...core.options import Store, Compositor
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
@@ -393,6 +393,10 @@ class GridPlot(CompositePlot):
                                                                   r == self.rows//2):
                 kwargs['show_legend'] = self.show_legend
                 kwargs['legend_position'] = 'right'
+            if (not isinstance(self.layout, GridMatrix) and not
+                ((c == self.cols//2 and r == 0) or
+                (c == 0 and r == self.rows//2))):
+                kwargs['labelled'] = []
 
             # Create subplot
             if view is not None:

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -244,6 +244,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
     invert_xaxis = param.Parameter(precedence=-1)
     invert_yaxis = param.Parameter(precedence=-1)
     invert_zaxis = param.Parameter(precedence=-1)
+    labelled = param.Parameter(precedence=-1)
     legend_cols = param.Parameter(precedence=-1)
     legend_position = param.Parameter(precedence=-1)
     logx = param.Parameter(precedence=-1)


### PR DESCRIPTION
This PR adds a plot option to control which axis labels to display. Currently we provide no control over whether to display specific axis labels. While you usually want axis labels there are cases where you have complex plot arrangements with shared axes when you do want control over it. I didn't want to add separate parameters for each so I have implemented it as a list of ``['x', 'y', ('z')]``. I'm very open to other suggestions but I do think we should offer some control over this.

Also includes a small addition to GridSpace plots to ensure that only one axis label is shown for the shared axes of those plots, which uses this mechanism.

Edit: Another option would be to contract it to a single string so you just say set 'xy', 'x' or 'y'.