### PR TITLE
note on the y coordinate in numpy.meshgrid

### DIFF
--- a/doc/Tutorials/Continuous_Coordinates.ipynb
+++ b/doc/Tutorials/Continuous_Coordinates.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's build a Numpy array regularly sampling this function at a density of 5 samples per mm: "
+    "``Coords`` function return a ``numpy`` meshgrid that will be helpful for regular sampling this function at a density of 5 samples per mm: "
    ]
   },
   {
@@ -87,7 +87,61 @@
    },
    "outputs": [],
    "source": [
-    "f5=f(*coords(region,5))\n",
+    "x5, y5 = coords(region,5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is important to note here that values of ``x`` coordinates are incrementing from left to right"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "once values of ``y`` coordinates are incrementing from top to bottom."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "y5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Same order of coordinates applies when we use created meshgrid to compute values of ``f`` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "f5=f(x5, y5)\n",
     "f5"
    ]
   },
@@ -109,7 +163,8 @@
     "r5 = hv.Raster(f5, label=\"R5\")\n",
     "i5 = hv.Image( f5, label=\"I5\", bounds=region)\n",
     "h5 = hv.HeatMap([(x, y, f5[4-y,x]) for x in range(0,5) for y in range(0,5)], label=\"H5\")\n",
-    "r5+i5+h5"
+    "flipped5 = hv.Image( np.flipud(f5), label=\"I5 flipped\", bounds=region)\n",
+    "r5+i5+h5+flipped5"
    ]
   },
   {
@@ -156,6 +211,13 @@
     "<TD><IMG src=\"http://ioam.github.io/topographica/_images/sheet_coords_-0.2_0.4.png\"></TD>\n",
     "</TR>\n",
     "</TABLE>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``I5 flipped`` plot on the right corresponds to situation when matrix ``f5`` was flipped upside down. After that operation value of the ``y`` coordinate on the axis corresponds exactly to the value that was passed to the function ``f(x,y)``. This may lead to confusion and therefore it is important to be aware that ``y`` coordinates returned by the ``numpy.meshgrid`` are flipped upside down in a first place. "
    ]
   },
   {

--- a/doc/Tutorials/Options.ipynb
+++ b/doc/Tutorials/Options.ipynb
@@ -37,7 +37,7 @@
     "import holoviews as hv\n",
     "hv.notebook_extension()\n",
     "\n",
-    "x,y = np.mgrid[-50:51, -50:51] * 0.1\n",
+    "y,x = np.mgrid[-50:51, -50:51] * 0.1\n",
     "image = hv.Image(np.sin(x**2+y**2), group=\"Function\", label=\"Sine\") \n",
     "\n",
     "coords = [(0.1*i, np.sin(0.1*i)) for i in range(100)]\n",


### PR DESCRIPTION
Adding small explanation why images in continuous coordinates tutorial are upside down.  
