### PR TITLE
Parser fixes

### DIFF
--- a/holoviews/ipython/parser.py
+++ b/holoviews/ipython/parser.py
@@ -86,7 +86,8 @@ class Parser(object):
         for keyword in grouped:
             # Tuple ('a', 3) becomes (,'a',3) and '(,' is never valid
             # Same for some of the other joining errors corrected here
-            for (fst,snd) in [('(,', '('), ('{,', '{'), ('=,','='), (',:',':')]:
+            for (fst,snd) in [('(,', '('), ('{,', '{'), ('=,','='),
+                              (',:',':'), (':,', ':'), (',,', ',')]:
                 keyword = keyword.replace(fst, snd)
             try:
                 kwargs.update(eval('dict(%s)' % keyword,

--- a/holoviews/ipython/parser.py
+++ b/holoviews/ipython/parser.py
@@ -43,6 +43,18 @@ class Parser(object):
         return kw[1:] if kw[0]==',' else kw
 
     @classmethod
+    def recurse_token(cls, token, inner):
+        recursed = []
+        for tok in token:
+            if isinstance(tok, list):
+                new_tok = [recurse_token(t, inner) if isinstance(t, list) else t
+                           for t in tok]
+                recursed.append((inner % ''.join(new_tok)))
+            else:
+                recursed.append(tok)
+        return recursed
+
+    @classmethod
     def collect_tokens(cls, parseresult, mode):
         """
         Collect the tokens from a (potentially) nested parse result.
@@ -53,6 +65,7 @@ class Parser(object):
         for token in parseresult.asList():
             # If value is a tuple, the token will be a list
             if isinstance(token, list):
+                token = cls.recurse_token(token, inner)
                 tokens[-1] = tokens[-1] + (inner % ''.join(token))
             else:
                 if token.strip() == ',': continue

--- a/tests/testparsers.py
+++ b/tests/testparsers.py
@@ -48,6 +48,20 @@ class OptsSpecPlotOptionsTests(ComparisonTestCase):
                     Options(title_format='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
+    def test_plot_opts_dict_with_space(self):
+        line = "Curve [fontsize={'xlabel': 10, 'title': 20}]"
+        expected = {'Curve': {'plot': Options(fontsize={'xlabel': 10, 'title': 20})}}
+        self.assertEqual(OptsSpec.parse(line), expected)
+
+    def test_plot_opts_dict_without_space(self):
+        line = "Curve [fontsize=dict(xlabel=10,title=20)]"
+        expected = {'Curve': {'plot': Options(fontsize={'xlabel': 10, 'title': 20})}}
+        self.assertEqual(OptsSpec.parse(line), expected)
+
+    def test_plot_opts_nested_brackets(self):
+        line = "Curve [title_format=', '.join(('A', 'B'))]"
+        expected = {'Curve': {'plot': Options(title_format='A, B')}}
+        self.assertEqual(OptsSpec.parse(line), expected)
 
 
 class OptsSpecStyleOptionsTests(ComparisonTestCase):
@@ -89,6 +103,38 @@ class OptsSpecStyleOptionsTests(ComparisonTestCase):
                                      b=True,
                                      color=Cycle(values=[1,2]))}}
         self.assertEqual(OptsSpec.parse(line), expected)
+
+    def test_style_opts_dict_with_space(self):
+        line = "Curve (fontsize={'xlabel': 10, 'title': 20})"
+        expected = {'Curve': {'style': Options(fontsize={'xlabel': 10, 'title': 20})}}
+        self.assertEqual(OptsSpec.parse(line), expected)
+
+    def test_style_opts_dict_without_space(self):
+        line = "Curve (fontsize={'xlabel': 10,'title': 20})"
+        expected = {'Curve': {'style': Options(fontsize={'xlabel': 10, 'title': 20})}}
+        self.assertEqual(OptsSpec.parse(line), expected)
+
+    def test_style_opts_cycle_function(self):
+        # Explicitly compare because list of arrays do not compare correctly
+        import numpy as np
+        np.random.seed(42)
+        line = "Curve (color=Cycle(values=list(np.random.rand(3,3))))"
+        options = OptsSpec.parse(line, {'np': np, 'Cycle': Cycle})
+        self.assertTrue('Curve' in options)
+        self.assertTrue('style' in options['Curve'])
+        self.assertTrue('color' in options['Curve']['style'].kwargs)
+        self.assertTrue(isinstance(options['Curve']['style'].kwargs['color'], Cycle))
+        values = np.array([[ 0.37454012,  0.95071431,  0.73199394],
+                           [ 0.59865848,  0.15601864,  0.15599452],
+                           [ 0.05808361,  0.86617615,  0.60111501]])
+        expected = {'Curve': {'style': Options(color=Cycle(values=list(values)))}}
+        self.assertEqual(np.array(options['Curve']['style'].kwargs['color'].values),
+                         values)
+
+    def test_style_opts_cycle_list(self):
+        line = "Curve (color=Cycle(values=['r', 'g', 'b']))"
+        expected = {'Curve': {'style': Options(color=Cycle(values=['r', 'g', 'b']))}}
+        self.assertEqual(OptsSpec.parse(line, {'Cycle': Cycle}), expected)
 
 
 


### PR DESCRIPTION
Two small fixes for the parser, the first fixes passing dictionary literals by eliminating duplicate commas generated by the parser, fixing part of the issue described in #270, e.g. this is now allowed:

```python
%%opts Scatter [fontsize={'title': '20pt'}]
hv.Scatter(np.random.rand(100,2), group='A')
```

Secondly it fixes a bug when a opts definition includes nested bracketing as described in #930, which described an issue where:

```
%%opts Curve (color=hv.Cycle(values=sns.color_palette('Set1')))
hv.Overlay([hv.Curve(np.arange(10)*i) for i in range(3)])
```

Was not evaluated correctly. This is now also correctly processed.

Note that this does not fix all issues mentioned in #270, e.g. ``aspect=dict(x=1, x=2, z=3)`` still fails to evaluate, but it provides a significant improvement in some cases.