### PR TITLE
Fixes for bokeh 0.12 compatibility

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -25,20 +25,8 @@ var BokehMethods = {
 			var data = this.frames[current];
 		}
 		if (data !== undefined) {
-			if (data.root !== undefined) {
-				var doc = Bokeh.index[data.root].model.document;
-			}
-			$.each(data.data, function(i, value) {
-				if (data.root !== undefined) {
-					var ds = doc.get_model_by_id(value.id);
-				} else {
-					var ds = Bokeh.Collections(value.type).get(value.id);
-				}
-				if (ds != undefined) {
-					ds.set(value.data);
-					ds.trigger('change');
-				}
-			});
+			var doc = Bokeh.index[data.root].model.document;
+			doc.apply_json_patch(data.patch);
 		}
 	},
 	dynamic_update : function(current){

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -4,14 +4,10 @@ import numpy as np
 import param
 
 from ...core.data import ArrayColumns
-from .renderer import bokeh_version
-from .util import models_to_json, bokeh_version
+from .util import compute_static_patch, models_to_json
 
 from bokeh.models import CustomJS, TapTool, ColumnDataSource
-if bokeh_version < '0.11':
-    from bokeh.protocol import serialize_json
-else:
-    from bokeh.core.json_encoder import serialize_json
+from bokeh.core.json_encoder import serialize_json
 
 
 class Callback(param.ParameterizedFunction):
@@ -71,20 +67,11 @@ class Callback(param.ParameterizedFunction):
         function callback(msg){
           if (msg.msg_type == "execute_result") {
             var data = JSON.parse(msg.content.data['text/plain'].slice(1, -1));
-            if (data.root !== undefined) {
-              var doc = Bokeh.index[data.root].model.document;
+            if (data !== undefined) {
+               console.log(data.root)
+               var doc = Bokeh.index[data.root].model.document;
+	       doc.apply_json_patch(data.patch);
             }
-            $.each(data.data, function(i, value) {
-              if (data.root !== undefined) {
-                var ds = doc.get_model_by_id(value.id);
-              } else {
-                var ds = Bokeh.Collections(value.type).get(value.id);
-              }
-              if (ds != undefined) {
-                ds.set(value.data);
-                ds.trigger('change');
-              }
-            });
           } else {
             console.log("Python callback returned unexpected message:", msg)
           }
@@ -145,14 +132,13 @@ class Callback(param.ParameterizedFunction):
             return self.serialize(objects)
 
 
-    def serialize(self, objects):
+    def serialize(self, models):
         """
         Serializes any Bokeh plot objects passed to it as a list.
         """
-        data = dict(data=models_to_json(objects))
-        if bokeh_version >= '0.11':
-            plot = self.plots[0]
-            data['root'] = plot.state._id
+        plot = self.plots[0]
+        patch = compute_static_patch(plot.document, models)
+        data = dict(root=plot.state._id, patch=patch)
         return serialize_json(data)
 
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1,19 +1,17 @@
 from collections import defaultdict
 
 import numpy as np
-from bokeh.models import CustomJS, TapTool, ColumnDataSource
-
-try:
-    from bokeh.protocol import serialize_json
-    bokeh_lt_011 = True
-except ImportError:
-    from bokeh.core.json_encoder import serialize_json
-    bokeh_lt_011 = False
-
 import param
 
 from ...core.data import ArrayColumns
-from .util import models_to_json
+from .renderer import bokeh_version
+from .util import models_to_json, bokeh_version
+
+from bokeh.models import CustomJS, TapTool, ColumnDataSource
+if bokeh_version < '0.11':
+    from bokeh.protocol import serialize_json
+else:
+    from bokeh.core.json_encoder import serialize_json
 
 
 class Callback(param.ParameterizedFunction):
@@ -152,7 +150,7 @@ class Callback(param.ParameterizedFunction):
         Serializes any Bokeh plot objects passed to it as a list.
         """
         data = dict(data=models_to_json(objects))
-        if not bokeh_lt_011:
+        if bokeh_version >= '0.11':
             plot = self.plots[0]
             data['root'] = plot.state._id
         return serialize_json(data)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -15,7 +15,7 @@ from ...core.options import abbreviated_exception
 from ..util import compute_sizes, get_sideplot_ranges, match_spec, map_colors
 from .element import ElementPlot, line_properties, fill_properties
 from .path import PathPlot, PolygonPlot
-from .util import get_cmap, mpl_to_bokeh, update_plot, rgb2hex
+from .util import get_cmap, mpl_to_bokeh, update_plot, rgb2hex, bokeh_version
 
 
 class PointPlot(ElementPlot):
@@ -377,11 +377,14 @@ class SideSpikesPlot(SpikesPlot):
         all axis labels including ticks and ylabel. Valid options are 'left',
         'right', 'bare' 'left-bare' and 'right-bare'.""")
 
-    border = param.Integer(default=30, doc="Default borders on plot")
+    border = param.Integer(default=30 if bokeh_version < '0.12' else 5,
+                           doc="Default borders on plot")
 
-    height = param.Integer(default=100, doc="Height of plot")
+    height = param.Integer(default=100 if bokeh_version < '0.12' else 50,
+                           doc="Height of plot")
 
-    width = param.Integer(default=100, doc="Width of plot")
+    width = param.Integer(default=100 if bokeh_version < '0.12' else 50,
+                          doc="Width of plot")
 
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -23,7 +23,7 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update
 from .callbacks import Callbacks
 from .plot import BokehPlot
-from .util import bokeh_version, mpl_to_bokeh, convert_datetime, update_plot
+from .util import mpl_to_bokeh, convert_datetime, update_plot
 
 
 # Define shared style properties for bokeh plots
@@ -280,9 +280,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.show_title:
             plot_props['title'] = self._format_title(key, separator=' ')
         if self.bgcolor:
-            bg_attr = 'background_fill'
-            if bokeh_version > '0.11': bg_attr += '_color'
-            plot_props[bg_attr] = self.bgcolor
+            plot_props['background_fill_color'] = self.bgcolor
         if self.border is not None:
             for p in ['left', 'right', 'top', 'bottom']:
                 plot_props['min_border_'+p] = self.border
@@ -675,10 +673,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         if legend_fontsize:
             plot.legend[0].label_text_font_size = legend_fontsize
 
-        if bokeh_version < '0.11':
-            plot.legend.orientation = self.legend_position
-        else:
-            plot.legend.location = self.legend_position
+        plot.legend.location = self.legend_position
         legends = plot.legend[0].legends
         new_legends = []
         for label, l in legends:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -23,8 +23,7 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update
 from .callbacks import Callbacks
 from .plot import BokehPlot
-from .renderer import bokeh_lt_011
-from .util import mpl_to_bokeh, convert_datetime, update_plot
+from .util import bokeh_version, mpl_to_bokeh, convert_datetime, update_plot
 
 
 # Define shared style properties for bokeh plots
@@ -277,14 +276,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a dictionary of plot properties.
         """
-        title_font = self._fontsize('title', 'title_text_font_size')
-        plot_props = dict(plot_height=self.height, plot_width=self.width,
-                          title_text_color='black', **title_font)
+        plot_props = dict(plot_height=self.height, plot_width=self.width)
         if self.show_title:
             plot_props['title'] = self._format_title(key, separator=' ')
         if self.bgcolor:
             bg_attr = 'background_fill'
-            if not bokeh_lt_011: bg_attr += '_color'
+            if bokeh_version > '0.11': bg_attr += '_color'
             plot_props[bg_attr] = self.bgcolor
         if self.border is not None:
             for p in ['left', 'right', 'top', 'bottom']:
@@ -678,7 +675,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         if legend_fontsize:
             plot.legend[0].label_text_font_size = legend_fontsize
 
-        if bokeh_lt_011:
+        if bokeh_version < '0.11':
             plot.legend.orientation = self.legend_position
         else:
             plot.legend.location = self.legend_position

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -554,7 +554,16 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             handles.append(plot.title)
 
         if self.current_frame:
-            framewise = self.lookup_options(self.current_frame, 'norm').options.get('framewise')
+            if self.subplots:
+                current_frames = [(sp.current_frame if isinstance(sp.current_frame, Element)
+                                   else sp.current_frame.values()[0])
+                                  for sp in self.subplots.values()
+                                  if sp.current_frame]
+                framewise = any(self.lookup_options(frame, 'norm').options.get('framewise')
+                                for frame in current_frames)
+            else:
+                opts = self.lookup_options(self.current_frame, 'norm')
+                framewise = opts.options.get('framewise')
             if framewise or isinstance(self.hmap, DynamicMap):
                 handles += [plot.x_range, plot.y_range]
         return handles

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -10,7 +10,7 @@ from ...core import (OrderedDict, CompositeOverlay, Store, Layout, GridMatrix,
                      AdjointLayout, NdLayout, Empty, GridSpace, HoloMap)
 from ...core import traversal
 from ...core.options import Compositor
-from ...core.util import basestring
+from ...core.util import basestring, wrap_tuple
 from ...element import Histogram
 from ..plot import DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
 from ..util import get_dynamic_mode, initialize_sampled
@@ -257,7 +257,7 @@ class GridPlot(BokehPlot, GenericCompositePlot):
         passed_plots = list(plots)
         for i, coord in enumerate(self.layout.keys(full_grid=True)):
             r = i % self.cols
-            subplot = self.subplots.get(coord, None)
+            subplot = self.subplots.get(wrap_tuple(coord), None)
             if subplot is not None:
                 plot = subplot.initialize_plot(ranges=ranges, plots=passed_plots)
                 plots[r].append(plot)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -15,7 +15,11 @@ from ...element import Histogram
 from ..plot import DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
 from ..util import get_dynamic_mode, initialize_sampled
 from .renderer import BokehRenderer
-from .util import layout_padding
+from .util import bokeh_version, layout_padding
+
+if bokeh_version >= '0.12':
+    from bokeh.layouts import gridplot
+
 
 class BokehPlot(DimensionedPlot):
     """
@@ -261,7 +265,10 @@ class GridPlot(BokehPlot, GenericCompositePlot):
             else:
                 plots[r].append(None)
                 passed_plots.append(None)
-        self.handles['plot'] = BokehGridPlot(children=plots[::-1])
+        if bokeh_version < '0.12':
+            self.handles['plot'] = BokehGridPlot(children=plots[::-1])
+        else:
+            self.handles['plot'] = gridplot(plots[::-1])
         self.handles['plots'] = plots
         if self.shared_datasource:
             self.sync_sources()
@@ -481,7 +488,7 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
 
         # Replace None types with empty plots
         # to avoid bokeh bug
-        if adjoined:
+        if adjoined and bokeh_version < '0.12':
             plots = layout_padding(plots)
 
         # Determine the most appropriate composite plot type
@@ -496,6 +503,8 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
                       for c, child in enumerate(row)
                       if child is not None]
             layout_plot = Tabs(tabs=panels)
+        elif bokeh_version >= '0.12':
+            layout_plot = gridplot(children=plots)
         elif len(plots) == 1 and not adjoined:
             layout_plot = VBox(children=[HBox(children=plots[0])])
         elif len(plots[0]) == 1:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1,6 +1,7 @@
+from distutils.version import LooseVersion
+
 from collections import defaultdict
 import numpy as np
-from ...core.options import abbreviated_exception
 
 try:
     from matplotlib import colors
@@ -8,17 +9,18 @@ try:
 except ImportError:
     cm, colors = None, None
 
-try:
+import bokeh
+bokeh_version = LooseVersion(bokeh.__version__)
+if bokeh_version < '0.11':
     from bokeh.enums import Palette
     from bokeh.plotting import Plot
-    bokeh_lt_011 = True
-except:
+else:
     from bokeh.core.enums import Palette
     from bokeh.models.plots import Plot
-    bokeh_lt_011 = False
-
 from bokeh.models import GlyphRenderer
 from bokeh.plotting import Figure
+
+from ...core.options import abbreviated_exception
 
 # Conversion between matplotlib and bokeh markers
 markers = {'s': {'marker': 'square'},
@@ -137,7 +139,7 @@ def models_to_json(models):
             continue
         else:
             ids.append(plotobj.ref['id'])
-        if bokeh_lt_011:
+        if bokeh_version < '0.11':
             json = plotobj.vm_serialize(changed_only=True)
         else:
             json = plotobj.to_json(False)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -11,12 +11,9 @@ except ImportError:
 
 import bokeh
 bokeh_version = LooseVersion(bokeh.__version__)
-if bokeh_version < '0.11':
-    from bokeh.enums import Palette
-    from bokeh.plotting import Plot
-else:
-    from bokeh.core.enums import Palette
-    from bokeh.models.plots import Plot
+from bokeh.core.enums import Palette
+from bokeh.document import Document
+from bokeh.models.plots import Plot
 from bokeh.models import GlyphRenderer
 from bokeh.plotting import Figure
 
@@ -139,16 +136,49 @@ def models_to_json(models):
             continue
         else:
             ids.append(plotobj.ref['id'])
-        if bokeh_version < '0.11':
-            json = plotobj.vm_serialize(changed_only=True)
-        else:
-            json = plotobj.to_json(False)
-            json.pop('tool_events', None)
-            json.pop('renderers', None)
-            json_data.append({'id': plotobj.ref['id'],
-                              'type': plotobj.ref['type'],
-                              'data': json})
+        json = plotobj.to_json(False)
+        json.pop('tool_events', None)
+        json.pop('renderers', None)
+        json_data.append({'id': plotobj.ref['id'],
+                          'type': plotobj.ref['type'],
+                          'data': json})
     return json_data
+
+
+def refs(json):
+    """
+    Finds all the references to other objects in the json
+    representation of a bokeh Document.
+    """
+    result = {}
+    for obj in json['roots']['references']:
+        result[obj['id']] = obj
+    return result
+
+
+def compute_static_patch(document, models):
+    """
+    Computes a patch to update an existing document without
+    diffing the json first, making it suitable for static updates
+    between arbitrary frames. Note that this only supports changed
+    attributes and will break if new models have been added since
+    the plot was first created.
+    """
+    json = document.to_json()
+    references = refs(json)
+    requested_updates = [m.ref['id'] for m in models]
+
+    value_refs = {}
+    events = []
+    for ref_id, obj in references.items():
+        if ref_id not in requested_updates:
+            continue
+        for key, val in obj['attributes'].items():
+            event = Document._event_for_attribute_change(references,
+                                                         obj, key, val,
+                                                         value_refs)
+            events.append(event)
+    return dict(events=events, references=list(value_refs.values()))
 
 
 def hsv_to_rgb(hsv):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -31,6 +31,10 @@ markers = {'s': {'marker': 'square'},
            '3': {'marker': 'triangle', 'orientation': np.pi},
            '4': {'marker': 'triangle', 'orientation': -np.pi/2}}
 
+# List of models that do not update correctly and must be ignored
+# Should only include models that have no direct effect on the display
+# and can therefore be safely ignored.
+IGNORED_MODELS = ['LinearAxis']
 
 def rgb2hex(rgb):
     """
@@ -169,14 +173,18 @@ def compute_static_patch(document, models):
 
     value_refs = {}
     events = []
+    update_types = defaultdict(list)
     for ref_id, obj in references.items():
-        if ref_id not in requested_updates:
+        if ref_id not in requested_updates and not obj['type'] in IGNORED_MODELS:
             continue
         for key, val in obj['attributes'].items():
             event = Document._event_for_attribute_change(references,
                                                          obj, key, val,
                                                          value_refs)
             events.append(event)
+            update_types[obj['type']].append(key)
+    value_refs = {ref_id: val for ref_id, val in value_refs.items()
+                  if val['type'] not in IGNORED_MODELS}
     return dict(events=events, references=list(value_refs.values()))
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -164,8 +164,7 @@ def compute_static_patch(document, models):
     attributes and will break if new models have been added since
     the plot was first created.
     """
-    json = document.to_json()
-    references = refs(json)
+    references = refs(document.to_json())
     requested_updates = [m.ref['id'] for m in models]
 
     value_refs = {}

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -1,18 +1,14 @@
 import json
-from distutils.version import LooseVersion
+
+from .util import bokeh_version
+from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 
 import param
 import bokeh
 from bokeh.io import Document
-
-if LooseVersion(bokeh.__version__) >= LooseVersion('0.11'):
-    bokeh_lt_011 = False
+if bokeh_version >= '0.11':
     from bokeh.io import _CommsHandle
     from bokeh.util.notebook import get_comms
-else:
-    bokeh_lt_011 = True
-
-from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 
 
 class BokehWidget(NdWidget):
@@ -43,7 +39,7 @@ class BokehWidget(NdWidget):
         first call and
         """
         self.plot.update(idx)
-        if self.embed or fig_format == 'html' or bokeh_lt_011:
+        if self.embed or fig_format == 'html' or bokeh_version < '0.11':
             return self.renderer.html(self.plot, fig_format)
         else:
             doc = self.plot.document

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -1,14 +1,12 @@
 import json
 
-from .util import bokeh_version
-from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
-
 import param
 import bokeh
 from bokeh.io import Document
-if bokeh_version >= '0.11':
-    from bokeh.io import _CommsHandle
-    from bokeh.util.notebook import get_comms
+from bokeh.io import _CommsHandle
+from bokeh.util.notebook import get_comms
+
+from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 
 
 class BokehWidget(NdWidget):
@@ -39,15 +37,13 @@ class BokehWidget(NdWidget):
         first call and
         """
         self.plot.update(idx)
-        if self.embed or fig_format == 'html' or bokeh_version < '0.11':
-            return self.renderer.html(self.plot, fig_format)
+        if self.embed or fig_format == 'html':
+            html = self.renderer.html(self.plot, fig_format)
+            return html
         else:
-            doc = self.plot.document
-
             if hasattr(doc, 'last_comms_handle'):
                 handle = doc.last_comms_handle
             else:
-                doc.add_root(self.plot.state)
                 handle = _CommsHandle(get_comms(doc.last_comms_target),
                                       doc, doc.to_json())
                 doc.last_comms_handle = handle


### PR DESCRIPTION
As the title says this PR makes HoloViews compatible with the upcoming bokeh 0.12 release. Since bokeh is going through rapid development cycles and we do not want to accumulate endless compatibility layers we are also dropping compatibility with 0.10 in this PR. The major component of this PR is in changing the way json patches are computed when using the widgets and callbacks, which has now been unified to use the same approach everywhere, bypassing the relatively slow patch diffing that bokeh uses by default and also dropping various hacks, which I've had to add to make things work across 0.10 and 0.11. This PR also does not yet add support for any of the new features in bokeh 0.12, those should follow in future PRs, for now this just makes sure all existing functionality continues to work.