### PR TITLE
Allow multiple streams attached to the same plot model

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -486,7 +486,9 @@ class DimensionedPlot(Plot):
         """
         traverse_setter(self, '_force', True)
         key = self.current_key if self.current_key else self.keys[0]
-        stream_params = stream_parameters(self.streams)
+        dim_streams = [stream for stream in self.streams
+                       if any(c in self.dimensions for c in stream.contents)]
+        stream_params = stream_parameters(dim_streams)
         key = tuple(None if d in stream_params else k
                     for d, k in zip(self.dimensions, key))
         stream_key = util.wrap_tuple_streams(key, self.dimensions, self.streams)

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -1,10 +1,12 @@
+import inspect
+
 import param
 
 from .core import DynamicMap, ViewableElement
 from .core.operation import ElementOperation
 from .core.util import Aliases
 from .core import util
-
+from .streams import Stream
 
 class Dynamic(param.ParameterizedFunction):
     """
@@ -36,8 +38,12 @@ class Dynamic(param.ParameterizedFunction):
             dmap = self._make_dynamic(map_obj, callback)
         if isinstance(self.p.operation, ElementOperation):
             streams = []
-            for s in self.p.streams:
-                stream = s()
+            for stream in self.p.streams:
+                if inspect.isclass(stream) and issubclass(stream, Stream):
+                    stream = stream()
+                elif not isinstance(stream, Stream):
+                    raise ValueError('Stream must only contain Stream '
+                                     'classes or instances')
                 stream.update(**{k: self.p.operation.p.get(k) for k, v in
                                  stream.contents.items()})
                 streams.append(stream)


### PR DESCRIPTION
Currently when multiple streams are attached to the same plot model they will override each other. This PR ensures that  either the python callback or the JS callback are merged depending on whether the callback is of the same type. This is mostly a problem if two separate plots attach distinct streams to a set of linked axes. It also includes a fix for Layouts with multiple streams of the same type across the subplots, which would previously complain about parameter overlap. Finally it allows supplying stream instances to operations instead of instantiating a Stream instance internally, which can be useful to get a handle on the stream.

Here's a demo:

```
points = hv.Points(np.random.multivariate_normal((0,0), [[0.1, 0.1], [0.1, 1.0]], (1000000,)))
Datashade(points) + decimate(points)
```

![linked_datadecimate](https://cloud.githubusercontent.com/assets/1550771/19133033/3d18f502-8b4e-11e6-9b6b-43ad0f3f3ab2.gif)
