### PR TITLE
Avoid updating data source if element data is unchanged

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -577,7 +577,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             return handles
 
         previous_id = self.handles.get('previous_id', None)
-        current_id = id(self.current_frame)
+        current_id = id(self.current_frame.data)
         for handle in self._update_handles:
             if (handle == 'source' and self.dynamic and
                 current_id == previous_id):


### PR DESCRIPTION
Instead of checking whether the Element has changed it now checks whether the element data attribute has changed, when deciding whether to send the data source data to bokeh plot.