### PR TITLE
Renamed Stream.value to 'contents' to avoid name clashes

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -557,7 +557,7 @@ class DynamicMap(HoloMap):
             retval = next(self.callback)
         else:
             # Additional validation needed to ensure kwargs don't clash
-            kwarg_items = [s.value.items() for s in self.streams]
+            kwarg_items = [s.contents.items() for s in self.streams]
             flattened = [el for kws in kwarg_items for el in kws]
             klist = [k for k,_ in flattened]
             clashes = set([k for k in klist if klist.count(k) > 1])

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -16,7 +16,7 @@ class Preprocessor(param.Parameterized):
     and returns a dictionary. Where possible, Preprocessors should have
     valid reprs that can be evaluated.
 
-    Preprocessors are used to set the value of a stream based on the
+    Preprocessors are used to set the contents of a stream based on the
     parameter values. They may be used for debugging purposes or to
     remap or repack parameter values before they are passed onto to the
     subscribers.
@@ -87,8 +87,8 @@ class Stream(param.Parameterized):
         subscriber may be set multiple times across streams but only
         needs to be called once.
         """
-        # Union of stream values
-        items = [stream.value.items() for stream in streams]
+        # Union of stream contents
+        items = [stream.contents.items() for stream in streams]
         union = [kv for kvs in items for kv in kvs]
         klist = [k for k,_ in union]
         clashes = set([k for k in klist if klist.count(k) > 1])
@@ -132,7 +132,7 @@ class Stream(param.Parameterized):
 
 
     @property
-    def value(self):
+    def contents(self):
         remapped = {k:v for k,v in self.get_param_values() if k!= 'name' }
         for preprocessor in self.preprocessors:
             remapped = preprocessor(remapped)
@@ -243,7 +243,7 @@ class ParamValues(Stream):
 
 
     @property
-    def value(self):
+    def contents(self):
         if isinstance(self._obj, type):
             remapped={k: getattr(self._obj,k)
                                for k in self._obj.params().keys() if k!= 'name'}

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -23,14 +23,14 @@ class TestPositionStreams(ComparisonTestCase):
     def test_positionX_init(self):
         PositionX()
 
-    def test_positionXY_init_values(self):
+    def test_positionXY_init_contents(self):
         position = PositionXY(x=1, y=3)
-        self.assertEqual(position.value, dict(x=1, y=3))
+        self.assertEqual(position.contents, dict(x=1, y=3))
 
-    def test_positionXY_update_values(self):
+    def test_positionXY_update_contents(self):
         position = PositionXY()
         position.update(x=5, y=10)
-        self.assertEqual(position.value, dict(x=5, y=10))
+        self.assertEqual(position.contents, dict(x=5, y=10))
 
     def test_positionY_const_parameter(self):
         position = PositionY()
@@ -56,27 +56,27 @@ class TestParamValuesStream(ComparisonTestCase):
         self.inner.x = 0
         self.inner.y = 0
 
-    def test_object_value(self):
+    def test_object_contents(self):
         obj = self.inner()
         stream = ParamValues(obj)
-        self.assertEqual(stream.value, {'x':0, 'y':0})
+        self.assertEqual(stream.contents, {'x':0, 'y':0})
 
     def test_class_value(self):
         stream = ParamValues(self.inner)
-        self.assertEqual(stream.value, {'x':0, 'y':0})
+        self.assertEqual(stream.contents, {'x':0, 'y':0})
 
     def test_object_value_update(self):
         obj = self.inner()
         stream = ParamValues(obj)
-        self.assertEqual(stream.value, {'x':0, 'y':0})
+        self.assertEqual(stream.contents, {'x':0, 'y':0})
         stream.update(x=5, y=10)
-        self.assertEqual(stream.value, {'x':5, 'y':10})
+        self.assertEqual(stream.contents, {'x':5, 'y':10})
 
     def test_class_value_update(self):
         stream = ParamValues(self.inner)
-        self.assertEqual(stream.value, {'x':0, 'y':0})
+        self.assertEqual(stream.contents, {'x':0, 'y':0})
         stream.update(x=5, y=10)
-        self.assertEqual(stream.value, {'x':5, 'y':10})
+        self.assertEqual(stream.contents, {'x':5, 'y':10})
 
 
 
@@ -142,8 +142,8 @@ class TestPreprocessors(ComparisonTestCase):
 
     def test_rename_preprocessor(self):
         position = PositionXY([Rename(x='x1',y='y1')], x=1, y=3)
-        self.assertEqual(position.value, dict(x1=1, y1=3))
+        self.assertEqual(position.contents, dict(x1=1, y1=3))
 
     def test_group_preprocessor(self):
         position = PositionXY([Group('mygroup')], x=1, y=3)
-        self.assertEqual(position.value, dict(mygroup={'x':1,'y':3}))
+        self.assertEqual(position.contents, dict(mygroup={'x':1,'y':3}))


### PR DESCRIPTION
A parameter called ``value`` would be very natural to use in a stream making it likely to clash with the ``value`` property. Renaming this property to ``contents`` should help avoid potential name clashes and confusion.

Ready to merge.