### PR TITLE
Filter style keywords according to backend

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -296,6 +296,17 @@ class Options(param.Parameterized):
         super(Options, self).__init__(allowed_keywords=allowed_keywords,
                                       merge_keywords=merge_keywords, key=key)
 
+    def filtered(self, allowed):
+        """
+        Return a new Options object that is filtered by the specified
+        list of keys. Mutating self.kwargs to filter is unsafe due to
+        the option expansion that occurs on initialization.
+        """
+        kws = {k:v for k,v in self.kwargs.items() if k in allowed}
+        return self.__class__(key=self.key,
+                              allowed_keywords=self.allowed_keywords,
+                              merge_keywords=self.merge_keywords, **kws)
+
 
     def __call__(self, allowed_keywords=None, **kwargs):
         """

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -338,6 +338,8 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
     show_grid = param.Boolean(default=True, doc="""
         Whether to overlay a grid on the axis.""")
 
+    style_opts = []
+
     def _process_hist(self, hist):
         """
         Subclassed to offset histogram by defined amount.

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -338,8 +338,6 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
     show_grid = param.Boolean(default=True, doc="""
         Whether to overlay a grid on the axis.""")
 
-    style_opts = []
-
     def _process_hist(self, hist):
         """
         Subclassed to offset histogram by defined amount.

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -68,9 +68,10 @@ class Plot(param.Parameterized):
 
     @classmethod
     def lookup_options(cls, obj, group):
+        plot_class = cls.renderer.plotting_class(obj)
         node = Store.lookup_options(cls.renderer.backend, obj, group)
-        if group == 'style' and cls.style_opts:
-            return node.filtered(cls.style_opts)
+        if group == 'style' and plot_class.style_opts:
+            return node.filtered(plot_class.style_opts)
         else:
             return node
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -68,7 +68,12 @@ class Plot(param.Parameterized):
 
     @classmethod
     def lookup_options(cls, obj, group):
-        return Store.lookup_options(cls.renderer.backend, obj, group)
+        node = Store.lookup_options(cls.renderer.backend, obj, group)
+        if group == 'style':
+            return node.filtered(cls.style_opts)
+        else:
+            return node
+
 
 
 class PlotSelector(object):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -69,7 +69,7 @@ class Plot(param.Parameterized):
     @classmethod
     def lookup_options(cls, obj, group):
         node = Store.lookup_options(cls.renderer.backend, obj, group)
-        if group == 'style':
+        if group == 'style' and cls.style_opts:
             return node.filtered(cls.style_opts)
         else:
             return node

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -68,10 +68,15 @@ class Plot(param.Parameterized):
 
     @classmethod
     def lookup_options(cls, obj, group):
-        plot_class = cls.renderer.plotting_class(obj)
+        try:
+            plot_class = cls.renderer.plotting_class(obj)
+            style_opts = plot_class.style_opts
+        except SkipRendering:
+            style_opts = None
+
         node = Store.lookup_options(cls.renderer.backend, obj, group)
-        if group == 'style' and plot_class.style_opts:
-            return node.filtered(plot_class.style_opts)
+        if group == 'style' and style_opts:
+            return node.filtered(style_opts)
         else:
             return node
 


### PR DESCRIPTION
I think this functionality is best expressed with a screenshot:

<img width="1010" alt="screen shot 2016-07-27 at 2 54 03 pm" src="https://cloud.githubusercontent.com/assets/890576/17177587/0a463412-540a-11e6-86b5-2c87b6ec2993.png">

Note that ``linewidth`` applies to matplotlib and ``line_width`` applies to Bokeh.