### PR TITLE
Fixed extents on bokeh HistogramPlot

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -231,6 +231,13 @@ class HistogramPlot(ElementPlot):
         self._get_hover_data(data, element, empty)
         return (data, mapping)
 
+    def get_extents(self, element, ranges):
+        x0, y0, x1, y1 = super(HistogramPlot, self).get_extents(element, ranges)
+        y0 = np.nanmin([0, y0])
+        y1 = np.nanmax([0, y1])
+        return (x0, y0, x1, y1)
+
+
 
 class SideHistogramPlot(HistogramPlot, ColorbarPlot):
 


### PR DESCRIPTION
The extents of the Histogram were not correctly computed previously showing just the region between the min and max bin value. Histograms bins should instead reach down (or up) to zero.