### PR TITLE
Fix for single row grid plots in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -215,7 +215,7 @@ class GridPlot(BokehPlot, GenericCompositePlot):
             if c == 0 and r != 0:
                 kwargs['xaxis'] = 'bottom-bare'
                 kwargs['width'] = 150
-            if c != 0 and r == 0 and not layout.ndims == 1:
+            if c != 0 and r == 0:
                 kwargs['yaxis'] = 'left-bare'
                 kwargs['height'] = 150
             if c == 0 and r == 0:


### PR DESCRIPTION
The logic in bokeh GridPlots was wrong, which was causing single dimensional layouts to be the wrong shape and not appropriately hide the axes.