### PR TITLE
Handle renderer options size and webgl in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -278,7 +278,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             title = ''
 
-        properties['webgl'] = self.renderer.webgl
+        properties['webgl'] = Store.renderers[self.renderer.backend].webgl
         return bokeh.plotting.Figure(x_axis_type=x_axis_type,
                                      y_axis_type=y_axis_type, title=title,
                                      tools=tools, **properties)
@@ -288,7 +288,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a dictionary of plot properties.
         """
-        plot_props = dict(plot_height=self.height, plot_width=self.width)
+        size_multiplier = Store.renderers[self.renderer.backend].size/100.
+        plot_props = dict(plot_height=int(self.height*size_multiplier),
+                          plot_width=int(self.width*size_multiplier))
         if bokeh_version < '0.12':
             plot_props.update(self._title_properties(key, plot, element))
         if self.bgcolor:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -811,7 +811,7 @@ class GenericOverlayPlot(GenericElementPlot):
                 zoffset += len(set([k for o in vmap for k in o.keys()])) - 1
         if not subplots:
             raise SkipRendering("%s backend could not plot any Elements "
-                                "in the Overlay." % self.backend)
+                                "in the Overlay." % self.renderer.backend)
         return subplots
 
 


### PR DESCRIPTION
Adds support for global scaling of bokeh plots via ``size`` output magic option and setting webgl option based on global renderer.