### PR TITLE
Switched to python initiated JupyterComm for mpl

### DIFF
--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -73,11 +73,10 @@ class Comm(param.Parameterized):
             self._on_msg(self.decode(msg))
 
 
-class JupyterPushComm(Comm):
+class JupyterComm(Comm):
     """
-    JupyterPushComm provides a Comm for simple unidirectional
-    communication from the python process to a frontend. The
-    Comm is opened before the first event is sent to the frontend.
+    JupyterComm provides a Comm for the notebook which is initialized
+    the first time data is pushed to the frontend.
     """
 
     template = """
@@ -89,11 +88,11 @@ class JupyterPushComm(Comm):
 
       if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
         comm_manager = Jupyter.notebook.kernel.comm_manager;
-        comm_manager.register_target("{comms_target}", register_handler);
+        comm_manager.register_target("{comms_target}", function(comm) {{ comm.on_msg(msg_handler);}});
       }}
     </script>
 
-    <div id="{comms_target}">
+    <div id="fig_{comms_target}">
       {init_frame}
     </div>
     """
@@ -120,12 +119,11 @@ class JupyterPushComm(Comm):
 
 
 
-class JupyterComm(Comm):
+class JupyterCommJS(Comm):
     """
-    JupyterComm allows for a bidirectional communication channel
-    inside the Jupyter notebook. The JupyterComm will register
-    a comm target on the IPython kernel comm manager, which will then
-    be opened by the templated code on the frontend.
+    JupyterCommJS provides a comms channel for the Jupyter notebook,
+    which is initialized on the frontend. This allows sending events
+    initiated on the frontend to python.
     """
 
     template = """
@@ -142,7 +140,7 @@ class JupyterComm(Comm):
       }}
     </script>
 
-    <div id="{comms_target}">
+    <div id="fig_{comms_target}">
       {init_frame}
     </div>
     """

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -13,7 +13,7 @@ from ..comms import JupyterComm
 
 mpl_msg_handler = """
 /* Backend specific body of the msg_handler, updates displayed frame */
-target = $('#{comms_target}');
+target = $('#fig_{comms_target}');
 img = $('<div />').html(msg);
 target.children().each(function () {{ $(this).remove() }})
 target.append(img)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -17,7 +17,7 @@ from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 
 from .. import DynamicMap
 from . import Plot
-from .comms import JupyterPushComm
+from .comms import JupyterComm
 from .util import displayable, collate
 
 from param.parameterized import bothmethod
@@ -133,7 +133,7 @@ class Renderer(Exporter):
     # Define comms class and message handler for each mode
     # The Comm opens a communication channel and the message
     # handler defines how the message is processed on the frontend
-    comms = {'default': (JupyterPushComm, None)}
+    comms = {'default': (JupyterComm, None)}
 
     # Define appropriate widget classes
     widgets = {'scrubber': ScrubberWidget, 'widgets': SelectionWidget}

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -97,11 +97,12 @@ HoloViewsWidget.prototype.update = function(current){
 }
 
 HoloViewsWidget.prototype.init_comms = function() {
-	var widget = this;
 	if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {
-		var comm_manager = Jupyter.notebook.kernel.comm_manager
-		comm = comm_manager.new_comm(this.id, {}, {}, {}, this.id);
-		comm.on_msg(function (msg) { widget.process_msg(msg) })
+		var widget = this;
+		comm_manager = Jupyter.notebook.kernel.comm_manager;
+        comm_manager.register_target(this.id, function (comm) {
+			comm.on_msg(function (msg) { widget.process_msg(msg) });
+		});
 	}
 }
 

--- a/tests/testcomms.py
+++ b/tests/testcomms.py
@@ -1,7 +1,7 @@
 from nose.tools import *
 
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting.comms import Comm, JupyterPushComm
+from holoviews.plotting.comms import Comm, JupyterComm
 
 
 class TestComm(ComparisonTestCase):
@@ -29,21 +29,21 @@ class TestComm(ComparisonTestCase):
 class TestJupyterComm(ComparisonTestCase):
 
     def test_init_comm(self):
-        JupyterPushComm(None)
+        JupyterComm(None)
 
     def test_init_comm_target(self):
-        comm = JupyterPushComm(None, target='Test')
+        comm = JupyterComm(None, target='Test')
         self.assertEqual(comm.target, 'Test')
 
     def test_decode(self):
         msg = {'content': {'data': 'Test'}}
-        decoded = JupyterPushComm.decode(msg)
+        decoded = JupyterComm.decode(msg)
         self.assertEqual(decoded, 'Test')
 
     def test_on_msg(self):
         def raise_error(msg):
             if msg == 'Error':
                 raise Exception()
-        comm = JupyterPushComm(None, target='Test', on_msg=raise_error)
+        comm = JupyterComm(None, target='Test', on_msg=raise_error)
         with self.assertRaises(Exception):
             comm._handle_msg({'content': {'data': 'Error'}})


### PR DESCRIPTION
Renamed JupyterPushComm to JupyterComm and used it for matplotlib. Avoids errors when Comm is not initialized in time when running through a notebook quickly.