### PR TITLE
Cast mpl data to string before updating live widget

### DIFF
--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -86,8 +86,9 @@ class MPLWidget(NdWidget):
             return ''
         frame = self._plot_figure(key)
         if self.renderer.mode == 'mpld3':
-            frame = self.encode_frames({0: frame})
-        return frame
+            return self.encode_frames({0: frame})
+        else:
+            return str(frame)
 
 
     def get_frames(self):


### PR DESCRIPTION
Currently a random quote appears in live matplotlib widgets because the data is unicode. Eventually we'll want to replace this with a websocket, so for now I'm just casting back to string. This is safe because all the data is base64 encoded (and it is what we used to do). This bug only affected Python2 because Python 3 does not have the ``u'`` prefix for string literals.