### PR TITLE
Correctly initialize comms and connect streams

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -282,7 +282,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
             dimensions, keys = traversal.unique_dimkeys(layout)
         MPLPlot.__init__(self, dimensions=dimensions, keys=keys, **params)
         if top_level:
-            self.comm = self.init_comm(element)
+            self.comm = self.init_comm(layout)
 
         self.layout = layout
         self.cyclic_index = 0

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -277,9 +277,13 @@ class RasterGridPlot(GridPlot, OverlayPlot):
 
     def __init__(self, layout, keys=None, dimensions=None, create_axes=False, ranges=None,
                  layout_num=1, **params):
-        if not keys or not dimensions:
+        top_level = keys is None
+        if top_level:
             dimensions, keys = traversal.unique_dimkeys(layout)
         MPLPlot.__init__(self, dimensions=dimensions, keys=keys, **params)
+        if top_level:
+            self.comm = self.init_comm(element)
+
         self.layout = layout
         self.cyclic_index = 0
         self.zorder = 0

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -197,6 +197,7 @@ class DimensionedPlot(Plot):
         self.current_key = None
         self.ranges = {}
         self.renderer = renderer if renderer else Store.renderers[self.backend].instance()
+        self.comm = None
 
         params = {k: v for k, v in params.items()
                   if k in self.params()}

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -275,3 +275,13 @@ def dim_axis_label(dimensions, separator=', '):
     if not isinstance(dimensions, list): dimensions = [dimensions]
     return separator.join([safe_unicode(d.pprint_label)
                            for d in dimensions])
+
+
+def attach_streams(plot, obj):
+    """
+    Attaches plot refresh to all streams on the object.
+    """
+    def append_refresh(dmap):
+        for stream in dmap.streams:
+            stream._hidden_subscribers.append(plot.refresh)
+    return obj.traverse(append_refresh, [DynamicMap])


### PR DESCRIPTION
This PR ensures that only the top-level plot instance creates a Comm instance and then attaches the plot.refresh method as a ``_hidden_subscriber`` to the stream. A simple test I used:

```python
posx = hv.streams.PositionX()
dmap = hv.DynamicMap(lambda x: hv.Image(np.random.rand(x+1,10)), kdims=[], streams=[posx])
```

```python
dmap + hv.Image(np.random.rand(10,10))
```

![image](https://cloud.githubusercontent.com/assets/1550771/18146862/da6862de-6fc9-11e6-988a-84325185d62a.png)

```python
for i in range(10):
    posx.update(x=i)
```

The plot updates in response to the position updates.
