### PR TITLE
Fix inverted coords on iris interface

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -129,7 +129,7 @@ class GridInterface(DictInterface):
         dimensions of the dataset.
         """
         if coord_dims is None:
-            coord_dims = dataset.dimensions('key', True)
+            coord_dims = dataset.dimensions('key', True)[::-1]
 
         # Reorient data
         invert = False
@@ -141,7 +141,7 @@ class GridInterface(DictInterface):
                 invert = True
             else:
                 slices.append(slice(None))
-        data = data.__getitem__(slices[::-1]) if invert else data
+        data = data.__getitem__(slices) if invert else data
 
         # Transpose data
         dims = [name for name in coord_dims[::-1]
@@ -150,7 +150,7 @@ class GridInterface(DictInterface):
         inds = [dims.index(kd.name) for kd in dataset.kdims]
         inds += dropped
         if inds:
-            data = data.transpose(inds[::-1])
+            data = data.transpose(inds)
 
         # Allow lower dimensional views into data
         if len(dataset.kdims) < 2:

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -137,7 +137,7 @@ class CubeInterface(GridInterface):
         dim = dataset.get_dimension(dim)
         if dim in dataset.vdims:
             coord_names = [c.name() for c in dataset.data.dim_coords]
-            data = dataset.data.copy().data.T
+            data = dataset.data.copy().data
             data = cls.canonicalize(dataset, data, coord_names)
             return data.T.flatten() if flat else data
         elif expanded:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -132,7 +132,7 @@ class XArrayInterface(GridInterface):
     def values(cls, dataset, dim, expanded=True, flat=True):
         data = dataset.data[dim].data
         if dim in dataset.vdims:
-            coord_dims = dataset.data[dim].dims[::-1]
+            coord_dims = dataset.data[dim].dims
             data = cls.canonicalize(dataset, data, coord_dims=coord_dims)
             return data.T.flatten() if flat else data
         elif expanded:

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -447,6 +447,19 @@ class GridDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
                                          self.grid_zs), kdims=['x', 'y'],
                                         vdims=['z'])
 
+    def test_canonical_vdim(self):
+        x = np.array([ 0.  ,  0.75,  1.5 ])
+        y = np.array([ 1.5 ,  0.75,  0.  ])
+        z = np.array([[ 0.06925999,  0.05800389,  0.05620127],
+                      [ 0.06240918,  0.05800931,  0.04969735],
+                      [ 0.05376789,  0.04669417,  0.03880118]])
+        dataset = Dataset((x, y, z), kdims=['x', 'y'], vdims=['z'])
+        canonical = np.array([[ 0.05376789,  0.04669417,  0.03880118],
+                              [ 0.06240918,  0.05800931,  0.04969735],
+                              [ 0.06925999,  0.05800389,  0.05620127]])
+        self.assertEqual(dataset.dimension_values('z', flat=False),
+                         canonical)
+
     def test_dataset_dim_vals_grid_kdims_xs(self):
         self.assertEqual(self.dataset_grid.dimension_values(0, expanded=False),
                          np.array([0, 1]))


### PR DESCRIPTION
The iris interface does not correctly canonicalize the array orientation in all cases, causing the plot to be inverted. Since the tests still seem to be passing there appears to be a hole in the tests that I'll patch before this is ready to merge.