### PR TITLE
Improvements and fixes for bokeh PolygonPlot

### DIFF
--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -3,6 +3,8 @@ from collections import defaultdict
 import numpy as np
 import param
 
+from bokeh.models import HoverTool
+
 from ...core import util
 from ..util import map_colors
 from .element import ElementPlot, line_properties, fill_properties
@@ -29,6 +31,23 @@ class PolygonPlot(PathPlot):
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
 
+    def _init_tools(self, element):
+        """
+        Processes the list of tools to be supplied to the plot.
+        """
+        tools = self.default_tools + self.tools
+        if self.batched:
+            element = element.last
+            dims = self.hmap.last.kdims
+        else:
+            dims = self.overlay_dims.keys()
+        dims += element.vdims
+        tooltips = [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
+                    for d in dims]
+        tools.append(HoverTool(tooltips=tooltips))
+        return tools
+
+
     def get_data(self, element, ranges=None, empty=False):
         xs = [] if empty else [path[:, 0] for path in element.data]
         ys = [] if empty else [path[:, 1] for path in element.data]
@@ -42,6 +61,11 @@ class PolygonPlot(PathPlot):
             colors = map_colors(np.array([element.level]), ranges[element.vdims[0].name], cmap)
             mapping['color'] = 'color'
             data['color'] = [] if empty else list(colors)*len(element.data)
+            dim_name = util.dimension_sanitizer(element.vdims[0].name)
+            data[dim_name] = [element.level for _ in range(len(xs))]
+            for k, v in self.overlay_dims.items():
+                dim = util.dimension_sanitizer(k.name)
+                data[dim] = [v for _ in range(len(xs))]
 
         return data, mapping
 
@@ -49,15 +73,17 @@ class PolygonPlot(PathPlot):
     def get_batched_data(self, element, ranges=None, empty=False):
         data = defaultdict(list)
         style = self.style.max_cycles(len(self.ordering))
-        for key, el in element.items():
+        for key, el in element.data.items():
+            self.overlay_dims = dict(zip(element.kdims, key))
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
-                data[k].append(eld[0])
+                data[k].extend(eld)
             if 'color' not in eldata:
                 zorder = self.get_zorder(element, key, el)
                 val = style[zorder].get('color')
                 elmapping['color'] = 'color'
                 if isinstance(val, tuple):
                     val = rgb2hex(val)
-                data['color'].append(val)
+                data['color'] += [val for _ in range(len(eldata['xs']))]
+
         return data, elmapping


### PR DESCRIPTION
A number of improvements and fixes for the bokeh PolygonPlot. Apart from fixing a bug in batched plotting this adds support for having the NdOverlay dimensions show up in the hover tools. This can be seen in action [here](http://examples.holoviews.org/EU_Referendum.html).