### PR TITLE
Mapping types complain when supplied with vdims

### DIFF
--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -87,6 +87,8 @@ class MultiDimensionalMapping(Dimensioned):
 
     kdims = param.List(default=[Dimension("Default")], constant=True)
 
+    vdims = param.List(default=[], bounds=(0, 0), constant=True)
+
     data_type = None          # Optional type checking of elements
     _deep_indexable = False
     _sorted = True


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/811, ``NdMapping`` types will now error when you supply any value dimensions (vdims).