### PR TITLE
Bokeh adjoined histogram adds support for live colormapping

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -186,11 +186,12 @@ class Callback(object):
         attributes = attributes_js(self.attributes)
         code = 'var data = {};\n' + attributes + self.code + self_callback
 
-        handles = dict(self.plot.handles)
+        handles = {}
         subplots = list(self.plot.subplots.values())[::-1] if self.plot.subplots else []
         plots = [self.plot] + subplots
         for plot in plots:
-            handles.update(plot.handles)
+            handles.update({k: v for k, v in plot.handles.items()
+                            if k in self.handles})
         # Set callback
         if id(handle.callback) in self._callbacks:
             cb = self._callbacks[id(handle.callback)]

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -263,16 +263,8 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
                         right=element.edges[1:])
 
         dim = element.get_dimension(0)
-        main = self.adjoined.main
-        range_item, main_range, _ = get_sideplot_ranges(self, element, main, ranges)
-        if isinstance(range_item, (Raster, Points, Polygons, Spikes)):
-            style = self.lookup_options(range_item, 'style')[self.cyclic_index]
-        else:
-            style = {}
-
-        if 'cmap' in style or 'palette' in style:
-            main_range = {dim.name: main_range}
-            cmapper = self._get_colormapper(dim, element, main_range, style)
+        cmapper = self._get_colormapper(dim, element, {}, {})
+        if cmapper:
             data[dim.name] = [] if empty else element.dimension_values(dim)
             mapping['fill_color'] = {'field': dim.name,
                                      'transform': cmapper}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -786,6 +786,16 @@ class ColorbarPlot(ElementPlot):
         # and then only updated
         low, high = ranges.get(dim.name, element.range(dim.name))
         palette = mplcmap_to_palette(style.pop('cmap', 'viridis'))
+        if self.adjoined:
+            cmappers = self.adjoined.traverse(lambda x: (x.handles.get('color_dim'),
+                                                         x.handles.get('color_mapper')))
+            cmappers = [cmap for cdim, cmap in cmappers if cdim == dim]
+            if cmappers:
+                cmapper = cmappers[0]
+                self.handles['color_mapper'] = cmapper
+                return cmapper
+            else:
+                return None
         if 'color_mapper' in self.handles:
             cmapper = self.handles['color_mapper']
             cmapper.low = low
@@ -795,6 +805,7 @@ class ColorbarPlot(ElementPlot):
             colormapper = LogColorMapper if self.logz else LinearColorMapper
             cmapper = colormapper(palette, low=low, high=high)
             self.handles['color_mapper'] = cmapper
+            self.handles['color_dim'] = dim
         return cmapper
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -219,7 +219,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         tools = [t for t in cb_tools + self.default_tools + self.tools
                  if t not in tool_names]
-        if 'hover' in tools+tool_names:
+        if 'hover' in tools:
             tools[tools.index('hover')] = HoverTool(tooltips=tooltips)
         return tools
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -205,10 +205,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     for d in dims]
 
         callbacks = callbacks+self.callbacks
-        cb_tools = []
+        cb_tools, tool_names = [], []
         for cb in callbacks:
             for handle in cb.handles:
                 if handle and handle in known_tools:
+                    tool_names.append(handle)
                     if handle == 'hover':
                         tool = HoverTool(tooltips=tooltips)
                     else:
@@ -216,8 +217,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     cb_tools.append(tool)
                     self.handles[handle] = tool
 
-        tools = cb_tools + self.default_tools + self.tools
-        if 'hover' in tools:
+        tools = [t for t in cb_tools + self.default_tools + self.tools
+                 if t not in tool_names]
+        if 'hover' in tools+tool_names:
             tools[tools.index('hover')] = HoverTool(tooltips=tooltips)
         return tools
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -363,7 +363,6 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
         """
         subplots = {}
         adjoint_clone = layout.clone(shared_data=False, id=layout.id)
-        subplot_opts = dict(adjoined=layout)
         main_plot = None
         for pos in positions:
             # Pos will be one of 'main', 'top' or 'right' or None
@@ -371,6 +370,7 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
             if element is None:
                 continue
 
+            subplot_opts = dict(adjoined=main_plot)
             # Options common for any subplot
             if type(element) in (NdLayout, Layout):
                 raise SkipRendering("Cannot plot nested Layouts.")


### PR DESCRIPTION
An adjoined histogram in bokeh now automatically shares the color mapper of whatever plot it is adjoined to it and adds a ``box_select`` tool with a ``CustomJS`` to update that colormapper based on the current selection. Since this callback is pure JS this will also work on static export.

![dynamic_colormap](https://cloud.githubusercontent.com/assets/1550771/19293839/a9fa9b0a-901f-11e6-893e-afb2b490f76a.gif)
