### PR TITLE
Dataset types use __nonzero/bool__ method for truthiness

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -426,6 +426,10 @@ class Dataset(Element):
         """
         return self.interface.length(self)
 
+    def __nonzero__(self):
+        return self.interface.nonzero(self)
+
+    __bool__ = __nonzero__
 
     @property
     def shape(self):

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -229,12 +229,8 @@ class DaskInterface(PandasInterface):
         return columns.data.compute()
 
     @classmethod
-    def length(cls, dataset):
-        """
-        Length of dask dataframe is unknown, always return 1
-        for performance, use shape to compute dataframe shape.
-        """
-        return 1
+    def nonzero(cls, dataset):
+        return True
 
 
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -208,5 +208,9 @@ class Interface(param.Parameterized):
         return len(dataset.data)
 
     @classmethod
+    def nonzero(cls, dataset):
+        return bool(cls.length(dataset))
+
+    @classmethod
     def redim(cls, dataset, dimensions):
         return dataset.data

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -629,7 +629,7 @@ class Dimensioned(LabelledData):
     @property
     def ddims(self):
         "The list of deep dimensions"
-        if self._deep_indexable and len(self):
+        if self._deep_indexable and self:
             return self.values()[0].dimensions()
         else:
             return []

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -309,12 +309,6 @@ class Points(Chart):
 
     _min_dims = 2                      # Minimum number of columns
 
-    def __iter__(self):
-        i = 0
-        while i < len(self):
-            yield tuple(self.data[i, ...])
-            i += 1
-
 
 
 class VectorField(Points):


### PR DESCRIPTION
As discussed in #988 this PR implements the ``__nonzero__`` (Py2) and ``__bool__`` (Py3) methods on Dataset ensuring, which is used instead of ``__len__``. This ensures that the dask interface can implement the ``__len__`` method correctly, without forcing code throughout holoviews to compute the length on a large out-of-core dask dataframe all the time.