### PR TITLE
Avoid hard dependencies on plotting backends

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -155,6 +155,11 @@ class notebook_extension(param.ParameterizedFunction):
                 self.warning("HoloViews %s backend could not be imported, "
                              "ensure %s is installed." % (backend, backend))
             finally:
+                if backend == 'matplotlib' and not notebook_extension._loaded:
+                    svg_exporter = Store.renderers['matplotlib'].instance(holomap=None,
+                                                                          fig='svg')
+                    holoviews.archive.exporters = [svg_exporter] +\
+                                                  holoviews.archive.exporters
                 OutputMagic.allowed['backend'] = list_backends()
                 OutputMagic.allowed['fig'] = list_formats('fig', backend)
                 OutputMagic.allowed['holomap'] = list_formats('holomap', backend)

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -13,7 +13,7 @@ from ..core.options import Store, Cycle, Palette
 from ..element.comparison import ComparisonTestCase
 from ..interface.collector import Collector
 from ..plotting.renderer import Renderer
-from .magics import load_magics, list_formats
+from .magics import load_magics, list_formats, list_backends
 from .display_hooks import display  # noqa (API import)
 from .display_hooks import set_display_hooks, OutputMagic
 from .widgets import RunProgress
@@ -155,7 +155,7 @@ class notebook_extension(param.ParameterizedFunction):
                 self.warning("HoloViews %s backend could not be imported, "
                              "ensure %s is installed." % (backend, backend))
             finally:
-                OutputMagic.allowed['backend'].append(backend)
+                OutputMagic.allowed['backend'] = list_backends()
                 OutputMagic.allowed['fig'] = list_formats('fig', backend)
                 OutputMagic.allowed['holomap'] = list_formats('holomap', backend)
         resources = self._get_resources(args, params)

--- a/holoviews/ipython/archive.py
+++ b/holoviews/ipython/archive.py
@@ -50,11 +50,6 @@ from ..core.io import FileArchive, Pickler
 from ..core.options import Store
 from ..plotting.renderer import HTML_TAGS, MIME_TYPES
 
-try:
-    # Only matplotlib outputs to graphical file formats at this time
-    renderers = [Store.renderers['matplotlib'].instance(holomap=None, fig='svg')]
-except:
-    renderers = []
 
 class NotebookArchive(FileArchive):
     """
@@ -62,7 +57,7 @@ class NotebookArchive(FileArchive):
     display hooks and automatically adds a notebook HTML snapshot to
     the archive upon export.
     """
-    exporters = param.List(default=renderers + [Pickler])
+    exporters = param.List(default=[Pickler])
 
     skip_notebook_export = param.Boolean(default=False, doc="""
         Whether to skip JavaScript capture of notebook data which may

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -95,6 +95,8 @@ def display_hook(fn):
     @wraps(fn)
     def wrapped(element):
         global FULL_TRACEBACK
+        if Store.current_backend is None:
+            return
         optstate = StoreOptions.state(element)
         try:
             html = fn(element,

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -357,10 +357,14 @@ class OutputMagic(OptionsMagic):
         is supplied in items.
         """
         backend = items.get('backend', '')
-        if not backend or backend == Store.current_backend:
+        prev_backend = Store.current_backend
+        renderer = Store.renderers[Store.current_backend]
+        prev_backend += ':%s' % renderer.mode
+        if not backend or backend == prev_backend:
             return options
 
-        cls._backend_options[Store.current_backend] = cls.options
+        cls._backend_options[prev_backend] = cls.options
+
         backend_options = cls._backend_options[backend]
         for p in ['fig', 'holomap']:
             opts = list_formats(p, backend)
@@ -378,9 +382,13 @@ class OutputMagic(OptionsMagic):
             else:
                 opt = cls.defaults[p]
                 backend_options[p] = opt
-            options[p] = opt
+
+        for opt in options:
+            if opt not in backend_options:
+                backend_options[opt] = options[opt]
+
         cls.set_backend(backend)
-        return options
+        return backend_options
 
 
     @classmethod

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -360,6 +360,7 @@ class OutputMagic(OptionsMagic):
         if not backend or backend == Store.current_backend:
             return options
 
+        cls._backend_options[Store.current_backend] = cls.options
         backend_options = cls._backend_options[backend]
         for p in ['fig', 'holomap']:
             opts = list_formats(p, backend)

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -385,10 +385,14 @@ class OutputMagic(OptionsMagic):
     @classmethod
     def initialize(cls):
         backend = cls.options.get('backend', cls.defaults['backend'])
-        cls.options = dict(cls.defaults)
-        cls._set_render_options(cls.defaults)
-        cls.set_backend(backend)
-
+        if backend in Store.renderers:
+            cls.options = dict(cls.defaults)
+            cls._set_render_options(cls.defaults)
+            cls.set_backend(backend)
+        else:
+            cls.options['backend'] = None
+            cls.defaults['backend'] = None
+            cls.set_backend(None)
 
     @classmethod
     def set_backend(cls, backend):

--- a/holoviews/plotting/__init__.py
+++ b/holoviews/plotting/__init__.py
@@ -10,17 +10,6 @@ from ..core.options import Cycle
 from .plot import Plot
 from .renderer import Renderer, HTML_TAGS # noqa (API import)
 
-try:
-    from . import mpl                     # noqa (API import)
-except ImportError:
-    pass
-
-try:
-    from . import bokeh                   # noqa (API import)
-except ImportError:
-    pass
-
-
 def public(obj):
     if not isinstance(obj, type): return False
     is_plot_or_cycle = any([issubclass(obj, bc) for bc in [Plot, Cycle]])


### PR DESCRIPTION
Addresses #528 in two ways. The main holoviews ``__init__.py`` no longer imports the ipython module automatically, which avoids initializing everything immediately. This means HoloViews can now be imported without all the plotting side-effects that causes, which was an issue raised by some users, e.g. see https://github.com/ioam/imagen/issues/48. Instead everything gets initialized when the notebook extension is loaded or the ipython and plotting modules are imported manually. Additionally I've made sure that the IPython extension and the magics correctly handle the case where no plotting library is available.

The only issue I see with this approach is that the notebook extension is now a simple wrapper, which does not define the parameters or a docstring. A better solution would be very welcome.