### PR TITLE
Sampled dynamic widgets now work by index, avoiding precision issues

### DIFF
--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -73,7 +73,8 @@ class MPLWidget(NdWidget):
 
     def update(self, key):
         if self.plot.dynamic == 'bounded' and not isinstance(key, int):
-            key = tuple(key)
+            key = tuple(dim.values[k] if dim.values else k
+                        for dim, k in zip(self.mock_obj.kdims, tuple(key)))
 
         if self.renderer.mode == 'nbagg':
             if not self.manager._shown:

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -266,14 +266,17 @@ class SelectionWidget(NdWidget):
             if self.plot.dynamic:
                 if dim.values:
                     if all(isnumeric(v) for v in dim.values):
-                        dim_vals = {i: v for i, v in enumerate(dim.values)}
+                        # Widgets currently detect dynamic mode by type
+                        # this value representation is now redundant
+                        # and should be removed in a refactor
+                        dim_vals = {i: i for i, v in enumerate(dim.values)}
                         widget_type = 'slider'
                         value_labels = escape_list(escape_vals([dim.pprint_value(v)
                                                                 for v in dim.values]))
                     else:
-                        dim_vals = escape_list(escape_vals(dim.values))
+                        dim_vals = list(range(len(dim.values)))
                         value_labels = escape_list(escape_vals([dim.pprint_value(v)
-                                                                for v in dim_vals]))
+                                                                for v in dim.values]))
                         widget_type = 'dropdown'
                     init_dim_vals.append(dim_vals[0])
                 else:
@@ -357,5 +360,7 @@ class SelectionWidget(NdWidget):
 
 
     def update(self, key):
-        if self.plot.dynamic: key = tuple(key)
+        if self.plot.dynamic:
+            key = tuple(dim.values[k] if dim.values else k
+                        for dim, k in zip(self.mock_obj.kdims, tuple(key)))
         return self._plot_figure(key)

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -112,7 +112,7 @@
                         var dim_val = ui.value;
 						var label = ui.value;
                     } else {
-                        var dim_val = vals[ui.value];
+                        var dim_val = ui.value;
 						var label = labels[ui.value];
                     }
 					var text = $('#textInput{{ id }}_{{ widget_data['dim'] }}');
@@ -179,16 +179,21 @@
         };
         widget.data("next_vals", {{ widget_data['next_vals'] }});
         widget.on('change', function(event, ui) {
-            var dim_val = $.data(this, 'values')[this.value];
-            if(anim{{ id }}) {
-                anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
-            }
+		    if ({{ dynamic }}) {
+                var dim_val = parseInt(this.value);
+			} else {
+			    var dim_val = $.data(this, 'values')[this.value];
+			}
             var next_vals = $.data(this, "next_vals");
             if (Object.keys(next_vals).length > 0) {
                 var new_vals = next_vals[dim_val];
                 var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
                 update_widget(next_widget, new_vals);
             }
+			if (anim{{ id }}) {
+                anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
+            }
+
         });
         </script>
         {% endif %}


### PR DESCRIPTION
Currently when working in sampled dynamic mode the values will loose precision and potentially break various lookups (see #647). This PR avoids sending the float values to Javascript working by index in the dimension values instead. The way the dynamic values are sent to JS now is now redundant (a mapping from index to index) but refactoring it would take a while so I suggest postponing that for now.