### PR TITLE
Skip rendering of nested Layouts

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -9,7 +9,7 @@ from bokeh.models.widgets import Panel, Tabs
 from ...core import (OrderedDict, CompositeOverlay, Store, Layout, GridMatrix,
                      AdjointLayout, NdLayout, Empty, GridSpace, HoloMap)
 from ...core import traversal
-from ...core.options import Compositor
+from ...core.options import Compositor, SkipRendering
 from ...core.util import basestring, wrap_tuple
 from ...element import Histogram
 from ..plot import DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
@@ -392,6 +392,8 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
                 continue
 
             # Options common for any subplot
+            if isinstance(element, Layout):
+                raise SkipRendering("Cannot plot nested Layouts.")
             vtype = element.type if isinstance(element, HoloMap) else element.__class__
             plot_type = Store.registry[self.renderer.backend].get(vtype, None)
             plotopts = self.lookup_options(element, 'plot').options

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -8,7 +8,7 @@ from matplotlib import gridspec, animation
 import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
-                     Collator, GridMatrix)
+                     Collator, GridMatrix, Layout)
 from ...core.options import Store, Compositor, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -9,7 +9,7 @@ import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
                      Collator, GridMatrix)
-from ...core.options import Store, Compositor
+from ...core.options import Store, Compositor, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
 from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
@@ -350,6 +350,8 @@ class GridPlot(CompositePlot):
             if not isinstance(coord, tuple): coord = (coord,)
             view = layout.data.get(coord, None)
             # Create subplot
+            if isinstance(view, Layout):
+                raise SkipRendering("Cannot plot nested Layouts.")
             if view is not None:
                 vtype = view.type if isinstance(view, HoloMap) else view.__class__
                 opts = self.lookup_options(view, 'plot').options


### PR DESCRIPTION
This ensures that a layout that is nested rather than combined raises SkipRendering exception causing the display of the object to be skipped and a warning to be emitted.