### PR TITLE
Add support for inverting axes and adjoining all Element types

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -16,8 +16,12 @@ class TextPlot(ElementPlot):
         mapping = dict(x='x', y='y', text='text')
         if empty:
             return dict(x=[], y=[], text=[]), mapping
-        return (dict(x=[element.x], y=[element.y],
-                     text=[element.text]), mapping)
+        if self.invert_axes:
+            data = dict(x=[element.y], y=[element.x])
+        else:
+            data = dict(x=[element.x], y=[element.y])
+        data['text'] = [element.text]
+        return (data, mapping)
 
 
     def get_batched_data(self, element, ranges=None, empty=False):
@@ -42,10 +46,12 @@ class LineAnnotationPlot(ElementPlot):
 
     def get_data(self, element, ranges=None, empty=False):
         data, mapping = {}, {}
-        if isinstance(element, HLine):
+        if (isinstance(element, HLine) or
+            (isinstance(element, VLine) and self.invert_axes)):
             mapping['bottom'] = element.data
             mapping['top'] = element.data
-        elif isinstance(element, VLine):
+        elif (isinstance(element, VLine) or
+              (isinstance(element, HLine) and self.invert_axes)):
             mapping['left'] = element.data
             mapping['right'] = element.data
         return (data, mapping)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -21,8 +21,9 @@ class PathPlot(ElementPlot):
     _mapping = dict(xs='xs', ys='ys')
 
     def get_data(self, element, ranges=None, empty=False):
-        xs = [] if empty else [path[:, 0] for path in element.data]
-        ys = [] if empty else [path[:, 1] for path in element.data]
+        xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
+        xs = [] if empty else [path[:, xidx] for path in element.data]
+        ys = [] if empty else [path[:, yidx] for path in element.data]
         return dict(xs=xs, ys=ys), dict(self._mapping)
 
     def get_batched_data(self, element, ranges=None, empty=False):
@@ -70,7 +71,7 @@ class PolygonPlot(PathPlot):
     def get_data(self, element, ranges=None, empty=False):
         xs = [] if empty else [path[:, 0] for path in element.data]
         ys = [] if empty else [path[:, 1] for path in element.data]
-        data = dict(xs=xs, ys=ys)
+        data = dict(xs=ys, ys=xs) if self.invert_axes else dict(xs=xs, ys=ys)
 
         style = self.style[self.cyclic_index]
         cmap = style.get('palette', style.get('cmap', None))

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -462,7 +462,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
     def get_data(self, element, ranges, style):
         xs, ys = (element.dimension_values(i) for i in range(2))
         self._compute_styles(element, ranges, style)
-        return (xs, ys), style, {}
+        return (ys, xs) if self.invert_axes else (xs, ys), style, {}
 
 
     def _compute_styles(self, element, ranges, style):
@@ -571,8 +571,9 @@ class VectorFieldPlot(ColorbarPlot):
     def get_data(self, element, ranges, style):
         input_scale = style.pop('scale', 1.0)
 
-        xs = element.dimension_values(0) if len(element.data) else []
-        ys = element.dimension_values(1) if len(element.data) else []
+        xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
+        xs = element.dimension_values(xidx) if len(element.data) else []
+        ys = element.dimension_values(yidx) if len(element.data) else []
         radians = element.dimension_values(2) if len(element.data) else []
         angles = list(np.rad2deg(radians))
         if self.rescale_lengths:

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -15,7 +15,10 @@ class PathPlot(ElementPlot):
     style_opts = ['alpha', 'color', 'linestyle', 'linewidth', 'visible']
 
     def get_data(self, element, ranges, style):
-        return (element.data,), style, {}
+        paths = element.data
+        if self.invert_axes:
+            paths = [p[:, ::-1] for p in paths]
+        return (paths,), style, {}
 
     def init_artists(self, ax, plot_args, plot_kwargs):
         line_segments = LineCollection(*plot_args, **plot_kwargs)
@@ -52,6 +55,8 @@ class PolygonPlot(ColorbarPlot):
         polys = []
         for segments in element.data:
             if segments.shape[0]:
+                if self.invert_axes:
+                    segments = segments[:, ::-1]
                 polys.append(Polygon(segments))
 
         if value is not None and np.isfinite(value):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -651,17 +651,29 @@ class AdjointLayoutPlot(CompositePlot):
         if right:
             ax = self.subaxes['right']
             subplot = self.subplots['right']
-            ax.set_position([bbox.x1 + bbox.width * subplot.border_size,
+            if isinstance(subplot, AdjoinedPlot):
+                subplot_size = subplot.subplot_size
+                border_size = subplot.border_size
+            else:
+                subplot_size = 0.25
+                border_size = 0.25
+            ax.set_position([bbox.x1 + bbox.width * border_size,
                              bbox.y0,
-                             bbox.width * subplot.subplot_size, bbox.height])
+                             bbox.width * subplot_size, bbox.height])
             if isinstance(subplot, GridPlot):
                 ax.set_aspect('equal')
         if top:
             ax = self.subaxes['top']
             subplot = self.subplots['top']
+            if isinstance(subplot, AdjoinedPlot):
+                subplot_size = subplot.subplot_size
+                border_size = subplot.border_size
+            else:
+                subplot_size = 0.25
+                border_size = 0.25
             ax.set_position([bbox.x0,
-                             bbox.y1 + bbox.height * subplot.border_size,
-                             bbox.width, bbox.height * subplot.subplot_size])
+                             bbox.y1 + bbox.height * border_size,
+                             bbox.width, bbox.height * subplot_size])
             if isinstance(subplot, GridPlot):
                 ax.set_aspect('equal')
 
@@ -1003,9 +1015,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             vtype = view.type if isinstance(view, HoloMap) else view.__class__
             if isinstance(view, GridSpace):
                 plotopts['create_axes'] = ax is not None
-            if pos == 'main':
-                plot_type = Store.registry['matplotlib'][vtype]
-            else:
+            plot_type = Store.registry['matplotlib'][vtype]
+            if pos != 'main' and vtype in MPLPlot.sideplots:
                 plot_type = MPLPlot.sideplots[vtype]
             num = num if len(self.coords) > 1 else 0
             subplots[pos] = plot_type(view, axis=ax, keys=self.keys,

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -796,6 +796,7 @@ class GenericOverlayPlot(GenericElementPlot):
                 opts['show_legend'] = False
             style = self.lookup_options(vmap.last, 'style').max_cycles(group_length)
             plotopts = dict(opts, cyclic_index=cyclic_index,
+                            invert_axes=self.invert_axes,
                             dimensions=self.dimensions, keys=self.keys,
                             layout_dimensions=self.layout_dimensions,
                             overlaid=overlay_type, ranges=ranges,


### PR DESCRIPTION
This PR adds support for almost all Element types to be used as adjoints in bokeh by correctly implementing axis inversions on the plotting classes.