### PR TITLE
Generalize VectorFieldPlot

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -349,7 +349,7 @@ class VectorField(Points):
     group = param.String(default='VectorField', constant=True)
 
     vdims = param.List(default=[Dimension('Angle', cyclic=True, range=(0,2*np.pi)),
-                                Dimension('Magnitude')], bounds=(1, 2))
+                                Dimension('Magnitude')], bounds=(1, None))
 
     _null_value = np.array([[], [], [], []]).T # For when data is None
     _min_dims = 3                              # Minimum number of columns

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -509,14 +509,14 @@ class VectorFieldPlot(ColorbarPlot):
     angle alone (with some common, arbitrary arrow length) or may be
     true polar vectors.
 
-    Optionally, the arrows may be colored but this dimension is
-    redundant with either the specified angle or magnitudes. This
-    choice is made by setting the color_dim parameter.
+    The color or magnitude can be mapped onto any dimension using the
+    color_index and size_index.
 
-    Note that the 'cmap' style argument controls the color map used to
-    color the arrows. The length of the arrows is controlled by the
-    'scale' style option where a value of 1.0 is such that the largest
-    arrow shown is no bigger than the smallest sampling distance.
+    The length of the arrows is controlled by the 'scale' style
+    option. The scaling of the arrows may also be controlled via the
+    normalize_lengths and rescale_lengths plot option, which will
+    normalize the lengths to a maximum of 1 and scale them according
+    to the minimum distance respectively.
     """
 
     color_index = param.ClassSelector(default=None, class_=(basestring, int),


### PR DESCRIPTION
This PR makes the VectorField element and plot mirror other elements more closely in that color and size can be mapped to any arbitrary dimension. It is a backwards compatibility breaking change but makes it more consistent and more powerful. I've used it extensively in my thesis for plots where the angle, magnitude and color are three separate dimensions:

![image](https://cloud.githubusercontent.com/assets/1550771/15723338/e0b0d464-2839-11e6-9671-240febb2d5e0.png)
