### PR TITLE
Disable DynamicMap._deep_indexable in display hook exceptions

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -601,7 +601,7 @@ class Dimensioned(LabelledData):
 
     def _valid_dimensions(self, dimensions):
         """Validates key dimension input
-        
+
         Returns kdims if no dimensions are specified"""
         if dimensions is None:
             dimensions = self.kdims

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -122,8 +122,7 @@ def display_hook(fn):
             sys.stderr.write("Rendering process skipped: %s" % str(e))
             return None
         except AbbreviatedException as e:
-            try:
-                option_state(element, state=optstate)
+            try: option_state(element, state=optstate)
             except: pass
             FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype,
                                                                   e.value,
@@ -134,8 +133,7 @@ def display_hook(fn):
             return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
 
         except Exception as e:
-            try:
-                option_state(element, state=optstate)
+            try: option_state(element, state=optstate)
             except: pass
             raise
     return wrapped

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -89,6 +89,13 @@ def last_frame(obj):
 # Display hooks #
 #===============#
 
+def option_state(element, state=None):
+    # Temporary fix to avoid issues with DynamicMap traversal
+    DynamicMap._deep_indexable = False
+    optstate = StoreOptions.state(element,state=state)
+    DynamicMap._deep_indexable = True
+    return optstate
+
 
 def display_hook(fn):
     @wraps(fn)
@@ -96,7 +103,7 @@ def display_hook(fn):
         global FULL_TRACEBACK
         if Store.current_backend is None:
             return
-        optstate = StoreOptions.state(element)
+        optstate = option_state(element)
         try:
             html = fn(element,
                       max_frames=OutputMagic.options['max_frames'],
@@ -115,7 +122,8 @@ def display_hook(fn):
             sys.stderr.write("Rendering process skipped: %s" % str(e))
             return None
         except AbbreviatedException as e:
-            try:    StoreOptions.state(element, state=optstate)
+            try:
+                option_state(element, state=optstate)
             except: pass
             FULL_TRACEBACK = '\n'.join(traceback.format_exception(e.etype,
                                                                   e.value,
@@ -126,7 +134,8 @@ def display_hook(fn):
             return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
 
         except Exception as e:
-            try:    StoreOptions.state(element, state=optstate)
+            try:
+                option_state(element, state=optstate)
             except: pass
             raise
     return wrapped


### PR DESCRIPTION
I am not sure this is the *correct* fix (setting DynamicMap as not being ``_deep_indexable) but it is a simple fix for the issue with style restoration on DynamicMaps in the display hooks.

The issue was that ``StopIteration`` was being raised in ``traverse`` on dynamic maps. There are two other possible approaches I can think of:

1. Give ``DynamicMap`` an alternative implementation of ``traverse``. I don't like this much as we rely on ``traverse`` a lot and expect it to always behave in a consistent way.
2. Temporarily declare ``DynamicMap`` as not being ``deep_indexable`` during style restoration.

I might look into option 2. now as it would be a less dramatic change.

