### PR TITLE
Ensure get_dynamic_item does not modify object

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -957,8 +957,8 @@ def get_dynamic_item(map_obj, dimensions, key):
     dmaps = map_obj.traverse(lambda x: x, ['DynamicMap'])
     dmap = dmaps[0] if dmaps else map_obj
     if key == () and (not dimensions or not dmap.kdims):
-        return key, map_obj.map(lambda x: x[()], ['DynamicMap', 'HoloMap'],
-                                clone=False)
+        map_obj.traverse(lambda x: x[()], ['DynamicMap'])
+        return key, map_obj.map(lambda x: x.last, ['DynamicMap'])
     elif isinstance(key, tuple):
         dims = {d.name: k for d, k in zip(dimensions, key)
                 if d in map_obj.kdims}
@@ -968,8 +968,8 @@ def get_dynamic_item(map_obj, dimensions, key):
         key_offset = max([key-map_obj.cache_size, 0])
         key = map_obj.keys()[min([key-key_offset,
                                   len(map_obj)-1])]
-        el = map_obj.map(lambda x: x[key], ['DynamicMap'],
-                         clone=False)
+        map_obj.traverse(lambda x: x[key], ['DynamicMap'])
+        el = map_obj.map(lambda x: x[key], ['DynamicMap'])
     elif key >= map_obj.counter:
         el = next(map_obj)
         key = list(map_obj.keys())[-1]


### PR DESCRIPTION
So this was a pretty nasty bug, turns out my usage of ``.map`` with ``clone=False`` was modifying the object causing various weird bugs. This PR is a bit of an ugly workaround updating the item in DynamicMaps using a ``map`` call that doesn't modify the object and updates it and a separate map call to actually get the item. Can't think of a better to solution to update composite objects (i.e. Layouts and AdjointLayout) containing dimensionless DynamicMaps since ``select`` won't work.