### PR TITLE
Added event method to DynamicMap

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -536,6 +536,22 @@ class DynamicMap(HoloMap):
                     raise StopIteration("Key value %s above upper bound %s"
                                         % (val, high))
 
+    def event(self, trigger=True, **kwargs):
+        """
+        This method allows any of the available stream parameters to be
+        updated in an event.
+        """
+        stream_params = set(util.stream_parameters(self.streams))
+        updated_streams = []
+        for stream in self.streams:
+            overlap = set(stream.params().keys()) & stream_params & set(kwargs.keys())
+            if overlap:
+                stream.update(**dict({k:kwargs[k] for k in overlap}, trigger=False))
+                updated_streams.append(stream)
+
+        if updated_streams and trigger:
+            updated_streams[0].trigger(updated_streams)
+
 
     def _style(self, retval):
         """


### PR DESCRIPTION

When prototyping the streams system, one thing we were wondering about was how to easily access streams from a DynamicMap in order to call ``update``. The problem is you either need to keep a handle on the stream object or would need to use some mechanism to access the stream via some (optional) assigned name or by index. This poses some difficult problems and this PR suggests an alternative approach that bypasses this issue completely.

The ``event`` method on a ``DynamicMap`` does not deal with stream objects, just stream parameters. The appropriate streams that require updating are computed behind the scenes which works well as the identity of the streams is often of less interest to the user than the set of stream parameters (these are the keyword arguments passed to the ``DynamicMap`` callback).

If nothing else, the ``event`` method is is useful for debugging it will always allow print statements to appear in the notebook. Note that this isn't true for direct Bokeh interaction streams which sends such print statements to the web console:

![image](https://cloud.githubusercontent.com/assets/890576/19419386/423b0d94-93ce-11e6-9957-3bc1d47fc772.png)

Earlier on, I proposed that the ``update`` method of streams could also be renamed to ``event`` for consistency - unfortunately ``update`` already exists on ``DynamicMap`` as it inherits the method from ``HoloMap`` otherwise I would have called this method ``update`` too.

I no longer feel this is particularly important. This PR will mean that users rarely use an ``update`` method in any context: it is rarely used by users on ``HoloMaps`` or ``DynamicMaps`` and this new ``event`` method means users won't have to use the ``update`` method on streams either. That said, I'm still open to renaming ``update`` on streams to ``event`` if we feel this is better for overall consistency.

Lastly, I will want to have a tutorial demonstrating the ``event`` method as a way of building visualizations with streams. In particular, I will want a notebook demonstrating it with a visualization using a mix of kdims and dimensioned streams.