### PR TITLE
Add Comms to allow updating plots dynamically

### DIFF
--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -228,7 +228,7 @@ class InfoPrinter(object):
     @classmethod
     def options_info(cls, plot_class, ansi=False, pattern=None):
         if plot_class.style_opts:
-            backend_name = plot_class.renderer.backend
+            backend_name = plot_class.backend
             style_info = ("\n(Consult %s's documentation for more information.)" % backend_name)
             style_keywords = '\t%s' % ', '.join(plot_class.style_opts)
             style_msg = '%s\n%s' % (style_keywords, style_info)

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -29,45 +29,7 @@ var BokehMethods = {
 			doc.apply_json_patch(data.patch);
 		}
 	},
-	dynamic_update : function(current){
-		if (current === undefined) {
-			return
-		}
-		if(this.dynamic) {
-			current = JSON.stringify(current);
-		}
-		function callback(initialized, msg){
-			/* This callback receives data from Python as a string
-			   in order to parse it correctly quotes are sliced off*/
-			if (msg.content.ename != undefined) {
-				this.process_error(msg);
-			}
-			if (msg.msg_type != "execute_result") {
-				console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
-				this.time = undefined;
-				this.wait = false;
-				return
-			}
-			this.timed = (Date.now() - this.time) * 1.1;
-			if (msg.msg_type == "execute_result") {
-				if (msg.content.data['text/plain'] === "'Complete'") {
-					this.wait = false;
-					if (this.queue.length > 0) {
-						this.time = Date.now();
-						this.dynamic_update(this.queue[this.queue.length-1]);
-						this.queue = [];
-					}
-					return
-			    }
-				var data = msg.content.data['text/plain'].slice(1, -1);
-				this.frames[current] = JSON.parse(data);
-				this.update(current);
-			}
-		}
-		var kernel = IPython.notebook.kernel;
-		callbacks = {iopub: {output: $.proxy(callback, this, this.initialized)}};
-		var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
-		kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
+	init_comms : function() {
 	}
 }
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -42,7 +42,7 @@ class BokehPlot(DimensionedPlot):
         The formatting string for the title of this plot, allows defining
         a label group separator and dimension labels.""")
 
-    renderer = BokehRenderer
+    backend = 'bokeh'
 
     @property
     def document(self):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -62,19 +62,19 @@ class BokehRenderer(Renderer):
         doc_handler = add_to_document(plot.state)
         with doc_handler:
             doc = doc_handler._doc
-            if plot.comm:
-                div = notebook_div(plot.state, plot.comm.target)
+            target = plot.comm.target if plot.comm else None
+            div = notebook_div(plot.state, target)
         plot.document = doc
         doc.add_root(plot.state)
         return div
 
 
-    def patch(self, plot):
+    def patch(self, plot, serialize=True):
         plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles)
                        for h in handles]
         patch = compute_static_patch(plot.document, plotobjects)
-        return self._apply_post_render_hooks(serialize_json(patch), plot, 'json')
-
+        processed = self._apply_post_render_hooks(patch, plot, 'json')
+        return serialize_json(processed) if serialize else processed
 
     @classmethod
     def plot_options(cls, obj, percent_size):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -3,7 +3,7 @@ import uuid
 from ...core import Store, HoloMap
 from ..renderer import Renderer, MIME_TYPES
 from .widgets import BokehScrubberWidget, BokehSelectionWidget
-from .util import compute_static_patch
+from .util import compute_static_patch, serialize_json
 
 import param
 from param.parameterized import bothmethod
@@ -12,7 +12,6 @@ from bokeh.embed import notebook_div
 from bokeh.io import load_notebook
 from bokeh.resources import CDN, INLINE
 
-from bokeh.core.json_encoder import serialize_json
 from bokeh.model import _ModelInDocument as add_to_document
 
 

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -54,7 +54,7 @@ class BokehRenderer(Renderer):
             html = "<div style='display: table; margin: 0 auto;'>%s</div>" % html
             return self._apply_post_render_hooks(html, obj, fmt), info
         elif fmt == 'json':
-            return self.patch(plot), info
+            return self.diff(plot), info
 
 
     def figure_data(self, plot, fmt='html', **kwargs):
@@ -68,7 +68,11 @@ class BokehRenderer(Renderer):
         return div
 
 
-    def patch(self, plot, serialize=True):
+    def diff(self, plot, serialize=True):
+        """
+        Returns a json diff required to update an existing plot with
+        the latest plot data.
+        """
         plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles)
                        for h in handles]
         patch = compute_static_patch(plot.document, plotobjects)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -13,12 +13,12 @@ except ImportError:
 import bokeh
 bokeh_version = LooseVersion(bokeh.__version__)
 from bokeh.core.enums import Palette
+from bokeh.core.json_encoder import serialize_json # noqa (API import)
 from bokeh.document import Document
 from bokeh.models.plots import Plot
 from bokeh.models import GlyphRenderer
 from bokeh.models.widgets import DataTable, Tabs
 from bokeh.plotting import Figure
-
 if bokeh_version >= '0.12':
     from bokeh.layouts import WidgetBox
 

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -5,7 +5,7 @@ from bokeh.io import _CommsHandle
 from bokeh.util.notebook import get_comms
 
 from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
-from .util import compute_static_patch, serialize_json
+from .util import serialize_json
 
 class BokehWidget(NdWidget):
 
@@ -39,7 +39,7 @@ class BokehWidget(NdWidget):
             if fig_format == 'html':
                 msg = self.renderer.html(self.plot, fig_format)
             else:
-                json_patch = self.renderer.patch(self.plot, serialize=False)
+                json_patch = self.renderer.diff(self.plot, serialize=False)
                 msg = dict(patch=json_patch, root=self.plot.state._id)
                 msg = serialize_json(msg)
             return msg

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -36,22 +36,15 @@ class BokehWidget(NdWidget):
         """
         self.plot.update(idx)
         if self.embed or fig_format == 'html':
-            html = self.renderer.html(self.plot, fig_format)
-            return html
-        else:
-            doc = self.plot.document
-            if hasattr(doc, 'last_comms_handle'):
-                handle = doc.last_comms_handle
+            if fig_format == 'html':
+                msg = self.renderer.html(self.plot, fig_format)
             else:
-                handle = _CommsHandle(get_comms(doc.last_comms_target),
-                                      doc, doc.to_json())
-                doc.last_comms_handle = handle
-
-            plotobjects = [h for handles in self.plot.traverse(lambda x: x.current_handles)
-                           for h in handles]
-            msg = compute_static_patch(doc, plotobjects)
-            handle.comms.send(json.dumps(msg))
-            return 'Complete'
+                json_patch = self.renderer.patch(self.plot, serialize=False)
+                msg = dict(patch=json_patch, root=self.plot.doc._id)
+            return msg
+        else:
+            self.plot.push()
+            return "Complete"
 
 
 class BokehSelectionWidget(BokehWidget, SelectionWidget):

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -5,7 +5,7 @@ from bokeh.io import _CommsHandle
 from bokeh.util.notebook import get_comms
 
 from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
-from .util import compute_static_patch
+from .util import compute_static_patch, serialize_json
 
 class BokehWidget(NdWidget):
 
@@ -40,7 +40,8 @@ class BokehWidget(NdWidget):
                 msg = self.renderer.html(self.plot, fig_format)
             else:
                 json_patch = self.renderer.patch(self.plot, serialize=False)
-                msg = dict(patch=json_patch, root=self.plot.doc._id)
+                msg = dict(patch=json_patch, root=self.plot.state._id)
+                msg = serialize_json(msg)
             return msg
         else:
             self.plot.push()

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -74,6 +74,7 @@ class JupyterComm(Comm):
     template = """
     <script>
       function msg_handler(msg) {{
+        var data = msg.content.data;
         {msg_handler}
       }}
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -18,8 +18,10 @@ class Comm(param.Parameterized):
 
     The template must accept three arguments:
 
-    * comms_target - A unique id to register to register as the comms target.
-    * msg_handler -  JS code that processes messages sent to the frontend.
+    * comms_target - A unique id to register to register as the
+                     comms target.
+    * msg_handler -  JS code which has the msg variable in scope and
+                     performs appropriate action for the supplied message.
     * init_frame  -  The initial frame to render on the frontend.
     """
 
@@ -80,7 +82,7 @@ class JupyterPushComm(Comm):
     template = """
     <script>
       function msg_handler(msg) {{
-        var data = msg.content.data;
+        var msg = msg.content.data;
         {msg_handler}
       }}
 
@@ -127,7 +129,7 @@ class JupyterComm(Comm):
     template = """
     <script>
       function msg_handler(msg) {{
-        var data = msg.content.data;
+        var msg = msg.content.data;
         {msg_handler}
       }}
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -49,7 +49,8 @@ class Comm(param.Parameterized):
         """
 
 
-    def decode(self, msg):
+    @classmethod
+    def decode(cls, msg):
         """
         Decode incoming message, e.g. by parsing json.
         """
@@ -104,7 +105,8 @@ class JupyterPushComm(Comm):
         self._comm.on_msg(self._handle_msg)
 
 
-    def decode(self, msg):
+    @classmethod
+    def decode(cls, msg):
         return msg['content']['data']
 
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -17,7 +17,7 @@ class Comm(param.Parameterized):
         """
         Initializes a Comms object
         """
-        self.target = target if target else str(uuid.uuid4())
+        self.target = target if target else uuid.uuid4().hex
         self._plot = plot
         self._on_msg = on_msg
         self._comm = None

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -1,0 +1,113 @@
+import uuid
+
+import param
+from ipykernel.comm import Comm as IPyComm
+
+
+class Comm(param.Parameterized):
+    """
+    Comm encompasses any uni- or bi-directional connection between
+    a python process and a frontend allowing passing of messages
+    between the two. A Comms class must implement methods
+    to initialize the connection, send data and handle received
+    message events.
+    """
+
+    def __init__(self, plot, target=None, on_msg=None):
+        """
+        Initializes a Comms object
+        """
+        self.target = target if target else str(uuid.uuid4())
+        self._plot = plot
+        self._on_msg = on_msg
+        self._comm = None
+
+
+    def init(self, on_msg=None):
+        """
+        Initializes comms channel.
+        """
+
+
+    def send(self, data):
+        """
+        Sends data to the frontend
+        """
+
+
+    def decode(self, msg):
+        """
+        Decode incoming message, e.g. by parsing json.
+        """
+        return msg
+
+
+    @property
+    def comm(self):
+        if not self._comm:
+            raise ValueError('Comm has not been initialized')
+        return self._comm
+
+
+    def _handle_msg(self, msg):
+        """
+        Decode received message before passing it to on_msg callback
+        if it has been defined.
+        """
+        if self._on_msg:
+            self._on_msg(self.decode(msg))
+
+
+
+class JupyterComm(Comm):
+    """
+    JupyterComm allows for a bidirectional communication channel
+    inside the Jupyter notebook. A JupyterComm requires the comm to be
+    registered on the frontend along with a message handler. This is
+    handled by the template, which accepts three arguments:
+
+    * comms_target - A unique id to register to register as the comms target.
+    * msg_handler -  JS code that processes messages sent to the frontend.
+    * init_frame  -  The initial frame to render on the frontend.
+    """
+
+    template = """
+    <script>
+      function msg_handler(msg) {{
+        {msg_handler}
+      }}
+
+      function register_handler(comm, msg) {{
+        comm.on_msg(msg_handler)
+      }}
+
+      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
+        comm_manager = Jupyter.notebook.kernel.comm_manager
+        comm_manager.register_target("{comms_target}", register_handler);
+      }}
+    </script>
+
+    <div id="{comms_target}">
+      {init_frame}
+    </div>
+    """
+
+    def init(self):
+        if self._comm:
+            self.warning("Comms already initialized")
+            return
+        self._comm = IPyComm(target_name=self.target, data={})
+        self._comm.on_msg(self._handle_msg)
+
+
+    def send(self, data):
+        """
+        Pushes data to comms socket
+        """
+        if not self._comm:
+            raise ValueError("Comm has not been initialized.")
+        self._comm.send(data)
+
+
+    def decode(self, msg):
+        return msg['content']['data']

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -106,7 +106,7 @@ class JupyterComm(Comm):
         Pushes data to comms socket
         """
         if not self._comm:
-            raise ValueError("Comm has not been initialized.")
+            self.init()
         self._comm.send(data)
 
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -70,9 +70,9 @@ class Comm(param.Parameterized):
             self._on_msg(self.decode(msg))
 
 
-class SimpleJupyterComm(Comm):
+class JupyterPushComm(Comm):
     """
-    SimpleJupyterComm provides a Comm for simple unidirectional
+    JupyterPushComm provides a Comm for simple unidirectional
     communication from the python process to a frontend. The
     Comm is opened before the first event is sent to the frontend.
     """

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -12,16 +12,18 @@ from mpl_toolkits.mplot3d import Axes3D
 from ..comms import JupyterComm
 
 mpl_msg_handler = """
+/* Backend specific body of the msg_handler, updates displayed frame */
 target = $('#{comms_target}');
-img = $('<div />').html(data);
+img = $('<div />').html(msg);
 target.children().each(function () {{ $(this).remove() }})
 target.append(img)
 """
 
 mpld3_msg_handler = """
+/* Backend specific body of the msg_handler, updates displayed frame */
 target = $('#fig_el{comms_target}');
 target.children().each(function () {{ $(this).remove() }});
-mpld3.draw_figure("fig_el{comms_target}", data);
+mpld3.draw_figure("fig_el{comms_target}", msg);
 """
 
 class NbAggCommSocket(CommSocket):

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -12,7 +12,6 @@ from mpl_toolkits.mplot3d import Axes3D
 from ..comms import JupyterComm
 
 mpl_msg_handler = """
-var data = msg.content.data;
 target = $('#{comms_target}');
 img = $('<div />').html(data);
 target.children().each(function () {{ $(this).remove() }})
@@ -20,7 +19,6 @@ target.append(img)
 """
 
 mpld3_msg_handler = """
-var data = msg.content.data;
 target = $('#fig_el{comms_target}');
 target.children().each(function () {{ $(this).remove() }});
 mpld3.draw_figure("fig_el{comms_target}", data);

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -24,13 +24,11 @@ target.children().each(function () {{ $(this).remove() }});
 mpld3.draw_figure("fig_el{comms_target}", data);
 """
 
-class WidgetCommSocket(CommSocket):
+class NbAggCommSocket(CommSocket):
     """
-    CustomCommSocket provides communication between the IPython
-    kernel and a matplotlib canvas element in the notebook.
-    A CustomCommSocket is required to delay communication
-    between the kernel and the canvas element until the widget
-    has been rendered in the notebook.
+    NbAggCommSocket subclasses the matplotlib CommSocket allowing
+    the opening of a comms channel to be delayed until the plot
+    is displayed.
     """
 
     def __init__(self, manager, target=None):
@@ -58,6 +56,10 @@ class WidgetCommSocket(CommSocket):
 
 
 class NbAggJupyterComm(JupyterComm):
+    """
+    Wraps a NbAggCommSocket to provide a consistent API to work for
+    updating nbagg plots.
+    """
 
     def get_figure_manager(self):
         fig = self._plot.state
@@ -68,8 +70,8 @@ class NbAggJupyterComm(JupyterComm):
         for ax in fig.get_axes():
             if isinstance(ax, Axes3D):
                 ax.mouse_init()
-        self._comm_socket = WidgetCommSocket(target=self.target,
-                                             manager=self.manager)
+        self._comm_socket = NbAggCommSocket(target=self.target,
+                                            manager=self.manager)
         return self.manager
 
 

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -1,0 +1,89 @@
+import uuid
+import warnings
+
+try:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from matplotlib.backends.backend_nbagg import CommSocket, new_figure_manager_given_figure
+except ImportError:
+    CommSocket = object
+from mpl_toolkits.mplot3d import Axes3D
+
+from ..comms import JupyterComm
+
+mpl_msg_handler = """
+var data = msg.content.data;
+target = $('#{comms_target}');
+img = $('<div />').html(data);
+target.children().each(function () {{ $(this).remove() }})
+target.append(img)
+"""
+
+mpld3_msg_handler = """
+var data = msg.content.data;
+target = $('#fig_el{comms_target}');
+target.children().each(function () {{ $(this).remove() }});
+mpld3.draw_figure("fig_el{comms_target}", data);
+"""
+
+class WidgetCommSocket(CommSocket):
+    """
+    CustomCommSocket provides communication between the IPython
+    kernel and a matplotlib canvas element in the notebook.
+    A CustomCommSocket is required to delay communication
+    between the kernel and the canvas element until the widget
+    has been rendered in the notebook.
+    """
+
+    def __init__(self, manager, target=None):
+        self.supports_binary = None
+        self.manager = manager
+        self.target = str(uuid.uuid4()) if target is None else target
+        self.html = "<div id=%r></div>" % self.target
+
+    def start(self):
+        try:
+            # Jupyter/IPython 4.0
+            from ipykernel.comm import Comm
+        except:
+            # IPython <=3.0
+            from IPython.kernel.comm import Comm
+
+        try:
+            self.comm = Comm('matplotlib', data={'id': self.target})
+        except AttributeError:
+            raise RuntimeError('Unable to create an IPython notebook Comm '
+                               'instance. Are you in the IPython notebook?')
+        self.comm.on_msg(self.on_message)
+        self.comm.on_close(lambda close_message: self.manager.clearup_closed())
+
+
+
+class NbAggJupyterComm(JupyterComm):
+
+    def get_figure_manager(self):
+        fig = self._plot.state
+        count = self._plot.renderer.counter
+        self.manager = new_figure_manager_given_figure(count, fig)
+
+        # Need to call mouse_init on each 3D axis to enable rotation support
+        for ax in fig.get_axes():
+            if isinstance(ax, Axes3D):
+                ax.mouse_init()
+        self._comm_socket = WidgetCommSocket(target=self.target,
+                                             manager=self.manager)
+        return self.manager
+
+
+    def init(self, on_msg=None):
+        if not self._comm:
+            self._comm_socket.start()
+            self._comm = self._comm_socket.comm
+            self.manager.add_web_socket(self._comm_socket)
+
+
+    def send(self, data):
+        if not self._comm:
+            self.init()
+        self._comm_socket.send_json({'type':'draw'})
+

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -36,7 +36,7 @@ class WidgetCommSocket(CommSocket):
     def __init__(self, manager, target=None):
         self.supports_binary = None
         self.manager = manager
-        self.target = str(uuid.uuid4()) if target is None else target
+        self.target = uuid.uuid4().hex if target is None else target
         self.html = "<div id=%r></div>" % self.target
 
     def start(self):

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -38,16 +38,8 @@ var MPLMethods = {
 	process_msg : function(msg) {
 		if (!(this.mode == 'nbagg')) {
 			var data = msg.content.data;
-			if(this.mode == 'mpld3'){
-				data = JSON.parse(data)[0];
-			}
-			current_frame = this.cache[this.current];
-			delete this.cache[this.current];
 			this.frames[this.current] = data;
-			this.update_cache();
-			if (current_frame) {
-				current_frame.remove()
-			}
+			this.update_cache(true);
 			this.update(this.current);
 		}
 	}

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -25,7 +25,7 @@ var MPLMethods = {
 		}
 	},
 	populate_cache : function(idx){
-		var cache_id = this.img_id+"_"+idx;
+		var cache_id = "_anim_img"+this.id+"_"+idx;
 		if(this.mode == 'mpld3') {
 			mpld3.draw_figure(cache_id, this.frames[idx]);
 		} else {
@@ -35,48 +35,23 @@ var MPLMethods = {
 			delete this.frames[idx];
 		}
 	},
-	dynamic_update : function(current){
-		if (this.dynamic) {
-			current = JSON.stringify(current);
+	process_msg : function(msg) {
+		if (!(this.mode == 'nbagg')) {
+			var data = msg.content.data;
+			if(this.mode == 'mpld3'){
+				data = JSON.parse(data)[0];
+			}
+			current_frame = this.cache[this.current];
+			delete this.cache[this.current];
+			this.frames[this.current] = data;
+			this.update_cache();
+			if (current_frame) {
+				current_frame.remove()
+			}
+			this.update(this.current);
 		}
-		function callback(msg){
-			/* This callback receives data from Python as a string
-			 in order to parse it correctly quotes are sliced off*/
-			if (msg.content.ename != undefined) {
-				this.process_error(msg);
-			}
-			if (msg.msg_type != "execute_result") {
-				console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
-				this.time = undefined;
-				return
-			}
-			if (!(this.mode == 'nbagg')) {
-				if(!(current in this.cache)) {
-					var data = msg.content.data['text/plain'].slice(1, -1);
-					if(this.mode == 'mpld3'){
-						data = JSON.parse(data)[0];
-					}
-					this.frames[current] = data;
-					this.update_cache();
-				}
-				this.update(current);
-			}
-			this.timed = (Date.now() - this.time) * 1.5;
-			this.wait = false;
-			if (this.queue.length > 0) {
-				var current_vals = this.queue[this.queue.length-1];
-				this.time = Date.now();
-				this.dynamic_update(current_vals);
-				this.queue = [];
-			}
-		}
-		var kernel = IPython.notebook.kernel;
-		callbacks = {iopub: {output: $.proxy(callback, this)}};
-		var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
-		kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
 	}
 }
-
 // Extend MPL widgets with backend specific methods
 extend(MPLSelectionWidget.prototype, MPLMethods);
 extend(MPLScrubberWidget.prototype, MPLMethods);

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -16,7 +16,6 @@ from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
 from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
 from ..util import get_dynamic_mode, initialize_sampled
-from .renderer import MPLRenderer
 from .util import compute_ratios, fix_aspect
 
 
@@ -30,7 +29,8 @@ class MPLPlot(DimensionedPlot):
     via the anim() method.
     """
 
-    renderer = MPLRenderer
+    backend = 'matplotlib'
+
     sideplots = {}
 
     fig_alpha = param.Number(default=1.0, bounds=(0, 1), doc="""

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -9,7 +9,6 @@ import matplotlib as mpl
 from matplotlib import pyplot as plt
 
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
-from mpl_toolkits.mplot3d import Axes3D
 
 import param
 from param.parameterized import bothmethod
@@ -18,6 +17,8 @@ from ...core import HoloMap
 from ...core.options import Store
 
 from ..renderer import Renderer, MIME_TYPES
+from .comms import (JupyterComm, NbAggJupyterComm,
+                    mpl_msg_handler, mpld3_msg_handler)
 from .widgets import MPLSelectionWidget, MPLScrubberWidget
 from .util import get_tight_bbox
 
@@ -81,6 +82,11 @@ class MPLRenderer(Renderer):
     widgets = {'scrubber': MPLScrubberWidget,
                'widgets': MPLSelectionWidget}
 
+    # Define comm targets by mode
+    comms = {'default': (JupyterComm, mpl_msg_handler),
+             'nbagg':   (NbAggJupyterComm, None),
+             'mpld3':   (JupyterComm, mpld3_msg_handler)}
+
     def __call__(self, obj, fmt='auto'):
         """
         Render the supplied HoloViews component or MPLPlot instance
@@ -135,6 +141,19 @@ class MPLRenderer(Renderer):
         return (w*dpi, h*dpi)
 
 
+    def patch(self, plot):
+        data = None
+        if self.mode != 'nbagg':
+            if self.mode == 'mpld3':
+                figure_format = 'json'
+            elif self.fig == 'auto':
+                figure_format = self.renderer.params('fig').objects[0]
+            else:
+                figure_format = self.fig
+            data = self.html(plot, figure_format, comm=False)
+        return data
+
+
     def _figure_data(self, plot, fmt='png', bbox_inches='tight', **kwargs):
         """
         Render matplotlib figure object and return the corresponding data.
@@ -144,7 +163,7 @@ class MPLRenderer(Renderer):
         """
         fig = plot.state
         if self.mode == 'nbagg':
-            manager = self.get_figure_manager(plot.state)
+            manager = plot.comm.get_figure_manager()
             if manager is None: return ''
             self.counter += 1
             manager.show()
@@ -156,7 +175,16 @@ class MPLRenderer(Renderer):
             if fmt == 'json':
                 return mpld3.fig_to_dict(fig)
             else:
-                return "<center>" + mpld3.fig_to_html(fig) + "<center/>"
+                figid = "fig_el"+plot.comm.target if plot.comm else None
+                html = mpld3.fig_to_html(fig, figid=figid)
+                html = "<center>" + html + "<center/>"
+                if plot.comm:
+                    comm, msg_handler = self.comms[self.mode]
+                    msg_handler = msg_handler.format(comms_target=plot.comm.target)
+                    return comm.template.format(init_frame=html,
+                                                msg_handler=msg_handler,
+                                                comms_target=plot.comm.target)
+                return html
 
         traverse_fn = lambda x: x.handles.get('bbox_extra_artists', None)
         extra_artists = list(chain(*[artists for artists in plot.traverse(traverse_fn)
@@ -184,16 +212,6 @@ class MPLRenderer(Renderer):
         if fmt == 'svg':
             data = data.decode('utf-8')
         return data
-
-
-    def get_figure_manager(self, fig):
-        from matplotlib.backends.backend_nbagg import new_figure_manager_given_figure
-        manager = new_figure_manager_given_figure(self.counter, fig)
-        # Need to call mouse_init on each 3D axis to enable rotation support
-        for ax in fig.get_axes():
-            if isinstance(ax, Axes3D):
-                ax.mouse_init()
-        return manager
 
 
     def _anim_data(self, anim, fmt):

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -141,7 +141,10 @@ class MPLRenderer(Renderer):
         return (w*dpi, h*dpi)
 
 
-    def patch(self, plot):
+    def diff(self, plot):
+        """
+        Returns the latest plot data to update an existing plot.
+        """
         data = None
         if self.mode != 'nbagg':
             if self.mode == 'mpld3':

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -3,44 +3,6 @@ import param
 
 from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 
-try:
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        from matplotlib.backends.backend_nbagg import CommSocket
-except ImportError:
-    CommSocket = object
-
-class WidgetCommSocket(CommSocket):
-    """
-    CustomCommSocket provides communication between the IPython
-    kernel and a matplotlib canvas element in the notebook.
-    A CustomCommSocket is required to delay communication
-    between the kernel and the canvas element until the widget
-    has been rendered in the notebook.
-    """
-
-    def __init__(self, manager):
-        self.supports_binary = None
-        self.manager = manager
-        self.uuid = str(uuid.uuid4())
-        self.html = "<div id=%r></div>" % self.uuid
-
-    def start(self):
-        try:
-            # Jupyter/IPython 4.0
-            from ipykernel.comm import Comm
-        except:
-            # IPython <=3.0
-            from IPython.kernel.comm import Comm
-
-        try:
-            self.comm = Comm('matplotlib', data={'id': self.uuid})
-        except AttributeError:
-            raise RuntimeError('Unable to create an IPython notebook Comm '
-                               'instance. Are you in the IPython notebook?')
-        self.comm.on_msg(self.on_message)
-        self.comm.on_close(lambda close_message: self.manager.clearup_closed())
-
 
 class MPLWidget(NdWidget):
 

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -36,23 +36,16 @@ class MPLWidget(NdWidget):
         if self.plot.dynamic == 'bounded' and not isinstance(key, int):
             key = tuple(dim.values[k] if dim.values else k
                         for dim, k in zip(self.mock_obj.kdims, tuple(key)))
-
-        if self.renderer.mode == 'nbagg':
-            if not self.manager._shown:
-                self.comm.start()
-                self.manager.add_web_socket(self.comm)
-                self.manager._shown = True
-            fig = self.plot[key]
-            fig.canvas.draw_idle()
-            return ''
-        frame = self._plot_figure(key)
+        self.plot[key]
         self.plot.push()
-        return "Complete"
+        return '' if self.renderer.mode == 'nbagg' else 'Complete'
+
 
     def get_frames(self):
         if self.renderer.mode == 'nbagg':
-            self.manager.display_js()
-            frames = {0: self.comm.html}
+            manager = self.plot.comm.get_figure_manager()
+            manager.display_js()
+            frames = {0: self.plot.comm._comm_socket.html}
         elif self.embed:
             return super(MPLWidget, self).get_frames()
         else:

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -18,7 +18,6 @@ class MPLWidget(NdWidget):
         super(MPLWidget, self).__init__(plot, renderer, **params)
         if self.renderer.mode == 'nbagg':
             self.cached = False
-            self.initialize_connection(plot)
 
 
     def _plot_figure(self, idx):
@@ -30,7 +29,7 @@ class MPLWidget(NdWidget):
                 figure_format = self.renderer.params('fig').objects[0]
             else:
                 figure_format = self.renderer.fig
-            return self.renderer.html(self.plot, figure_format)
+            return self.renderer.html(self.plot, figure_format, comm=False)
 
 
     def update(self, key):
@@ -47,11 +46,8 @@ class MPLWidget(NdWidget):
             fig.canvas.draw_idle()
             return ''
         frame = self._plot_figure(key)
-        if self.renderer.mode == 'mpld3':
-            return self.encode_frames({0: frame})
-        else:
-            return str(frame)
-
+        self.plot.push()
+        return "Complete"
 
     def get_frames(self):
         if self.renderer.mode == 'nbagg':
@@ -79,11 +75,6 @@ class MPLWidget(NdWidget):
             frames = dict(frames)
             return json.dumps(frames)
 
-
-    def initialize_connection(self, plot):
-        plot.update(0)
-        self.manager = self.renderer.get_figure_manager(plot.state)
-        self.comm = WidgetCommSocket(self.manager)
 
 
 class MPLSelectionWidget(MPLWidget, SelectionWidget):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -68,12 +68,12 @@ class Plot(param.Parameterized):
     @classmethod
     def lookup_options(cls, obj, group):
         try:
-            plot_class = cls.renderer.plotting_class(obj)
+            plot_class = Store.renderers[cls.backend].plotting_class(obj)
             style_opts = plot_class.style_opts
         except SkipRendering:
             style_opts = None
 
-        node = Store.lookup_options(cls.renderer.backend, obj, group)
+        node = Store.lookup_options(cls.backend, obj, group)
         if group == 'style' and style_opts:
             return node.filtered(style_opts)
         else:
@@ -178,7 +178,7 @@ class DimensionedPlot(Plot):
 
     def __init__(self, keys=None, dimensions=None, layout_dimensions=None,
                  uniform=True, subplot=False, adjoined=None, layout_num=0,
-                 style=None, subplots=None, dynamic=False, **params):
+                 style=None, subplots=None, dynamic=False, renderer=None, **params):
         self.subplots = subplots
         self.adjoined = adjoined
         self.dimensions = dimensions
@@ -195,6 +195,8 @@ class DimensionedPlot(Plot):
         self.current_frame = None
         self.current_key = None
         self.ranges = {}
+        self.renderer = renderer if renderer else Store.renderers[self.backend].instance()
+
         params = {k: v for k, v in params.items()
                   if k in self.params()}
         super(DimensionedPlot, self).__init__(**params)
@@ -420,7 +422,7 @@ class DimensionedPlot(Plot):
             selected = {o: options.options[o]
                         for o in opts if o in options.options}
             if opt_type == 'plot' and defaults:
-                plot = Store.registry[cls.renderer.backend].get(type(x))
+                plot = Store.registry[cls.backend].get(type(x))
                 selected['defaults'] = {o: getattr(plot, o) for o in opts
                                         if o not in selected and hasattr(plot, o)}
             key = keyfn(x) if keyfn else None

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -497,8 +497,8 @@ class DimensionedPlot(Plot):
         """
         if self.comm is None:
             raise Exception('Renderer does not have a comm.')
-        patch = self.renderer.patch(self)
-        self.comm.send(patch)
+        diff = self.renderer.diff(self)
+        self.comm.send(diff)
 
 
     def __len__(self):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -199,7 +199,8 @@ class DimensionedPlot(Plot):
 
         comm = None
         if self.dynamic or self.renderer.widget_mode == 'live':
-            self.comm = self.renderer.comms[self.renderer.mode][0](self)
+            comm = self.renderer.comms[self.renderer.mode][0](self)
+        self.comm = comm
         params = {k: v for k, v in params.items()
                   if k in self.params()}
         super(DimensionedPlot, self).__init__(**params)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -149,7 +149,7 @@ class Renderer(Exporter):
 
 
     @bothmethod
-    def get_plot(self_or_cls, obj):
+    def get_plot(self_or_cls, obj, renderer=None):
         """
         Given a HoloViews Viewable return a corresponding plot instance.
         """
@@ -170,10 +170,12 @@ class Renderer(Exporter):
                 except StopIteration: # Exhausted DynamicMap
                     raise SkipRendering("DynamicMap generator exhausted.")
 
+        if not renderer: renderer = self_or_cls.instance()
         if not isinstance(obj, Plot):
             obj = Layout.from_values(obj) if isinstance(obj, AdjointLayout) else obj
             plot_opts = self_or_cls.plot_options(obj, self_or_cls.size)
-            plot = self_or_cls.plotting_class(obj)(obj, **plot_opts)
+            plot = self_or_cls.plotting_class(obj)(obj, renderer=renderer,
+                                                   **plot_opts)
             plot.update(0)
         else:
             plot = obj
@@ -187,7 +189,7 @@ class Renderer(Exporter):
         """
         if isinstance(obj, tuple(self.widgets.values())):
             return obj, 'html'
-        plot = self.get_plot(obj)
+        plot = self.get_plot(obj, renderer=self)
 
         fig_formats = self.mode_formats['fig'][self.mode]
         holomap_formats = self.mode_formats['holomap'][self.mode]

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -17,7 +17,7 @@ from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
 from .. import DynamicMap
 from . import Plot
-from .comms import SimpleJupyterComm
+from .comms import JupyterPushComm
 from .util import displayable, collate
 
 from param.parameterized import bothmethod
@@ -133,7 +133,7 @@ class Renderer(Exporter):
     # Define comms class and message handler for each mode
     # The Comm opens a communication channel and the message
     # handler defines how the message is processed on the frontend
-    comms = {'default': (SimpleJupyterComm, None)}
+    comms = {'default': (JupyterPushComm, None)}
 
     # Define appropriate widget classes
     widgets = {'scrubber': ScrubberWidget, 'widgets': SelectionWidget}

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -17,6 +17,7 @@ from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
 from .. import DynamicMap
 from . import Plot
+from .comms import JupyterComm
 from .util import displayable, collate
 
 from param.parameterized import bothmethod
@@ -128,6 +129,9 @@ class Renderer(Exporter):
     # Defines the valid output formats for each mode.
     mode_formats = {'fig': {'default': [None, 'auto']},
                     'holomap': {'default': [None, 'auto']}}
+
+    # Define comms class and message handler for each mode
+    comms = {'default': (JupyterComm, None)}
 
     # Define appropriate widget classes
     widgets = {'scrubber': ScrubberWidget, 'widgets': SelectionWidget}
@@ -245,9 +249,11 @@ class Renderer(Exporter):
         return data
 
 
-    def html(self, obj, fmt=None, css=None):
+    def html(self, obj, fmt=None, css=None, comm=True):
         """
         Renders plot or data structure and wraps the output in HTML.
+        The comm argument defines whether the HTML output includes
+        code to initialize a Comm, if the plot supplies one.
         """
         plot, fmt =  self._validate(obj, fmt)
         figdata, _ = self(plot, fmt)
@@ -270,7 +276,15 @@ class Renderer(Exporter):
         b64 = base64.b64encode(figdata).decode("utf-8")
         (mime_type, tag) = MIME_TYPES[fmt], HTML_TAGS[fmt]
         src = HTML_TAGS['base64'].format(mime_type=mime_type, b64=b64)
-        return tag.format(src=src, mime_type=mime_type, css=css)
+        html = tag.format(src=src, mime_type=mime_type, css=css)
+        if comm and plot.comm is not None:
+            comm, msg_handler = self.comms[self.mode]
+            msg_handler = msg_handler.format(comms_target=plot.comm.target)
+            return comm.template.format(init_frame=html,
+                                        msg_handler=msg_handler,
+                                        comms_target=plot.comm.target)
+        else:
+            return html
 
 
     def static_html(self, obj, fmt=None, template=None):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -17,7 +17,7 @@ from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
 from .. import DynamicMap
 from . import Plot
-from .comms import JupyterComm
+from .comms import SimpleJupyterComm
 from .util import displayable, collate
 
 from param.parameterized import bothmethod
@@ -131,7 +131,9 @@ class Renderer(Exporter):
                     'holomap': {'default': [None, 'auto']}}
 
     # Define comms class and message handler for each mode
-    comms = {'default': (JupyterComm, None)}
+    # The Comm opens a communication channel and the message
+    # handler defines how the message is processed on the frontend
+    comms = {'default': (SimpleJupyterComm, None)}
 
     # Define appropriate widget classes
     widgets = {'scrubber': ScrubberWidget, 'widgets': SelectionWidget}

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -104,7 +104,7 @@ class NdWidget(param.Parameterized):
 
     def __init__(self, plot, renderer=None, **params):
         super(NdWidget, self).__init__(**params)
-        self.id = uuid.uuid4().hex
+        self.id = plot.comm.target if plot.comm else uuid.uuid4().hex
         self.plot = plot
         self.dimensions = plot.dimensions
         self.keys = plot.keys
@@ -189,7 +189,8 @@ class NdWidget(param.Parameterized):
             css = self.display_options.get('css', {})
             figure_format = self.display_options.get('figure_format',
                                                      self.renderer.fig)
-            return self.renderer.html(self.plot, figure_format, css=css)
+            return self.renderer.html(self.plot, figure_format, css=css,
+                                      comm=False)
 
 
     def update(self, key):

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -68,7 +68,7 @@ HoloViewsWidget.prototype.dynamic_update = function(current){
 	kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
 }
 
-HoloViewsWidget.prototype.update_cache = function(){
+HoloViewsWidget.prototype.update_cache = function(force){
     var frame_len = Object.keys(this.frames).length;
     for (var i=0; i<frame_len; i++) {
         if(!this.load_json || this.dynamic)  {
@@ -76,11 +76,12 @@ HoloViewsWidget.prototype.update_cache = function(){
         } else {
             frame = i;
         }
-        if(!(frame in this.cache)) {
-            this.cache[frame] = $('<div />').appendTo("#"+"_anim_img"+this.id).hide();
-            var cache_id = "_anim_img"+this.id+"_"+frame;
-            this.cache[frame].attr("id", cache_id);
-            this.populate_cache(frame);
+        if(!(frame in this.cache) || force) {
+			if ((frame in this.cache) && force) { this.cache[frame].remove() }
+			this.cache[frame] = $('<div />').appendTo("#"+"_anim_img"+this.id).hide();
+			var cache_id = "_anim_img"+this.id+"_"+frame;
+			this.cache[frame].attr("id", cache_id);
+			this.populate_cache(frame);
         }
     }
 }

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -30,22 +30,42 @@ HoloViewsWidget.prototype.from_json = function() {
 }
 
 HoloViewsWidget.prototype.dynamic_update = function(current){
-    function callback(msg){
-        /* This callback receives data from Python as a string
-         in order to parse it correctly quotes are sliced off*/
-        var data = msg.content.data['text/plain'].slice(1, -1);
-        this.frames[current] = data;
-        this.update_cache();
-        this.update(current);
-    }
-    if(!(current in this.cache)) {
-        var kernel = IPython.notebook.kernel;
-        callbacks = {iopub: {output: $.proxy(callback, this)}};
-        var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
-        kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
-    } else {
-        this.update(current);
-    }
+	if (current === undefined) {
+		return
+	}
+	if(this.dynamic) {
+		current = JSON.stringify(current);
+	}
+	function callback(initialized, msg){
+		/* This callback receives data from Python as a string
+		   in order to parse it correctly quotes are sliced off*/
+		if (msg.content.ename != undefined) {
+			this.process_error(msg);
+		}
+		if (msg.msg_type != "execute_result") {
+			console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
+			this.time = undefined;
+			this.wait = false;
+			return
+		}
+		this.timed = (Date.now() - this.time) * 1.1;
+		if (msg.msg_type == "execute_result") {
+			if (msg.content.data['text/plain'] === "'Complete'") {
+				this.wait = false;
+				if (this.queue.length > 0) {
+					this.time = Date.now();
+					this.dynamic_update(this.queue[this.queue.length-1]);
+					this.queue = [];
+				}
+				return
+			}
+		}
+	}
+	this.current = current;
+	var kernel = IPython.notebook.kernel;
+	callbacks = {iopub: {output: $.proxy(callback, this, this.initialized)}};
+	var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
+	kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
 }
 
 HoloViewsWidget.prototype.update_cache = function(){
@@ -57,8 +77,8 @@ HoloViewsWidget.prototype.update_cache = function(){
             frame = i;
         }
         if(!(frame in this.cache)) {
-            this.cache[frame] = $('<div />').appendTo("#" + this.img_id).hide();
-            var cache_id = this.img_id+"_"+frame;
+            this.cache[frame] = $('<div />').appendTo("#"+"_anim_img"+this.id).hide();
+            var cache_id = "_anim_img"+this.id+"_"+frame;
             this.cache[frame].attr("id", cache_id);
             this.populate_cache(frame);
         }
@@ -75,11 +95,20 @@ HoloViewsWidget.prototype.update = function(current){
     }
 }
 
+HoloViewsWidget.prototype.init_comms = function() {
+	var widget = this;
+	var comm_manager = Jupyter.notebook.kernel.comm_manager
+    comm_manager.register_target(this.id, function (comm, msg) {
+		widget.comm = comm;
+		comm.on_msg(function(msg) { widget.process_msg(msg) });
+    });
+}
+
+HoloViewsWidget.prototype.process_msg = function(msg) {
+}
 
 function SelectionWidget(frames, id, slider_ids, keyMap, dim_vals, notFound, load_json, mode, cached, json_path, dynamic){
     this.frames = frames;
-    this.fig_id = "fig_" + id;
-    this.img_id = "_anim_img" + id;
     this.id = id;
     this.slider_ids = slider_ids;
     this.keyMap = keyMap
@@ -95,6 +124,9 @@ function SelectionWidget(frames, id, slider_ids, keyMap, dim_vals, notFound, loa
     this.init_slider(this.current_vals[0]);
 	this.queue = [];
 	this.wait = false;
+	if (!this.cached || this.dynamic) {
+		this.init_comms()
+	}
 }
 
 SelectionWidget.prototype = new HoloViewsWidget;
@@ -138,12 +170,10 @@ SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
 	}
 	this.queue = [];
 	this.time = Date.now();
+	this.current_frame = current;
     if(this.dynamic) {
         this.dynamic_update(this.current_vals)
-        return;
-    }
-    this.current_frame = current;
-    if(this.cached) {
+    } else if(this.cached) {
         this.update(current)
     } else {
         this.dynamic_update(current)
@@ -153,11 +183,9 @@ SelectionWidget.prototype.set_frame = function(dim_val, dim_idx){
 
 /* Define the ScrubberWidget class */
 function ScrubberWidget(frames, num_frames, id, interval, load_json, mode, cached, json_path, dynamic){
-    this.img_id = "_anim_img" + id;
     this.slider_id = "_anim_slider" + id;
     this.loop_select_id = "_anim_loop_select" + id;
     this.id = id;
-    this.fig_id = "fig_" + id;
     this.interval = interval;
     this.current_frame = 0;
     this.direction = 0;
@@ -174,6 +202,9 @@ function ScrubberWidget(frames, num_frames, id, interval, load_json, mode, cache
     this.init_slider(0);
 	this.wait = false;
 	this.queue = [];
+	if (!this.cached || this.dynamic) {
+		this.init_comms()
+	}
 }
 
 ScrubberWidget.prototype = new HoloViewsWidget;

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -99,10 +99,8 @@ HoloViewsWidget.prototype.update = function(current){
 HoloViewsWidget.prototype.init_comms = function() {
 	var widget = this;
 	var comm_manager = Jupyter.notebook.kernel.comm_manager
-    comm_manager.register_target(this.id, function (comm, msg) {
-		widget.comm = comm;
-		comm.on_msg(function(msg) { widget.process_msg(msg) });
-    });
+	comm = comm_manager.new_comm(this.id, {}, {}, {}, this.id);
+	comm.on_msg(function (msg) { widget.process_msg(msg) })
 }
 
 HoloViewsWidget.prototype.process_msg = function(msg) {

--- a/tests/testcomms.py
+++ b/tests/testcomms.py
@@ -1,0 +1,49 @@
+from nose.tools import *
+
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting.comms import Comm, JupyterPushComm
+
+
+class TestComm(ComparisonTestCase):
+
+    def test_init_comm(self):
+        Comm(None)
+
+    def test_init_comm_target(self):
+        comm = Comm(None, target='Test')
+        self.assertEqual(comm.target, 'Test')
+
+    def test_decode(self):
+        msg = 'Test'
+        self.assertEqual(Comm.decode(msg), msg)
+
+    def test_on_msg(self):
+        def raise_error(msg):
+            if msg == 'Error':
+                raise Exception()
+        comm = Comm(None, target='Test', on_msg=raise_error)
+        with self.assertRaises(Exception):
+            comm._handle_msg('Error')
+
+
+class TestJupyterComm(ComparisonTestCase):
+
+    def test_init_comm(self):
+        JupyterPushComm(None)
+
+    def test_init_comm_target(self):
+        comm = JupyterPushComm(None, target='Test')
+        self.assertEqual(comm.target, 'Test')
+
+    def test_decode(self):
+        msg = {'content': {'data': 'Test'}}
+        decoded = JupyterPushComm.decode(msg)
+        self.assertEqual(decoded, 'Test')
+
+    def test_on_msg(self):
+        def raise_error(msg):
+            if msg == 'Error':
+                raise Exception()
+        comm = JupyterPushComm(None, target='Test', on_msg=raise_error)
+        with self.assertRaises(Exception):
+            comm._handle_msg({'content': {'data': 'Error'}})

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -13,6 +13,7 @@ try:
     from matplotlib import pyplot
     pyplot.switch_backend('agg')
     from holoviews.plotting.mpl import OverlayPlot
+    from holoviews.plotting.comms import JupyterPushComms
     renderer = Store.renderers['matplotlib']
 except:
     pyplot = None
@@ -23,6 +24,11 @@ class TestPlotInstantiation(ComparisonTestCase):
     def setUp(self):
         if pyplot is None:
             raise SkipTest("Matplotlib required to test plot instantiation")
+        self.default_comm = renderer.comms['default']
+        renderer.comms['default'] = JupyterPushComms
+
+    def teardown(self):
+        renderer.comms['default'] = self.default_comm
 
     def test_interleaved_overlay(self):
         """


### PR DESCRIPTION
This PR introduces Comms classes which allow bidirectionally communicating between the python process and a frontend. Additionally it gives Plot instances access to the current renderer and instantiates a Comms class, allowing updates to plots to be pushed to the frontend using the new ``refresh`` and ``push`` methods. Supports updating regular matplotlib plots, nbagg plots, mpld3 plots and bokeh plots. 