### PR TITLE
Bokeh colorbars

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -232,7 +232,7 @@ class HistogramPlot(ElementPlot):
         return (data, mapping)
 
 
-class SideHistogramPlot(HistogramPlot):
+class SideHistogramPlot(HistogramPlot, ColorbarPlot):
 
     style_opts = HistogramPlot.style_opts + ['cmap']
 
@@ -255,19 +255,20 @@ class SideHistogramPlot(HistogramPlot):
             data = dict(top=element.values, left=element.edges[:-1],
                         right=element.edges[1:])
 
-        dim = element.get_dimension(0).name
+        dim = element.get_dimension(0)
         main = self.adjoined.main
-        range_item, main_range, dim = get_sideplot_ranges(self, element, main, ranges)
-        vals = element.dimension_values(dim)
+        range_item, main_range, _ = get_sideplot_ranges(self, element, main, ranges)
         if isinstance(range_item, (Raster, Points, Polygons, Spikes)):
             style = self.lookup_options(range_item, 'style')[self.cyclic_index]
         else:
             style = {}
 
         if 'cmap' in style or 'palette' in style:
-            cmap = get_cmap(style.get('cmap', style.get('palette', None)))
-            data['color'] = [] if empty else map_colors(vals, main_range, cmap)
-            mapping['fill_color'] = 'color'
+            main_range = {dim.name: main_range}
+            mapper = self._get_colormapper(dim, element, main_range, style)
+            data[dim.name] = [] if empty else element.dimension_values(dim)
+            mapping['fill_color'] = {'field': dim.name,
+                                     'transform': mapper}
         self._get_hover_data(data, element, empty)
         return (data, mapping)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -265,10 +265,10 @@ class SideHistogramPlot(HistogramPlot, ColorbarPlot):
 
         if 'cmap' in style or 'palette' in style:
             main_range = {dim.name: main_range}
-            mapper = self._get_colormapper(dim, element, main_range, style)
+            cmapper = self._get_colormapper(dim, element, main_range, style)
             data[dim.name] = [] if empty else element.dimension_values(dim)
             mapping['fill_color'] = {'field': dim.name,
-                                     'transform': mapper}
+                                     'transform': cmapper}
         self._get_hover_data(data, element, empty)
         return (data, mapping)
 
@@ -350,10 +350,10 @@ class SpikesPlot(PathPlot, ColorbarPlot):
         data = dict(zip(('xs', 'ys'), (xs, ys)))
         cdim = element.get_dimension(self.color_index)
         if cdim:
-            mapper = self._get_colormapper(cdim, element, ranges, style)
+            cmapper = self._get_colormapper(cdim, element, ranges, style)
             data[cdim.name] = [] if empty else element.dimension_values(cdim)
             mapping['color'] = {'field': cdim.name,
-                                'transform': mapper}
+                                'transform': cmapper}
 
         if 'hover' in self.tools+self.default_tools and not empty:
             for d in dims:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -710,8 +710,7 @@ class ColorbarPlot(ElementPlot):
 
     def _get_colormapper(self, dim, element, ranges, style):
         low, high = ranges.get(dim.name)
-        if 'cmap' in style:
-            palette = mplcmap_to_palette(style.pop('cmap', None))
+        palette = mplcmap_to_palette(style.pop('cmap', 'viridis'))
         colormapper = LogColorMapper if self.logz else LinearColorMapper
         cmapper = colormapper(palette, low=low, high=high)
         if 'color_mapper' not in self.handles:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -689,6 +689,9 @@ class ColorbarPlot(ElementPlot):
 
     _update_handles = ['color_mapper', 'source', 'glyph']
 
+    _colorbar_defaults = dict(bar_line_color='black', label_standoff=8,
+                              major_tick_line_color='black')
+
     def _draw_colorbar(self, plot, color_mapper):
         if LogColorMapper and isinstance(color_mapper, LogColorMapper):
             ticker = LogTicker()
@@ -701,8 +704,7 @@ class ColorbarPlot(ElementPlot):
         if any(isinstance(model, ColorBar) for model in getattr(plot, pos, [])):
             return
 
-        opts = dict(cbar_opts['opts'], bar_line_color='black',
-                    label_standoff=8, major_tick_line_color='black')
+        opts = dict(cbar_opts['opts'], self._colorbar_defaults)
         color_bar = ColorBar(color_mapper=color_mapper, ticker=ticker,
                              **dict(opts, **self.colorbar_opts))
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -739,6 +739,7 @@ class ColorbarPlot(ElementPlot):
             if cm:
                 self.handles['color_mapper'].low = cm.low
                 self.handles['color_mapper'].high = cm.high
+                self.handles['color_mapper'].palette = cm.palette
         merged = dict(properties, **mapping)
         glyph.set(**{k: v for k, v in merged.items()
                      if k in allowed_properties})

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -675,7 +675,9 @@ class ColorbarPlot(ElementPlot):
             ticker = LogTicker()
         else:
             ticker = BasicTicker()
-        cbar_opts = self.colorbar_specs[self.colorbar_position]
+        cbar_opts = dict(self.colorbar_specs[self.colorbar_position],
+                         bar_line_color='black', label_standoff=8,
+                         major_tick_line_color='black')
 
         # Check if there is a colorbar in the same position
         pos = cbar_opts['pos']

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -640,18 +640,40 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
 
 class ColorbarPlot(ElementPlot):
+    """
+    ColorbarPlot provides methods to create colormappers and colorbar
+    models which can be added to a glyph. Additionally it provides
+    parameters to control the position and other styling options of
+    the colorbar. The default colorbar_position options are defined
+    by the colorbar_specs, but may be overridden by the colorbar_opts.
+    """
+
+    colorbar_specs = {'right':     {'pos': 'right',
+                                    'opts': {'location': (0, 0)}},
+                      'left':      {'pos': 'left',
+                                    'opts':{'location':(0, 0)}},
+                      'bottom':    {'pos': 'below',
+                                    'opts': {'location': (0, 0),
+                                             'orientation':'horizontal'}},
+                      'top':       {'pos': 'above',
+                                    'opts': {'location':(0, 0),
+                                             'orientation':'horizontal'}},
+                      'top_right':   {'pos': 'center',
+                                      'opts': {'location': 'top_right'}},
+                      'top_left':    {'pos': 'center',
+                                      'opts': {'location': 'top_left'}},
+                      'bottom_left': {'pos': 'center',
+                                      'opts': {'location': 'bottom_left',
+                                               'orientation': 'horizontal'}},
+                      'bottom_right': {'pos': 'center',
+                                      'opts': {'location': 'bottom_right',
+                                               'orientation': 'horizontal'}}}
 
     colorbar = param.Boolean(default=False, doc="""
         Whether to display a colorbar.""")
 
-    colorbar_position = param.ObjectSelector(objects=["top_right",
-                                                      "top_left",
-                                                      "bottom_left",
-                                                      "bottom_right",
-                                                      'right', 'left',
-                                                      'top', 'bottom'],
-                                             default="right",
-                                             doc="""
+    colorbar_position = param.ObjectSelector(objects=list(colorbar_specs),
+                                             default="right", doc="""
         Allows selecting between a number of predefined colorbar position
         options. The predefined options may be customized in the
         colorbar_specs class attribute.""")
@@ -661,21 +683,6 @@ class ColorbarPlot(ElementPlot):
         the options defined in the colorbar_specs class attribute. Includes
         location, orientation, height, width, scale_alpha, title, title_props,
         margin, padding, background_fill_color and more.""")
-
-    colorbar_specs = {'right': {'pos': 'right', 'opts': {'location': (0, 0)}},
-                      'left': {'pos': 'left', 'opts':{'location':(0, 0)}},
-                      'top_right': {'pos': 'center', 'opts': {'location': 'top_right'}},
-                      'top_left': {'pos': 'center', 'opts': {'location': 'top_left'}},
-                      'top': {'opts': {'location':(0, 0), 'orientation':'horizontal'},
-                              'pos': 'above'},
-                      'bottom': {'opts': {'location': (0, 0), 'orientation':'horizontal'},
-                                 'pos': 'below'},
-                      'bottom_left': {'pos': 'center',
-                                      'opts': {'location': 'bottom_center',
-                                               'orientation': 'horizontal'}},
-                      'bottom_right': {'pos': 'center',
-                                      'opts': {'location': 'bottom_right',
-                                               'orientation': 'horizontal'}}}
 
     logz  = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the z-axis.""")

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -694,17 +694,17 @@ class ColorbarPlot(ElementPlot):
             ticker = LogTicker()
         else:
             ticker = BasicTicker()
-        cbar_opts = dict(self.colorbar_specs[self.colorbar_position],
-                         bar_line_color='black', label_standoff=8,
-                         major_tick_line_color='black')
+        cbar_opts = dict(self.colorbar_specs[self.colorbar_position])
 
         # Check if there is a colorbar in the same position
         pos = cbar_opts['pos']
         if any(isinstance(model, ColorBar) for model in getattr(plot, pos, [])):
             return
 
+        opts = dict(cbar_opts['opts'], bar_line_color='black',
+                    label_standoff=8, major_tick_line_color='black')
         color_bar = ColorBar(color_mapper=color_mapper, ticker=ticker,
-                             **dict(cbar_opts['opts'], **self.colorbar_opts))
+                             **dict(opts, **self.colorbar_opts))
 
         plot.add_layout(color_bar, pos)
         self.handles['colorbar'] = color_bar

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -717,6 +717,9 @@ class ColorbarPlot(ElementPlot):
         palette = mplcmap_to_palette(style.pop('cmap', 'viridis'))
         colormapper = LogColorMapper if self.logz else LinearColorMapper
         cmapper = colormapper(palette, low=low, high=high)
+
+        # The initial colormapper instance is cached the first time
+        # and then updated with the values from new instances
         if 'color_mapper' not in self.handles:
             self.handles['color_mapper'] = cmapper
         return cmapper

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -710,6 +710,19 @@ class ColorbarPlot(ElementPlot):
         return ret
 
 
+    def _update_glyph(self, glyph, properties, mapping):
+        allowed_properties = glyph.properties()
+        cmappers = [v.get('transform') for v in mapping.values()
+                    if isinstance(v, dict)]
+        cmappers.append(properties.pop('color_mapper', None))
+        for cm in cmappers:
+            if cm:
+                self.handles['color_mapper'].low = cm.low
+                self.handles['color_mapper'].high = cm.high
+        merged = dict(properties, **mapping)
+        glyph.set(**{k: v for k, v in merged.items()
+                     if k in allowed_properties})
+
 
 class LegendPlot(ElementPlot):
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -113,6 +113,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     tools = param.List(default=[], doc="""
         A list of plugin tools to use on the plot.""")
 
+    toolbar = param.ObjectSelector(default='right',
+                                   objects=["above", "below",
+                                            "left", "right", None],
+                                   doc="""
+        The toolbar location, must be one of 'above', 'below',
+        'left', 'right', None.""")
+
     xaxis = param.ObjectSelector(default='bottom',
                                  objects=['top', 'bottom', 'bare', 'top-bare',
                                           'bottom-bare', None], doc="""
@@ -277,7 +284,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         axis_types, labels, plot_ranges = self._axes_props(plots, subplots, element, ranges)
         xlabel, ylabel, _ = labels
         x_axis_type, y_axis_type = axis_types
-        tools = self._init_tools(element)
         properties = dict(plot_ranges)
         properties['x_axis_label'] = xlabel if 'x' in self.show_labels else ' '
         properties['y_axis_label'] = ylabel if 'y' in self.show_labels else ' '
@@ -287,11 +293,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             title = ''
 
+        if self.toolbar:
+            tools = self._init_tools(element)
+            properties['tools'] = tools
+            properties['toolbar_location'] = self.toolbar
+
         properties['webgl'] = Store.renderers[self.renderer.backend].webgl
         return bokeh.plotting.Figure(x_axis_type=x_axis_type,
-                                     toolbar_location='above',
                                      y_axis_type=y_axis_type, title=title,
-                                     tools=tools, **properties)
+                                     **properties)
 
 
     def _plot_properties(self, key, plot, element):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -687,6 +687,8 @@ class ColorbarPlot(ElementPlot):
     logz  = param.Boolean(default=False, doc="""
          Whether to apply log scaling to the z-axis.""")
 
+    _update_handles = ['color_mapper', 'source', 'glyph']
+
     def _draw_colorbar(self, plot, color_mapper):
         if LogColorMapper and isinstance(color_mapper, LogColorMapper):
             ticker = LogTicker()

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -289,6 +289,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         properties['webgl'] = Store.renderers[self.renderer.backend].webgl
         return bokeh.plotting.Figure(x_axis_type=x_axis_type,
+                                     toolbar_location='above',
                                      y_axis_type=y_axis_type, title=title,
                                      tools=tools, **properties)
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -7,7 +7,7 @@ from bokeh.models import HoverTool
 
 from ...core import util
 from ..util import map_colors
-from .element import ElementPlot, line_properties, fill_properties
+from .element import ElementPlot, ColorbarPlot, line_properties, fill_properties
 from .util import get_cmap, rgb2hex
 
 
@@ -44,7 +44,7 @@ class PathPlot(ElementPlot):
         return data, elmapping
 
 
-class PolygonPlot(PathPlot):
+class PolygonPlot(ColorbarPlot, PathPlot):
 
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
@@ -74,15 +74,17 @@ class PolygonPlot(PathPlot):
         data = dict(xs=ys, ys=xs) if self.invert_axes else dict(xs=xs, ys=ys)
 
         style = self.style[self.cyclic_index]
-        cmap = style.get('palette', style.get('cmap', None))
         mapping = dict(self._mapping)
-        if cmap and element.level is not None:
-            cmap = get_cmap(cmap)
-            colors = map_colors(np.array([element.level]), ranges[element.vdims[0].name], cmap)
-            mapping['color'] = 'color'
-            data['color'] = [] if empty else list(colors)*len(element.data)
-            dim_name = util.dimension_sanitizer(element.vdims[0].name)
+
+        if element.vdims and element.level is not None:
+            cdim = element.vdims[0]
+            mapper = self._get_colormapper(cdim, element, ranges, style)
+            data[cdim.name] = [] if empty else element.dimension_values(2)
+            mapping['fill_color'] = {'field': cdim.name,
+                                     'transform': mapper}
+
         if 'hover' in self.tools+self.default_tools:
+            dim_name = util.dimension_sanitizer(element.vdims[0].name)
             for k, v in self.overlay_dims.items():
                 dim = util.dimension_sanitizer(k.name)
                 data[dim] = [v for _ in range(len(xs))]
@@ -99,7 +101,7 @@ class PolygonPlot(PathPlot):
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].extend(eld)
-            if 'color' not in eldata:
+            if 'color' not in elmapping:
                 zorder = self.get_zorder(element, key, el)
                 val = style[zorder].get('color')
                 elmapping['color'] = 'color'

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -78,10 +78,10 @@ class PolygonPlot(ColorbarPlot, PathPlot):
 
         if element.vdims and element.level is not None:
             cdim = element.vdims[0]
-            mapper = self._get_colormapper(cdim, element, ranges, style)
+            cmapper = self._get_colormapper(cdim, element, ranges, style)
             data[cdim.name] = [] if empty else element.dimension_values(2)
             mapping['fill_color'] = {'field': cdim.name,
-                                     'transform': mapper}
+                                     'transform': cmapper}
 
         if 'hover' in self.tools+self.default_tools:
             dim_name = util.dimension_sanitizer(element.vdims[0].name)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -16,7 +16,6 @@ class RasterPlot(ColorbarPlot):
 
     style_opts = ['cmap']
     _plot_methods = dict(single='image')
-    _update_handles = ['color_mapper', 'source', 'glyph']
 
     def __init__(self, *args, **kwargs):
         super(RasterPlot, self).__init__(*args, **kwargs)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -53,16 +53,6 @@ class RasterPlot(ColorbarPlot):
         return properties
 
 
-    def _update_glyph(self, glyph, properties, mapping):
-        allowed_properties = glyph.properties()
-        cmap = properties.pop('color_mapper', None)
-        if cmap:
-            glyph.color_mapper.low = cmap.low
-            glyph.color_mapper.high = cmap.high
-        merged = dict(properties, **mapping)
-        glyph.set(**{k: v for k, v in merged.items()
-                     if k in allowed_properties})
-
 
 class ImagePlot(RasterPlot):
 


### PR DESCRIPTION
Since version 0.12.2 bokeh finally support colorbars and client-side colormapping for all kinds of glyphs. This PR adds a ColorbarPlot mixin class which handles the creation of a Colorbar and a ColorMapper. Additionally it replaces the manual colormapping that was previously done in Python for various plot types. I have also moved the toolbar to the top so it does not overlap with a colorbar by default and because it is more consistent.

To Do:

* [x] Test each changed Element in more detail
* [x] Implement color_mapper range updating
* [x] Update HeatMapPlot in #849 once this has been merged.
* [x] Add some unit tests to ensure colorbars get instantiated correctly

Examples:

Different ``colorbar_position``s:

<img width="641" alt="screen shot 2016-09-14 at 12 54 54 am" src="https://cloud.githubusercontent.com/assets/1550771/18495445/e57457ae-7a15-11e6-8d5d-3585e897e38d.png">

Log colormapping on points:

<img width="266" alt="screen shot 2016-09-14 at 12 45 16 am" src="https://cloud.githubusercontent.com/assets/1550771/18495448/e9701aa0-7a15-11e6-9b15-00081fa4b6fc.png">

QuadMesh:

<img width="279" alt="screen shot 2016-09-14 at 12 45 48 am" src="https://cloud.githubusercontent.com/assets/1550771/18495449/ec7f2704-7a15-11e6-8d59-9dd9b3ef1f9b.png">

Polygons (more sensible on a Choropleth):

<img width="287" alt="screen shot 2016-09-14 at 12 43 54 am" src="https://cloud.githubusercontent.com/assets/1550771/18495456/f6d0dd6a-7a15-11e6-94a5-24d0efafd7f1.png">