### PR TITLE
Widgets ignore dimension streams

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -803,15 +803,23 @@ def dimensionless_contents(streams, kdims):
     with any of the key dimensions.
     """
     names = stream_parameters(streams)
-    kdim_names = [kdim.name for kdim in kdims]
-    return [name for name in names if name not in kdim_names]
+    return [name for name in names if name not in kdims]
+
+
+def streamless_dimensions(streams, kdims):
+    """
+    Return a list of dimensions that have not been associated with
+    any streams.
+    """
+    params = stream_parameters(streams)
+    return [d for d in kdims if d not in params]
 
 
 def wrap_tuple_streams(unwrapped, kdims, streams):
     """
     Fills in tuple keys with dimensioned stream values as appropriate.
     """
-    param_groups = [(s.params().keys(), s) for s in streams]
+    param_groups = [(s.contents.keys(), s) for s in streams]
     pairs = [(name,s)  for (group, s) in param_groups for name in group]
     substituted = []
     for pos,el in enumerate(wrap_tuple(unwrapped)):
@@ -822,6 +830,16 @@ def wrap_tuple_streams(unwrapped, kdims, streams):
                 el = stream.contents[name]
         substituted.append(el)
     return tuple(substituted)
+
+
+def drop_streams(streams, keys, kdims):
+    """
+    Drop any dimensionsed streams from the keys and kdims.
+    """
+    stream_params = stream_parameters(streams)
+    inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
+                       if kdim not in stream_params])
+    return dims, [tuple(key[ind] for ind in inds) for key in keys]
 
 
 def itervalues(obj):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -806,7 +806,7 @@ def dimensionless_contents(streams, kdims):
     return [name for name in names if name not in kdims]
 
 
-def streamless_dimensions(streams, kdims):
+def unbound_dimensions(streams, kdims):
     """
     Return a list of dimensions that have not been associated with
     any streams.
@@ -832,7 +832,7 @@ def wrap_tuple_streams(unwrapped, kdims, streams):
     return tuple(substituted)
 
 
-def drop_streams(streams, keys, kdims):
+def drop_streams(streams, kdims, keys):
     """
     Drop any dimensionsed streams from the keys and kdims.
     """

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -43,10 +43,6 @@ class BokehWidget(NdWidget):
                 msg = dict(patch=json_patch, root=self.plot.state._id)
                 msg = serialize_json(msg)
             return msg
-        else:
-            self.plot.push()
-            return "Complete"
-
 
 class BokehSelectionWidget(BokehWidget, SelectionWidget):
     pass

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -32,15 +32,6 @@ class MPLWidget(NdWidget):
             return self.renderer.html(self.plot, figure_format, comm=False)
 
 
-    def update(self, key):
-        if self.plot.dynamic == 'bounded' and not isinstance(key, int):
-            key = tuple(dim.values[k] if dim.values else k
-                        for dim, k in zip(self.mock_obj.kdims, tuple(key)))
-        self.plot[key]
-        self.plot.push()
-        return '' if self.renderer.mode == 'nbagg' else 'Complete'
-
-
     def get_frames(self):
         if self.renderer.mode == 'nbagg':
             manager = self.plot.comm.get_figure_manager()

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -572,8 +572,7 @@ class GenericElementPlot(DimensionedPlot):
                                                  **dict(params, **plot_opts))
         if top_level:
             self.comm = self.init_comm(element)
-        if isinstance(self.hmap, DynamicMap):
-            self.streams = self.hmap.streams
+        self.streams = self.hmap.streams if isinstance(self.hmap, DynamicMap) else []
 
         # Update plot and style options for batched plots
         if self.batched:

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import param
 from ..core.io import Exporter
 from ..core.options import Store, StoreOptions, SkipRendering
-from ..core.util import find_file, unicode, streamless_dimensions
+from ..core.util import find_file, unicode, unbound_dimensions
 from .. import Layout, HoloMap, AdjointLayout
 from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
@@ -204,7 +204,7 @@ class Renderer(Exporter):
             if (((len(plot) == 1 and not plot.dynamic)
                 or (len(plot) > 1 and self.holomap is None) or
                 (plot.dynamic and len(plot.keys[0]) == 0)) or
-                not streamless_dimensions(plot.streams, plot.dimensions)):
+                not unbound_dimensions(plot.streams, plot.dimensions)):
                 fmt = fig_formats[0] if self.fig=='auto' else self.fig
             else:
                 fmt = holomap_formats[0] if self.holomap=='auto' else self.holomap

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 import param
 from ..core.io import Exporter
 from ..core.options import Store, StoreOptions, SkipRendering
-from ..core.util import find_file, unicode
+from ..core.util import find_file, unicode, streamless_dimensions
 from .. import Layout, HoloMap, AdjointLayout
 from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
@@ -201,9 +201,10 @@ class Renderer(Exporter):
         holomap_formats = self.mode_formats['holomap'][self.mode]
 
         if fmt in ['auto', None]:
-            if ((len(plot) == 1 and not plot.dynamic)
+            if (((len(plot) == 1 and not plot.dynamic)
                 or (len(plot) > 1 and self.holomap is None) or
-                (plot.dynamic and len(plot.keys[0]) == 0)):
+                (plot.dynamic and len(plot.keys[0]) == 0)) or
+                not streamless_dimensions(plot.streams, plot.dimensions)):
                 fmt = fig_formats[0] if self.fig=='auto' else self.fig
             else:
                 fmt = holomap_formats[0] if self.holomap=='auto' else self.holomap

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -107,7 +107,7 @@ class NdWidget(param.Parameterized):
         super(NdWidget, self).__init__(**params)
         self.id = plot.comm.target if plot.comm else uuid.uuid4().hex
         self.plot = plot
-        dims, keys = drop_streams(drop_streams, plot.keys, plot.dimensions)
+        dims, keys = drop_streams(plot.streams, plot.keys, plot.dimensions)
         self.dimensions, self.keys = dims, keys
         self.json_data = {}
         if self.plot.dynamic: self.embed = False

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -107,8 +107,10 @@ class NdWidget(param.Parameterized):
         super(NdWidget, self).__init__(**params)
         self.id = plot.comm.target if plot.comm else uuid.uuid4().hex
         self.plot = plot
-        dims, keys = drop_streams(plot.streams, plot.keys, plot.dimensions)
-        self.dimensions, self.keys = dims, keys
+        self.dimensions, self.keys = drop_streams(plot.streams,
+                                                  plot.dimensions,
+                                                  plot.keys)
+
         self.json_data = {}
         if self.plot.dynamic: self.embed = False
         if renderer is None:


### PR DESCRIPTION
Widgets now ignore dimensions which are defined through a stream ensuring that only widgets for non-stream dimensions are displayed.