### PR TITLE
Allowed partial dimension overlap in DynamicMaps

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -559,6 +559,8 @@ class GenericElementPlot(DimensionedPlot):
         elif self.dynamic:
             key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
             if not isinstance(key, tuple): key = (key,)
+            key_map = dict(zip([d.name for d in self.hmap.kdims], key))
+            key = tuple(key_map.get(d.name, None) for d in self.dimensions)
             if not key in self.keys:
                 self.keys.append(key)
             self.current_frame = frame

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -4,14 +4,16 @@ Tests of plot instantiation (not display tests, just instantiation)
 
 from unittest import SkipTest
 import numpy as np
-from holoviews import Curve, Scatter, Overlay
+from holoviews import (Dimension, Curve, Scatter, Overlay, DynamicMap,
+                       Store, Image, VLine)
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
     # Standardize backend due to random inconsistencies
     from matplotlib import pyplot
     pyplot.switch_backend('agg')
-    from holoviews.plotting import OverlayPlot
+    from holoviews.plotting.mpl import OverlayPlot
+    renderer = Store.renderers['matplotlib']
 except:
     pyplot = None
 
@@ -29,3 +31,11 @@ class TestPlotInstantiation(ComparisonTestCase):
         o = Overlay([Curve(np.array([[0, 1]])) , Scatter([[1,1]]) , Curve(np.array([[0, 1]]))])
         OverlayPlot(o)
 
+    def test_dynamic_nonoverlap(self):
+        kdims = [Dimension('File', range=(0.01, 1)),
+                 Dimension('SliceDimension', range=(0.01, 1)),
+                 Dimension('Coordinates', range=(0.01, 1))]
+        dmap1 = DynamicMap(lambda x, y, z: Image(np.random.rand(10,10)), kdims=kdims)
+        dmap2 = DynamicMap(lambda x: Curve(np.random.rand(10,2))*VLine(x),
+                           kdims=kdims[:1])
+        renderer.get_widget(dmap1 + dmap2, 'selection')


### PR DESCRIPTION
The code on DimensionedPlot was not robust to partial overlap in dimensions when plotting DynamicMap types. This PR ensures that partial keys (i.e. keys that are not of the same dimensionality as the overall plot) are padded with Nones before being inserted into the list of keys, ensuring that all keys are of the right length.