### PR TITLE
Improvements to bokeh callbacks

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -44,11 +44,21 @@ class BokehPlot(DimensionedPlot):
 
     renderer = BokehRenderer
 
+    @property
+    def document(self):
+        return self._document
+
+    @document.setter
+    def document(self, doc):
+        self._document = doc
+        if self.subplots:
+            for plot in self.subplots.values():
+                plot.document = doc
+
     def __init__(self, *args, **params):
         super(BokehPlot, self).__init__(*args, **params)
-        self.document = None
+        self._document = None
         self.root = None
-
 
     def get_data(self, element, ranges=None, empty=False):
         """


### PR DESCRIPTION
This PR now includes various improvements to the bokeh callbacks system.

1. Instead of sending the data to the browser via the regular display machinery it now hooks into the WebSocket Comms that is also used by our widgets. This is cleaner and avoids having to handle the JSON string manually in the callback JS code. 

2. Instead of using some arbitrary throttling value it makes use of blocking callbacks until the previous callback has confirmed it has completed. Additionally it maintains a queue to ensure that the last scheduled event actually gets executed. As a final safeguard it also has a timeout to ensure that if anything goes wrong the callback does not stay in a permanently blocked state.

3. Small changes to make DownsampleColumns a bit faster and avoid having to convert a pandas dataframe to a numpy array for downsampling.