### PR TITLE
Fixed batched plotting for bokeh PathPlot

### DIFF
--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -35,14 +35,11 @@ class PathPlot(ElementPlot):
                 data[k].extend(eld)
             zorder = self.get_zorder(element, key, el)
             val = style[zorder].get('color')
-            elmapping['color'] = 'color'
-            if isinstance(val, tuple):
-                val = rgb2hex(val)
-            data['color'] += [val for _ in range(len(eldata['xs']))]
-        if len(set(data.get('color'))) == 1:
-            data.pop('color')
-            elmapping.pop('color')
-
+            if val:
+                elmapping['line_color'] = 'color'
+                if isinstance(val, tuple):
+                    val = rgb2hex(val)
+                data['color'] += [val for _ in range(len(eldata.values()[0]))]
         return data, elmapping
 
 


### PR DESCRIPTION
This PR fixes batched plotting of Path, Spikes and ErrorBars (which all have plot classes which subclass from PathPlot). The previous approach a) did not consider that Spikes and ErrorBars also use PathPlot and b) removes an optimization where it would not send color data if only a single color was set, which caused issues when some frames had multiple colors and some had only a single color.