### PR TITLE
Empty layout now display as text repr

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -51,9 +51,9 @@ class SkipRendering(Exception):
     hooks fall back to a text repr. Used to skip rendering of
     DynamicMaps with exhausted element generators.
     """
-    def __init__(self, warn=True):
+    def __init__(self, message="", warn=True):
         self.warn = warn
-        super(SkipRendering, self).__init__()
+        super(SkipRendering, self).__init__(message)
 
 
 class OptionError(Exception):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -51,7 +51,9 @@ class SkipRendering(Exception):
     hooks fall back to a text repr. Used to skip rendering of
     DynamicMaps with exhausted element generators.
     """
-    pass
+    def __init__(self, warn=True):
+        self.warn = warn
+        super(SkipRendering, self).__init__()
 
 
 class OptionError(Exception):

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -121,7 +121,8 @@ def display_hook(fn):
 
             return html
         except SkipRendering as e:
-            sys.stderr.write("Rendering process skipped: %s" % str(e))
+            if e.warn:
+                sys.stderr.write("Rendering process skipped: %s" % str(e))
             return None
         except AbbreviatedException as e:
             try: option_state(element, state=optstate)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1016,7 +1016,7 @@ class GenericLayoutPlot(GenericCompositePlot):
         if not isinstance(layout, (NdLayout, Layout)):
             raise ValueError("GenericLayoutPlot only accepts Layout objects.")
         if len(layout.values()) == 0:
-            raise ValueError("Cannot display empty layout")
+            raise SkipRendering(warn=False)
 
         super(GenericLayoutPlot, self).__init__(layout, **params)
         self.subplots = {}


### PR DESCRIPTION

This PR addresses #980 by raising ``SkipRendering`` for empty layouts. In addition, it adds a ``warn`` option to ``SkipRendering`` making it possible to suppress the usual warning.