### PR TITLE
Added support for dynamic groupby on all data interfaces

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -399,7 +399,7 @@ class Dataset(Element):
                 if np.isscalar(group):
                     return group_type(([group],), group=self.group,
                                       label=self.label, vdims=self.vdims)
-                return group_type(group).reindex(group_dims)
+                return group_type(group.reindex(group_dims))
             dynamic_dims = [d(values=list(self.interface.values(self, d.name, False)))
                             for d in dimensions]
             return DynamicMap(load_subset, kdims=dynamic_dims)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -395,7 +395,11 @@ class Dataset(Element):
             group_dims = [d.name for d in self.kdims if d not in dimensions]
             def load_subset(*args):
                 constraint = dict(zip(dim_names, args))
-                return group_type(self.select(**constraint).reindex(group_dims))
+                group = self.select(**constraint)
+                if np.isscalar(group):
+                    return group_type(([group],), group=self.group,
+                                      label=self.label, vdims=self.vdims)
+                return group_type(group).reindex(group_dims)
             dynamic_dims = [d(values=list(self.interface.values(self, d.name, False)))
                             for d in dimensions]
             return DynamicMap(load_subset, kdims=dynamic_dims)

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -291,7 +291,9 @@ class GridInterface(DictInterface):
                 vdata = data[vdim.name]
                 if dropped_axes:
                     vdata = vdata.squeeze(axis=dropped_axes)
-                data[vdim.name] = np.transpose(vdata, axes)
+                if len(axes) > 1:
+                    vdata = np.transpose(vdata, axes)
+                data[vdim.name] = vdata
         return data
 
 

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -148,6 +148,14 @@ class CubeInterface(GridInterface):
         does not need to be reindexed, the Element can simply
         reorder its key dimensions.
         """
+        if kdims and len(kdims) != dataset.ndims:
+            drop_dims = [kd for kd in dataset.kdims if kd not in kdims]
+            constraints = {}
+            for d in drop_dims:
+                vals = cls.values(dataset, d, False)
+                if len(vals):
+                    constraints[d.name] = vals[0]
+            return dataset.data.extract(iris.Constraint(**constraints))
         return dataset.data
 
 

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -165,15 +165,6 @@ class CubeInterface(GridInterface):
         constraints = [d.name for d in dims]
         slice_dims = [d for d in dataset.kdims if d not in dims]
 
-        if dynamic:
-            def load_subset(*args):
-                constraint = iris.Constraint(**dict(zip(constraints, args)))
-                return dataset.clone(dataset.data.extract(constraint),
-                                      new_type=group_type,
-                                      **dict(kwargs, kdims=slice_dims))
-            dynamic_dims = [d(values=list(cls.values(dataset, d, False))) for d in dims]
-            return DynamicMap(load_subset, kdims=dynamic_dims)
-
         unique_coords = product(*[cls.values(dataset, d, expanded=False)
                                   for d in dims])
         data = []

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -280,6 +280,12 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
                           kdims=['Gender'])
         self.assertEqual(self.table.groupby(['Gender']), grouped)
 
+    def test_dataset_groupby_dynamic(self):
+        grouped_dataset = self.table.groupby('Gender', dynamic=True)
+        self.assertEqual(grouped_dataset['M'],
+                         self.table.select(Gender='M').reindex(['Age']))
+        self.assertEqual(grouped_dataset['F'],
+                         self.table.select(Gender='F').reindex(['Age']))
 
     def test_dataset_add_dimensions_value_ht(self):
         table = self.dataset_ht.add_dimension('z', 1, 0)
@@ -491,6 +497,15 @@ class GridDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
     def test_dataset_groupby(self):
         self.assertEqual(self.dataset_hm.groupby('x').keys(), list(self.xs))
 
+    def test_dataset_groupby_dynamic(self):
+        array = np.random.rand(11, 11)
+        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+                          kdims=['x', 'y'], vdims=['z'])
+        grouped = dataset.groupby('x', dynamic=True)
+        first = Dataset({'y': self.y_ints, 'z': array[:, 0]},
+                        kdims=['y'], vdims=['z'])
+        self.assertEqual(grouped[0], first)
+
 
 
 class IrisDatasetTest(GridDatasetTest):
@@ -523,7 +538,6 @@ class IrisDatasetTest(GridDatasetTest):
 
     def test_dataset_sample_hm(self):
         pass
-
 
 
 class XArrayDatasetTest(GridDatasetTest):


### PR DESCRIPTION
A dynamic version of groupby proved exceptionally useful for large datasets we can now handle via the iris interface. However it can trivially be implemented in a general way using select, which is what I've done here. 

However there's also some cases where the behavior is not well defined. When you apply a dynamic groupby to columnar dataset, it can be sparse, which means that some portions of the cartesian grid the DynamicMap defines can be empty.  A simple example would be something like this:

```python
import holoviews as hv
dataset = hv.Dataset((['UK', 'UK', 'USA'], [1995, 1996, 1995],  [0.1, 0.2, 0.3]),
                     kdims=['Country', 'Year', 'Index'], vdims=['Value'])
dmap = dataset.groupby(['Country', 'Year'], dynamic=True)
```

```
:DynamicMap   [Country,Year]
```

```python
assert len(dmap['USA', 1996]) == 0
```

Here the value entry for USA and 1996 did not exist, so it returned an empty Element. Alternatively it could raise a KeyError. However the semantics of a DynamicMap mean that anything inside the space defined by theDimensions should be addressable, I think returning an empty Element might be more appropriate. However when you access a value that was not defined in the original Dataset it should definitely raise a KeyError:

```python
dmap['Canada', 1955]
```

So I'll have to make sure that ``DynamicMap.__getitem__`` (and select) ensure that when in bounded mode it checks the requested key is in the defined values, not just the bounds. 