### PR TITLE
Corrected Contours value_dimension parameter to vdims

### DIFF
--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -98,7 +98,7 @@ class Contours(Path):
     level = param.Number(default=None, doc="""
         Optional level associated with the set of Contours.""")
 
-    value_dimension = param.List(default=[Dimension('Level')], doc="""
+    vdims = param.List(default=[Dimension('Level')], doc="""
         Contours optionally accept a value dimension, corresponding
         to the supplied values.""", bounds=(1,1))
 


### PR DESCRIPTION
Seems this was doubly wrong, the parameter was called value_dimension, so it didn't get caught when renaming value_dimensions -> vdims.