### PR TITLE
Added support for LogColorMapper in bokeh Raster plots

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -2,6 +2,10 @@ import numpy as np
 import param
 
 from bokeh.models.mappers import LinearColorMapper
+try:
+    from bokeh.models.mappers import LogColorMapper
+except ImportError:
+    LogColorMapper = None
 
 from ...core.util import cartesian_product
 from ...element import Image, Raster, RGB
@@ -12,6 +16,9 @@ from .util import mplcmap_to_palette, get_cmap, hsv_to_rgb
 
 
 class RasterPlot(ElementPlot):
+
+    logz  = param.Boolean(default=False, doc="""
+         Whether to apply log scaling to the z-axis.""")
 
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
@@ -53,7 +60,8 @@ class RasterPlot(ElementPlot):
         low, high = ranges.get(val_dim)
         if 'cmap' in properties:
             palette = mplcmap_to_palette(properties.pop('cmap', None))
-        cmap = LinearColorMapper(palette, low=low, high=high)
+        colormapper = LogColorMapper if self.logz else LinearColorMapper
+        cmap = colormapper(palette, low=low, high=high)
         properties['color_mapper'] = cmap
         if 'color_mapper' not in self.handles:
             self.handles['color_mapper'] = cmap


### PR DESCRIPTION
Adds support for the ``LogColorMapper`` via the ``logz`` option on ``Raster`` based plots.

```
arr = np.random.rand(10,10)*10000
zero_arr = arr.copy()
zero_arr[5,5] = 0.
hv.Image(arr) + hv.Image(arr)(plot=dict(logz=True))
```

![image](https://cloud.githubusercontent.com/assets/1550771/16282911/974a77fa-38c2-11e6-9429-d1bc26e6b466.png)
