### PR TITLE
Fix Bokeh QuadMesh example

### DIFF
--- a/doc/Tutorials/Bokeh_Elements.ipynb
+++ b/doc/Tutorials/Bokeh_Elements.ipynb
@@ -56,7 +56,7 @@
     "\n",
     "<dl class=\"dl-horizontal\">\n",
     "  <dt><a href=\"#Raster\"><code>Raster</code></a></dt><dd>The base class of all rasters containing two-dimensional arrays. <font color='green'>&#x2713;</font></dd>\n",
-    "  <dt><a href=\"#QuadMesh\"><code>QuadMesh</code></a></dt><dd>Raster type specifying 2D bins with two-dimensional array of values. <font color='red'>&#x2717;</font></dd>\n",
+    "  <dt><a href=\"#QuadMesh\"><code>QuadMesh</code></a></dt><dd>Raster type specifying 2D bins with two-dimensional array of values. <font color='green'>&#x2713;</font></dd>\n",
     "  <dt><a href=\"#HeatMap\"><code>HeatMap</code></a></dt><dd>Raster displaying sparse, discontinuous data collected in a two-dimensional space. <font color='green'>&#x2713;</font></dd>\n",
     "  <dt><a href=\"#Image\"><code>Image</code></a></dt><dd>Raster containing a two-dimensional array covering a continuous space (sliceable). <font color='green'>&#x2713;</font></dd>\n",
     "  <dt><a href=\"#RGB\"><code>RGB</code></a></dt><dd>Image with 3 (R,G,B) or 4 (R,G,B,Alpha) color channels. <font color='green'>&#x2713;</font></dd>\n",

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -5,6 +5,7 @@ from bokeh.models.mappers import LinearColorMapper
 
 from ...core.util import cartesian_product
 from ...element import Image, Raster, RGB
+from ..renderer import SkipRendering
 from ..util import map_colors
 from .element import ElementPlot, line_properties, fill_properties
 from .util import mplcmap_to_palette, get_cmap, hsv_to_rgb
@@ -158,6 +159,8 @@ class QuadMeshPlot(ElementPlot):
             style = self.style[self.cyclic_index]
             cmap = style.get('palette', style.get('cmap', None))
             cmap = get_cmap(cmap)
+            if len(set(v.shape for v in element.data)) == 1:
+                raise SkipRendering("Bokeh QuadMeshPlot only supports rectangular meshes")
             zvals = element.data[2].T.flatten()
             colors = map_colors(zvals, ranges[z], cmap)
             xvals = element.dimension_values(0, False)


### PR DESCRIPTION
I've updated the index of the Bokeh Elements tutorial to indicate it's supported. Additionally I'm now raising an SkipRendering error for non-rectangular QuadMeshes which are not yet supported.