### PR TITLE
Added stream activate and deactivate methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh pandas jupyter ipython=4.2.0 param matplotlib=1.5.1 xarray datashader
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh pandas jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader
   - source activate test-environment
   - conda install -c conda-forge  -c scitools iris sip=4.18 plotly
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -106,6 +106,9 @@ class Stream(param.Parameterized):
         for subscriber in subscribers:
             subscriber(**dict(union))
 
+        for stream in streams:
+            stream.deactivate()
+
 
     def __init__(self, preprocessors=[], source=None, subscribers=[], **params):
         """
@@ -124,6 +127,15 @@ class Stream(param.Parameterized):
         super(Stream, self).__init__(**params)
         if source:
             self.registry[id(source)].append(self)
+
+
+    def deactivate(self):
+        """
+        Allows defining an action after the stream has been triggered,
+        e.g. resetting parameters on streams with transient events.
+        """
+        pass
+
 
     @property
     def source(self):
@@ -153,6 +165,7 @@ class Stream(param.Parameterized):
         If trigger is enabled, the trigger classmethod is invoked on
         this particular Stream instance.
         """
+        self.activate()
         params = self.params().values()
         constants = [p.constant for p in params]
         for param in params:
@@ -160,9 +173,6 @@ class Stream(param.Parameterized):
         self.set_param(**kwargs)
         for (param, const) in zip(params, constants):
             param.constant = const
-
-        if trigger:
-            self.trigger([self])
 
 
     def __repr__(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -165,7 +165,6 @@ class Stream(param.Parameterized):
         If trigger is enabled, the trigger classmethod is invoked on
         this particular Stream instance.
         """
-        self.activate()
         params = self.params().values()
         constants = [p.constant for p in params]
         for param in params:
@@ -173,6 +172,9 @@ class Stream(param.Parameterized):
         self.set_param(**kwargs)
         for (param, const) in zip(params, constants):
             param.constant = const
+
+        if trigger:
+            self.trigger([self])
 
 
     def __repr__(self):


### PR DESCRIPTION
Adds ``Stream.activate`` and ``Stream.deactivate`` methods to streams to be triggered just before updating parameters and just after triggering the stream respectively. This allows defining custom actions after an event, e.g. in order to reset the value after an event has been processed.