### PR TITLE
Added log option to histogram operation

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -479,7 +479,7 @@ class histogram(ElementOperation):
       Specifies whether the histogram will be rescaled for each Raster in a UniformNdMapping.""")
 
     log = param.Boolean(default=False, doc="""
-      Whether to apply log scaling """)
+      Whether to use base 10 logarithmic samples for the bin edges.""")
 
     mean_weighted = param.Boolean(default=False, doc="""
       Whether the weighted frequencies are averaged.""")

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -265,7 +265,7 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
 
     def get_data(self, element, ranges=None, empty=None):
         if self.invert_axes:
-            mapping = dict(top='left', bottom='right', left=0, right='top')
+            mapping = dict(top='right', bottom='left', left=0, right='top')
         else:
             mapping = dict(top='top', bottom=0, left='left', right='right')
 


### PR DESCRIPTION
This adds a log option to the histogram operation, which automatically generates logarithmic sampling for the histogram bins. Also includes a small fix to fix bokeh histograms with inverted axes.