### PR TITLE
Correctly convert glyph properties before updating them

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -456,6 +456,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     def _update_glyph(self, glyph, properties, mapping):
         allowed_properties = glyph.properties()
+        properties = mpl_to_bokeh(properties)
         merged = dict(properties, **mapping)
         glyph.set(**{k: v for k, v in merged.items()
                      if k in allowed_properties})


### PR DESCRIPTION
Tiny fix to ensure that colors are processed correctly. Most of this processing should be moved out of the ``mpl_to_bokeh`` method into one that is independent of matplotlib soon, but that's a separate PR.