### PR TITLE
Applying dimension formatters to Bokeh Table values

### DIFF
--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -28,7 +28,9 @@ class TablePlot(BokehPlot, GenericElementPlot):
 
     def get_data(self, element, ranges=None, empty=False):
         dims = element.dimensions()
-        return ({d.name: [] if empty else element.dimension_values(d) for d in dims},
+        return ({d.name: [] if empty else
+                 [d.pprint_value(v) for v in element.dimension_values(d)]
+                 for d in dims},
                 {d.name: d.name for d in dims})
 
 


### PR DESCRIPTION
This PR fixes the value formatting in Bokeh Tables that were previously unformatted.