### PR TITLE
Added dask data interface

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -46,6 +46,12 @@ try:
 except ImportError:
     pass
 
+try:
+    from .dask import DaskInterface
+    datatypes.append('dask')
+except ImportError:
+    pass
+
 from ..dimension import Dimension
 from ..element import Element
 from ..spaces import HoloMap, DynamicMap

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -317,7 +317,7 @@ class Dataset(Element):
             selection = dict(zip(self.dimensions(label=True), slices))
         data = self.select(**selection)
         if value_select:
-            if len(data) == 1:
+            if data.shape[0] == 1:
                 return data[value_select][0]
             else:
                 return data.reindex(vdims=[value_select])

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -1,0 +1,215 @@
+from __future__ import absolute_import
+
+try:
+    import itertools.izip as zip
+except ImportError:
+    pass
+
+import numpy as np
+import pandas as pd
+import dask.dataframe as dd
+from dask.dataframe import DataFrame
+from dask.dataframe.core import Scalar
+
+from .. import util
+from ..element import Element
+from ..ndmapping import NdMapping, item_check
+from .interface import Interface
+from .pandas import PandasInterface
+
+
+class DaskInterface(PandasInterface):
+
+    types = (DataFrame,)
+
+    datatype = 'dask'
+
+    default_partitions = 100
+
+    @classmethod
+    def init(cls, eltype, data, kdims, vdims):
+        data, kdims, vdims = PandasInterface.init(eltype, data, kdims, vdims)
+        if not isinstance(data, DataFrame):
+            data = dd.from_pandas(data, npartitions=cls.default_partitions, sort=False)
+        return data, kdims, vdims
+
+    @classmethod
+    def shape(cls, dataset):
+        return (len(dataset.data), len(dataset.data.columns))
+
+    @classmethod
+    def range(cls, columns, dimension):
+        column = columns.data[columns.get_dimension(dimension).name]
+        if column.dtype.kind == 'O':
+            column = np.sort(column[column.notnull()].compute())
+            return column[0], column[-1]
+        else:
+            return (column.min().compute(), column.max().compute())
+
+    @classmethod
+    def sort(cls, columns, by=[]):
+        columns.warning('Dask dataframes do not support sorting')
+        return columns.data
+
+    @classmethod
+    def values(cls, columns, dim, expanded=True, flat=True):
+        data = columns.data[dim]
+        if not expanded:
+            data = data.unique()
+        return data.compute().values
+
+    @classmethod
+    def select_mask(cls, dataset, selection):
+        """
+        Given a Dataset object and a dictionary with dimension keys and
+        selection keys (i.e tuple ranges, slices, sets, lists or literals)
+        return a boolean mask over the rows in the Dataset object that
+        have been selected.
+        """
+        select_mask = None
+        for dim, k in selection.items():
+            if isinstance(k, tuple):
+                k = slice(*k)
+            masks = []
+            series = dataset.data[dim]
+            if isinstance(k, slice):
+                if k.start is not None:
+                    masks.append(k.start <= series)
+                if k.stop is not None:
+                    masks.append(series < k.stop)
+            elif isinstance(k, (set, list)):
+                iter_slc = None
+                for ik in k:
+                    mask = series == ik
+                    if iter_slc is None:
+                        iter_slc = mask
+                    else:
+                        iter_slc |= mask
+                masks.append(iter_slc)
+            elif callable(k):
+                masks.append(k(series))
+            else:
+                masks.append(series == k)
+            for mask in masks:
+                if select_mask:
+                    select_mask &= mask
+                else:
+                    select_mask = mask
+        return select_mask
+
+    @classmethod
+    def select(cls, columns, selection_mask=None, **selection):
+        df = columns.data
+        if selection_mask is not None:
+            print selection_mask
+            return df[selection_mask]
+        selection_mask = cls.select_mask(columns, selection)
+        indexed = cls.indexed(columns, selection)
+        df = df if selection_mask is None else df[selection_mask]
+        if indexed and len(df) == 1:
+            return df[columns.vdims[0].name].compute().iloc[0]
+        return df
+    
+    @classmethod
+    def groupby(cls, columns, dimensions, container_type, group_type, **kwargs):
+        index_dims = [columns.get_dimension(d) for d in dimensions]
+        element_dims = [kdim for kdim in columns.kdims
+                        if kdim not in index_dims]
+
+        group_kwargs = {}
+        if group_type != 'raw' and issubclass(group_type, Element):
+            group_kwargs = dict(util.get_param_values(columns),
+                                kdims=element_dims)
+        group_kwargs.update(kwargs)
+
+        groupby = columns.data.groupby(dimensions)
+        indices = columns.data[dimensions].compute().values
+        coords = list(util.unique_iterator((tuple(ind) for ind in indices)))
+        data = []
+        for coord in coords:
+            if any(isinstance(c, float) and np.isnan(c) for c in coord):
+                continue
+            if len(coord) == 1:
+                coord = coord[0]
+            group = group_type(groupby.get_group(coord), **group_kwargs)
+            data.append((coord, group))
+        if issubclass(container_type, NdMapping):
+            with item_check(False):
+                return container_type(data, kdims=index_dims)
+        else:
+            return container_type(data)
+    
+    @classmethod
+    def aggregate(cls, columns, dimensions, function, **kwargs):
+        data = columns.data
+        cols = [d.name for d in columns.kdims if d in dimensions]
+        vdims = columns.dimensions('value', True)
+        dtypes = data.dtypes
+        numeric = [c for c, dtype in zip(dtypes.index, dtypes.values)
+                   if dtype.kind in 'iufc' and c in vdims]
+        reindexed = data[cols+numeric]
+
+        inbuilts = {'amin': 'min', 'amax': 'max', 'mean': 'mean',
+                    'std': 'std', 'sum': 'sum', 'var': 'var'}
+        if len(dimensions):
+            groups = reindexed.groupby(cols, sort=False)
+            if (hasattr(function, 'func_name') and function.func_name in inbuilts):
+                agg = getattr(groups, inbuilts[function.func_name])()
+            else:
+                agg = groups.apply(function, axis=1)
+            return agg.reset_index()
+        else:
+            if (hasattr(function, 'func_name') and function.func_name in inbuilts):
+                agg = getattr(reindexed, inbuilts[function.func_name])()
+            else:
+                raise NotImplementedError
+            return pd.DataFrame(agg.compute()).T
+
+    @classmethod
+    def unpack_scalar(cls, columns, data):
+        """
+        Given a columns object and data in the appropriate format for
+        the interface, return a simple scalar.
+        """
+        if len(data.columns) > 1 or len(data) != 1:
+            return data
+        if isinstance(data, dd.DataFrame):
+            data = data.compute()
+        return data.iat[0,0]
+
+    @classmethod
+    def sample(cls, columns, samples=[]):
+        data = columns.data
+        dims = columns.dimensions('key', label=True)
+        mask = None
+        for sample in samples:
+            if np.isscalar(sample): sample = [sample]
+            for i, (c, v) in enumerate(zip(dims, sample)):
+                dim_mask = data[c]==v
+                if mask is None:
+                    mask = dim_mask
+                else:
+                    mask |= dim_mask
+        return data[mask]
+
+    @classmethod
+    def add_dimension(cls, columns, dimension, dim_pos, values, vdim):
+        data = columns.data
+        if dimension.name not in data.columns:
+            if not np.isscalar(values):
+                err = 'Dask dataframe does not support assigning non-scalar value.'
+                raise NotImplementedError(err)
+            data = data.assign(**{dimension.name: values})
+        return data
+
+    @classmethod
+    def concat(cls, columns_objs):
+        cast_objs = cls.cast(columns_objs)
+        return dd.concat([col.data for col in cast_objs])
+
+    @classmethod
+    def dframe(cls, columns, dimensions):
+        return columns.data.compute()
+
+
+Interface.register(DaskInterface)

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -169,14 +169,14 @@ class DaskInterface(PandasInterface):
                     'std': 'std', 'sum': 'sum', 'var': 'var'}
         if len(dimensions):
             groups = reindexed.groupby(cols, sort=False)
-            if (hasattr(function, 'func_name') and function.func_name in inbuilts):
-                agg = getattr(groups, inbuilts[function.func_name])()
+            if (function.__name__ in inbuilts):
+                agg = getattr(groups, inbuilts[function.__name__])()
             else:
-                agg = groups.apply(function, axis=1)
+                agg = groups.apply(function)
             return agg.reset_index()
         else:
-            if (hasattr(function, 'func_name') and function.func_name in inbuilts):
-                agg = getattr(reindexed, inbuilts[function.func_name])()
+            if (function.__name__ in inbuilts):
+                agg = getattr(reindexed, inbuilts[function.__name__])()
             else:
                 raise NotImplementedError
             return pd.DataFrame(agg.compute()).T

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -447,7 +447,7 @@ class Comparison(ComparisonInterface):
     @classmethod
     def compare_dataset(cls, el1, el2, msg='Dataset'):
         cls.compare_dimensioned(el1, el2)
-        if len(el1) != len(el2):
+        if el1.shape[0] != el2.shape[0]:
             raise AssertionError("%s not of matching length." % msg)
         dimension_data = [(d, el1[d], el2[d]) for d in el1.dimensions()]
         for dim, d1, d2 in dimension_data:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -134,11 +134,7 @@ class aggregate(ElementOperation):
         vdims = obj.vdims
         x, y = obj.dimensions(label=True)[:2]
         is_df = lambda x: isinstance(x, Dataset) and x.interface in DF_INTERFACES
-        if isinstance(obj, Dataset):
-            df = obj.data if is_df(obj) else obj.dframe()
-            paths.append(df)
-            glyph = 'line' if (pd.isnull(df[x]) & pd.isnull(df[y])).any() else 'points'
-        elif isinstance(obj, Path):
+        if isinstance(obj, Path):
             glyph = 'line'
             for p in obj.data:
                 df = pd.DataFrame(p, columns=obj.dimensions('key', True))

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -109,7 +109,7 @@ class HomogeneousColumnTypes(object):
     def test_dataset_add_dimensions_value_hm(self):
         table = self.dataset_hm.add_dimension('z', 1, 0)
         self.assertEqual(table.kdims[1], 'z')
-        self.compare_arrays(table.dimension_values('z'), np.zeros(len(table)))
+        self.compare_arrays(table.dimension_values('z'), np.zeros(table.shape[0]))
 
     def test_dataset_add_dimensions_values_hm(self):
         table =  self.dataset_hm.add_dimension('z', 1, range(1,12))
@@ -294,7 +294,7 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
     def test_dataset_add_dimensions_value_ht(self):
         table = self.dataset_ht.add_dimension('z', 1, 0)
         self.assertEqual(table.kdims[1], 'z')
-        self.compare_arrays(table.dimension_values('z'), np.zeros(len(table)))
+        self.compare_arrays(table.dimension_values('z'), np.zeros(table.shape[0]))
 
     def test_dataset_add_dimensions_values_ht(self):
         table = self.dataset_ht.add_dimension('z', 1, range(1,12))

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -15,6 +15,10 @@ try:
 except:
     pd = None
 
+try:
+    import dask.dataframe as dd
+except:
+    dd = None
 
 
 class HomogeneousColumnTypes(object):
@@ -259,7 +263,7 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
                           kdims=['x'], vdims=['z'])
         self.assertEqual(dataset.reduce(['y'], np.mean), reduced)
 
-    def test_column_aggregate_ht(self):
+    def test_dataset_aggregate_ht(self):
         aggregated = Dataset({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]},
                              kdims=self.kdims[:1], vdims=self.vdims)
         self.compare_dataset(self.table.aggregate(['Gender'], np.mean), aggregated)
@@ -383,6 +387,52 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         self.data_instance_type = pd.DataFrame
         self.init_data()
 
+
+class DaskDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
+    """
+    Test of the pandas DaskDataset interface.
+    """
+
+    def setUp(self):
+        if dd is None:
+            raise SkipTest("dask not available")
+        self.restore_datatype = Dataset.datatype
+        Dataset.datatype = ['dask']
+        self.data_instance_type = dd.DataFrame
+        self.init_data()
+
+    def test_dataset_reduce_ht(self):
+        reduced = Dataset({'Age': self.age,
+                           'Weight':self.weight,
+                           'Height':self.height},
+                          kdims=self.kdims[1:], vdims=self.vdims,
+                          datatype=['dataframe']).sort()
+        self.assertEqual(self.table.reduce(['Gender'], np.mean), reduced)
+
+    def test_dataset_aggregate_ht(self):
+        aggregated = Dataset({'Gender':['F', 'M'], 'Weight':[10, 16.5],
+                              'Height':[0.8, 0.7]},
+                             kdims=self.kdims[:1], vdims=self.vdims)
+        self.compare_dataset(self.table.aggregate(['Gender'], np.mean), aggregated)
+
+    # Disabled tests for NotImplemented methods
+    def test_dataset_add_dimensions_values_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_add_dimensions_values_ht(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_ht(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_string_ht(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_boolean_index(self):
+        raise SkipTest("Not supported")
 
 
 class DictDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
@@ -624,22 +674,22 @@ class IrisDatasetTest(GridDatasetTest):
 
     # Disabled tests for NotImplemented methods
     def test_dataset_add_dimensions_values_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_sort_vdim_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_1D_reduce_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_2D_reduce_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_2D_aggregate_partial_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_sample_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
 class XArrayDatasetTest(GridDatasetTest):
     """
@@ -655,10 +705,10 @@ class XArrayDatasetTest(GridDatasetTest):
 
     # Disabled tests for NotImplemented methods
     def test_dataset_add_dimensions_values_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_sort_vdim_hm(self):
-        pass
+        raise SkipTest("Not supported")
 
     def test_dataset_sample_hm(self):
-        pass
+        raise SkipTest("Not supported")


### PR DESCRIPTION
This PR adds an interface for Dask Dataframes making it possible to work with very large out-of-core dataframes. The interface is almost complete with some notable exceptions:

1. Dask dataframes do not support sorting which means that the ``sort`` method simply warns and continues.
2. Not all functions can be easily applied to a dask dataframe so some functions applied with ``aggregate`` and ``reduce`` will fail.
3. Dask does not support setting ``sort=False`` on aggregations, meaning that the aggregation groups are sorted and do not preserve the same order as other interfaces.
4. Dask does not easily support adding a new column to an existing dataframe unless it is a scalar, therefore ``add_dimension`` will error when supplied a non-scalar value.

Otherwise the full dataset test suite is being run against the interface so it all seems to be working.

Here is an example loading a 1.1GB CSV file and generating a DynamicMap of datashaded images grouped by the origin of the flights. In this example only the flight origins have to be loaded to apply the groupby. The aggregated data is not loaded until the first datashaded plot is displayed:

```python
%%timeit -r 1 -n 1
df = pd.read_csv('../apps/opensky.csv')
dataset = hv.Dataset(df, vdims=['velocity'])
groups = dataset.to(hv.Points, ['longitude', 'latitude'], [], ['origin'], dynamic=True)
shaded_origins=datashade(groups)
```
>1 loop, best of 1: 22 s per loop

```python
%%timeit -r 1 -n 1
df = dd.read_csv('../apps/opensky.csv', blocksize=50000000)
dataset = hv.Dataset(df, vdims=['velocity'])
groups = dataset.to(hv.Points, ['longitude', 'latitude'], [], ['origin'], dynamic=True)
shaded_origins=datashade(groups)
```
>1 loop, best of 1: 8.19 s per loop

And here is an example execution graph from a fairly complex expression, computing the mean velocity for every flight callsign originating in Algeria.

```python
hv.Dataset(dd.read_csv('../apps/opensky.csv', blocksize=50000000), vdims=['velocity'])\
.select(origin='Algeria').aggregate(['icao24'], np.mean).data.visualize()
```

![image](https://cloud.githubusercontent.com/assets/1550771/20032566/8c0389b8-a384-11e6-8840-6d52fcbebfbe.png)

And here's a task execution plot from a datashader aggregation executed on two remote workers:

<img width="1296" alt="screen shot 2016-11-06 at 1 29 43 am" src="https://cloud.githubusercontent.com/assets/1550771/20034742/0e88fc2e-a3c1-11e6-93db-a7288db0ccfb.png">

Overall this will do for us what xarray/iris have done for gridded data, letting us lazily load columnar data, extending our reach to datasets that are more than a few gigabytes.