### PR TITLE
Removed bokeh resize tool until v1.0 release

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -98,7 +98,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for linked panning and zooming.""")
 
     default_tools = param.List(default=['save', 'pan', 'wheel_zoom',
-                                        'box_zoom', 'resize', 'reset'],
+                                        'box_zoom', 'reset'],
         doc="A list of plugin tools to use on the plot.")
 
     tools = param.List(default=[], doc="""


### PR DESCRIPTION
The bokeh resize tool is broken since the layout work they did, hopefully it will be fixed in v1.0 but for now let's remove it.