### PR TITLE
Added ipython_canary_method to disabled prefix list

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -37,7 +37,7 @@ except ImportError:
 
 
 Collector.interval_hook = RunProgress
-AttrTree._disabled_prefixes = ['_repr_']
+AttrTree._disabled_prefixes = ['_repr_','_ipython_canary_method_should_not_exist']
 
 def show_traceback():
     """


### PR DESCRIPTION
Fixes the annoying appearance of ``_ipython_canary_method_should_not_exist`` on AttrTrees such as Layouts and Overlays.