### PR TITLE
DynamicMap with streams force callback on first lookup after refresh

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -710,7 +710,7 @@ class DynamicMap(HoloMap):
         if self.mode == 'open' and (self.counter % self.cache_interval)!=0:
             return
         if len(self) >= cache_size:
-            first_key = next(self.data.iterkeys())
+            first_key = next(k for k in self.data)
             self.data.pop(first_key)
         self.data[key] = val
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -477,6 +477,7 @@ class DynamicMap(HoloMap):
 
         self.call_mode = self._validate_mode()
         self.mode = 'bounded' if self.call_mode == 'key' else 'open'
+        self._stream_cache_lookup = False
 
 
     def _initial_key(self):
@@ -672,7 +673,8 @@ class DynamicMap(HoloMap):
 
         # Cache lookup
         try:
-            if util.dimensionless_contents(self.streams, self.kdims):
+            if (util.dimensionless_contents(self.streams, self.kdims) and
+                not self._stream_cache_lookup):
                 raise KeyError('Using dimensionless streams disables DynamicMap cache')
             cache = super(DynamicMap,self).__getitem__(key)
             # Return selected cache items in a new DynamicMap

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -477,7 +477,7 @@ class DynamicMap(HoloMap):
 
         self.call_mode = self._validate_mode()
         self.mode = 'bounded' if self.call_mode == 'key' else 'open'
-        self._stream_cache_lookup = False
+        self._dimensionless_cache = False
 
 
     def _initial_key(self):
@@ -673,8 +673,8 @@ class DynamicMap(HoloMap):
 
         # Cache lookup
         try:
-            if (util.dimensionless_contents(self.streams, self.kdims) and
-                not self._stream_cache_lookup):
+            dimensionless = util.dimensionless_contents(self.streams, self.kdims)
+            if (dimensionless and not self._dimensionless_cache):
                 raise KeyError('Using dimensionless streams disables DynamicMap cache')
             cache = super(DynamicMap,self).__getitem__(key)
             # Return selected cache items in a new DynamicMap

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -140,12 +140,12 @@ class enable_streams_cache(object):
     part of some processing pipeline.
     """
 
-    def __init__(self, obj, enable):
+    def __init__(self, obj, allow_cache_lookup=True):
         self.obj = obj
-        self._enable = enable
+        self._allow_cache_lookup = enable
 
     def __enter__(self):
-        self.set_cache_flag(self._enable)
+        self.set_cache_flag(self._allow_cache_lookup)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.set_cache_flag(False)

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -150,7 +150,7 @@ class enable_streams_cache(object):
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.set_cache_flag(False)
 
-    def set_cache_flag(self, value)
+    def set_cache_flag(self, value):
         self.obj.traverse(lambda x: setattr(x, '_stream_cache_lookup', value),
                           ['DynamicMap'])
 

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -130,19 +130,19 @@ def hierarchical(keys):
     return hierarchies
 
 
-class enable_streams_cache(object):
+class dimensionless_cache(object):
     """
-    Context manager which temporarily enables lookup of frame in cache
-    on a DynamicMap with streams. Allows passing any Dimensioned
-    object which might contain a DynamicMap and whether to enable the
-    cache. This allows looking up an item without triggering the
-    callback. Useful when the object is looked up multiple times as
-    part of some processing pipeline.
+    Context manager which temporarily enables lookup of frame in the
+    cache on a DynamicMap with dimensionless streams. Allows passing
+    any Dimensioned object which might contain a DynamicMap and
+    whether to enable the cache. This allows looking up an item
+    without triggering the callback. Useful when the object is looked
+    up multiple times as part of some processing pipeline.
     """
 
     def __init__(self, obj, allow_cache_lookup=True):
         self.obj = obj
-        self._allow_cache_lookup = enable
+        self._allow_cache_lookup = allow_cache_lookup
 
     def __enter__(self):
         self.set_cache_flag(self._allow_cache_lookup)

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -128,3 +128,29 @@ def hierarchical(keys):
                 store1[v2].append(v1)
         hierarchies.append(store2 if hierarchy else {})
     return hierarchies
+
+
+class enable_streams_cache(object):
+    """
+    Context manager which temporarily enables lookup of frame in cache
+    on a DynamicMap with streams. Allows passing any Dimensioned
+    object which might contain a DynamicMap and whether to enable the
+    cache. This allows looking up an item without triggering the
+    callback. Useful when the object is looked up multiple times as
+    part of some processing pipeline.
+    """
+
+    def __init__(self, obj, enable):
+        self.obj = obj
+        self._enable = enable
+
+    def __enter__(self):
+        self.set_cache_flag(self._enable)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.set_cache_flag(False)
+
+    def set_cache_flag(self, value)
+        self.obj.traverse(lambda x: setattr(x, '_stream_cache_lookup', value),
+                          ['DynamicMap'])
+

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -787,7 +787,7 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     If no_duplicates is enabled, a KeyError will be raised if there are
     parameter name clashes across the streams.
     """
-    param_groups = [s.params().keys() for s in streams]
+    param_groups = [s.contents.keys() for s in streams]
     names = [name for group in param_groups for name in group]
 
     if no_duplicates:

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -150,7 +150,7 @@ class MPLRenderer(Renderer):
             if self.mode == 'mpld3':
                 figure_format = 'json'
             elif self.fig == 'auto':
-                figure_format = self.renderer.params('fig').objects[0]
+                figure_format = self.params('fig').objects[0]
             else:
                 figure_format = self.fig
             data = self.html(plot, figure_format, comm=False)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -210,7 +210,6 @@ class DimensionedPlot(Plot):
         """
         Get the state of the Plot for a given frame number.
         """
-        self.force = True
         if not self.dynamic == 'open' and isinstance(frame, int) and frame > len(self):
             self.warning("Showing last frame available: %d" % len(self))
         if not self.drawn: self.handles['fig'] = self.initialize_plot()

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -18,7 +18,7 @@ from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor, SkipRendering
 from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
-from ..core.traversal import enable_streams_cache
+from ..core.traversal import dimensionless_cache
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
                    attach_streams, traverse_setter)
@@ -603,7 +603,7 @@ class GenericElementPlot(DimensionedPlot):
             self.current_key = key
             return self.current_frame
         elif self.dynamic:
-            with enable_streams_cache(self.hmap, not self._force or not self.drawn):
+            with dimensionless_cache(self.hmap, not self._force or not self.drawn):
                 key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
             traverse_setter(self, '_force', False)
             if not isinstance(key, tuple): key = (key,)
@@ -949,7 +949,7 @@ class GenericCompositePlot(DimensionedPlot):
                                     if d in item.dimensions('key')], key)
                 self.current_key = tuple(k[1] for k in dim_keys)
             elif item.traverse(lambda x: x, [DynamicMap]):
-                with enable_streams_cache(item, not self._force or not self.drawn):
+                with dimensionless_cache(item, not self._force or not self.drawn):
                     key, frame = util.get_dynamic_item(item, self.dimensions, key)
                 layout_frame[path] = frame
                 continue

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -613,7 +613,7 @@ class GenericElementPlot(DimensionedPlot):
             self.current_key = key
             return self.current_frame
         elif self.dynamic:
-            with enable_streams_cache(self.hmap, not self.force):
+            with enable_streams_cache(self.hmap, not self.force or not self.drawn):
                 key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
             self.force = False
             if not isinstance(key, tuple): key = (key,)
@@ -959,7 +959,7 @@ class GenericCompositePlot(DimensionedPlot):
                                     if d in item.dimensions('key')], key)
                 self.current_key = tuple(k[1] for k in dim_keys)
             elif item.traverse(lambda x: x, [DynamicMap]):
-                with enable_streams_cache(item, not self.force):
+                with enable_streams_cache(item, not self.force or not self.drawn):
                     key, frame = util.get_dynamic_item(item, self.dimensions, key)
                 layout_frame[path] = frame
                 continue

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -285,3 +285,11 @@ def attach_streams(plot, obj):
         for stream in dmap.streams:
             stream._hidden_subscribers.append(plot.refresh)
     return obj.traverse(append_refresh, [DynamicMap])
+
+
+def traverse_setter(obj, attribute, value):
+    """
+    Traverses the object and sets the supplied attribute on the
+    object. Supports Dimensioned and DimensionedPlot types.
+    """
+    obj.traverse(lambda x: setattr(x, attribute, value))


### PR DESCRIPTION
Currently the plotting code will request a particular key from a single DynamicMap multiple times during plotting which should be avoided due to potentially random state.