### PR TITLE
Skip rendering when no matching plotting class is found

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -363,7 +363,8 @@ class Renderer(Exporter):
         try:
             plotclass = Store.registry[cls.backend][element_type]
         except KeyError:
-            raise Exception("No corresponding plot type found for %r" % type(obj))
+            raise SkipRendering("No plotting class for {0} "
+                                "found".format(element_type.__name__))
         return plotclass
 
 


### PR DESCRIPTION
Rather than raising an error when a nested object containing objects which cannot be renderered is displayed (e.g. a HoloMap of ``Datasets``) rather than raising a useless error message this will simply raise a ``SkipRendering`` error, which just raises a warning and then prints the repr, which is more useful.