### PR TITLE
Fixed empty NdOverlay on initialization in batched mode

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -44,6 +44,8 @@ class LineAnnotationPlot(ElementPlot):
 
     _update_handles = ['glyph']
 
+    _plot_methods = dict(single='Span')
+
     def get_data(self, element, ranges=None, empty=False):
         data, mapping = {}, {}
         mapping['dimension'] = 'width' if isinstance(element, HLine) else 'height'

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -26,7 +26,7 @@ import param
 
 from ...core import (Store, HoloMap, Overlay, DynamicMap,
                      CompositeOverlay, Element)
-from ...core.options import abbreviated_exception
+from ...core.options import abbreviated_exception, SkipRendering
 from ...core import util
 from ...element import RGB
 from ...streams import Stream, RangeXY, RangeX, RangeY
@@ -1013,7 +1013,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     def initialize_plot(self, ranges=None, plot=None, plots=None):
         key = self.keys[-1]
-        element = [el for el in self.hmap.data.values() if len(el)][-1]
+        nonempty = [el for el in self.hmap.data.values() if len(el)]
+        if not nonempty:
+            raise SkipRendering('All Overlays empty, cannot initialize plot.')
+        element = nonempty[-1]
         ranges = self.compute_ranges(self.hmap, key, ranges)
         if plot is None and not self.tabs and not self.batched:
             plot = self._init_plot(key, element, ranges=ranges, plots=plots)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -539,7 +539,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Initializes a new plot object with the last available frame.
         """
         # Get element key and ranges for frame
-        element = self.hmap.last
+        if self.batched:
+            element = [el for el in self.hmap.data.values() if len(el)][-1]
+        else:
+            element = self.hmap.last
         key = self.keys[-1]
         ranges = self.compute_ranges(self.hmap, key, ranges)
         self.current_ranges = ranges
@@ -1010,7 +1013,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     def initialize_plot(self, ranges=None, plot=None, plots=None):
         key = self.keys[-1]
-        element = self._get_frame(key)
+        element = [el for el in self.hmap.data.values() if len(el)][-1]
         ranges = self.compute_ranges(self.hmap, key, ranges)
         if plot is None and not self.tabs and not self.batched:
             plot = self._init_plot(key, element, ranges=ranges, plots=plots)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -559,8 +559,8 @@ class GenericElementPlot(DimensionedPlot):
             self.hmap = element
 
         plot_element = self.hmap.last
-        if self.batched:
-            plot_element = plot_element.last
+        if self.batched and not isinstance(self, GenericOverlayPlot):
+            plot_element = [el for el in plot_element if len(el) > 0][-1]
 
         top_level = keys is None
         if top_level:
@@ -851,7 +851,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
             if issubclass(plottype, GenericOverlayPlot):
                 opts['show_legend'] = self.show_legend
-            elif self.batched:
+            elif self.batched and 'batched' in plottype._plot_methods:
                 opts['batched'] = self.batched
             if len(ordering) > self.legend_limit:
                 opts['show_legend'] = False


### PR DESCRIPTION
Previously some parts of the plotting code would receive empty NdOverlays on initialization causing it to break. Now the plot is initialized on the last non-empty frame. Since the plot is updated subsequently with the correct frame this should not cause any issues.