### PR TITLE
Overlay collate

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -367,10 +367,6 @@ class Layout(AttrTree, Dimensioned):
 
 
     @classmethod
-    def _from_values(cls, val):
-        return reduce(lambda x,y: x+y, val).display('auto')
-
-    @classmethod
     def from_values(cls, val):
         """
         Returns a Layout given a list (or tuple) of viewable
@@ -379,15 +375,20 @@ class Layout(AttrTree, Dimensioned):
         collection = isinstance(val, (list, tuple))
         if type(val) is cls:
             return val
-        elif collection and len(val)>1:
-            return cls._from_values(val)
-        elif collection:
-            val = val[0]
-        group = group_sanitizer(val.group)
-        group = ''.join([group[0].upper(), group[1:]])
-        label = label_sanitizer(val.label if val.label else 'I')
-        label = ''.join([label[0].upper(), label[1:]])
-        return cls(items=[((group, label), val)])
+        elif not collection:
+            val = [val]
+        paths, items = [], []
+        count = 2
+        for v in val:
+            group = group_sanitizer(v.group)
+            group = ''.join([group[0].upper(), group[1:]])
+            label = label_sanitizer(v.label if v.label else 'I')
+            label = ''.join([label[0].upper(), label[1:]])
+            new_path, count = cls.new_path((group, label), v, paths, count)
+            new_path = tuple(''.join((p[0].upper(), p[1:])) for p in new_path)
+            paths.append(new_path)
+            items.append((new_path, v))
+        return cls(items=items)
 
 
     def __init__(self, items=None, identifier=None, parent=None, **kwargs):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -149,6 +149,14 @@ class Overlay(Layout, CompositeOverlay):
         return Overlay(items=self.relabel_item_paths(items)).display('all')
 
 
+    def collate(self):
+        """
+        Collates any objects in the Overlay resolving any issues
+        the recommended nesting structure.
+        """
+        return reduce(lambda x,y: x*y, self.values())
+
+
     def collapse(self, function):
         """
         Collapses all the Elements in the Overlay using the

--- a/tests/testcollation.py
+++ b/tests/testcollation.py
@@ -7,10 +7,12 @@ import unittest
 
 import numpy as np
 
-from holoviews.core import Collator, HoloMap, NdOverlay
+from holoviews.core import Collator, HoloMap, NdOverlay, Overlay, GridSpace
 from holoviews.element import Curve
+from holoviews.element.comparison import ComparisonTestCase
 
-class TestCollation(unittest.TestCase):
+
+class TestCollation(ComparisonTestCase):
     def setUp(self):
         alphas, betas, deltas = 2, 2, 2
         Bs = list(range(100))
@@ -67,3 +69,14 @@ class TestCollation(unittest.TestCase):
         collated = collated()
         self.assertEqual(repr(collated), repr(layout))
         self.assertEqual(collated.dimensions(), layout.dimensions())
+
+    def test_overlay_hmap_collate(self):
+        hmap = HoloMap({i: Curve(np.arange(10)*i) for i in range(3)})
+        overlaid = Overlay([hmap, hmap, hmap]).collate()
+        self.assertEqual(overlaid, hmap*hmap*hmap)
+
+    def test_overlay_gridspace_collate(self):
+        grid = GridSpace({(i,j): Curve(np.arange(10)*i) for i in range(3)
+                          for j in range(3)})
+        overlaid = Overlay([grid, grid, grid]).collate()
+        self.assertEqual(overlaid, grid*grid*grid)


### PR DESCRIPTION
This PR addresses issue #530, which suggested that creating an Overlay of HoloMaps to make it easy to declare certain datastructures. This PR reimplements the ``Layout.from_values`` method to be more efficient by not creating a bunch of intermediate objects, which also makes it possible to create an Overlay of HoloMaps and GridSpaces. Additionally it adds a trivial ``collate`` implementation which simply mirrors the old ``from_values`` implementation by reducing all the objects with the ``__mul__`` operator. Finally it sets up Overlays of HoloMaps and GridSpaces to be automatically collated and issue a warning like we already do for other invalid nesting structures.