### PR TITLE
Catch and warn about interface exceptions

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -24,6 +24,9 @@ try:
     DFColumns = PandasInterface
 except ImportError:
     pass
+except Exception as e:
+    param.main.warning('Pandas interface failed to import with '
+                       'following error: %s' % e)
 
 try:
     import iris # noqa (Availability import)
@@ -31,6 +34,9 @@ try:
     datatypes.append('cube')
 except ImportError:
     pass
+except Exception as e:
+    param.main.warning('Iris interface failed to import with '
+                       'following error: %s' % e)
 
 from ..dimension import Dimension, replace_dimensions
 from ..element import Element


### PR DESCRIPTION
This PR ensures errors importing the pandas or iris interfaces doesn't break importing holoviews raising a warning instead. As far as I can tell the numpy RuntimeErrors this is meant to catch bypass it somehow, but when I tried it those errors did not break the holoviews import anyway. So this should address the mentioned error in https://github.com/ioam/holoviews/issues/732 and guard against anything else that could go wrong in pandas or iris.

Edit: Thinking about it iris must already be catching that particular numpy error, which is why I couldn't catch it again.