### PR TITLE
Handle backend JS/CSS dependencies for static export better

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -38,7 +38,8 @@ class BokehRenderer(Renderer):
     widgets = {'scrubber': BokehScrubberWidget,
                'widgets': BokehSelectionWidget}
 
-    backend_dependencies = {'js': CDN.js_files, 'css': CDN.css_files}
+    backend_dependencies = {'js': CDN.js_files if CDN.js_files else tuple(INLINE.js_raw),
+                            'css': CDN.css_files if CDN.css_files else tuple(INLINE.css_raw)}
 
     _loaded = False
 


### PR DESCRIPTION
Automatically adds backend JS/CSS dependencies to ``static_html`` output and handles inlined bokeh dependencies if CDN is not available (e.g. for dev builds of bokeh).