### PR TITLE
Indicate color clipping and control clipping colors

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -754,9 +754,12 @@ class ColorbarPlot(ElementPlot):
         margin, padding, background_fill_color and more.""")
 
     clipping_colors = param.Dict(default={}, doc="""
-        Dictionary to specify colors for clipped values, allows setting
-        color for NaN values and for values above and below the min and
-        max value.""")
+        Dictionary to specify colors for clipped values, allows
+        setting color for NaN values and for values above and below
+        the min and max value. The min, max or NaN color may specify
+        an RGB(A) color as a color hex string of the form #FFFFFF or
+        #FFFFFFFF or a length 3 or length 4 tuple specifying values in
+        the range 0-1 or a named HTML color.""")
 
     logz  = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the z-axis.""")
@@ -803,9 +806,14 @@ class ColorbarPlot(ElementPlot):
                 return None
         colors = self.clipping_colors
         opts = {'low': low, 'high': high}
-        if 'max' in colors: opts['high_color'] = colors['max']
-        if 'min' in colors: opts['low_color'] = colors['min']
-        if 'NaN' in colors: opts['nan_color'] = colors['NaN']
+        color_opts = [('NaN', 'nan_color'), ('max', 'high_color'), ('min', 'low_color')]
+        for name, opt in color_opts:
+            color = colors.get(name)
+            if not color:
+                continue
+            elif isinstance(color, tuple):
+                color = [int(c*255) if i<3 else c for i, c in enumerate(color)]
+            opts[opt] = color
         if 'color_mapper' in self.handles:
             cmapper = self.handles['color_mapper']
             cmapper.palette = palette

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -753,7 +753,7 @@ class ColorbarPlot(ElementPlot):
         location, orientation, height, width, scale_alpha, title, title_props,
         margin, padding, background_fill_color and more.""")
 
-    clipping_colors = param.Dict(default={'NaN': (0, 0, 0, 1)}, doc="""
+    clipping_colors = param.Dict(default={}, doc="""
         Dictionary to specify colors for clipped values, allows setting
         color for NaN values and for values above and below the min and
         max value.""")

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -753,6 +753,11 @@ class ColorbarPlot(ElementPlot):
         location, orientation, height, width, scale_alpha, title, title_props,
         margin, padding, background_fill_color and more.""")
 
+    clipping_colors = param.Dict(default={'NaN': (0, 0, 0, 1)}, doc="""
+        Dictionary to specify colors for clipped values, allows setting
+        color for NaN values and for values above and below the min and
+        max value.""")
+
     logz  = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the z-axis.""")
 
@@ -796,14 +801,18 @@ class ColorbarPlot(ElementPlot):
                 return cmapper
             else:
                 return None
+        colors = self.clipping_colors
+        opts = {'low': low, 'high': high}
+        if 'max' in colors: opts['high_color'] = colors['max']
+        if 'min' in colors: opts['low_color'] = colors['min']
+        if 'NaN' in colors: opts['nan_color'] = colors['NaN']
         if 'color_mapper' in self.handles:
             cmapper = self.handles['color_mapper']
-            cmapper.low = low
-            cmapper.high = high
             cmapper.palette = palette
+            cmapper.set(**opts)
         else:
             colormapper = LogColorMapper if self.logz else LinearColorMapper
-            cmapper = colormapper(palette, low=low, high=high)
+            cmapper = colormapper(palette, **opts)
             self.handles['color_mapper'] = cmapper
             self.handles['color_dim'] = dim
         return cmapper

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -107,6 +107,14 @@ class HSVPlot(RGBPlot):
 
 class HeatmapPlot(ColorbarPlot):
 
+    clipping_colors = param.Dict(default={'NaN': 'white'}, doc="""
+        Dictionary to specify colors for clipped values, allows
+        setting color for NaN values and for values above and below
+        the min and max value. The min, max or NaN color may specify
+        an RGB(A) color as a color hex string of the form #FFFFFF or
+        #FFFFFFFF or a length 3 or length 4 tuple specifying values in
+        the range 0-1 or a named HTML color.""")
+
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -517,7 +517,7 @@ class ColorbarPlot(ElementPlot):
     colorbar = param.Boolean(default=False, doc="""
         Whether to draw a colorbar.""")
 
-    clipping_colors = param.Dict(default={'NaN': (0, 0, 0, 1)}, doc="""
+    clipping_colors = param.Dict(default={}, doc="""
         Dictionary to specify colors for clipped values, allows setting
         color for NaN values and for values above and below the min and
         max value.""")
@@ -664,9 +664,9 @@ class ColorbarPlot(ElementPlot):
                              'alpha': val[3] if len(val) > 3 else 1}
             elif isinstance(val, util.basestring):
                 colors[k] = {'color': val}
-        if 'max' in colors: cmap.set_over(colors['max'])
-        if 'min' in colors: cmap.set_under(colors['min'])
-        if 'NaN' in colors: cmap.set_bad(colors['NaN'])
+        if 'max' in colors: cmap.set_over(**colors['max'])
+        if 'min' in colors: cmap.set_under(**colors['min'])
+        if 'NaN' in colors: cmap.set_bad(**colors['NaN'])
         opts['cmap'] = cmap
 
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -518,9 +518,12 @@ class ColorbarPlot(ElementPlot):
         Whether to draw a colorbar.""")
 
     clipping_colors = param.Dict(default={}, doc="""
-        Dictionary to specify colors for clipped values, allows setting
-        color for NaN values and for values above and below the min and
-        max value.""")
+        Dictionary to specify colors for clipped values, allows
+        setting color for NaN values and for values above and below
+        the min and max value. The min, max or NaN color may specify
+        an RGB(A) color as a color hex string of the form #FFFFFF or
+        #FFFFFFFF or a length 3 or length 4 tuple specifying values in
+        the range 0-1 or a named HTML color.""")
 
     cbar_padding = param.Number(default=0.01, doc="""
         Padding between colorbar and other plots.""")
@@ -663,7 +666,12 @@ class ColorbarPlot(ElementPlot):
                 colors[k] = {'color': val[:3],
                              'alpha': val[3] if len(val) > 3 else 1}
             elif isinstance(val, util.basestring):
-                colors[k] = {'color': val}
+                color = val
+                alpha = 1
+                if color.startswith('#') and len(color) == 9:
+                    alpha = int(color[-2:], 16)/255.
+                    color = color[:-2]
+                colors[k] = {'color': color, 'alpha': alpha}
         if 'max' in colors: cmap.set_over(**colors['max'])
         if 'min' in colors: cmap.set_under(**colors['min'])
         if 'NaN' in colors: cmap.set_bad(**colors['NaN'])

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -517,7 +517,7 @@ class ColorbarPlot(ElementPlot):
     colorbar = param.Boolean(default=False, doc="""
         Whether to draw a colorbar.""")
 
-    clipping_colors = param.Dict(default={'NaN': ('w', 1)}, doc="""
+    clipping_colors = param.Dict(default={'NaN': (0, 0, 0, 1)}, doc="""
         Dictionary to specify colors for clipped values, allows setting
         color for NaN values and for values above and below the min and
         max value.""")
@@ -657,12 +657,16 @@ class ColorbarPlot(ElementPlot):
         # Define special out-of-range colors on colormap
         cmap_name = opts.pop('cmap', None)
         cmap = copy.copy(plt.cm.get_cmap('gray' if cmap_name is None else cmap_name))
-        if 'max' in self.clipping_colors:
-            cmap.set_over(*util.wrap_tuple(self.clipping_colors['max']))
-        if 'min' in self.clipping_colors:
-            cmap.set_under(*util.wrap_tuple(self.clipping_colors['min']))
-        if 'NaN' in self.clipping_colors:
-            cmap.set_bad(*util.wrap_tuple(self.clipping_colors['NaN']))
+        colors = {}
+        for k, val in self.clipping_colors.items():
+            if isinstance(val, tuple):
+                colors[k] = {'color': val[:3],
+                             'alpha': val[3] if len(val) > 3 else 1}
+            elif isinstance(val, util.basestring):
+                colors[k] = {'color': val}
+        if 'max' in colors: cmap.set_over(colors['max'])
+        if 'min' in colors: cmap.set_under(colors['min'])
+        if 'NaN' in colors: cmap.set_bad(colors['NaN'])
         opts['cmap'] = cmap
 
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -1,4 +1,4 @@
-import math
+import math, copy
 
 import param
 import numpy as np
@@ -517,8 +517,10 @@ class ColorbarPlot(ElementPlot):
     colorbar = param.Boolean(default=False, doc="""
         Whether to draw a colorbar.""")
 
-    cbar_width = param.Number(default=0.05, doc="""
-        Width of the colorbar as a fraction of the main plot""")
+    clipping_colors = param.Dict(default={'NaN': ('w', 1)}, doc="""
+        Dictionary to specify colors for clipped values, allows setting
+        color for NaN values and for values above and below the min and
+        max value.""")
 
     cbar_padding = param.Number(default=0.01, doc="""
         Padding between colorbar and other plots.""")
@@ -530,10 +532,17 @@ class ColorbarPlot(ElementPlot):
         set to None default matplotlib ticking behavior is
         applied.""")
 
+    cbar_width = param.Number(default=0.05, doc="""
+        Width of the colorbar as a fraction of the main plot""")
+
     symmetric = param.Boolean(default=False, doc="""
         Whether to make the colormap symmetric around zero.""")
 
     _colorbars = {}
+
+    def __init__(self, *args, **kwargs):
+        super(ColorbarPlot, self).__init__(*args, **kwargs)
+        self._cbar_extend = 'neither'
 
     def _adjust_cbar(self, cbar, label, dim):
         noalpha = math.floor(self.style[self.cyclic_index].get('alpha', 1)) == 1
@@ -593,7 +602,7 @@ class ColorbarPlot(ElementPlot):
             scaled_w = w*width
             cax = fig.add_axes([l+w+padding+(scaled_w+padding+w*0.15)*offset,
                                 b, scaled_w, h])
-            cbar = plt.colorbar(artist, cax=cax)
+            cbar = plt.colorbar(artist, cax=cax, extend=self._cbar_extend)
             self._adjust_cbar(cbar, label, dim)
             self.handles['cax'] = cax
             self.handles['cbar'] = cbar
@@ -635,6 +644,27 @@ class ColorbarPlot(ElementPlot):
             opts['norm'] = norm
         opts['vmin'] = clim[0]
         opts['vmax'] = clim[1]
+
+        # Check whether the colorbar should indicate clipping
+        el_min, el_max = element.range(vdim)
+        if el_min < opts['vmin'] and el_max > opts['vmax']:
+            self._cbar_extend = 'both'
+        elif el_min < opts['vmin']:
+            self._cbar_extend = 'min'
+        elif el_max > opts['vmax']:
+            self._cbar_extend = 'max'
+
+        # Define special out-of-range colors on colormap
+        cmap_name = opts.pop('cmap', None)
+        cmap = copy.copy(plt.cm.get_cmap('gray' if cmap_name is None else cmap_name))
+        if 'max' in self.clipping_colors:
+            cmap.set_over(*util.wrap_tuple(self.clipping_colors['max']))
+        if 'min' in self.clipping_colors:
+            cmap.set_under(*util.wrap_tuple(self.clipping_colors['min']))
+        if 'NaN' in self.clipping_colors:
+            cmap.set_bad(*util.wrap_tuple(self.clipping_colors['NaN']))
+        opts['cmap'] = cmap
+
 
 
 class LegendPlot(ElementPlot):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -658,8 +658,7 @@ class ColorbarPlot(ElementPlot):
             self._cbar_extend = 'max'
 
         # Define special out-of-range colors on colormap
-        cmap_name = opts.pop('cmap', None)
-        cmap = copy.copy(plt.cm.get_cmap('gray' if cmap_name is None else cmap_name))
+        cmap = copy.copy(plt.cm.get_cmap(opts.get('cmap')))
         colors = {}
         for k, val in self.clipping_colors.items():
             if isinstance(val, tuple):

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -148,12 +148,8 @@ class HeatMapPlot(RasterPlot):
 
     def get_data(self, element, ranges, style):
         _, style, axis_kwargs = super(HeatMapPlot, self).get_data(element, ranges, style)
-        data = element.raster
-        data = np.ma.array(data, mask=np.logical_not(np.isfinite(data)))
-        cmap_name = style.pop('cmap', None)
-        cmap = copy.copy(plt.cm.get_cmap('gray' if cmap_name is None else cmap_name))
-        cmap.set_bad('w', 1.)
-        style['cmap'] = cmap
+        mask = np.logical_not(np.isfinite(element.raster))
+        data = np.ma.array(element.raster, mask=mask)
         style['annotations'] = self._annotate_values(element)
         return [data], style, axis_kwargs
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -90,6 +90,14 @@ class RasterPlot(ColorbarPlot):
 
 class HeatMapPlot(RasterPlot):
 
+    clipping_colors = param.Dict(default={'NaN': 'white'}, doc="""
+        Dictionary to specify colors for clipped values, allows
+        setting color for NaN values and for values above and below
+        the min and max value. The min, max or NaN color may specify
+        an RGB(A) color as a color hex string of the form #FFFFFF or
+        #FFFFFFFF or a length 3 or length 4 tuple specifying values in
+        the range 0-1 or a named HTML color.""")
+
     show_values = param.Boolean(default=False, doc="""
         Whether to annotate each pixel with its value.""")
 


### PR DESCRIPTION
As the title says, adds a plot option to extend the colorbar in a particular. Here's an example:

```python
%%opts Image [colorbar=True]
hv.Layout([hv.Image(np.random.rand(10,10))(plot=dict(cbar_extend=opt))
           for opt in ['min', 'max', 'both']])
```

![image](https://cloud.githubusercontent.com/assets/1550771/15228141/9c7ab380-1882-11e6-8e0c-919e49906937.png)

Can also consider automatically enabling this if your data falls outside the specified range but that's another discussion.