### PR TITLE
Fix for HoloMap.sample without pandas

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -325,7 +325,7 @@ class HoloMap(UniformNdMapping):
                 raise NotImplementedError("Regular sampling not implemented "
                                           "for high-dimensional Views.")
 
-            samples = util.unique_array(self.last.closest(linsamples))
+            samples = list(util.unique_iterator(self.last.closest(linsamples)))
 
         sampled = self.clone([(k, view.sample(samples, **sample_values))
                               for k, view in self.data.items()])


### PR DESCRIPTION
Fix for #662, unique_array is meant to handle arrays and the closest call returns a list. Switched to ``unique_iterator`` to keep samples sorted. 