### PR TITLE
Dynamic Callable API

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -161,8 +161,14 @@ class ElementOperation(Operation):
 
 
 class OperationCallable(Callable):
+    """
+    OperationCallable allows wrapping an ElementOperation and the
+    objects it is processing to allow traversing the operations
+    applied on a DynamicMap.
+    """
 
-    operation = param.ClassSelector(class_=ElementOperation)
+    operation = param.ClassSelector(class_=ElementOperation, doc="""
+        The ElementOperation being wrapped.""")
 
 
 class MapOperation(param.ParameterizedFunction):

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -14,7 +14,7 @@ from .dimension import ViewableElement
 from .element import Element, HoloMap, GridSpace, Collator
 from .layout import Layout
 from .overlay import NdOverlay, Overlay
-from .spaces import DynamicMap
+from .spaces import DynamicMap, Callable
 from .traversal import unique_dimkeys
 from . import util
 
@@ -159,6 +159,10 @@ class ElementOperation(Operation):
             raise ValueError("Cannot process type %r" % type(element).__name__)
         return processed
 
+
+class OperationCallable(Callable):
+
+    operation = param.ClassSelector(class_=ElementOperation)
 
 
 class MapOperation(param.ParameterizedFunction):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -29,7 +29,7 @@ class Overlayable(object):
                 element = other[args]
                 return self * element
             callback = Callable(callable_function=dynamic_mul,
-                                objects=[self, other])
+                                inputs=[self, other])
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,10 +24,14 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from ..util import Dynamic
-            def dynamic_mul(element):
+            from .spaces import Callable
+            def dynamic_mul(*args, **kwargs):
+                element = other[args]
                 return self * element
-            return Dynamic(other, operation=dynamic_mul)
+            callback = Callable(callable_function=dynamic_mul,
+                                objects=[self, other])
+            return other.clone(shared_data=False, callback=callback,
+                               streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -144,7 +144,7 @@ class HoloMap(UniformNdMapping):
             except KeyError:
                 pass
             return Overlay(layers)
-        callback = Callable(callable_function=dynamic_mul, objects=[self, other])
+        callback = Callable(callable_function=dynamic_mul, inputs=[self, other])
         if map_obj:
             return map_obj.clone(callback=callback, shared_data=False,
                                  kdims=dimensions, streams=[])
@@ -211,7 +211,7 @@ class HoloMap(UniformNdMapping):
                     element = self[args]
                     return element * other
                 callback = Callable(callable_function=dynamic_mul,
-                                    objects=[self, other])
+                                    inputs=[self, other])
                 return self.clone(shared_data=False, callback=callback,
                                   streams=[])
             items = [(k, v * other) for (k, v) in self.data.items()]
@@ -401,18 +401,18 @@ class HoloMap(UniformNdMapping):
 
 class Callable(param.Parameterized):
     """
-    Callable allows wrapping callbacks on one or more DynamicMaps such
-    that the operation and the objects that are part of the operation
-    are made available. This allows traversing a DynamicMap that wraps
-    multiple operations and is primarily used to extracting any
-    streams attached to the object.
+    Callable allows wrapping callbacks on one or more DynamicMaps
+    allowing their inputs (and in future outputs) to be defined.
+    This makes it possible to wrap DynamicMaps with streams and
+    makes it possible to traverse the graph of operations applied
+    to a DynamicMap.
     """
 
     callable_function = param.Callable(default=lambda x: x, doc="""
          The callable function being wrapped.""")
 
-    objects = param.List(default=[], doc="""
-         The objects the callable function is processing.""")
+    inputs = param.List(default=[], doc="""
+         The list of inputs the callable function is wrapping.""")
 
     def __call__(self, *args, **kwargs):
         return self.callable_function(*args, **kwargs)
@@ -425,7 +425,7 @@ def get_streams(dmap):
     layer_streams = list(dmap.streams)
     if not isinstance(dmap.callback, Callable):
         return layer_streams
-    for o in dmap.callback.objects:
+    for o in dmap.callback.inputs:
         if isinstance(o, DynamicMap):
             layer_streams += get_streams(o)
     return layer_streams

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -418,16 +418,17 @@ class Callable(param.Parameterized):
         return self.callable_function(*args, **kwargs)
 
 
-def get_streams(dmap):
+def get_nested_streams(dmap):
     """
-    Get streams from DynamicMap with Callable callback.
+    Get all (potentially nested) streams from DynamicMap with Callable
+    callback.
     """
     layer_streams = list(dmap.streams)
     if not isinstance(dmap.callback, Callable):
         return layer_streams
     for o in dmap.callback.inputs:
         if isinstance(o, DynamicMap):
-            layer_streams += get_streams(o)
+            layer_streams += get_nested_streams(o)
     return layer_streams
 
 
@@ -726,8 +727,8 @@ class DynamicMap(HoloMap):
 
         # Cache lookup
         try:
-            dimensionless = util.dimensionless_contents(get_streams(self),
-                                                        self.kdims, False)
+            dimensionless = util.dimensionless_contents(get_nested_streams(self),
+                                                        self.kdims, no_duplicates=False)
             if (dimensionless and not self._dimensionless_cache):
                 raise KeyError('Using dimensionless streams disables DynamicMap cache')
             cache = super(DynamicMap,self).__getitem__(key)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -409,6 +409,19 @@ class Callable(param.Parameterized):
         return self.callable_function(*args, **kwargs)
 
 
+def get_streams(dmap):
+    """
+    Get streams from DynamicMap with Callable callback.
+    """
+    layer_streams = list(dmap.streams)
+    if not isinstance(dmap.callback, Callable):
+        return layer_streams
+    for o in dmap.callback.objects:
+        if isinstance(o, DynamicMap):
+            layer_streams += get_streams(o)
+    return layer_streams
+
+
 class DynamicMap(HoloMap):
     """
     A DynamicMap is a type of HoloMap where the elements are dynamically
@@ -704,7 +717,8 @@ class DynamicMap(HoloMap):
 
         # Cache lookup
         try:
-            dimensionless = util.dimensionless_contents(self.streams, self.kdims)
+            dimensionless = util.dimensionless_contents(get_streams(self),
+                                                        self.kdims, False)
             if (dimensionless and not self._dimensionless_cache):
                 raise KeyError('Using dimensionless streams disables DynamicMap cache')
             cache = super(DynamicMap,self).__getitem__(key)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -400,10 +400,19 @@ class HoloMap(UniformNdMapping):
 
 
 class Callable(param.Parameterized):
+    """
+    Callable allows wrapping callbacks on one or more DynamicMaps such
+    that the operation and the objects that are part of the operation
+    are made available. This allows traversing a DynamicMap that wraps
+    multiple operations and is primarily used to extracting any
+    streams attached to the object.
+    """
 
-    callable_function = param.Callable(default=lambda x: x)
+    callable_function = param.Callable(default=lambda x: x, doc="""
+         The callable function being wrapped.""")
 
-    objects = param.List(default=[])
+    objects = param.List(default=[], doc="""
+         The objects the callable function is processing.""")
 
     def __call__(self, *args, **kwargs):
         return self.callable_function(*args, **kwargs)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -799,21 +799,21 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     return [name for name in names if name not in exclude]
 
 
-def dimensionless_contents(streams, kdims):
+def dimensionless_contents(streams, kdims, no_duplicates=True):
     """
     Return a list of stream parameters that have not been associated
     with any of the key dimensions.
     """
-    names = stream_parameters(streams)
+    names = stream_parameters(streams, no_duplicates)
     return [name for name in names if name not in kdims]
 
 
-def unbound_dimensions(streams, kdims):
+def unbound_dimensions(streams, kdims, no_duplicates=True):
     """
     Return a list of dimensions that have not been associated with
     any streams.
     """
-    params = stream_parameters(streams)
+    params = stream_parameters(streams, no_duplicates)
     return [d for d in kdims if d not in params]
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -683,8 +683,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 rangex, rangey = True, True
             elif isinstance(self.hmap, DynamicMap):
                 rangex, rangey = True, True
-                callbacks = [cb for p in [self]+list(self.subplots.values())
-                             for cb in p.callbacks]
+                subplots = list(self.subplots.values()) if self.subplots else []
+                callbacks = [cb for p in [self]+subplots for cb in p.callbacks]
                 streams = [s for cb in callbacks for s in cb.streams]
                 for stream in streams:
                     if isinstance(stream, RangeXY):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -22,7 +22,7 @@ from ..core.traversal import dimensionless_cache
 from ..core.util import stream_parameters
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
-                   attach_streams, traverse_setter)
+                   attach_streams, traverse_setter, get_streams)
 
 
 class Plot(param.Parameterized):
@@ -578,7 +578,7 @@ class GenericElementPlot(DimensionedPlot):
                                                  **dict(params, **plot_opts))
         if top_level:
             self.comm = self.init_comm(element)
-        self.streams = self.hmap.streams if isinstance(self.hmap, DynamicMap) else []
+        self.streams = get_streams(self.hmap) if isinstance(self.hmap, DynamicMap) else []
 
         # Update plot and style options for batched plots
         if self.batched:
@@ -928,7 +928,7 @@ class GenericCompositePlot(DimensionedPlot):
         if top_level:
             self.comm = self.init_comm(layout)
         self.traverse(lambda x: setattr(x, 'comm', self.comm))
-        self.streams = [s for streams in layout.traverse(lambda x: x.streams,
+        self.streams = [s for streams in layout.traverse(lambda x: get_streams(streams),
                                                          [DynamicMap])
                         for s in streams]
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -22,7 +22,7 @@ from ..core.traversal import dimensionless_cache
 from ..core.util import stream_parameters
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
-                   attach_streams, traverse_setter, get_streams)
+                   attach_streams, traverse_setter, get_nested_streams)
 
 
 class Plot(param.Parameterized):
@@ -578,7 +578,10 @@ class GenericElementPlot(DimensionedPlot):
                                                  **dict(params, **plot_opts))
         if top_level:
             self.comm = self.init_comm(element)
-        self.streams = get_streams(self.hmap) if isinstance(self.hmap, DynamicMap) else []
+        streams = []
+        if isinstance(self.hmap, DynamicMap):
+            streams = get_nested_streams(self.hmap)
+        self.streams = streams
 
         # Update plot and style options for batched plots
         if self.batched:
@@ -928,9 +931,9 @@ class GenericCompositePlot(DimensionedPlot):
         if top_level:
             self.comm = self.init_comm(layout)
         self.traverse(lambda x: setattr(x, 'comm', self.comm))
-        self.streams = [s for streams in layout.traverse(lambda x: get_streams(x),
-                                                         [DynamicMap])
-                        for s in streams]
+        nested_streams = layout.traverse(lambda x: get_nested_streams(x),
+                                         [DynamicMap])
+        self.streams = [s for streams in nested_streams for s in streams]
 
 
     def _get_frame(self, key):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -928,7 +928,7 @@ class GenericCompositePlot(DimensionedPlot):
         if top_level:
             self.comm = self.init_comm(layout)
         self.traverse(lambda x: setattr(x, 'comm', self.comm))
-        self.streams = [s for streams in layout.traverse(lambda x: get_streams(streams),
+        self.streams = [s for streams in layout.traverse(lambda x: get_streams(x),
                                                          [DynamicMap])
                         for s in streams]
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -204,7 +204,7 @@ class Renderer(Exporter):
             if (((len(plot) == 1 and not plot.dynamic)
                 or (len(plot) > 1 and self.holomap is None) or
                 (plot.dynamic and len(plot.keys[0]) == 0)) or
-                not unbound_dimensions(plot.streams, plot.dimensions)):
+                not unbound_dimensions(plot.streams, plot.dimensions, False)):
                 fmt = fig_formats[0] if self.fig=='auto' else self.fig
             else:
                 fmt = holomap_formats[0] if self.holomap=='auto' else self.holomap

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -204,7 +204,7 @@ class Renderer(Exporter):
             if (((len(plot) == 1 and not plot.dynamic)
                 or (len(plot) > 1 and self.holomap is None) or
                 (plot.dynamic and len(plot.keys[0]) == 0)) or
-                not unbound_dimensions(plot.streams, plot.dimensions, False)):
+                not unbound_dimensions(plot.streams, plot.dimensions, no_duplicates=False)):
                 fmt = fig_formats[0] if self.fig=='auto' else self.fig
             else:
                 fmt = holomap_formats[0] if self.holomap=='auto' else self.holomap

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -5,7 +5,7 @@ import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     GridSpace, NdLayout, Store, Callable, Overlay)
-from ..core.spaces import get_streams
+from ..core.spaces import get_nested_streams
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
                          get_overlay_spec, unique_iterator, safe_unicode)
 
@@ -296,7 +296,7 @@ def attach_streams(plot, obj):
     Attaches plot refresh to all streams on the object.
     """
     def append_refresh(dmap):
-        for stream in get_streams(dmap):
+        for stream in get_nested_streams(dmap):
             stream._hidden_subscribers.append(plot.refresh)
     return obj.traverse(append_refresh, [DynamicMap])
 
@@ -307,16 +307,9 @@ def get_sources(obj, index=None):
     DynamicMap objects, returning a list of sources
     indexed by the Overlay layer.
     """
-    if isinstance(obj, DynamicMap):
-        if isinstance(obj.callback, Callable):
-            if len(obj.callback.inputs) > 1:
-                layers = [(None, obj)]
-            else:
-                layers = [(index, obj)]
-        else:
-            return [(index, obj)]
-    else:
-        return [(index, obj)]
+    layers = [(index, obj)]
+    if not isinstance(obj, DynamicMap) or not isinstance(obj.callback, Callable):
+        return layers
     index = 0 if index is None else int(index)
     for o in obj.callback.inputs:
         if isinstance(o, Overlay):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -4,7 +4,8 @@ import numpy as np
 import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
-                    GridSpace, NdLayout, Store, Overlay)
+                    GridSpace, NdLayout, Store, Callable, Overlay)
+from ..core.spaces import get_streams
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
                          get_overlay_spec, unique_iterator, safe_unicode)
 
@@ -295,9 +296,41 @@ def attach_streams(plot, obj):
     Attaches plot refresh to all streams on the object.
     """
     def append_refresh(dmap):
-        for stream in dmap.streams:
+        for stream in get_streams(dmap):
             stream._hidden_subscribers.append(plot.refresh)
     return obj.traverse(append_refresh, [DynamicMap])
+
+
+def get_sources(obj, index=None):
+    """
+    Traverses Callable graph to resolve sources on
+    DynamicMap objects, returning a list of sources
+    indexed by the Overlay layer.
+    """
+    if isinstance(obj, DynamicMap):
+        if isinstance(obj.callback, Callable):
+            if len(obj.callback.objects) > 1:
+                layers = [(None, obj)]
+            else:
+                layers = [(index, obj)]
+        else:
+            return [(index, obj)]
+    else:
+        return [(index, obj)]
+    index = 0 if index is None else int(index)
+    for o in obj.callback.objects:
+        if isinstance(o, Overlay):
+            layers.append((None, o))
+            for i, o in enumerate(overlay):
+                layers.append((index+i, o))
+            index += len(o)
+        elif isinstance(o, DynamicMap):
+            layers += get_sources(o, index)
+            index = layers[-1][0]+1
+        else:
+            layers.append((index, o))
+            index += 1
+    return layers
 
 
 def traverse_setter(obj, attribute, value):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -309,7 +309,7 @@ def get_sources(obj, index=None):
     """
     if isinstance(obj, DynamicMap):
         if isinstance(obj.callback, Callable):
-            if len(obj.callback.objects) > 1:
+            if len(obj.callback.inputs) > 1:
                 layers = [(None, obj)]
             else:
                 layers = [(index, obj)]
@@ -318,7 +318,7 @@ def get_sources(obj, index=None):
     else:
         return [(index, obj)]
     index = 0 if index is None else int(index)
-    for o in obj.callback.objects:
+    for o in obj.callback.inputs:
         if isinstance(o, Overlay):
             layers.append((None, o))
             for i, o in enumerate(overlay):

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -108,7 +108,11 @@ class NdWidget(param.Parameterized):
         super(NdWidget, self).__init__(**params)
         self.id = plot.comm.target if plot.comm else uuid.uuid4().hex
         self.plot = plot
-        self.dimensions, self.keys = drop_streams(plot.streams,
+        streams = []
+        for stream in plot.streams:
+            if any(k in plot.dimensions for k in stream.contents):
+                streams.append(stream)
+        self.dimensions, self.keys = drop_streams(streams,
                                                   plot.dimensions,
                                                   plot.keys)
 

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -47,7 +47,7 @@ class Dynamic(param.ParameterizedFunction):
                 elif not isinstance(stream, Stream):
                     raise ValueError('Stream must only contain Stream '
                                      'classes or instances')
-                stream.update(**{k: self.p.operation.p.get(k) for k, v in
+                stream.update(**{k: self.p.operation.p.get(k, v) for k, v in
                                  stream.contents.items()})
                 streams.append(stream)
             return dmap.clone(streams=streams)

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -80,9 +80,9 @@ class Dynamic(param.ParameterizedFunction):
                 return self._process(el, key)
         if isinstance(self.p.operation, ElementOperation):
             return OperationCallable(callable_function=dynamic_operation,
-                                     objects=[map_obj], operation=self.p.operation)
+                                     inputs=[map_obj], operation=self.p.operation)
         else:
-            return Callable(callable_function=dynamic_operation, objects=[map_obj])
+            return Callable(callable_function=dynamic_operation, inputs=[map_obj])
 
 
     def _make_dynamic(self, hmap, dynamic_fn):


### PR DESCRIPTION
As described in #895, we needed a way to access streams on DynamicMaps wrapping other DynamicMaps or overlays containing one or more DynamicMaps. This PR implements a ``Callable`` object, which is used to wrap the DynamicMap callbacks generated by all internal operations. This makes it possible to access streams and stream sources on nested DynamicMaps and hook them up appropriately in the plotting code. 

Currently the Callable object is very straightforward, exposing a ``callable_function`` and ``objects`` parameter, which correspond to the callback and the list of objects the callback wraps around, e.g. in an overlaying operation between a ``DynamicMap`` and a ``Points`` Elements, the ``callable_function`` would be a function which overlays the two objects and the ``objects`` a list containing both objects.

Using two helper functions ``get_streams`` and ``get_sources`` we can then look up all the streams and sources that are associated with a particular plot and more specifically a specific layer in an Overlay.

The PR is still lacking docstrings and tests but it already works.

The best example to confirm it is working is this example of two separate selection callbacks attached to two separate data sources:

```python
%%opts Points [tools=['box_select', 'lasso_select', 'tap']]
points = hv.Points(np.random.multivariate_normal((0, 0), [[1, 0.1], [0.1, 1]], (1000,)))
points2 = hv.Points(np.random.multivariate_normal((0, 0), [[1, 0.1], [0.1, 1]], (1000,)))

sel1 = Selection1D()
sel2 = Selection1D()
hv.DynamicMap(lambda index: points, kdims=[], streams=[sel1]) *\
hv.DynamicMap(lambda index: hv.HLine(points['y'][index].mean() if index else -10), kdims=[], streams=[sel1]) *\
hv.DynamicMap(lambda index: points2, kdims=[], streams=[sel2]) *\
hv.DynamicMap(lambda index: hv.HLine(points2['y'][index].mean() if index else -10), kdims=[], streams=[sel2])
```

![dual_selection](https://cloud.githubusercontent.com/assets/1550771/19665257/0b4dc848-9a3c-11e6-8fb0-9e98abd07dca.gif)
