### PR TITLE
Correctly set batched plot options

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -503,10 +503,10 @@ class GenericElementPlot(DimensionedPlot):
                                kdims=['Frame'], id=element.id)
         else:
             self.hmap = element
+
+        plot_element = self.hmap.last
         if self.batched:
-            plot_element = self.hmap.last.last
-        else:
-            plot_element = self.hmap.last
+            plot_element = plot_element.last
 
         self.style = self.lookup_options(plot_element, 'style') if style is None else style
         dimensions = self.hmap.kdims if dimensions is None else dimensions
@@ -517,9 +517,13 @@ class GenericElementPlot(DimensionedPlot):
         super(GenericElementPlot, self).__init__(keys=keys, dimensions=dimensions,
                                                  dynamic=dynamic,
                                                  **dict(params, **plot_opts))
+
+        # Update plot and style options for batched plots
         if self.batched:
             self.ordering = util.layer_sort(self.hmap)
-            self.set_param(**self.lookup_options(self.hmap.last, 'plot').options)
+            overlay_opts = self.lookup_options(self.hmap.last, 'plot').options.items()
+            opts = {k: v for k, v in overlay_opts if k in self.params()}
+            self.set_param(**opts)
             self.style = self.lookup_options(plot_element, 'style').max_cycles(len(self.ordering))
         else:
             self.ordering = []

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -503,10 +503,15 @@ class GenericElementPlot(DimensionedPlot):
                                kdims=['Frame'], id=element.id)
         else:
             self.hmap = element
-        self.style = self.lookup_options(self.hmap.last, 'style') if style is None else style
+        if self.batched:
+            plot_element = self.hmap.last.last
+        else:
+            plot_element = self.hmap.last
+
+        self.style = self.lookup_options(plot_element, 'style') if style is None else style
         dimensions = self.hmap.kdims if dimensions is None else dimensions
         keys = keys if keys else list(self.hmap.data.keys())
-        plot_opts = self.lookup_options(self.hmap.last, 'plot').options
+        plot_opts = self.lookup_options(plot_element, 'plot').options
 
         dynamic = False if not isinstance(element, DynamicMap) or element.sampled else element.mode
         super(GenericElementPlot, self).__init__(keys=keys, dimensions=dimensions,
@@ -514,7 +519,8 @@ class GenericElementPlot(DimensionedPlot):
                                                  **dict(params, **plot_opts))
         if self.batched:
             self.ordering = util.layer_sort(self.hmap)
-            self.style = self.lookup_options(self.hmap.last.last, 'style').max_cycles(len(self.ordering))
+            self.set_param(**self.lookup_options(self.hmap.last, 'plot').options)
+            self.style = self.lookup_options(plot_element, 'style').max_cycles(len(self.ordering))
         else:
             self.ordering = []
 


### PR DESCRIPTION
Correctly respect the plot options set on the batched elements. Previously inherited all plot options from the NdOverlay, which a) could cause unsupported parameters being set and b) ignored plot options set on the Element. This appropriately combines the plot options from set on the NdOverlay and Element plot.