### PR TITLE
Ensure that iris does not override supplied dimensions

### DIFF
--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -10,11 +10,11 @@ import numpy as np
 
 from .interface import Interface
 from .grid import GridInterface
+from ..dimension import Dimension
 from ..ndmapping import (NdMapping, item_check, sorted_context)
 from ..spaces import HoloMap
 from .. import util
 
-from holoviews.core.dimension import Dimension
 
 
 def get_date_format(coord):
@@ -102,11 +102,12 @@ class CubeInterface(GridInterface):
                 if len(coord) == 0:
                     raise ValueError('Key dimension %s not found in '
                                      'Iris cube.' % kd)
-                coords.append(coord[0])
+                coords.append(kd if isinstance(kd, Dimension) else coord[0])
         else:
             coords = data.dim_coords
             coords = sorted(coords, key=sort_coords)
-        kdims = [coord_to_dimension(crd) for crd in coords]
+        kdims = [crd if isinstance(crd, Dimension) else coord_to_dimension(crd)
+                 for crd in coords]
         if vdims is None:
             vdims = [Dimension(data.name(), unit=str(data.units))]
 


### PR DESCRIPTION
Previously the iris interface was simply overriding any dimensions supplied by the user, this ensures user supplied dimensions are handled correctly.