### PR TITLE
Ignore empty slice warning when plotting Layout containing Empty

### DIFF
--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -53,11 +53,11 @@ def normalize_ratios(ratios):
 
 def compute_ratios(ratios, normalized=True):
     unpacked = unpack_adjoints(ratios)
-    if normalized:
-        unpacked = normalize_ratios(unpacked)
-    sorted_ratios = sorted(unpacked.items())
     with warnings.catch_warnings():
         warnings.filterwarnings('ignore', r'All-NaN (slice|axis) encountered')
+        if normalized:
+            unpacked = normalize_ratios(unpacked)
+        sorted_ratios = sorted(unpacked.items())
         return np.nanmax(np.vstack([v for _, v in sorted_ratios]), axis=0)
 
 


### PR DESCRIPTION
Ensures no warning is raised when plotting Layout containing Empty element as described in #888.