### PR TITLE
Added support for adding legends outside plot in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -705,12 +705,17 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
     legend_position = param.ObjectSelector(objects=["top_right",
                                                     "top_left",
                                                     "bottom_left",
-                                                    "bottom_right"],
+                                                    "bottom_right",
+                                                    'right', 'left',
+                                                    'top', 'bottom'],
                                                     default="top_right",
                                                     doc="""
         Allows selecting between a number of predefined legend position
         options. The predefined options may be customized in the
         legend_specs class attribute.""")
+
+    legend_cols = param.Integer(default=False, doc="""
+       Whether to lay out the legend as columns.""")
 
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
@@ -718,6 +723,11 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
     style_opts = legend_dimensions + line_properties + text_properties
 
     _update_handles = ['source']
+
+    legend_specs = {'right': dict(pos='right', loc=(5, -40)),
+                    'left': dict(pos='left', loc=(0, -40)),
+                    'top': dict(pos='above', loc=(120, 5)),
+                    'bottom': dict(pos='below', loc=(60, 0))}
 
     def _process_legend(self):
         plot = self.handles['plot']
@@ -745,7 +755,9 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         if legend_fontsize:
             plot.legend[0].label_text_font_size = legend_fontsize
 
-        plot.legend.location = self.legend_position
+        if self.legend_position not in self.legend_specs:
+            plot.legend.location = self.legend_position
+        plot.legend.orientation = 'horizontal' if self.legend_cols else 'vertical'
         legends = plot.legend[0].legends
         new_legends = []
         for label, l in legends:
@@ -754,6 +766,13 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
             legend_labels.append(label)
             new_legends.append((label, l))
         plot.legend[0].legends[:] = new_legends
+        if self.legend_position in self.legend_specs:
+            legend = plot.legend[0]
+            plot.legend[:] = []
+            legend.plot = None
+            leg_opts = self.legend_specs[self.legend_position]
+            legend.location = leg_opts['loc']
+            plot.add_layout(plot.legend[0], leg_opts['pos'])
 
 
     def _init_tools(self, element):


### PR DESCRIPTION
As the title says, this allows placing legends outside the axis itself with options that mirror those also present in matplotlib. Positioning is still a bit fiddly and doesn't work perfectly for all plots but the behavior is pretty good overall. Here are some simple examples:

```python
hv.Layout([(hv.Curve(np.random.rand(10,2), label='A') * hv.Curve(np.random.rand(10,2), label='B'))(plot=dict(legend_position=pos)).relabel(pos)
           for pos in ['left', 'right', 'top', 'bottom']]).cols(2)
```

![image](https://cloud.githubusercontent.com/assets/1550771/17177217/428ff8a0-5408-11e6-8b64-2a7e264ded33.png)

Additionally I also added the legend_columns plot options. In matplotlib this option is an integer to control the number of columns in a legend, bokeh only supports an orientation, which is equivalent to setting the number of columns higher than the number of entries in the legend. For consistency between the backends I'd still argue that naming them the same thing and treating any non-zero ``legend_columns`` value as a horizontal legend layout makes sense:

```python
%%opts Overlay [legend_cols=True]
hv.Layout([(hv.Curve(np.random.rand(10,2), label='A') * hv.Curve(np.random.rand(10,2), label='B'))(plot=dict(legend_position=pos)).relabel(pos)
           for pos in ['left', 'right', 'top', 'bottom']]).cols(2)
```

<img width="631" alt="screen shot 2016-07-27 at 2 45 27 pm" src="https://cloud.githubusercontent.com/assets/1550771/17177348/d238e458-5408-11e6-95b3-cd98d9c799c7.png">

Overall this is an improvement, it's just a bit annoying that bokeh treats legends, axes and anything else that's placed outside the main plot as part of the plot area, which means it won't preserve aspects and squish plots as you see above, but I'm hoping that's something they'll address soon.