### PR TITLE
Added function to strip bokeh update events from specific models

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -212,6 +212,9 @@ def delete_refs(obj, locs, delete):
     Delete all references to specific model types by recursively
     traversing the object and looking for the models to be deleted in
     the supplied locations.
+
+    Note: Can be deleted once bokeh stops raising errors when updating
+          LinearAxis.computed_bounds
     """
     if isinstance(obj, dict):
         if 'type' in obj and obj['type'] in delete:


### PR DESCRIPTION
Fixes previous approach to stripping certain models from bokeh update events. Both LinearAxis and LogAxis complain when updated saying that ``computed_bounds`` cannot be changed. Previously I was crudely looking for these objects, as I found out this is not sufficient in some cases. I've now added a function that traverses the model data and makes sure all references to those models are deleted. I'll investigate this bug with bokeh, but in the meantime it doesn't seem to do any harm since we never update the axis name or switch out an axis anyway.