### PR TITLE
Implemented redim method on Dimensioned objects

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -394,9 +394,8 @@ class Dataset(Element):
         """
         Replace dimensions on the dataset and allows renaming
         dimensions in the dataset. Dimension mapping should map
-        between the old dimension name and either a dictionary of the
-        new attributes or a completely new dimension to replace it
-        with.
+        between the old dimension name and a dictionary of the new
+        attributes, a completely new dimension or a new string name.
         """
         if specs is not None:
             if not isinstance(specs, list):
@@ -407,11 +406,11 @@ class Dataset(Element):
         kdims = replace_dimensions(self.kdims, dimensions)
         vdims = replace_dimensions(self.vdims, dimensions)
         zipped_dims = zip(self.kdims+self.vdims, kdims+vdims)
-        renames = {pk.name: nk.name for pk, nk in zipped_dims if pk != nk}
-        renamed = self.data
+        renames = {pk.name: nk for pk, nk in zipped_dims if pk != nk}
+        data = self.data
         if renames:
-            renamed = self.interface.rename(self, renames)
-        return self.clone(renamed, kdims=kdims, vdims=vdims)
+            data = self.interface.redim(self, renames)
+        return self.clone(data, kdims=kdims, vdims=vdims)
 
 
     def dimension_values(self, dim, expanded=True, flat=True):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -123,8 +123,8 @@ class DictInterface(Interface):
         return OrderedDict(data)
 
     @classmethod
-    def rename(cls, dataset, renames):
-        return OrderedDict([(renames.get(k, k), v)
+    def redim(cls, dataset, dimensions):
+        return OrderedDict([(dimensions.get(k, dataset.get_dimension(k)).name, v)
                             for k,v in dataset.data.items()])
 
     @classmethod

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -122,6 +122,10 @@ class DictInterface(Interface):
         data.insert(dim_pos, (dim, values))
         return OrderedDict(data)
 
+    @classmethod
+    def rename(cls, dataset, renames):
+        return OrderedDict([(renames.get(k, k), v)
+                            for k,v in dataset.data.items()])
 
     @classmethod
     def concat(cls, dataset_objs):

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -204,3 +204,7 @@ class Interface(param.Parameterized):
     @classmethod
     def length(cls, dataset):
         return len(dataset.data)
+
+    @classmethod
+    def rename(cls, dataset, renames):
+        return dataset.data

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -206,5 +206,5 @@ class Interface(param.Parameterized):
         return len(dataset.data)
 
     @classmethod
-    def rename(cls, dataset, renames):
+    def redim(cls, dataset, dimensions):
         return dataset.data

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -201,6 +201,21 @@ class CubeInterface(GridInterface):
 
 
     @classmethod
+    def rename(cls, dataset, renames):
+        """
+        Rename coords on the Cube.
+        """
+        new_dataset = dataset.data.copy()
+        for name, new_name in renames.items():
+            if name == dataset.data.name():
+                new_dataset.rename(new_name)
+            for coord in dataset.data.dim_coords:
+                if name == coord.name():
+                    coord.rename(new_name)
+        return new_dataset
+
+
+    @classmethod
     def length(cls, dataset):
         """
         Returns the total number of samples in the dataset.

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -201,17 +201,17 @@ class CubeInterface(GridInterface):
 
 
     @classmethod
-    def rename(cls, dataset, renames):
+    def redim(cls, dataset, dimensions):
         """
         Rename coords on the Cube.
         """
         new_dataset = dataset.data.copy()
-        for name, new_name in renames.items():
-            if name == dataset.data.name():
-                new_dataset.rename(new_name)
-            for coord in dataset.data.dim_coords:
+        for name, new_dim in dimensions.items():
+            if name == new_dataset.name():
+                new_dataset.rename(new_dim.name)
+            for coord in new_dataset.dim_coords:
                 if name == coord.name():
-                    coord.rename(new_name)
+                    coord.rename(new_dim.name)
         return new_dataset
 
 

--- a/holoviews/core/data/ndelement.py
+++ b/holoviews/core/data/ndelement.py
@@ -76,6 +76,10 @@ class NdElementInterface(Interface):
         return Dimensioned.get_dimension_type(columns, dim)
 
     @classmethod
+    def rename(cls, dataset, renames):
+        return dataset.data.redim(**renames)
+
+    @classmethod
     def shape(cls, columns):
         return (len(columns), len(columns.dimensions()))
 

--- a/holoviews/core/data/ndelement.py
+++ b/holoviews/core/data/ndelement.py
@@ -76,8 +76,8 @@ class NdElementInterface(Interface):
         return Dimensioned.get_dimension_type(columns, dim)
 
     @classmethod
-    def rename(cls, dataset, renames):
-        return dataset.data.redim(**renames)
+    def redim(cls, dataset, dimensions):
+        return dataset.data.redim(**dimensions)
 
     @classmethod
     def shape(cls, columns):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -152,8 +152,9 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def rename(cls, dataset, renames):
-        return dataset.data.rename(columns=renames)
+    def redim(cls, dataset, dimensions):
+        column_renames = {k: v.name for k, v in dimensions.items()}
+        return dataset.data.rename(columns=column_renames)
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -152,6 +152,11 @@ class PandasInterface(Interface):
 
 
     @classmethod
+    def rename(cls, dataset, renames):
+        return dataset.data.rename(columns=renames)
+
+
+    @classmethod
     def sort(cls, columns, by=[]):
         import pandas as pd
         if not isinstance(by, list): by = [by]
@@ -210,7 +215,7 @@ class PandasInterface(Interface):
     @classmethod
     def dframe(cls, columns, dimensions):
         if dimensions:
-            return columns.reindex(columns=dimensions)
+            return columns.reindex(dimensions).data.copy()
         else:
             return columns.data.copy()
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -39,6 +39,35 @@ def param_aliases(d):
     return d
 
 
+def replace_dimensions(dimensions, overrides):
+    """
+    Replaces dimensions in a list with a dictionary of overrides.
+    Overrides should be indexed by the dimension name with values that
+    is either a Dimension object, a string name or a dictionary
+    specifying the dimension parameters to override.
+    """
+    replaced = []
+    for d in dimensions:
+        if d.name in overrides:
+            override = overrides[d.name]
+        else:
+            override = None
+
+        if override is None:
+            replaced.append(d)
+        elif isinstance(override, basestring):
+            replaced.append(d(override))
+        elif isinstance(override, Dimension):
+            replaced.append(override)
+        elif isinstance(override, dict):
+            replaced.append(d(**override))
+        else:
+            raise ValueError('Dimension can only be overridden '
+                             'with another dimension or a dictionary '
+                             'of attributes')
+    return replaced
+
+
 class Dimension(param.Parameterized):
     """
     Dimension objects are used to specify some important general
@@ -764,6 +793,35 @@ class Dimensioned(LabelledData):
                     items.append((k, v))
             selection = selection.clone(items)
         return selection
+
+
+    def redim(self, specs=None, **dimensions):
+        """
+        Replaces existing dimensions in an object with new dimensions
+        or changing specific attributes of a dimensions. Dimension
+        mapping should map between the old dimension name and either a
+        dictionary of the new attributes or a completely new dimension
+        to replace it with.
+        """
+        if specs is None:
+            applies = True
+        else:
+            if not isinstance(specs, list):
+                specs = [specs]
+            applies = any(self.matches(spec) for spec in specs)
+
+        redimmed = self
+        if self._deep_indexable:
+            deep_mapped = [(k, v.redim(specs, **dimensions))
+                           for k, v in self.items()]
+            redimmed = self.clone(deep_mapped)
+
+        if applies:
+            kdims = replace_dimensions(self.kdims, dimensions)
+            vdims = replace_dimensions(self.vdims, dimensions)
+            return redimmed.clone(kdims=kdims, vdims=vdims)
+        else:
+            return redimmed
 
 
     def dimension_values(self, dimension, expanded=True, flat=True):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -799,9 +799,9 @@ class Dimensioned(LabelledData):
         """
         Replaces existing dimensions in an object with new dimensions
         or changing specific attributes of a dimensions. Dimension
-        mapping should map between the old dimension name and either a
-        dictionary of the new attributes or a completely new dimension
-        to replace it with.
+        mapping should map between the old dimension name and a
+        dictionary of the new attributes, a completely new dimension
+        or a new string name.
         """
         if specs is None:
             applies = True

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -83,6 +83,17 @@ class HomogeneousColumnTypes(object):
                                  kdims=['x'], vdims=['y'])
         self.assertEqual(dataset.sort('y'), dataset_sorted)
 
+
+    def test_dataset_redim_hm_kdim(self):
+        redimmed = self.dataset_hm.redim(x='Time')
+        self.assertEqual(redimmed.dimension_values('Time'),
+                         self.dataset_hm.dimension_values('x'))
+
+    def test_dataset_redim_hm_vdim(self):
+        redimmed = self.dataset_hm.redim(y='Value')
+        self.assertEqual(redimmed.dimension_values('Value'),
+                         self.dataset_hm.dimension_values('y'))
+
     def test_dataset_sample_hm(self):
         samples = self.dataset_hm.sample([0, 5, 10]).dimension_values('y')
         self.assertEqual(samples, np.array([0, 10, 20]))

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -1,7 +1,7 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
-from holoviews.core import Dimensioned
+from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
 
 
@@ -18,3 +18,22 @@ class DimensionedTest(ComparisonTestCase):
             view.label = 'another label'
             raise AssertionError("Label should be a constant parameter.")
         except TypeError: pass
+
+    def test_dimensionsed_redim_string(self):
+        dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
+        redimensioned = dimensioned.clone(kdims=['Test'])
+        self.assertEqual(redimensioned, dimensioned.redim(x='Test'))
+
+    def test_dimensionsed_redim_dimension(self):
+        dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
+        redimensioned = dimensioned.clone(kdims=['Test'])
+        self.assertEqual(redimensioned, dimensioned.redim(x=Dimension('Test')))
+
+    def test_dimensionsed_redim_dict(self):
+        dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
+        redimensioned = dimensioned.clone(kdims=['Test'])
+        self.assertEqual(redimensioned, dimensioned.redim(x={'name': 'Test'}))
+
+    def test_dimensionsed_redim_dict_range(self):
+        redimensioned = Dimensioned('Arbitrary Data', kdims=['x']).redim(x={'range': (0, 10)})
+        self.assertEqual(redimensioned.kdims[0].range, (0, 10))

--- a/tests/testndmapping.py
+++ b/tests/testndmapping.py
@@ -97,6 +97,12 @@ class NdIndexableMappingTest(ComparisonTestCase):
 
         self.assertEqual([d.name for d in reduced_ndmap.kdims], reduced_dims)
 
+    def test_idxmapping_redim(self):
+        data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
+        ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])
+        redimmed = ndmap.redim(intdim='Integer')
+        self.assertEqual(redimmed.kdims, [Dimension('Integer'), Dimension('floatdim')])
+
     def test_idxmapping_add_dimension(self):
         ndmap = MultiDimensionalMapping(self.init_items_1D_list, kdims=[self.dim1])
         ndmap2d = ndmap.add_dimension(self.dim2, 0, 0.5)
@@ -136,6 +142,21 @@ class HoloMapTest(ComparisonTestCase):
         self.columns = Dataset(np.column_stack([self.xs, self.y_ints]),
                                kdims=['x'], vdims=['y'])
 
+    def test_holomap_redim(self):
+        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+                                   kdims=['x'], vdims=['y'])
+                        for i in range(10)}, kdims=['z'])
+        redimmed = hmap.redim(x='Time')
+        self.assertEqual(redimmed.dimensions('all', True),
+                         ['z', 'Time', 'y'])
+
+    def test_holomap_redim_nested(self):
+        hmap = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},
+                                   kdims=['x'], vdims=['y'])
+                        for i in range(10)}, kdims=['z'])
+        redimmed = hmap.redim(x='Time', z='Magnitude')
+        self.assertEqual(redimmed.dimensions('all', True),
+                         ['Magnitude', 'Time', 'y'])
 
     def test_columns_collapse_heterogeneous(self):
         collapsed = HoloMap({i: Dataset({'x':self.xs, 'y': self.ys * i},


### PR DESCRIPTION
This PR adds the ``redim`` method to easily replace dimensions or certain attributes on dimensions in a nested object (following the proposal in #714). The dimension overrides are supplied as keyword arguments to the method with the keyword matching the existing dimension by name and the value supplying one of three overrides:

1. A simple string to rename the dimension, e.g. ``curve.redim(x='Time')``.
2. A dictionary of parameter settings, e.g. ``curve.redim(x={'range': (0, 10), 'name': 'Time'})``
3. A new Dimension object, e.g. ``curve.redim(x=hv.Dimension('Time'))``.

The objects the redim applies to can be narrowed down with a specification, which is already in use on the ``traverse``, ``map`` and ``select`` method. This allows only applying the ``redim`` to certain objects in  three different ways:

1. The type of the object, e.g. ``layout.redim(hv.Curve, x='Time')``
2. A string specification of the form type{{.group}.label}, e.g. ``layout.redim('Curve.GDP', x='Time')``
3. A function, e.g. ``layout.redim(lambda x: x.vdims[0].name == 'GDP', x='Time')``

The implementation exists in two places, on ``Dimensioned`` and on ``Dataset``. The implementation on Dataset is required because a change to the dimension names has to be reflected in the underlying datasource. The ``rename`` implementation on all the interfaces so far is pretty trivial and I think it's good functionality to have anyway. Overall I'm pretty happy with this and will be very useful to have, as now it'll be possible to quickly rename dimensions and adjust their ranges.

I still need to work on the docstrings, docs and add unit tests.