### PR TITLE
Fixed extent handling in batched mode

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -181,10 +181,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         # Get the bottom layer and range element
         el = element.traverse(lambda x: x, [Element])
         el = el[0] if el else element
-        if self.batched and not isinstance(self, OverlayPlot):
-            range_el = el
-        else:
-            range_el = element
 
         dims = el.dimensions()
         xlabel, ylabel, zlabel = self._get_axis_labels(dims)
@@ -215,7 +211,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             y_axis_type = 'log' if self.logy else 'auto'
 
+        # Get the Element that determines the range and get_extents
+        range_el = el if self.batched and not isinstance(self, OverlayPlot) else element
         l, b, r, t = self.get_extents(range_el, ranges)
+
         if not 'x_range' in plot_ranges:
             if 'x_range' in ranges:
                 plot_ranges['x_range'] = ranges['x_range']

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -596,7 +596,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def framewise(self):
         """
         Property to determine whether the current frame should have
-        framewise normalization enabled.
+        framewise normalization enabled. Required for bokeh plotting
+        classes to determine whether to send updated ranges for each
+        frame.
         """
         current_frames = [el for f in self.traverse(lambda x: x.current_frame)
                           for el in (f.traverse(lambda x: x, [Element])

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -818,9 +818,14 @@ class GenericOverlayPlot(GenericElementPlot):
     def get_extents(self, overlay, ranges):
         extents = []
         items = overlay.items()
-        for key, subplot in self.subplots.items():
-            layer = overlay.data.get(key, None)
+        if self.batched:
+            subplot = self.subplots.values()[0]
+            subplots = [(k, subplot) for k in overlay.data.keys()]
+        else:
+            subplots = self.subplots.items()
+        for key, subplot in subplots:
             found = False
+            layer = overlay.data.get(key, None)
             if isinstance(self.hmap, DynamicMap) and layer is None:
                 for _, layer in items:
                     if isinstance(layer, subplot.hmap.type):


### PR DESCRIPTION
While introducing batched mode I did not correctly handle computing the extents. This PR consists of two main fixes, a) the GenericOverlayPlot now correctly computes the extents for a batched plot, and b) the bokeh backend now correctly detects framewise normalization modes (via a property) and always makes sure no NaNs are set on the axis ranges (which can cause the plot to blow up).