### PR TITLE
Fixed coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,7 @@ script:
   - cd doc/nbpublisher; chmod +x test_notebooks.py; ./test_notebooks.py
   - chmod +x concat_html.py; ./concat_html.py ../test_data ../test_html
   - cd ../../; mv doc/Tutorials/.coverage ./.coverage.notebooks
-  - coverage combine
+  - coverage combine --append
 
 after_script:
   - if [ "$TRAVIS_BRANCH" == 'master' ]; then


### PR DESCRIPTION
The coverage module introduced a backward compatibility breaking change in v4.2 (see https://coverage.readthedocs.io/en/coverage-4.2/changes.html#version-4-2-2016-07-26). This PR ensures coverage reports are combined correctly again.