### PR TITLE
Ensure that empty overlay frame does not break

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -845,6 +845,6 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
                          "were not initialized correctly and could not be "
                          "rendered.")
 
-        if not self.overlaid and not self.tabs and not self.batched:
+        if element and not self.overlaid and not self.tabs and not self.batched:
             self._update_ranges(element, ranges)
             self._update_plot(key, self.handles['plot'], element)


### PR DESCRIPTION
As the title says, when there's an empty frame in bokeh's OverlayPlot, it should not try to compute and set extents.