### PR TITLE
Added 'LogTickFormatter' to the set of ignored Bokeh models

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -41,7 +41,7 @@ markers = {'s': {'marker': 'square'},
 # LinearAxis.computed_bounds cannot be updated
 IGNORED_MODELS = ['LinearAxis', 'LogAxis', 'DatetimeAxis',
                   'CategoricalAxis' 'BasicTicker', 'BasicTickFormatter',
-                  'FixedTicker', 'FuncTickFormatter']
+                  'FixedTicker', 'FuncTickFormatter', 'LogTickFormatter']
 
 # Where to look for the ignored models
 LOCATIONS = ['new', 'below', 'right', 'left',


### PR DESCRIPTION
Simple PR that fixes using ``logy=True`` with Bokeh plots (at least for ``Curve`` plots).