### PR TITLE
Fixed bokeh shared_datasource setting

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -33,7 +33,7 @@ class BokehPlot(DimensionedPlot):
     height = param.Integer(default=300, doc="""
         Height of the plot in pixels""")
 
-    shared_datasource = param.Boolean(default=False, doc="""
+    shared_datasource = param.Boolean(default=True, doc="""
         Whether Elements drawing the data from the same object should
         share their Bokeh data source allowing for linked brushing
         and other linked behaviors.""")
@@ -306,7 +306,7 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
     shared_axes = param.Boolean(default=True, doc="""
         Whether axes should be shared across plots""")
 
-    shared_datasource = param.Boolean(default=True, doc="""
+    shared_datasource = param.Boolean(default=False, doc="""
         Whether Elements drawing the data from the same object should
         share their Bokeh data source allowing for linked brushing
         and other linked behaviors.""")


### PR DESCRIPTION
I recently disabled the ``shared_datasource`` option because it can potentially cause problems. However I meant to disable it by default on Layouts only. This sets the behavior I had originally meant to apply.