### PR TITLE
Improved abbreviated exception and traceback processing

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -33,6 +33,7 @@ Store:
 
 """
 import pickle
+import traceback
 from contextlib import contextmanager
 from collections import OrderedDict
 
@@ -109,8 +110,14 @@ class AbbreviatedException(Exception):
     def __str__(self):
         abbrev = '%s: %s' % (self.etype.__name__, self.msg)
         msg = ('To view the original traceback, catch this exception '
-               'and access the traceback attribute.')
+               'and call print_traceback() method.')
         return '%s\n\n%s' % (abbrev, msg)
+
+    def print_traceback(self):
+        """
+        Print the traceback of the exception wrapped by the AbbreviatedException.
+        """
+        traceback.print_exception(self.etype, self.value, self.traceback)
 
 
 class abbreviated_exception(object):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -54,6 +54,7 @@ class BackendError(Exception):
     """
     pass
 
+
 class SkipRendering(Exception):
     """
     A SkipRendering exception in the plotting code will make the display
@@ -61,6 +62,7 @@ class SkipRendering(Exception):
     DynamicMaps with exhausted element generators.
     """
     pass
+
 
 class OptionError(Exception):
     """
@@ -87,6 +89,36 @@ class OptionError(Exception):
             msg = ("Invalid key for group %r on path %r;\n"
                     % (group_name, path)) + msg
         return msg
+
+
+class AbbreviatedException(Exception):
+    """
+    Raised by the abbreviate_exception context manager when it is
+    appropriate to present an abbreviated the traceback and exception
+    message in the notebook.
+
+    Particularly useful when processing style options supplied by the
+    user which may not be valid.
+    """
+    def __init__(self, etype, value, traceback):
+        self.etype = etype
+        self.value = value
+        self.traceback = traceback
+        self.msg = str(value)
+
+
+class abbreviated_exception(object):
+    """
+    Context manager used to to abbreviate tracebacks using an
+    AbbreviatedException when a backend may raise an error due to
+    incorrect style options.
+    """
+    def __enter__(self):
+        return self
+
+    def __exit__(self, etype, value, traceback):
+        if isinstance(value, Exception):
+            raise AbbreviatedException(etype, value, traceback)
 
 
 class Cycle(param.Parameterized):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -106,6 +106,12 @@ class AbbreviatedException(Exception):
         self.traceback = traceback
         self.msg = str(value)
 
+    def __str__(self):
+        abbrev = 'Abbreviated %s: %s' % (self.etype.__name__, self.msg)
+        msg = ('To view the original traceback, catch this exception '
+               'and access the traceback attribute.')
+        return '%s\n\n%s' % (abbrev, msg)
+
 
 class abbreviated_exception(object):
     """

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -107,7 +107,7 @@ class AbbreviatedException(Exception):
         self.msg = str(value)
 
     def __str__(self):
-        abbrev = 'Abbreviated %s: %s' % (self.etype.__name__, self.msg)
+        abbrev = '%s: %s' % (self.etype.__name__, self.msg)
         msg = ('To view the original traceback, catch this exception '
                'and access the traceback attribute.')
         return '%s\n\n%s' % (abbrev, msg)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -9,7 +9,7 @@ from IPython import get_ipython
 from IPython.core.ultratb import AutoFormattedTB
 
 import holoviews
-from ..core.options import Store, StoreOptions, BackendError, SkipRendering
+from ..core.options import Store, StoreOptions, BackendError, SkipRendering, AbbreviatedException
 from ..core import (ViewableElement, UniformNdMapping,
                     HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
                     CompositeOverlay, DynamicMap)
@@ -113,31 +113,21 @@ def display_hook(fn):
         except SkipRendering as e:
             sys.stderr.write("Rendering process skipped: %s" % str(e))
             return None
-        except Exception as e:
-            try:
-                StoreOptions.state(element, state=optstate)
-                frame = inspect.trace()[-1]
-                mod = inspect.getmodule(frame[0])
-                module = (mod.__name__ if mod else frame[1]).split('.')[0]
-                backends = Store.renderers.keys()
-                abbreviate =  isinstance(e, BackendError) or module in backends
-                if ABBREVIATE_TRACEBACKS and abbreviate:
-                    AutoTB = AutoFormattedTB(mode = 'Verbose',color_scheme='Linux')
-                    buff = io.StringIO()
-                    AutoTB(out=buff)
-                    buff.seek(0)
-                    FULL_TRACEBACK = buff.read()
-                    info = dict(name=type(e).__name__,
-                                message=str(e).replace('\n','<br>'))
-                    msg ='<i> [Call ipython.show_traceback() for details]</i>'
-                    return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
-            except:
-                FULL_TRACEBACK = traceback.format_exc()
-                msg = ('<i>Error catching exception:</i> %r <br>'
-                       'Call ipython.show_traceback() for details')
-                return msg % e
-            raise e
+        except AbbreviatedException as e:
+            try:    StoreOptions.state(element, state=optstate)
+            except: pass
+            FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype,
+                                                                  e.value,
+                                                                  e.traceback))
+            info = dict(name=e.etype.__name__,
+                        message=str(e.value).replace('\n','<br>'))
+            msg =  '<i> [Call holoviews or hv.ipython.show_traceback() for details]</i>'
+            return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
 
+        except Exception as e:
+            try:    StoreOptions.state(element, state=optstate)
+            except: pass
+            raise e
     return wrapped
 
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -9,7 +9,7 @@ from IPython import get_ipython
 from IPython.core.ultratb import AutoFormattedTB
 
 import holoviews
-from ..core.options import Store, StoreOptions, BackendError, SkipRendering, AbbreviatedException
+from ..core.options import Store, StoreOptions, SkipRendering, AbbreviatedException
 from ..core import (ViewableElement, UniformNdMapping,
                     HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
                     CompositeOverlay, DynamicMap)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -121,7 +121,7 @@ def display_hook(fn):
                                                                   e.traceback))
             info = dict(name=e.etype.__name__,
                         message=str(e.value).replace('\n','<br>'))
-            msg =  '<i> [Call holoviews or hv.ipython.show_traceback() for details]</i>'
+            msg =  '<i> [Call holoviews.ipython.show_traceback() for details]</i>'
             return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
 
         except Exception as e:

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -2,11 +2,10 @@
 Definition and registration of display hooks for the IPython Notebook.
 """
 from functools import wraps
-import sys, traceback, inspect, io
+import sys, traceback
 
 import IPython
 from IPython import get_ipython
-from IPython.core.ultratb import AutoFormattedTB
 
 import holoviews
 from ..core.options import Store, StoreOptions, SkipRendering, AbbreviatedException

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -127,7 +127,7 @@ def display_hook(fn):
         except Exception as e:
             try:    StoreOptions.state(element, state=optstate)
             except: pass
-            raise e
+            raise
     return wrapped
 
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -10,6 +10,7 @@ import param
 
 from ...element import Raster, Points, Polygons, Spikes
 from ...core.util import max_range, basestring
+from ...core.options import abbreviated_exception
 from ..util import compute_sizes, get_sideplot_ranges, match_spec, map_colors
 from .element import ElementPlot, line_properties, fill_properties
 from .path import PathPlot, PolygonPlot
@@ -372,7 +373,8 @@ class ChartPlot(ElementPlot):
             raise Exception("Can't overlay Bokeh Charts based plot properties")
 
         init_element = element.clone(element.interface.concat(self.hmap.values()))
-        plot = self._init_chart(init_element, ranges)
+        with abbreviate_exception():
+            plot = self._init_chart(init_element, ranges)
 
         self.handles['plot'] = plot
         self.handles['glyph_renderers'] = [r for r in plot.renderers
@@ -411,7 +413,8 @@ class ChartPlot(ElementPlot):
 
 
     def _update_chart(self, key, element, ranges):
-        new_chart = self._init_chart(element, ranges)
+        with abbreviate_exception():
+            new_chart = self._init_chart(element, ranges)
         old_chart = self.handles['plot']
         update_plot(old_chart, new_chart)
         properties = self._plot_properties(key, old_chart, element)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -16,6 +16,7 @@ import param
 
 from ...core import (Store, HoloMap, Overlay, DynamicMap,
                      CompositeOverlay, Element)
+from ...core.options import abbreviated_exception
 from ...core import util
 from ...element import RGB
 from ..plot import GenericElementPlot, GenericOverlayPlot
@@ -448,13 +449,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.handles['source'] = source
 
         properties = self._glyph_properties(plot, element, source, ranges)
-        renderer, glyph = self._init_glyph(plot, mapping, properties)
+        with abbreviated_exception():
+            renderer, glyph = self._init_glyph(plot, mapping, properties)
         self.handles['glyph'] = glyph
         if isinstance(renderer, Renderer):
             self.handles['glyph_renderer'] = renderer
 
         # Update plot, source and glyph
-        self._update_glyph(glyph, properties, mapping)
+        with abbreviated_exception():
+            self._update_glyph(glyph, properties, mapping)
         if not self.overlaid:
             self._update_plot(key, plot, element)
         if self.callbacks:
@@ -502,7 +505,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.style = self.lookup_options(element, 'style')
         if glyph:
             properties = self._glyph_properties(plot, element, source, ranges)
-            self._update_glyph(self.handles['glyph'], properties, mapping)
+            with abbreviated_exception():
+                self._update_glyph(self.handles['glyph'], properties, mapping)
         if not self.overlaid:
             self._update_ranges(element, ranges)
             self._update_plot(key, plot, element)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 import numpy as np
+from ...core.options import abbreviated_exception
 
 try:
     from matplotlib import colors
@@ -38,8 +39,9 @@ def mplcmap_to_palette(cmap):
     """
     if colors is None:
         raise ValueError("Using cmaps on objects requires matplotlib.")
-    colormap = cm.get_cmap(cmap) #choose any matplotlib colormap here
-    return [colors.rgb2hex(m) for m in colormap(np.arange(colormap.N))]
+    with abbreviated_exception():
+        colormap = cm.get_cmap(cmap) #choose any matplotlib colormap here
+        return [colors.rgb2hex(m) for m in colormap(np.arange(colormap.N))]
 
 
 def get_cmap(cmap):
@@ -47,10 +49,11 @@ def get_cmap(cmap):
     Returns matplotlib cmap generated from bokeh palette or
     directly accessed from matplotlib.
     """
-    rgb_vals = getattr(Palette, cmap, None)
-    if rgb_vals:
-        return colors.ListedColormap(rgb_vals, name=cmap)
-    return cm.get_cmap(cmap)
+    with abbreviated_exception():
+        rgb_vals = getattr(Palette, cmap, None)
+        if rgb_vals:
+            return colors.ListedColormap(rgb_vals, name=cmap)
+        return cm.get_cmap(cmap)
 
 
 def mpl_to_bokeh(properties):
@@ -66,9 +69,11 @@ def mpl_to_bokeh(properties):
         elif k == 'marker':
             new_properties.update(markers.get(v, {'marker': v}))
         elif k == 'color' or k.endswith('_color'):
-            v = colors.ColorConverter.colors.get(v, v)
+            with abbreviated_exception():
+                v = colors.ColorConverter.colors.get(v, v)
             if isinstance(v, tuple):
-                v = colors.rgb2hex(v)
+                with abbreviated_exception():
+                    v = colors.rgb2hex(v)
             new_properties[k] = v
         else:
             new_properties[k] = v

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -2,6 +2,7 @@ import matplotlib
 from matplotlib import patches as patches
 
 from ...core.util import match_spec
+from ...core.options import abbreviated_exception
 from .element import ElementPlot
 
 
@@ -22,7 +23,8 @@ class AnnotationPlot(ElementPlot):
         ranges = match_spec(annotation, ranges)
         axis = self.handles['axis']
         opts = self.style[self.cyclic_index]
-        handles = self.draw_annotation(axis, annotation.data, opts)
+        with abbreviated_exception():
+            handles = self.draw_annotation(axis, annotation.data, opts)
         self.handles['annotations'] = handles
         return self._finalize_axis(key, ranges=ranges)
 
@@ -31,7 +33,8 @@ class AnnotationPlot(ElementPlot):
         for element in self.handles['annotations']:
             element.remove()
 
-        self.handles['annotations'] = self.draw_annotation(axis, annotation.data, style)
+        with abbreviated_exception():
+            self.handles['annotations'] = self.draw_annotation(axis, annotation.data, style)
 
 
 class VLinePlot(AnnotationPlot):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -9,6 +9,7 @@ import param
 from ...core import util
 from ...core import (OrderedDict, NdOverlay, DynamicMap,
                      CompositeOverlay, Element3D, Element)
+from ...core.options import abbreviated_exception
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update
 from .plot import MPLPlot
@@ -453,7 +454,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             style['label'] = element.label
 
         plot_data, plot_kwargs, axis_kwargs = self.get_data(element, ranges, style)
-        handles = self.init_artists(ax, plot_data, plot_kwargs)
+
+        with abbreviated_exception():
+            handles = self.init_artists(ax, plot_data, plot_kwargs)
         self.handles.update(handles)
 
         return self._finalize_axis(self.keys[-1], ranges=ranges, **axis_kwargs)
@@ -465,7 +468,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         """
         self.teardown_handles()
         plot_data, plot_kwargs, axis_kwargs = self.get_data(element, ranges, style)
-        handles = self.init_artists(axis, plot_data, plot_kwargs)
+
+        with abbreviated_exception():
+            handles = self.init_artists(axis, plot_data, plot_kwargs)
         self.handles.update(handles)
         return axis_kwargs
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -13,6 +13,7 @@ import param
 from ..core import OrderedDict
 from ..core import util, traversal
 from ..core.element import Element
+from ..core.options import abbreviated_exception
 from ..core.overlay import Overlay, CompositeOverlay
 from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor
@@ -746,7 +747,8 @@ class GenericOverlayPlot(GenericElementPlot):
             if not isinstance(plottype, PlotSelector) and issubclass(plottype, GenericOverlayPlot):
                 zoffset += len(set([k for o in vmap for k in o.keys()])) - 1
         if not subplots:
-            raise BackendError(self.renderer.backend)
+            with abbreviated_exception():
+                raise BackendError(self.renderer.backend)
 
         return subplots
 


### PR DESCRIPTION

PR to address #507 which eliminates the hackish code that didn't work particularly well and replaces it with a more targeted solution. We now need to use the ``abbreviated_exception`` context manager in the plotting code as appropriate. All other exceptions and tracebacks now remain unaffected.