### PR TITLE
Added bokeh QuadMeshPlot

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -131,7 +131,7 @@ options.Polygons = Options('style', color=Cycle())
 # Rasters
 options.Image = Options('style', cmap='hot')
 options.Raster = Options('style', cmap='hot')
-options.QuadMesh = Options('style', cmap='hot')
+options.QuadMesh = Options('style', cmap='hot', line_alpha=0)
 options.HeatMap = Options('style', cmap='RdYlBu_r', line_alpha=0)
 
 # Annotations

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -6,7 +6,7 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         RGB, Histogram, Spread, HeatMap, Contours, Bars,
                         Box, Bounds, Ellipse, Polygons, BoxWhisker,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
-                        Table, ItemTable, Area, HSV)
+                        Table, ItemTable, Area, HSV, QuadMesh)
 from ...core.options import Options, Cycle
 from ...interface import DFrame
 from ..plot import PlotSelector
@@ -19,7 +19,7 @@ from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideSpikesPlot, AreaPlot)
 from .path import PathPlot, PolygonPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
-from .raster import RasterPlot, RGBPlot, HeatmapPlot, HSVPlot
+from .raster import RasterPlot, RGBPlot, HeatmapPlot, HSVPlot, QuadMeshPlot
 from .renderer import BokehRenderer
 from .tabular import TablePlot
 
@@ -49,6 +49,7 @@ Store.register({Overlay: OverlayPlot,
                 Raster: RasterPlot,
                 HeatMap: HeatmapPlot,
                 Histogram: HistogramPlot,
+                QuadMesh: QuadMeshPlot,
 
                 # Paths
                 Path: PathPlot,


### PR DESCRIPTION
Had this lying around for a while and took only a few minutes to polish. Works just like the matplotlib version:

For comparison:

Bokeh:

![image](https://cloud.githubusercontent.com/assets/1550771/15092143/5e8b9396-1459-11e6-999d-37627f8e7fde.png)

Matplotlib:

![image](https://cloud.githubusercontent.com/assets/1550771/15092149/710e3a50-1459-11e6-9598-36f04ef31243.png)
