### PR TITLE
Initial prototype for Dimension preset system

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -91,6 +91,7 @@ class Dimension(param.Parameterized):
     # Defines default formatting by type
     type_formatters = {}
     unit_format = ' ({unit})'
+    presets = {} # A dictionary-like mapping name or (name, unit) to a preset
 
     def __init__(self, name, **params):
         """
@@ -98,6 +99,11 @@ class Dimension(param.Parameterized):
         """
         if isinstance(name, Dimension):
             existing_params = dict(name.get_param_values())
+        elif (name, params.get('unit', None)) in self.presets.keys():
+                preset = self.presets[(name, params['unit'])]
+                existing_params = dict(preset.get_param_values())
+        elif name in self.presets.keys():
+            existing_params = dict(self.presets[name].get_param_values())
         else:
             existing_params = {'name': name}
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -91,7 +91,8 @@ class Dimension(param.Parameterized):
     # Defines default formatting by type
     type_formatters = {}
     unit_format = ' ({unit})'
-    presets = {} # A dictionary-like mapping name or (name, unit) to a preset
+    presets = {} # A dictionary-like mapping name, (name,) or
+                 # (name, unit) to a preset Dimension object
 
     def __init__(self, name, **params):
         """

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -101,8 +101,8 @@ class Dimension(param.Parameterized):
         if isinstance(name, Dimension):
             existing_params = dict(name.get_param_values())
         elif (name, params.get('unit', None)) in self.presets.keys():
-                preset = self.presets[(str(name), str(params['unit']))]
-                existing_params = dict(preset.get_param_values())
+            preset = self.presets[(str(name), str(params['unit']))]
+            existing_params = dict(preset.get_param_values())
         elif name in self.presets.keys():
             existing_params = dict(self.presets[str(name)].get_param_values())
         elif (name,) in self.presets.keys():

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -104,6 +104,8 @@ class Dimension(param.Parameterized):
                 existing_params = dict(preset.get_param_values())
         elif name in self.presets.keys():
             existing_params = dict(self.presets[name].get_param_values())
+        elif (name,) in self.presets.keys():
+            existing_params = dict(self.presets[(name,)].get_param_values())
         else:
             existing_params = {'name': name}
 


### PR DESCRIPTION
This approach is very simple and I rather like it:

* Entirely optional.
* 6 lines of code and could have been only 4 lines of code if I only wanted to support ``(name, unit)`` lookups
* Works completely transparently with no changes to the code required anywhere else. Create a dimension and if there is a matching preset defined, the other dimension parameters are filled in.
* Works from specific to general. If a preset with a ``(name, unit)`` match is found, that is used first. If a preset with only ``name`` defined is found, that is then used, allowing the unit to be filled in from the dimension name (useful if only one possible unit makes sense).
* ``hv.Dimension.presets`` is nice an convenient for access/definition (and now has a nice repr!)

It doesn't allow sharing but I don't see an issue. If you aren't happy with a preset, make sure you define it the way you want it (e.g at the top of the notebook) before building your elements. You are free to change the preset definitions at any time.
