### PR TITLE
Dataset range fix

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -187,7 +187,7 @@ class Dataset(Element):
         object.
         """
         dim = self.get_dimension(dim)
-        if dim.range != (None, None):
+        if None not in dim.range:
             return dim.range
         elif dim in self.dimensions():
             if len(self):
@@ -197,11 +197,18 @@ class Dataset(Element):
         if data_range:
             soft_range = [r for r in dim.soft_range if r is not None]
             if soft_range:
-                return util.max_range([drange, soft_range])
-            else:
-                return drange
+                drange = util.max_range([drange, soft_range])
         else:
-            return dim.soft_range
+            drange = dim.soft_range
+        fixed_min = None if dim.range[0] is None else dim.range[0]
+        fixed_max = None if dim.range[1] is None else dim.range[1]
+        if fixed_min:
+            return (fixed_min, drange[1])
+        elif fixed_max:
+            return (drange[0], fixed_max)
+        else:
+            return drange
+
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -200,12 +200,10 @@ class Dataset(Element):
                 drange = util.max_range([drange, soft_range])
         else:
             drange = dim.soft_range
-        fixed_min = None if dim.range[0] is None else dim.range[0]
-        fixed_max = None if dim.range[1] is None else dim.range[1]
-        if fixed_min:
-            return (fixed_min, drange[1])
-        elif fixed_max:
-            return (drange[0], fixed_max)
+        if dim.range[0] is not None:
+            return (dim.range[0], drange[1])
+        elif dim.range[1] is not None:
+            return (drange[0], dim.range[1])
         else:
             return drange
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -369,6 +369,9 @@ class SpikesPlot(PathPlot, ColorbarPlot):
         l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges)
         if len(element.dimensions()) == 1:
             b, t = self.position, self.position+self.spike_length
+        else:
+            b = np.nanmin([0, b])
+            t = np.nanmax([0, t])
         return l, b, r, t
 
     def get_data(self, element, ranges=None, empty=False):

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -907,9 +907,12 @@ class SpikesPlot(PathPlot, ColorbarPlot):
 
     def get_extents(self, element, ranges):
         l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges)
-        ndims = len(element.dimensions(label=True))
-        max_length = t if ndims > 1 else self.spike_length
-        return (l, self.position, r, self.position+max_length)
+        if len(element.dimensions()) == 1:
+            b, t = self.position, self.position+self.spike_length
+        else:
+            b = np.nanmin([0, b])
+            t = np.nanmax([0, t])
+        return l, b, r, t
 
 
     def get_data(self, element, ranges, style):


### PR DESCRIPTION
The ``Dataset.range`` method was not correctly processing one-sided fixed ranges, e.g. a Dimension with ``range=(0, None)`` would override the actual upper-bound with None, rather than letting it auto-compute the part of the range that is unspecified. This PR fixes this issue and adds a small fix for computing the correct extents on SpikesPlots.