### PR TITLE
Add Datashader operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh pandas jupyter ipython=4.2.0 param matplotlib=1.5.1 xarray
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh pandas jupyter ipython=4.2.0 param matplotlib=1.5.1 xarray datashader
   - source activate test-environment
   - conda install -c conda-forge  -c scitools iris sip=4.18 plotly
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -37,7 +37,17 @@ class XArrayInterface(GridInterface):
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
 
-        if not isinstance(data, xr.Dataset):
+        if isinstance (data, xr.DataArray):
+            if data.name:
+                vdim = Dimension(data.name)
+            elif vdims:
+                vdim = vdims[0]
+            elif len(vdim_param.default) == 1:
+                vdim = vdim_param.default[0]
+            vdims = [vdim]
+            kdims = [Dimension(d) for d in data.dims[::-1]]
+            data = xr.Dataset({vdim.name: data})
+        elif not isinstance(data, xr.Dataset):
             if kdims is None:
                 kdims = kdim_param.default
             if vdims is None:

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -70,81 +70,6 @@ class Operation(param.ParameterizedFunction):
             raise ValueError("Extents across the overlay are inconsistent")
 
 
-class Dynamic(Operation):
-    """
-    Dynamically applies a callable to the Elements in any HoloViews
-    object. Will return a DynamicMap wrapping the original map object,
-    which will lazily evaluate when a key is requested. By default
-    Dynamic applies a no-op, making it useful for converting HoloMaps
-    to a DynamicMap.
-
-    Any supplied kwargs will be passed to the callable and any streams
-    will be instantiated on the returned DynamicMap.
-    """
-
-    callable = param.Callable(default=lambda x: x, doc="""
-        Function or ElementOperation to apply to DynamicMap items
-        dynamically.""")
-
-    kwargs = param.Dict(default={}, doc="""
-        Keyword arguments passed to the function.""")
-
-    streams = param.List(default=[], doc="""
-        List of streams to attach to the returned DynamicMap""")
-
-    def __call__(self, map_obj, **params):
-        self.p = param.ParamOverrides(self, params)
-        callback = self._dynamic_operation(map_obj)
-        if isinstance(map_obj, DynamicMap):
-            dmap = map_obj.clone(callback=callback, shared_data=False)
-        else:
-            dmap = self._make_dynamic(map_obj, callback)
-        if isinstance(self.p.callable, ElementOperation):
-            return dmap.clone(streams=[s() for s in self.p.streams])
-        return dmap
-
-
-    def _process(self, element):
-        if isinstance(self.p.callable, Operation):
-            return self.p.callable.process_element(element, **self.p.kwargs)
-        else:
-            return self.p.callable(element, **self.p.kwargs)
-
-
-    def _dynamic_operation(self, map_obj):
-        """
-        Generate function to dynamically apply the operation.
-        Wraps an existing HoloMap or DynamicMap.
-        """
-        if not isinstance(map_obj, DynamicMap):
-            def dynamic_operation(*key, **kwargs):
-                self.p.kwargs.update(kwargs)
-                return self._process(map_obj[key])
-            return dynamic_operation
-
-        def dynamic_operation(*key, **kwargs):
-            key = key[0] if map_obj.mode == 'open' else key
-            self.p.kwargs.update(kwargs)
-            _, el = util.get_dynamic_item(map_obj, map_obj.kdims, key)
-            return self._process(el)
-
-        return dynamic_operation
-
-
-    def _make_dynamic(self, hmap, dynamic_fn):
-        """
-        Accepts a HoloMap and a dynamic callback function creating
-        an equivalent DynamicMap from the HoloMap.
-        """
-        if isinstance(hmap, ViewableElement):
-            return DynamicMap(dynamic_fn, kdims=[])
-        dim_values = zip(*hmap.data.keys())
-        params = util.get_param_values(hmap)
-        kdims = [d(values=list(set(values))) for d, values in
-                 zip(hmap.kdims, dim_values)]
-        return DynamicMap(dynamic_fn, **dict(params, kdims=kdims))
-
-
 
 class ElementOperation(Operation):
     """
@@ -204,9 +129,10 @@ class ElementOperation(Operation):
             processed = GridSpace(grid_data, label=element.label,
                                   kdims=element.kdims)
         elif dynamic:
+            from ..util import Dynamic
             streams = getattr(self, 'streams', [])
             processed = Dynamic(element, streams=streams,
-                                callable=self, kwargs=params)
+                                operation=self, kwargs=params)
         elif isinstance(element, ViewableElement):
             processed = self._process(element)
         elif isinstance(element, DynamicMap):

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -82,7 +82,7 @@ class ElementOperation(Operation):
     An ElementOperation can be set to be dynamic, which will return a
     DynamicMap with a callback that will apply the operation
     dynamically. An ElementOperation may also supply a list of Stream
-    classes on the streams attribute, which can allow dynamic control
+    classes on a streams parameter, which can allow dynamic control
     over the parameters on the operation.
     """
 

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -78,6 +78,12 @@ class ElementOperation(Operation):
     input, a processed holomap is returned as output where the
     individual elements have been transformed accordingly. An
     ElementOperation may turn overlays in new elements or vice versa.
+
+    An ElementOperation can be set to be dynamic, which will return a
+    DynamicMap with a callback that will apply the operation
+    dynamically. An ElementOperation may also supply a list of Stream
+    classes on the streams attribute, which can allow dynamic control
+    over the parameters on the operation.
     """
 
     dynamic = param.ObjectSelector(default='default',

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -107,7 +107,7 @@ class ElementOperation(Operation):
         raise NotImplementedError
 
 
-    def process_element(self, element, key=None, **params):
+    def process_element(self, element, key, **params):
         """
         The process_element method allows a single element to be
         operated on given an externally supplied key.

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,10 +24,10 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .operation import DynamicFunction
+            from .operation import Dynamic
             def dynamic_mul(element):
                 return self * element
-            return DynamicFunction(other, function=dynamic_mul)
+            return Dynamic(other, callable=dynamic_mul)
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,10 +24,10 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .operation import Dynamic
+            from ..util import Dynamic
             def dynamic_mul(element):
                 return self * element
-            return Dynamic(other, callable=dynamic_mul)
+            return Dynamic(other, operation=dynamic_mul)
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -204,10 +204,10 @@ class HoloMap(UniformNdMapping):
             return self.clone(items, kdims=dimensions, label=self._label, group=self._group)
         elif isinstance(other, self.data_type):
             if isinstance(self, DynamicMap):
-                from .operation import Dynamic
+                from ..util import Dynamic
                 def dynamic_mul(element):
                     return element * other
-                return Dynamic(self, callable=dynamic_mul)
+                return Dynamic(self, operation=dynamic_mul)
             items = [(k, v * other) for (k, v) in self.data.items()]
             return self.clone(items, label=self._label, group=self._group)
         else:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -204,10 +204,10 @@ class HoloMap(UniformNdMapping):
             return self.clone(items, kdims=dimensions, label=self._label, group=self._group)
         elif isinstance(other, self.data_type):
             if isinstance(self, DynamicMap):
-                from .operation import DynamicFunction
+                from .operation import Dynamic
                 def dynamic_mul(element):
                     return element * other
-                return DynamicFunction(self, function=dynamic_mul)
+                return Dynamic(self, callable=dynamic_mul)
             items = [(k, v * other) for (k, v) in self.data.items()]
             return self.clone(items, label=self._label, group=self._group)
         else:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -19,6 +19,7 @@ from ..core import (ElementOperation, Element, Dimension, NdOverlay,
                     Overlay, CompositeOverlay, Dataset)
 from ..core.util import get_param_values
 from ..element import GridImage, Path, Curve, Contours, RGB
+from ..streams import RangeXY
 
 
 @dispatch(Element)
@@ -102,6 +103,8 @@ class Aggregate(ElementOperation):
 
     y_sampling = param.Number(default=None, doc="""
         Specifies the smallest allowed sampling interval along the y-axis.""")
+
+    streams = [RangeXY]
 
     @classmethod
     def get_agg_data(cls, obj, category=None):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -161,10 +161,10 @@ class Aggregate(ElementOperation):
 
         # Compute highest allowed sampling density
         width, height = self.p.width, self.p.height
-        if self.x_sampling:
+        if self.p.x_sampling:
             x_range = xend - xstart
             width = int(min([(x_range/self.p.x_sampling), width]))
-        if self.y_sampling:
+        if self.p.y_sampling:
             y_range = yend - ystart
             height = int(min([(y_range/self.p.y_sampling), height]))
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -104,7 +104,9 @@ class Aggregate(ElementOperation):
     y_sampling = param.Number(default=None, doc="""
         Specifies the smallest allowed sampling interval along the y-axis.""")
 
-    streams = [RangeXY]
+    streams = param.List(default=[RangeXY], doc="""
+        List of streams that are applied if dynamic=True, allowing
+        for dynamic interaction with the plot.""")
 
     @classmethod
     def get_agg_data(cls, obj, category=None):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -199,7 +199,7 @@ class Shade(ElementOperation):
                                         doc="""
         The normalization operation applied before colormapping.
         Valid options include 'linear', 'log', 'eq_hist', 'cbrt',
-        and any valid transfer function that acces data, mask, nbins
+        and any valid transfer function that has data, mask, nbins
         arguments.""")
 
     @classmethod

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -9,7 +9,6 @@ import xarray as xr
 import datashader as ds
 import datashader.transfer_functions as tf
 
-import datashader.core
 from datashader.core import bypixel
 from datashader.pandas import pandas_pipeline
 from datashape.dispatch import dispatch
@@ -17,6 +16,7 @@ from datashape import discover as dsdiscover
 
 from ..core import (ElementOperation, Element, Dimension, NdOverlay,
                     Overlay, CompositeOverlay, Dataset)
+from ..core.data import ArrayInterface, PandasInterface
 from ..core.util import get_param_values
 from ..element import GridImage, Path, Curve, Contours, RGB
 from ..streams import RangeXY
@@ -28,7 +28,10 @@ def discover(dataset):
     Allows datashader to correctly discover the dtypes of the data
     in a holoviews Element.
     """
-    return dsdiscover(dataset.dframe().head())
+    if isinstance(dataset.interface, (PandasInterface, ArrayInterface)):
+        return dsdiscover(dataset.data)
+    else:
+        return dsdiscover(dataset.dframe())
 
 
 @bypixel.pipeline.register(Element)
@@ -72,13 +75,14 @@ class Aggregate(ElementOperation):
     """
     Aggregate implements 2D binning for any valid HoloViews Element
     type using datashader. By default it will simply count the number
-    of values in each bin but custom aggregators can be supplied
+    of values in each bin but other aggregators can be supplied
     implementing mean, max, min and other reduction operations.
 
     The bins of the aggregate are defined by the width and height and
     the x_range and y_range. If x_sampling or y_sampling are supplied
     the operation will ensure that a bin is no smaller than the
-    minimum sampling distance.
+    minimum sampling distance by reducing the width and height when
+    the zoomed in beyond the minimum sampling distance.
     """
 
     aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
@@ -187,7 +191,6 @@ class Shade(ElementOperation):
                                          doc="""
         The normalization operation applied before colormapping.""")
 
-
     @classmethod
     def concatenate(cls, overlay):
         """
@@ -251,50 +254,16 @@ class Shade(ElementOperation):
 
 
 
+class Datashade(Aggregate, Shade):
+    """
+    Applies the Aggregate and Shade operations, aggregating all
+    elements in the supplied object and then applying normalization
+    and colormapping the aggregated data returning RGB elements.
 
-class Datashade(ElementOperation):
-
-    aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
-                                     default=ds.count())
-
-    cmap = param.ClassSelector(class_=(Iterable, Callable), doc="""
-        Iterable or callable which returns colors as hex colors.
-        Callable type must allow mapping colors between 0 and 1.""")
-
-    height = param.Integer(default=800, doc="""
-       The height of the aggregated image in pixels.""")
-
-    normalization = param.ObjectSelector(default='eq_hist',
-                                         objects=['linear', 'log',
-                                                  'eq_hist', 'cbrt'],
-                                         doc="""
-        The normalization operation applied before colormapping.""")
-
-    streams = param.List(default=[RangeXY], doc="""
-        List of streams that are applied if dynamic=True, allowing
-        for dynamic interaction with the plot.""")
-
-    width = param.Integer(default=600, doc="""
-       The width of the aggregated image in pixels.""")
-
-    x_range  = param.NumericTuple(default=None, length=2, doc="""
-       The x_range as a tuple of min and max x-value. Auto-ranges
-       if set to None.""")
-
-    y_range  = param.NumericTuple(default=None, length=2, doc="""
-       The x_range as a tuple of min and max y-value. Auto-ranges
-       if set to None.""")
-
-    x_sampling = param.Number(default=None, doc="""
-        Specifies the smallest allowed sampling interval along the y-axis.""")
-
-    y_sampling = param.Number(default=None, doc="""
-        Specifies the smallest allowed sampling interval along the y-axis.""")
+    See Aggregate and Shade operations for more details.
+    """
 
     def _process(self, element, key=None):
-        params = self.p.items()
-        agg_kwargs = {p: v for p, v in params if p in Aggregate.params()}
-        shade_kwargs = {p: v for p, v in params if p in Shade.params()}
-        aggregate = Aggregate.instance(**agg_kwargs).process_element(element)
-        shaded = Shade.instance(**shade_kwargs).process_element(aggregate)
+        aggregate = Aggregate._process(self, element, key)
+        shaded = Shade._process(self, aggregate, key)
         return shaded

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -176,9 +176,15 @@ class Aggregate(ElementOperation):
 
 class Shade(ElementOperation):
     """
-    Shade applies a normalization function to the data and then
-    applies colormapping to an Image or NdOverlay of Images, returning
-    an RGB Element.
+    Shade applies a normalization function followed by colormapping to
+    an Image or NdOverlay of Images, returning an RGB Element.
+    The data must be in the form of a 2D or 3D DataArray, but NdOverlays
+    of 2D Images will be automatically converted to a 3D array.
+
+    In the 2D case data is normalized and colormapped, while a 3D
+    array representing categorical aggregates will be supplied a color
+    key for each category. The colormap (cmap) may be supplied as an
+    Iterable or a Callable.
     """
 
     cmap = param.ClassSelector(class_=(Iterable, Callable), doc="""

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1,0 +1,208 @@
+from __future__ import absolute_import
+
+from collections import Callable, Iterable
+
+import param
+import numpy as np
+import pandas as pd
+import xarray as xr
+import datashader as ds
+import datashader.transfer_functions as tf
+
+import datashader.core
+from datashader.core import bypixel
+from datashader.pandas import pandas_pipeline
+from datashape.dispatch import dispatch
+from datashape import discover as dsdiscover
+
+from ..core import (ElementOperation, Element, Dimension, NdOverlay,
+                    Overlay, CompositeOverlay, Dataset)
+from ..core.util import get_param_values
+from ..element import GridImage, Path, Curve, Contours, RGB
+
+
+@dispatch(Element)
+def discover(dataset):
+    """
+    Allows datashader to correctly discover the dtypes of the data
+    in a holoviews Element.
+    """
+    return dsdiscover(dataset.dframe().head())
+
+
+@bypixel.pipeline.register(Element)
+def dataset_pipeline(dataset, schema, canvas, glyph, summary):
+    """
+    Defines how to apply a datashader pipeline to a holoviews Element,
+    using multidispatch. Returns an Image type with the appropriate
+    bounds and dimensions. Passing the returned Image to datashader
+    transfer functions is not yet supported.
+    """
+    x0, x1 = canvas.x_range
+    y0, y1 = canvas.y_range
+    kdims = [dataset.get_dimension(d) for d in (glyph.x, glyph.y)]
+
+    column = summary.column
+    if column and isinstance(summary, ds.count_cat):
+        name = '%s Count' % summary.column
+    else:
+        name = column
+    vdims = [dataset.get_dimension(column)(name) if column
+             else Dimension('Count')]
+
+    aggregate = pandas_pipeline(dataset.dframe(), schema, canvas,
+                                glyph, summary)
+    aggregate = aggregate.rename({'x_axis': kdims[0].name,
+                                  'y_axis': kdims[1].name})
+
+    params = dict(get_param_values(dataset), kdims=kdims,
+                  datatype=['xarray'], vdims=vdims)
+
+    if aggregate.ndim == 2:
+        return GridImage(aggregate, **params)
+    else:
+        return NdOverlay({c: GridImage(aggregate.sel(**{column: c}),
+                                       **params)
+                          for c in aggregate.coords[column].data},
+                         kdims=[dataset.get_dimension(column)])
+
+
+class Aggregate(ElementOperation):
+
+    aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
+                                     default=ds.count())
+
+    height = param.Integer(default=800)
+
+    width = param.Integer(default=600)
+
+    x_range  = param.NumericTuple(default=None, length=2,
+                                  allow_None=True)
+
+    y_range  = param.NumericTuple(default=None, length=2,
+                                  allow_None=True)
+
+    x_sampling = param.Number(default=None, doc="""
+        Specifies the smallest allowed sampling interval along the y-axis.""")
+
+    y_sampling = param.Number(default=None, doc="""
+        Specifies the smallest allowed sampling interval along the y-axis.""")
+
+    @classmethod
+    def get_agg_data(cls, obj, category=None):
+        paths = []
+        kdims = obj.kdims
+        vdims = obj.vdims
+        x, y = obj.dimensions(label=True)[:2]
+        if isinstance(obj, Path):
+            line = True
+            for p in obj.data:
+                df = pd.DataFrame(p, columns=obj.dimensions('key', True))
+                if isinstance(obj, Contours) and obj.vdims and obj.level:
+                    df[obj.vdims[0].name] = p.level
+                paths.append(df)
+        elif isinstance(obj, CompositeOverlay):
+            for key, el in obj.data.items():
+                x, y, element, line = cls.get_agg_data(el)
+                df = element.dframe()
+                if isinstance(obj, NdOverlay):
+                    df = df.assign(**dict(zip(obj.dimensions('key', True), key)))
+                paths.append(df)
+            kdims += element.kdims
+            vdims = element.vdims
+        elif isinstance(obj, Element):
+            line = isinstance(obj, Curve)
+            paths.append(obj.dframe())
+        if line:
+            empty = paths[0][:1].copy()
+            empty.loc[0, :] = (np.NaN,) * empty.shape[1]
+            paths = [elem for path in paths for elem in (path, empty)][:-1]
+        df = pd.concat(paths).reset_index(drop=True)
+        if category and df[category].dtype.name != 'category':
+            df[category] = df[category].astype('category')
+        return x, y, Dataset(df, kdims=kdims, vdims=vdims), line
+
+
+    def _process(self, element, key=None):
+        agg_fn = self.p.aggregator
+        category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
+        x, y, data, line = self.get_agg_data(element, category)
+
+        if self.p.x_range:
+            xstart, xend = self.p.x_range
+        else:
+            xstart, xend = data.range(x)
+        if self.p.y_range:
+            ystart, yend = self.p.y_range
+        else:
+            ystart, yend = data.range(y)
+
+        # Compute highest allowed sampling density
+        width, height = self.p.width, self.p.height
+        if self.x_sampling:
+            x_range = xend - xstart
+            width = int(min([(x_range/self.p.x_sampling), width]))
+        if self.y_sampling:
+            y_range = yend - ystart
+            height = int(min([(y_range/self.p.y_sampling), height]))
+
+        cvs = ds.Canvas(plot_width=width, plot_height=height,
+                        x_range=(xstart, xend), y_range=(ystart, yend))
+
+        if line:
+            return cvs.line(data, x, y, self.p.aggregator)
+        else:
+            return cvs.points(data, x, y, self.p.aggregator)
+            
+
+def uint32_to_uint8(img):
+    return np.flipud(img.view(dtype=np.uint8).reshape(img.shape + (4,)))
+
+
+class Shade(ElementOperation):
+
+    cmap = param.ClassSelector(class_=(Iterable, Callable))
+
+    how = param.ObjectSelector(default='eq_hist', objects=['linear', 'log', 'eq_hist'])
+
+    @classmethod
+    def concatenate(cls, overlay):
+        if not isinstance(overlay, NdOverlay):
+            raise ValueError('Only NdOverlays can be concatenated')
+        xarr = xr.concat([v.data.T for v in overlay.values()], dim=overlay.kdims[0].name)
+        params = dict(get_param_values(overlay.last), vdims=overlay.last.vdims,
+                      kdims=overlay.kdims+overlay.last.kdims)
+        return Dataset(xarr.T, **params)
+
+    def _process(self, element, key=None):
+        if isinstance(element, NdOverlay):
+            bounds = element.last.bounds
+            element = self.concatenate(element)
+        else:
+            bounds = element.bounds
+
+        array = element.data[element.vdims[0].name]
+        kdims = element.kdims
+        shade_opts = dict(how=self.p.how)
+        if element.ndims > 2:
+            kdims = element.kdims[1:]
+            categories = array.shape[-1]
+            if not self.p.cmap:
+                pass
+            elif isinstance(self.p.cmap, Iterator):
+                shade_opts['color_key'] = [c for i, c in
+                                           zip(range(categories), self.p.cmap)]
+            else:
+                shade_opts['color_key'] = [self.p.cmap(s) for s in
+                                           np.linspace(0, 1, categories)]
+        elif not self.p.cmap:
+            pass
+        elif isinstance(self.p.cmap, Callable):
+            shade_opts['cmap'] = [self.p.cmap(s) for s in np.linspace(0, 1, 256)]
+        else:
+            shade_opts['cmap'] = self.p.cmap
+        img = tf.shade(array, **shade_opts)
+        params = dict(get_param_values(element), kdims=kdims,
+                      bounds=bounds)
+        params.pop('vdims')
+        return RGB(uint32_to_uint8(img.data), **params)

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -74,15 +74,20 @@ def dataset_pipeline(dataset, schema, canvas, glyph, summary):
 class Aggregate(ElementOperation):
     """
     Aggregate implements 2D binning for any valid HoloViews Element
-    type using datashader. By default it will simply count the number
-    of values in each bin but other aggregators can be supplied
-    implementing mean, max, min and other reduction operations.
+    type using datashader. I.e., this operation turns a HoloViews
+    Element or overlay of Elements into an hv.Image or an overlay of
+    hv.Images by rasterizing it, which provides a fixed-sized
+    representation independent of the original dataset size.
+
+    By default it will simply count the number of values in each bin
+    but other aggregators can be supplied implementing mean, max, min
+    and other reduction operations.
 
     The bins of the aggregate are defined by the width and height and
     the x_range and y_range. If x_sampling or y_sampling are supplied
-    the operation will ensure that a bin is no smaller than the
-    minimum sampling distance by reducing the width and height when
-    the zoomed in beyond the minimum sampling distance.
+    the operation will ensure that a bin is no smaller than theminimum
+    sampling distance by reducing the width and height when the zoomed
+    in beyond the minimum sampling distance.
     """
 
     aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
@@ -199,7 +204,7 @@ class Shade(ElementOperation):
                                         doc="""
         The normalization operation applied before colormapping.
         Valid options include 'linear', 'log', 'eq_hist', 'cbrt',
-        and any valid transfer function that has data, mask, nbins
+        and any valid transfer function that accepts data, mask, nbins
         arguments.""")
 
     @classmethod

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -17,7 +17,7 @@ from datashape import discover as dsdiscover
 from ..core import (ElementOperation, Element, Dimension, NdOverlay,
                     Overlay, CompositeOverlay, Dataset)
 from ..core.data import ArrayInterface, PandasInterface
-from ..core.util import get_param_values
+from ..core.util import get_param_values, basestring
 from ..element import GridImage, Path, Curve, Contours, RGB
 from ..streams import RangeXY
 
@@ -87,6 +87,9 @@ class Aggregate(ElementOperation):
 
     aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
                                      default=ds.count())
+
+    dynamic = param.Boolean(default=True, doc="""
+       Enables dynamic processing by default.""")
 
     height = param.Integer(default=800, doc="""
        The height of the aggregated image in pixels.""")
@@ -191,11 +194,13 @@ class Shade(ElementOperation):
         Iterable or callable which returns colors as hex colors.
         Callable type must allow mapping colors between 0 and 1.""")
 
-    normalization = param.ObjectSelector(default='eq_hist',
-                                         objects=['linear', 'log',
-                                                  'eq_hist', 'cbrt'],
-                                         doc="""
-        The normalization operation applied before colormapping.""")
+    normalization = param.ClassSelector(default='eq_hist',
+                                        class_=(basestring, Callable),
+                                        doc="""
+        The normalization operation applied before colormapping.
+        Valid options include 'linear', 'log', 'eq_hist', 'cbrt',
+        and any valid transfer function that acces data, mask, nbins
+        arguments.""")
 
     @classmethod
     def concatenate(cls, overlay):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -28,7 +28,7 @@ from ...core import (Store, HoloMap, Overlay, DynamicMap,
 from ...core.options import abbreviated_exception
 from ...core import util
 from ...element import RGB
-from ...streams import Stream
+from ...streams import Stream, RangeXY, RangeX, RangeY
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update
 from .plot import BokehPlot
@@ -660,8 +660,24 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             handles.append(plot.title)
 
         if self.current_frame:
-            if self.framewise or isinstance(self.hmap, DynamicMap):
-                handles += [plot.x_range, plot.y_range]
+            if self.framewise:
+                rangex, rangey = True, True
+            elif isinstance(self.hmap, DynamicMap):
+                rangex, rangey = True, True
+                for stream in self.hmap.streams:
+                    if isinstance(stream, RangeXY):
+                        rangex, rangey = False, False
+                        break
+                    elif isinstance(stream, RangeX):
+                        rangex = False
+                    elif isinstance(stream, RangeY):
+                        rangey = False
+            else:
+                rangex, rangey = False, False
+            if rangex:
+                handles += [plot.x_range]
+            if rangey:
+                handles += [plot.y_range]
         return handles
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -223,10 +223,10 @@ class RangeXY(Stream):
     Axis ranges along x- and y-axis in data coordinates.
     """
 
-    x_range = param.NumericTuple(default=(0, 1), constant=True, doc="""
+    x_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
       Range of the x-axis of a plot in data coordinates""")
 
-    y_range = param.NumericTuple(default=(0, 1), constant=True, doc="""
+    y_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
       Range of the y-axis of a plot in data coordinates""")
 
 
@@ -235,7 +235,7 @@ class RangeX(Stream):
     Axis range along x-axis in data coordinates.
     """
 
-    x_range = param.NumericTuple(default=(0, 1), constant=True, doc="""
+    x_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
       Range of the x-axis of a plot in data coordinates""")
 
 
@@ -244,7 +244,7 @@ class RangeY(Stream):
     Axis range along y-axis in data coordinates.
     """
 
-    y_range = param.NumericTuple(default=(0, 1), constant=True, doc="""
+    y_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
       Range of the y-axis of a plot in data coordinates""")
 
 

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -2,7 +2,9 @@ import param
 
 from .core import DynamicMap, ViewableElement
 from .core.operation import ElementOperation
+from .core.util import Aliases
 from .core import util
+
 
 class Dynamic(param.ParameterizedFunction):
     """

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -19,7 +19,7 @@ class Dynamic(param.ParameterizedFunction):
     """
 
     operation = param.Callable(default=lambda x: x, doc="""
-        Callable to apply to DynamicMap items dynamically.""")
+        Operation or user-defined callable to apply dynamically""")
 
     kwargs = param.Dict(default={}, doc="""
         Keyword arguments passed to the function.""")

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -2,7 +2,7 @@ import param
 
 from .core import DynamicMap, ViewableElement
 from .core.operation import ElementOperation
-
+from .core import util
 
 class Dynamic(param.ParameterizedFunction):
     """
@@ -33,7 +33,13 @@ class Dynamic(param.ParameterizedFunction):
         else:
             dmap = self._make_dynamic(map_obj, callback)
         if isinstance(self.p.operation, ElementOperation):
-            return dmap.clone(streams=[s() for s in self.p.streams])
+            streams = []
+            for s in self.p.streams:
+                stream = s()
+                stream.update(**{k: self.p.operation.p.get(k) for k, v in
+                                 stream.contents.items()})
+                streams.append(stream)
+            return dmap.clone(streams=streams)
         return dmap
 
 

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -1,0 +1,78 @@
+import param
+
+from .core import DynamicMap, ViewableElement
+from .core.operation import ElementOperation
+
+
+class Dynamic(param.ParameterizedFunction):
+    """
+    Dynamically applies a callable to the Elements in any HoloViews
+    object. Will return a DynamicMap wrapping the original map object,
+    which will lazily evaluate when a key is requested. By default
+    Dynamic applies a no-op, making it useful for converting HoloMaps
+    to a DynamicMap.
+
+    Any supplied kwargs will be passed to the callable and any streams
+    will be instantiated on the returned DynamicMap.
+    """
+
+    operation = param.Callable(default=lambda x: x, doc="""
+        Callable to apply to DynamicMap items dynamically.""")
+
+    kwargs = param.Dict(default={}, doc="""
+        Keyword arguments passed to the function.""")
+
+    streams = param.List(default=[], doc="""
+        List of streams to attach to the returned DynamicMap""")
+
+    def __call__(self, map_obj, **params):
+        self.p = param.ParamOverrides(self, params)
+        callback = self._dynamic_operation(map_obj)
+        if isinstance(map_obj, DynamicMap):
+            dmap = map_obj.clone(callback=callback, shared_data=False)
+        else:
+            dmap = self._make_dynamic(map_obj, callback)
+        if isinstance(self.p.operation, ElementOperation):
+            return dmap.clone(streams=[s() for s in self.p.streams])
+        return dmap
+
+
+    def _process(self, element, key=None):
+        if isinstance(self.p.operation, ElementOperation):
+            return self.p.operation.process_element(element, key, **self.p.kwargs)
+        else:
+            return self.p.operation(element, **self.p.kwargs)
+
+
+    def _dynamic_operation(self, map_obj):
+        """
+        Generate function to dynamically apply the operation.
+        Wraps an existing HoloMap or DynamicMap.
+        """
+        if not isinstance(map_obj, DynamicMap):
+            def dynamic_operation(*key, **kwargs):
+                self.p.kwargs.update(kwargs)
+                return self._process(map_obj[key], key)
+            return dynamic_operation
+
+        def dynamic_operation(*key, **kwargs):
+            key = key[0] if map_obj.mode == 'open' else key
+            self.p.kwargs.update(kwargs)
+            _, el = util.get_dynamic_item(map_obj, map_obj.kdims, key)
+            return self._process(el, key)
+
+        return dynamic_operation
+
+
+    def _make_dynamic(self, hmap, dynamic_fn):
+        """
+        Accepts a HoloMap and a dynamic callback function creating
+        an equivalent DynamicMap from the HoloMap.
+        """
+        if isinstance(hmap, ViewableElement):
+            return DynamicMap(dynamic_fn, kdims=[])
+        dim_values = zip(*hmap.data.keys())
+        params = util.get_param_values(hmap)
+        kdims = [d(values=list(set(values))) for d, values in
+                 zip(hmap.kdims, dim_values)]
+        return DynamicMap(dynamic_fn, **dict(params, kdims=kdims))

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -1,6 +1,6 @@
 import numpy as np
 from holoviews import Dimension, DynamicMap, Image, HoloMap
-from holoviews.core.operation import DynamicFunction
+from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
 frequencies =  np.linspace(0.5,2.0,5)
@@ -82,19 +82,19 @@ class DynamicTestSampledBounded(ComparisonTestCase):
 
 class DynamicTestOperation(ComparisonTestCase):
 
-    def test_dynamic_function(self):
+    def test_dynamic_operation(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, sampled=True)
-        dmap_with_fn = DynamicFunction(dmap, function=lambda x: x.clone(x.data*2))
+        dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
 
-    def test_dynamic_function_with_kwargs(self):
+    def test_dynamic_operation_with_kwargs(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, sampled=True)
         def fn(x, multiplier=2):
             return x.clone(x.data*multiplier)
-        dmap_with_fn = DynamicFunction(dmap, function=fn, kwargs=dict(multiplier=3))
+        dmap_with_fn = Dynamic(dmap, operation=fn, kwargs=dict(multiplier=3))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*3))
 
 


### PR DESCRIPTION
As suggested in #812 this adds datashader operations to HoloViews, making it trivial to aggregate any Element type into an Image or stack of images and then shade it. The PR currently adds two main operations:

* Aggregate: Takes any 2D dataset with or without values and generates a ``GridImage`` aggregate wrapping an xarray DataArray.
* Shade: Takes the output of an aggregate and applies color interpolation and a transfer function ('linear', 'log', 'eq_hist'), returning an RGB element.

I've not yet written docstrings or any tests yet, but I do have the initial skeleton of a tutorial: https://anaconda.org/philippjfr/holoviews_datashader/notebook