### PR TITLE
Disable shared datasources on Layouts by default

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -33,7 +33,7 @@ class BokehPlot(DimensionedPlot):
     height = param.Integer(default=300, doc="""
         Height of the plot in pixels""")
 
-    shared_datasource = param.Boolean(default=True, doc="""
+    shared_datasource = param.Boolean(default=False, doc="""
         Whether Elements drawing the data from the same object should
         share their Bokeh data source allowing for linked brushing
         and other linked behaviors.""")


### PR DESCRIPTION
Sharing of datasources can cause issues when it is updated in one plot but not the other. In Grids this will not occur but on a Layout it can, so sharing of datasources should only be enabled when specifically requested.