### PR TITLE
Added support for tick formatters in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -356,7 +356,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     axis_props['ticker'] = FixedTicker(ticks=ticker)
 
         dim = element.get_dimension(ax_mapping[axis])
-        if ax_mapping and dim:
+        if FuncTickFormatter is not None and ax_mapping and dim:
             formatter = None
             if dim.value_format:
                 formatter = dim.value_format

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -363,13 +363,18 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             elif dim.type in dim.type_formatters:
                 formatter = dim.type_formatters[dim.type]
             if formatter:
+                msg = ('%s dimension formatter could not be '
+                       'converted to tick formatter. ' % dim.name)
                 try:
                     formatter = FuncTickFormatter.from_py_func(formatter)
-                except:
-                    self.warning('%s dimension formatter could not be '
-                                 'converted to tick formatter. Ensure '
-                                 'flexx is installed and pyscript can '
-                                 'compile the function.' % dim.name)
+                except RuntimeError:
+                    self.warning(msg+'Ensure Flexx is installed '
+                                 '("conda install -c bokeh flexx" or '
+                                 '"pip install flexx")')
+                except Exception as e:
+                    error = 'Pyscript raised an error: {0}'.format(e)
+                    error = error.replace('%', '%%')
+                    self.warning(msg+error)
                 else:
                     axis_props['formatter'] = formatter
         return axis_props

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -1,4 +1,5 @@
 import re
+import inspect
 
 import numpy as np
 from matplotlib import ticker
@@ -14,7 +15,13 @@ def wrap_formatter(formatter):
     if isinstance(formatter, ticker.Formatter):
         return formatter
     elif callable(formatter):
-        return ticker.FuncFormatter(formatter)
+        args = [arg for arg in inspect.getargspec(formatter).args
+                if arg != 'self']
+        wrapped = formatter
+        if len(args) == 1:
+            def wrapped(val, pos=None):
+                return formatter(val)
+        return ticker.FuncFormatter(wrapped)
     elif isinstance(formatter, basestring):
         if re.findall(r"\{(\w+)\}", formatter):
             return ticker.StrMethodFormatter(formatter)


### PR DESCRIPTION
As the title says this adds support for supplying arbitrary Python functions as tick formatters for the axes. A simple example is a formatter that displays seconds as minutes.

```python
def formatter(seconds):
    m, s = divmod(seconds, 60)
    s = ('%d' % s) if s > 9 else ('0%s' % s)
    return "%d:%s" % (m, s)

hv.Curve(np.random.rand(300)).redim(x=dict(value_format=formatter, unit='min'))
```
![image](https://cloud.githubusercontent.com/assets/1550771/16270500/682cf7a6-388e-11e6-801b-bb9812da0a39.png)

Note that this depends on ``flexx`` being installed because compiling the python function to JS requires pyscript. Currently it will warn if flexx can't be imported or the function cannot be compiled.