### PR TITLE
Allows closest to automatically capitalize group and label lookup

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -500,8 +500,8 @@ class OptionTree(AttrTree):
         object
         """
         components = (obj.__class__.__name__,
-                      group_sanitizer(obj.group),
-                      label_sanitizer(obj.label))
+                      group_sanitizer(obj.group.capitalize()),
+                      label_sanitizer(obj.label.capitalize()))
         return self.find(components).options(group)
 
 


### PR DESCRIPTION
As OptionTree already capitalizes by default this will help elements with lowercase group and label strings to lookup their options correctly.