### PR TITLE
Suppress resources warning for failed backend imports

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -149,10 +149,16 @@ class notebook_extension(param.ParameterizedFunction):
                    if name in args or params.get(name, False)]
         if not imports or 'matplotlib' not in Store.renderers:
             imports = imports + [('matplotlib', 'mpl')]
+
+        args = list(args)
         for backend, imp in imports:
             try:
                 __import__('holoviews.plotting.%s' % imp)
             except ImportError:
+                if backend in args:
+                    args.pop(backend)
+                if backend in params:
+                    params.pop(backend)
                 self.warning("HoloViews %s backend could not be imported, "
                              "ensure %s is installed." % (backend, backend))
             finally:


### PR DESCRIPTION
When a backend can't be imported the resources warning will be suppressed ensuring that only one warning is raised.