### PR TITLE
Add GridMatrix example to documentation

### DIFF
--- a/doc/Tutorials/Containers.ipynb
+++ b/doc/Tutorials/Containers.ipynb
@@ -454,7 +454,49 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Of course, each item in the grid can also be a combination of other plots, such as an ``Overlay`` or an ``NdOverlay`` (below)."
+    "Of course, each item in the grid can also be a combination of other plots, such as an ``Overlay`` or an ``NdOverlay`` (below).\n",
+    "\n",
+    "## ``GridMatrix``  <a id='GridMatrix'></a>\n",
+    "\n",
+    "Both ``GridSpace`` and ``GridMatrix`` are very useful for multi-variate analysis. While ``GridSpace`` allows faceting the data by one or two dimensions, a ``GridMatrix`` is most useful to plot multiple variables against each other.\n",
+    "\n",
+    "A simple example is to plot values drawn from various distributions against each other. First we create a ``Table`` containing the values for each distribution then we apply the ``gridmatrix`` operation, which will generate a ``GridMatrix`` instance:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts GridMatrix [fig_size=150 padding=0.05] Scatter [show_grid=False] (alpha=0.1 s=7) Histogram {+axiswise}\n",
+    "distributions = [np.random.rayleigh, np.random.normal, np.random.exponential, np.random.logistic]\n",
+    "dist_table = hv.Table(tuple(d(2, size=1000) for d in distributions), vdims=[d.__name__ for d in distributions])\n",
+    "hv.operation.gridmatrix(dist_table).relabel(group='Distributions')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This also allows comparing multi-variate distributions easily. Here we generate three-dimensional distributions of various types and pass it to the gridmatrix operation either as a HoloMap or as a NdOverlay allowing us to view the distributions individually or overlaid on top of each other."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Layout [hspace=0.2 fig_size=150] Scatter (alpha=0.1) Histogram (alpha=0.3)\n",
+    "cycle = hv.plotting.Cycle()\n",
+    "holomap = hv.HoloMap({d.__name__: hv.Points(d(2, size=(1000, 3)))\n",
+    "                      for i, d in enumerate(distributions)}, kdims=['Distribution'])\n",
+    "hv.operation.gridmatrix(holomap) + hv.operation.gridmatrix(holomap.overlay())"
    ]
   },
   {

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -23,8 +23,9 @@ from unittest import TestCase
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
 from . import *    # noqa (All Elements need to support comparison)
-from ..core import Element, Empty, AdjointLayout, Overlay, Dimension, HoloMap, \
-                   Dimensioned, Layout, NdLayout, NdOverlay, GridSpace, DynamicMap
+from ..core import (Element, Empty, AdjointLayout, Overlay, Dimension,
+                    HoloMap, Dimensioned, Layout, NdLayout, NdOverlay,
+                    GridSpace, DynamicMap, GridMatrix)
 from ..core.options import Options, Cycle
 from ..interface.pandas import DFrame as PandasDFrame
 from ..interface.pandas import DataFrameView
@@ -180,6 +181,7 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[AdjointLayout] = cls.compare_adjointlayouts
         cls.equality_type_funcs[NdOverlay] =     cls.compare_ndoverlays
         cls.equality_type_funcs[GridSpace] =     cls.compare_grids
+        cls.equality_type_funcs[GridMatrix] =     cls.compare_grids
         cls.equality_type_funcs[HoloMap] =       cls.compare_holomap
         cls.equality_type_funcs[DynamicMap] =    cls.compare_dynamicmap
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -630,7 +630,7 @@ class gridmatrix(param.ParameterizedFunction):
                                       adjoin=False)(norm=dict(axiswise=True, framewise=True))
                 else:
                     values = element.dimension_values(d1)
-                    el = p.diagonal_type(values, kdims=[d1])
+                    el = p.diagonal_type(values, vdims=[d1])
             else:
                 el = p.chart_type(el_data, kdims=[d1],
                                   vdims=[d2], datatype=['dataframe', 'dictionary'])


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/513, adds examples for the GridMatrix container to the Containers Tutorial. Shows two ways of using a GridMatrix, the first example looks like this, comparing a number of 1D distributions against each other:

![image](https://cloud.githubusercontent.com/assets/1550771/14922322/de921898-0e2e-11e6-9883-3a6c6aff676c.png)

and a GridMatrix of HoloMaps example showing 2D distributions individually and overlaid:

![image](https://cloud.githubusercontent.com/assets/1550771/14922354/05fcf574-0e2f-11e6-98e5-79daacebb271.png)
