### PR TITLE
Correctly set matplotlib colorbar tick locators

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -553,12 +553,12 @@ class ColorbarPlot(ElementPlot):
             cbar.solids.set_edgecolor("face")
         cbar.set_label(label)
         if isinstance(self.cbar_ticks, ticker.Locator):
-            cbar.set_major_locator(self.cbar_ticks)
+            cbar.ax.yaxis.set_major_locator(self.cbar_ticks)
         elif self.cbar_ticks == 0:
             cbar.set_ticks([])
         elif isinstance(self.cbar_ticks, int):
             locator = ticker.MaxNLocator(self.cbar_ticks)
-            cbar.set_major_locator(locator)
+            cbar.ax.yaxis.set_major_locator(locator)
         elif isinstance(self.cbar_ticks, list):
             if all(isinstance(t, tuple) for t in self.cbar_ticks):
                 ticks, labels = zip(*self.cbar_ticks)


### PR DESCRIPTION
Fixes issue #565, the locators were being set using a non-existent method.