### PR TITLE
Reenable layout constraint solver workaround in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -500,7 +500,7 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
 
         # Replace None types with empty plots
         # to avoid bokeh bug
-        if adjoined and bokeh_version < '0.12':
+        if adjoined:
             plots = layout_padding(plots)
 
         # Determine the most appropriate composite plot type


### PR DESCRIPTION
In bokeh 0.12 the bokeh layout constraint solver was finally updated to correctly handle empty parts of a plot. However apparently it does not correctly handle the size of the empty plots. This PR reenables the workaround that explicitly inserts an empty plot.