### PR TITLE
Ensure that NdOverlay is propagated correctly in dynamic batched mode

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -852,11 +852,18 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         ranges = self.compute_ranges(range_obj, key, ranges)
         for k, subplot in self.subplots.items():
             empty, el = False, None
+            # If in Dynamic mode propagate elements to subplots
             if isinstance(self.hmap, DynamicMap) and element:
-                idx = dynamic_update(self, subplot, k, element, items)
-                empty = idx is None
-                if not empty:
-                    _, el = items.pop(idx)
+                # In batched mode NdOverlay is passed to subplot directly
+                if self.batched:
+                    el = element
+                    empty = False
+                # If not batched get the Element matching the subplot
+                else:
+                    idx = dynamic_update(self, subplot, k, element, items)
+                    empty = idx is None
+                    if not empty:
+                        _, el = items.pop(idx)
             subplot.update_frame(key, ranges, element=el, empty=(empty or all_empty))
 
         if isinstance(self.hmap, DynamicMap) and items:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -547,9 +547,8 @@ class GenericElementPlot(DimensionedPlot):
         spec = util.get_overlay_spec(overlay, key, el)
         try:
             return self.ordering.index(spec)
-        except IndexError:
-            if spec not in self.ordering:
-                self.ordering = util.layer_sort(self.hmap)
+        except ValueError:
+            self.ordering = sorted(self.ordering+[spec])
             return self.ordering.index(spec)
 
 


### PR DESCRIPTION
When an OverlayPlot is used in dynamic mode it is responsible for delegating the layers in the Overlay/NdOverlay to the appropriate subplots. This handling works fine when each layer in an NdOverlay is assigned its own plot (as is the case in regular non-batched mode), what was missing was handling for dynamic mode + batched mode in which case it just passes the whole NdOverlay to the subplot. This PR makes sure that happens.