### PR TITLE
Extended dimension values support

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -14,7 +14,7 @@ import param
 from ..core.util import (basestring, sanitize_identifier,
                          group_sanitizer, label_sanitizer, max_range,
                          find_range, dimension_sanitizer, OrderedDict,
-                         safe_unicode, unicode, dt64_to_dt)
+                         safe_unicode, unicode, dt64_to_dt, unique_array)
 from .options import Store, StoreOptions
 from .pprint import PrettyPrinter
 
@@ -147,6 +147,7 @@ class Dimension(param.Parameterized):
             dimension_sanitizer.add_aliases(**{alias:long_name})
             all_params['name'] = long_name
 
+        all_params['values'] = list(unique_array(params.get('values', [])))
         super(Dimension, self).__init__(**all_params)
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -147,7 +147,10 @@ class Dimension(param.Parameterized):
             dimension_sanitizer.add_aliases(**{alias:long_name})
             all_params['name'] = long_name
 
-        all_params['values'] = list(unique_array(params.get('values', [])))
+        if not isinstance(params.get('values',None),basestring):
+            all_params['values'] = list(unique_array(params.get('values', [])))
+        elif params['values'] != 'initial':
+            raise Exception("Values argument can only be set with the string 'initial'.")
         super(Dimension, self).__init__(**all_params)
 
 

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -1,8 +1,87 @@
 """
 Test cases for Dimension and Dimensioned object behaviour.
 """
+from unittest import SkipTest
 from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
+
+import numpy as np
+try:
+    import pandas as pd
+except:
+    pd = None
+
+
+class DimensionTest(ComparisonTestCase):
+
+    def setUp(self):
+        self.values1 = [0,1,2,3,4,5,6]
+        self.values2 = ['a','b','c','d']
+
+        self.duplicates1 = [0,1,0,2,3,4,3,2,5,5,6]
+        self.duplicates2 = ['a','b','b','a','c','a','c','d','d']
+
+    def test_dimension_values_list1(self):
+        dim = Dimension('test', values=self.values1)
+        self.assertEqual(dim.values, self.values1)
+
+    def test_dimension_values_list2(self):
+        dim = Dimension('test', values=self.values2)
+        self.assertEqual(dim.values, self.values2)
+
+    def test_dimension_values_list_duplicates1(self):
+        dim = Dimension('test', values=self.duplicates1)
+        self.assertEqual(dim.values, self.values1)
+
+    def test_dimension_values_list_duplicates2(self):
+        dim = Dimension('test', values=self.duplicates2)
+        self.assertEqual(dim.values, self.values2)
+
+    def test_dimension_values_array1(self):
+        dim = Dimension('test', values=np.array(self.values1))
+        self.assertEqual(dim.values, self.values1)
+
+    def test_dimension_values_array2(self):
+        dim = Dimension('test', values=np.array(self.values2))
+        self.assertEqual(dim.values, self.values2)
+
+    def test_dimension_values_array_duplicates1(self):
+        dim = Dimension('test', values=np.array(self.duplicates1))
+        self.assertEqual(dim.values, self.values1)
+
+    def test_dimension_values_array_duplicates2(self):
+        dim = Dimension('test', values=np.array(self.duplicates2))
+        self.assertEqual(dim.values, self.values2)
+
+    def test_dimension_values_series1(self):
+        if pd is None:
+            raise SkipTest("Pandas not available")
+        df = pd.DataFrame({'col':self.values1})
+        dim = Dimension('test', values=df['col'])
+        self.assertEqual(dim.values, self.values1)
+
+    def test_dimension_values_series2(self):
+        if pd is None:
+            raise SkipTest("Pandas not available")
+        df = pd.DataFrame({'col':self.values2})
+        dim = Dimension('test', values=df['col'])
+        self.assertEqual(dim.values, self.values2)
+
+
+    def test_dimension_values_series_duplicates1(self):
+        if pd is None:
+            raise SkipTest("Pandas not available")
+        df = pd.DataFrame({'col':self.duplicates1})
+        dim = Dimension('test', values=df['col'])
+        self.assertEqual(dim.values, self.values1)
+
+
+    def test_dimension_values_series_duplicates2(self):
+        if pd is None:
+            raise SkipTest("Pandas not available")
+        df = pd.DataFrame({'col':self.duplicates2})
+        dim = Dimension('test', values=df['col'])
+        self.assertEqual(dim.values, self.values2)
 
 
 class DimensionedTest(ComparisonTestCase):


### PR DESCRIPTION
This PR implements a feature request by @basnijholt on gitter to support numpy arrays and pandas Series as direct specifications for ``Dimension.values`` coupled with automatic de-duplication of values.