### PR TITLE
Switched AttrTree dir mode to 'user'

### DIFF
--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -43,7 +43,7 @@ class AttrTree(object):
         else:
             return dir(type(self)) + list(dict_keys)
 
-    def __init__(self, items=None, identifier=None, parent=None, dir_mode='default'):
+    def __init__(self, items=None, identifier=None, parent=None, dir_mode='user'):
         """
         identifier: A string identifier for the current node (if any)
         parent:     The parent node (if any)


### PR DESCRIPTION
By design, `AttrTrees` are supposed to allow easy tab-completion with capitalized names coming first and lowercase attributes coming later. This is the reason we capitalize the path components of Layouts and Overlays.

In some recent version of IPython, this behavior has been broken:

![image](https://cloud.githubusercontent.com/assets/890576/19274291/8ce62d8e-8fc7-11e6-9c6f-28b7ac775521.png)

Infuriatingly, the tab-completer even ignores the order of the values output by `__dir__`.

As a result, I've switched the dir_mode to 'user' to make AttrTrees work as intended. It means you won't see tab completion of the methods (e.g select) but at least you will see the items of the AttrTree properly.
