### PR TITLE
Added norm style option to all ColorbarPlot classes

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -477,7 +477,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
 
     style_opts = ['alpha', 'color', 'edgecolors', 'facecolors',
                   'linewidth', 'marker', 'size', 'visible',
-                  'cmap', 'vmin', 'vmax']
+                  'cmap', 'vmin', 'vmax', 'norm']
 
     _disabled_opts = ['size']
     _plot_methods = dict(single='scatter')
@@ -574,7 +574,7 @@ class VectorFieldPlot(ColorbarPlot):
     style_opts = ['alpha', 'color', 'edgecolors', 'facecolors',
                   'linewidth', 'marker', 'visible', 'cmap',
                   'scale', 'headlength', 'headaxislength', 'pivot',
-                  'width','headwidth']
+                  'width','headwidth', 'norm']
 
     _plot_methods = dict(single='quiver')
 

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -166,7 +166,8 @@ class SurfacePlot(Plot3D):
         Valid values are 'surface', 'wireframe' and 'contour'.""")
 
     style_opts = ['antialiased', 'cmap', 'color', 'shade',
-                  'linewidth', 'facecolors', 'rstride', 'cstride']
+                  'linewidth', 'facecolors', 'rstride', 'cstride',
+                  'norm']
 
     def init_artists(self, ax, plot_data, plot_kwargs):
         if self.plot_type == "wireframe":
@@ -196,7 +197,8 @@ class TrisurfacePlot(Plot3D):
     colorbar = param.Boolean(default=False, doc="""
         Whether to add a colorbar to the plot.""")
 
-    style_opts = ['cmap', 'color', 'shade', 'linewidth', 'edgecolor']
+    style_opts = ['cmap', 'color', 'shade', 'linewidth', 'edgecolor',
+                  'norm']
 
     _plot_methods = dict(single='plot_trisurf')
 


### PR DESCRIPTION
The ``norm`` plot option was not consistently exposed on all ``ElementPlot``s that support the argument. Addresses issue #808.