### PR TITLE
Ensure non-None values aren't ignored in bokeh json messages

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -228,7 +228,7 @@ def delete_refs(obj, locs, delete):
         for k, v in list(obj.items()):
             if k in locs:
                 ref = delete_refs(v, locs, delete)
-                if ref:
+                if ref is not None:
                     new_obj[k] = ref
             else:
               new_obj[k] = v


### PR DESCRIPTION
The code that deletes references which cannot easily be updated in bokeh has a small bug where values that evaluate as False were deleted, when it really should just have been deleting Nones. This caused events to set the visibility of glyphs to False to be deleted for example.