### PR TITLE
Generalized FileArchive add method signature

### DIFF
--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -640,7 +640,7 @@ class FileArchive(Archive):
         except: raise Exception("Timestamp format invalid")
 
 
-    def add(self, obj=None, filename=None, data=None, info={}):
+    def add(self, obj=None, filename=None, data=None, info={}, **kwargs):
         """
         If a filename is supplied, it will be used. Otherwise, a
         filename will be generated from the supplied object. Note that


### PR DESCRIPTION

Simple PR to make FileArchive signature of add method compatible with ``NotebookArchive``. This means that tests should be able to run if nbformat isn't available i.e when ``FileArchive`` is set because ``NotebookArchive`` is unavailable.