### PR TITLE
Added support for slicing/indexing with predicate functions

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -171,6 +171,8 @@ class GridInterface(DictInterface):
             for ik in ind:
                 iter_slcs.append(values == ik)
             mask = np.logical_or.reduce(iter_slcs)
+        elif callable(ind):
+            mask = ind(values)
         elif ind is None:
             mask = None
         else:

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -121,6 +121,8 @@ class Interface(param.Parameterized):
                 for ik in k:
                     iter_slcs.append(arr == ik)
                 mask &= np.logical_or.reduce(iter_slcs)
+            elif callable(k):
+                mask &= k(arr)
             else:
                 index_mask = arr == k
                 if dataset.ndims == 1 and np.sum(index_mask) == 0:

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -579,7 +579,8 @@ class NdMapping(MultiDimensionalMapping):
         map_slice = self._transform_indices(map_slice)
         map_slice = self._expand_slice(map_slice)
 
-        if all(not isinstance(el, (slice, set, list, tuple)) for el in map_slice):
+        if all(not (isinstance(el, (slice, set, list, tuple)) or callable(el))
+               for el in map_slice):
             return self._dataslice(self.data[map_slice], data_slice)
         else:
             conditions = self._generate_conditions(map_slice)
@@ -659,6 +660,8 @@ class NdMapping(MultiDimensionalMapping):
                 conditions.append(self._values_condition(dim_slice))
             elif dim_slice is Ellipsis:
                 conditions.append(self._all_condition())
+            elif callable(dim_slice):
+                conditions.append(dim_slice)
             elif isinstance(dim_slice, (tuple)):
                 raise IndexError("Keys may only be selected with sets or lists, not tuples.")
             else:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -865,7 +865,7 @@ class GridSpace(UniformNdMapping):
         values are numeric, otherwise applies no transformation.
         """
         ndims = self.ndims
-        if all(not isinstance(el, slice) for el in key):
+        if all(not (isinstance(el, slice) or callable(el)) for el in key):
             dim_inds = []
             for dim in self.kdims:
                 dim_type = self.get_dimension_type(dim)
@@ -884,7 +884,7 @@ class GridSpace(UniformNdMapping):
                 num_keys = iter(keys[idx])
             key = tuple(next(num_keys) if i in dim_inds else next(str_keys)
                         for i in range(self.ndims))
-        elif any(not isinstance(el, slice) for el in key):
+        elif any(not (isinstance(el, slice) or callable(el)) for el in key):
             index_inds = [idx for idx, el in enumerate(key)
                          if not isinstance(el, (slice, str))]
             if len(index_inds):

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -102,11 +102,15 @@ class HomogeneousColumnTypes(object):
         self.assertEqual(table.kdims[1], 'z')
         self.compare_arrays(table.dimension_values('z'), np.array(list(range(1,12))))
 
-
     def test_dataset_slice_hm(self):
         dataset_slice = Dataset({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]},
                                 kdims=['x'], vdims=['y'])
         self.assertEqual(self.dataset_hm[5:9], dataset_slice)
+
+    def test_dataset_slice_fn_hm(self):
+        dataset_slice = Dataset({'x':range(5, 9), 'y':[2 * i for i in range(5, 9)]},
+                                kdims=['x'], vdims=['y'])
+        self.assertEqual(self.dataset_hm[lambda x: (x >= 5) & (x < 9)], dataset_slice)
 
     def test_dataset_1D_reduce_hm(self):
         dataset = Dataset({'x':self.xs, 'y':self.y_ints}, kdims=['x'], vdims=['y'])

--- a/tests/testdimselect.py
+++ b/tests/testdimselect.py
@@ -40,6 +40,12 @@ class DimensionedSelectionTest(ComparisonTestCase):
                          self.img_map[1:3, 1:3])
 
 
+    def test_function_holoslice(self):
+        self.assertEqual(self.img_map.select(a=lambda x: 1 <= x < 3,
+                                             b=lambda x: 1 <= x < 3),
+                         self.img_map[1:3, 1:3])
+
+
     def test_sanitized_holoslice(self):
         self.assertEqual(self.sanitized_map.select(A_B=(1,3)),
                          self.sanitized_map[1:3])


### PR DESCRIPTION
Implements the suggestion in #619 supporting predicate functions which return Booleans for slicing on both NdMapping types and the data interfaces.