### PR TITLE
Fixed initial frame Renderer bounding box calculation

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -232,6 +232,7 @@ class MPLRenderer(Renderer):
         if kw['bbox_inches'] == 'tight':
             if not fig_id in MPLRenderer.drawn:
                 fig.set_dpi(self.dpi)
+                fig.canvas.draw()
                 renderer = fig._cachedRenderer
                 bbox_inches = fig.get_tightbbox(renderer)
                 bbox_artists = kw.pop("bbox_extra_artists", [])


### PR DESCRIPTION
Very annoying the bounding box calculation has been broken for the initial frame for a while. I assume this will change some test data as well. The regression occurred in this commit: https://github.com/ioam/holoviews/commit/637fe63a475943e03be57a41db6fc62d6de394e1 