### PR TITLE
Corrected QuadMesh clim style option to clims

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -205,7 +205,7 @@ class ImagePlot(RasterPlot):
 
 class QuadMeshPlot(ColorbarPlot):
 
-    style_opts = ['alpha', 'cmap', 'clim', 'edgecolors', 'norm', 'shading',
+    style_opts = ['alpha', 'cmap', 'clims', 'edgecolors', 'norm', 'shading',
                   'linestyles', 'linewidths', 'hatch', 'visible']
 
     _plot_methods = dict(single='pcolormesh')


### PR DESCRIPTION
Fixes issue #942, the ``clims`` style option was misnamed as ``clim``, which caused it not to be respected in some cases.