### PR TITLE
Implement Image interface

### DIFF
--- a/doc/Tutorials/Continuous_Coordinates.ipynb
+++ b/doc/Tutorials/Continuous_Coordinates.ipynb
@@ -378,7 +378,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Similarly, if we ask for the value of a given *y* location in continuous space, we will get a ``Curve`` with the array row closest to that *y* value in the ``Image`` 2D array returned as an array of $x$ values and the corresponding *z* value from the image:"
+    "Similarly, if we ask for the value of a given *y* location in continuous space, we will get a ``Curve`` with the array row closest to that *y* value in the ``Image`` 2D array returned as arrays of $x$ values and the corresponding *z* value from the image:"
    ]
   },
   {
@@ -394,19 +394,9 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "r10.data"
-   ]
-  },
-  {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+   },
    "source": [
     "The same sampling syntax can be used on HoloViews objects with any number of continuous-coordinate dimensions, in each case returning a HoloViews object of the correct dimensionality.  This support for working in continuous spaces makes it much more natural to work with HoloViews objects than directly with the underlying raw Numpy arrays, but the raw data always remains available when needed."
    ]

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -290,12 +290,12 @@ class Dataset(Element):
         if selection_specs and not any(self.matches(sp) for sp in selection_specs):
             return self
 
-        data, kwargs = self.interface.select(self, **selection)
+        data = self.interface.select(self, **selection)
 
         if np.isscalar(data):
             return data
         else:
-            return self.clone(data, **kwargs)
+            return self.clone(data)
 
 
     def reindex(self, kdims=None, vdims=None):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -167,7 +167,7 @@ class Dataset(Element):
         initialized = Interface.initialize(type(self), data, kdims, vdims,
                                            datatype=kwargs.get('datatype'))
         (data, self.interface, dims, extra_kws) = initialized
-        super(Dataset, self).__init__(data, **dict(extra_kws, **dict(kwargs, **dims)))
+        super(Dataset, self).__init__(data, **dict(kwargs, **dict(dims, **extra_kws)))
         self.interface.validate(self)
 
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -150,6 +150,9 @@ class Dataset(Element):
     # Define a class used to transform Datasets into other Element types
     _conversion_interface = DataConversion
 
+    _vdim_reductions = {}
+    _kdim_reductions = {}
+
     def __init__(self, data, **kwargs):
         if isinstance(data, Element):
             pvals = util.get_param_values(data)
@@ -305,13 +308,16 @@ class Dataset(Element):
         else:
             key_dims = [self.get_dimension(k, strict=True) for k in kdims]
 
+        new_type = None
         if vdims is None:
             val_dims = [d for d in self.vdims if not kdims or d not in kdims]
         else:
             val_dims = [self.get_dimension(v, strict=True) for v in vdims]
+            new_type = self._vdim_reductions.get(len(val_dims), type(self))
 
         data = self.interface.reindex(self, key_dims, val_dims)
-        return self.clone(data, kdims=key_dims, vdims=val_dims)
+        return self.clone(data, kdims=key_dims, vdims=val_dims,
+                          new_type=new_type)
 
 
     def __getitem__(self, slices):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -422,7 +422,9 @@ class Dataset(Element):
         if np.isscalar(aggregated):
             return aggregated
         else:
-            new_type = None if ndims >= min_d and ndims <= max_d else Dataset
+            new_type = None
+            if (min_d is not None and ndims < min_d) or (max_d is not None and ndims > max_d):
+                new_type = Dataset
             try:
                 return self.clone(aggregated, kdims=kdims, vdims=vdims,
                                   new_type=new_type)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -196,12 +196,14 @@ class Dataset(Element):
         will return the closest actual sample coordinates.
         """
         if self.ndims > 1:
-            NotImplementedError("Closest method currently only "
-                                "implemented for 1D Elements")
+            raise NotImplementedError("Closest method currently only "
+                                      "implemented for 1D Elements")
 
         xs = self.dimension_values(0)
+        if xs.dtype.kind in 'SO':
+            raise NotImplementedError("Closest only supported for numeric types")
         idxs = [np.argmin(np.abs(xs-coord)) for coord in coords]
-        return [xs[idx] for idx in idxs] if len(coords) > 1 else xs[idxs[0]]
+        return [xs[idx] for idx in idxs]
 
 
     def sort(self, by=[]):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -387,10 +387,14 @@ class Dataset(Element):
                 sample[self.get_dimension_index(dim)] = val
             samples = [tuple(sample)]
 
-        from ...element import Table
+        from ...element import Table, Curve
         if len(samples) == 1:
             sel = {kd.name: s for kd, s in zip(self.kdims, samples[0])}
             selection = self.select(**sel)
+            if self.interface.gridded and self.ndims == 2 and len(sel) == 1:
+                new_type = Curve
+            else:
+                new_type = Table
             selection = [samples[0]+(selection,)] if np.isscalar(selection) else selection.columns()
             return self.clone(selection, new_type=Table)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -344,7 +344,7 @@ class Dataset(Element):
             value_select = slices[self.ndims]
         elif len(slices) == self.ndims+1 and isinstance(slices[self.ndims],
                                                         (Dimension,str)):
-            raise Exception("%r is not an available value dimension'" % slices[self.ndims])
+            raise Exception("%r is not an available value dimension" % slices[self.ndims])
         else:
             selection = dict(zip(self.dimensions(label=True), slices))
         data = self.select(**selection)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -99,6 +99,16 @@ class DataConversion(object):
         if vdims is None:
             vdims = self._element.vdims
         if vdims and not isinstance(vdims, list): vdims = [vdims]
+
+        # Checks Element type supports dimensionality
+        type_name = new_type.__name__
+        for dim_type, dims in (('kdims', kdims), ('vdims', vdims)):
+            min_d, max_d = new_type.params(dim_type).bounds
+            if ((min_d is not None and len(dims) < min_d) or
+                (max_d is not None and len(dims) > max_d)):
+                raise ValueError("%s %s must be between length %s and %s." %
+                                 (type_name, dim_type, min_d, max_d))
+
         if groupby is None:
             groupby = [d for d in self._element.kdims if d not in kdims+vdims]
         elif groupby and not isinstance(groupby, list):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -373,12 +373,14 @@ class Dataset(Element):
         return data
 
 
-    def sample(self, samples=[], **kwargs):
+    def sample(self, samples=[], closest=True, **kwargs):
         """
         Allows sampling of Dataset as an iterator of coordinates
         matching the key dimensions, returning a new object containing
         just the selected samples. Alternatively may supply kwargs
-        to sample a coordinate on an object.
+        to sample a coordinate on an object. By default it will attempt
+        to snap to the nearest coordinate if the Element supports it,
+        snapping may be disabled with the closest argument.
         """
         if kwargs and samples:
             raise Exception('Supply explicit list of samples or kwargs, not both.')
@@ -416,10 +418,11 @@ class Dataset(Element):
         if len(lens) > 1:
             raise IndexError('Sample coordinates must all be of the same length.')
 
-        try:
-            samples = self.closest(samples)
-        except NotImplementedError:
-            pass
+        if closest:
+            try:
+                samples = self.closest(samples)
+            except NotImplementedError:
+                pass
         samples = [util.wrap_tuple(s) for s in samples]
         return self.clone(self.interface.sample(self, samples), new_type=Table)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -105,7 +105,11 @@ class DataConversion(object):
             groupby = [groupby]
 
         if self._element.interface.gridded:
-            selected = self._element
+            dropped_kdims = [kd for kd in self._element.kdims if kd not in groupby+kdims]
+            if dropped_kdims:
+                selected = self._element.reindex(groupby+kdims, vdims)
+            else:
+                selected = self._element
         else:
             selected = self._element.reindex(groupby+kdims, vdims)
         params = {'kdims': [selected.get_dimension(kd, strict=True) for kd in kdims],
@@ -114,7 +118,7 @@ class DataConversion(object):
         if selected.group != selected.params()['group'].default:
             params['group'] = selected.group
         params.update(kwargs)
-        if len(kdims) == selected.ndims:
+        if len(kdims) == selected.ndims or not groupby:
             element = new_type(selected, **params)
             return element.sort() if sort else element
         group = selected.groupby(groupby, container_type=HoloMap,

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -183,7 +183,7 @@ class ArrayInterface(Interface):
             selection_mask = cls.select_mask(dataset, selection)
         indexed = cls.indexed(dataset, selection)
         data = np.atleast_2d(dataset.data[selection_mask, :])
-        if len(data) == 1 and indexed:
+        if len(data) == 1 and indexed and len(dataset.vdims) == 1:
             data = data[0, dataset.ndims]
         return data
 

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -185,7 +185,7 @@ class ArrayInterface(Interface):
         data = np.atleast_2d(dataset.data[selection_mask, :])
         if len(data) == 1 and indexed:
             data = data[0, dataset.ndims]
-        return data, {}
+        return data
 
 
     @classmethod

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -124,7 +124,7 @@ class DaskInterface(PandasInterface):
         selection_mask = cls.select_mask(columns, selection)
         indexed = cls.indexed(columns, selection)
         df = df if selection_mask is None else df[selection_mask]
-        if indexed and len(df) == 1:
+        if indexed and len(df) == 1 and len(columns.vdims) == 1:
             return df[columns.vdims[0].name].compute().iloc[0]
         return df
     

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -125,7 +125,7 @@ class DaskInterface(PandasInterface):
         indexed = cls.indexed(columns, selection)
         df = df if selection_mask is None else df[selection_mask]
         if indexed and len(df) == 1:
-            return df[columns.vdims[0].name].compute().iloc[0], {}
+            return df[columns.vdims[0].name].compute().iloc[0]
         return df
     
     @classmethod

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -126,7 +126,7 @@ class DaskInterface(PandasInterface):
         df = df if selection_mask is None else df[selection_mask]
         if indexed and len(df) == 1:
             return df[columns.vdims[0].name].compute().iloc[0], {}
-        return df, {}
+        return df
     
     @classmethod
     def groupby(cls, columns, dimensions, container_type, group_type, **kwargs):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -220,8 +220,8 @@ class DictInterface(Interface):
         data = OrderedDict((k, list(compress(v, selection_mask)))
                            for k, v in dataset.data.items())
         if indexed and len(list(data.values())[0]) == 1:
-            return data[dataset.vdims[0].name][0], {}
-        return data, {}
+            return data[dataset.vdims[0].name][0]
+        return data
 
 
     @classmethod

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -219,7 +219,7 @@ class DictInterface(Interface):
         indexed = cls.indexed(dataset, selection)
         data = OrderedDict((k, list(compress(v, selection_mask)))
                            for k, v in dataset.data.items())
-        if indexed and len(list(data.values())[0]) == 1:
+        if indexed and len(list(data.values())[0]) == 1 and len(dataset.vdims) == 1:
             return data[dataset.vdims[0].name][0]
         return data
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -199,9 +199,9 @@ class GridInterface(DictInterface):
             select = dict(zip(dim_names, unique_key))
             if drop_dim:
                 group_data = dataset.select(**select)
-                group_data = group_data if np.isscalar(group_data) else group_data.columns()
+                group_data, _ = group_data if np.isscalar(group_data) else (group_data.columns(), None)
             else:
-                group_data = cls.select(dataset, **select)
+                group_data, _ = cls.select(dataset, **select)
             if np.isscalar(group_data):
                 group_data = {dataset.vdims[0].name: np.atleast_1d(group_data)}
                 for dim, v in zip(dim_names, unique_key):

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -231,6 +231,8 @@ class GridInterface(DictInterface):
                 mask &= ind.start <= values
             if ind.stop is not None:
                 mask &= values < ind.stop
+            if mask is True:
+                mask = np.ones(values.shape, dtype=np.bool)
         elif isinstance(ind, (set, list)):
             iter_slcs = []
             for ik in ind:
@@ -272,15 +274,15 @@ class GridInterface(DictInterface):
             else:
                 values = values[mask]
             value_select.append(mask)
-            data[dim.name] = values
+            data[dim.name] = np.array([values]) if np.isscalar(values) else values
         int_inds = [np.argwhere(v) for v in value_select][::-1]
         index = np.ix_(*[np.atleast_1d(np.squeeze(ind)) if ind.ndim > 1 else np.atleast_1d(ind)
                          for ind in int_inds])
         for vdim in dataset.vdims:
             data[vdim.name] = dataset.data[vdim.name][index]
 
-        if indexed and len(data[dataset.vdims[0].name]) == 1:
-            return data[dataset.vdims[0].name][0]
+        if indexed and len(dataset.vdims) == 1:
+            return data[dataset.vdims[0].name][0, 0]
 
         return data
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -199,9 +199,9 @@ class GridInterface(DictInterface):
             select = dict(zip(dim_names, unique_key))
             if drop_dim:
                 group_data = dataset.select(**select)
-                group_data, _ = group_data if np.isscalar(group_data) else (group_data.columns(), None)
+                group_data = group_data if np.isscalar(group_data) else (group_data.columns(), None)
             else:
-                group_data, _ = cls.select(dataset, **select)
+                group_data = cls.select(dataset, **select)
             if np.isscalar(group_data):
                 group_data = {dataset.vdims[0].name: np.atleast_1d(group_data)}
                 for dim, v in zip(dim_names, unique_key):
@@ -280,9 +280,9 @@ class GridInterface(DictInterface):
             data[vdim.name] = dataset.data[vdim.name][index]
 
         if indexed and len(data[dataset.vdims[0].name]) == 1:
-            return data[dataset.vdims[0].name][0], {}
+            return data[dataset.vdims[0].name][0]
 
-        return data, {}
+        return data
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -295,10 +295,6 @@ class GridInterface(DictInterface):
         arrays = [dataset.data[vdim.name] for vdim in dataset.vdims]
         data = defaultdict(list)
 
-        first_sample = util.wrap_tuple(samples[0])
-        if any(len(util.wrap_tuple(s)) != len(first_sample) for s in samples):
-            raise IndexError('Sample coordinates must all be of the same length.')
-
         for sample in samples:
             if np.isscalar(sample): sample = [sample]
             if len(sample) != ndims:

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -282,7 +282,8 @@ class GridInterface(DictInterface):
             data[vdim.name] = dataset.data[vdim.name][index]
 
         if indexed and len(dataset.vdims) == 1:
-            return data[dataset.vdims[0].name][0, 0]
+            arr = np.squeeze(data[dataset.vdims[0].name])
+            return arr if np.isscalar(arr) else arr[()]
 
         return data
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -281,10 +281,13 @@ class GridInterface(DictInterface):
         for vdim in dataset.vdims:
             data[vdim.name] = dataset.data[vdim.name][index]
 
-        if indexed and len(dataset.vdims) == 1:
-            arr = np.squeeze(data[dataset.vdims[0].name])
-            return arr if np.isscalar(arr) else arr[()]
-
+        if indexed:
+            if len(dataset.vdims) == 1:
+                arr = np.squeeze(data[dataset.vdims[0].name])
+                return arr if np.isscalar(arr) else arr[()]
+            else:
+                return np.array([np.squeeze(data[vd.name])
+                                 for vd in dataset.vdims])
         return data
 
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -199,7 +199,7 @@ class GridInterface(DictInterface):
             select = dict(zip(dim_names, unique_key))
             if drop_dim:
                 group_data = dataset.select(**select)
-                group_data = group_data if np.isscalar(group_data) else (group_data.columns(), None)
+                group_data = group_data if np.isscalar(group_data) else group_data.columns()
             else:
                 group_data = cls.select(dataset, **select)
             if np.isscalar(group_data):

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -92,8 +92,11 @@ class GridInterface(DictInterface):
 
 
     @classmethod
-    def shape(cls, dataset):
-        return cls.length(dataset), len(dataset.dimensions()),
+    def shape(cls, dataset, gridded=False):
+        if gridded:
+            return dataset.data[dataset.vdims[0].name].shape
+        else:
+            return (cls.length(dataset), len(dataset.dimensions()))
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -231,6 +231,7 @@ class GridInterface(DictInterface):
                 mask &= ind.start <= values
             if ind.stop is not None:
                 mask &= values < ind.stop
+            # Expand empty mask
             if mask is True:
                 mask = np.ones(values.shape, dtype=np.bool)
         elif isinstance(ind, (set, list)):

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -274,11 +274,11 @@ class ImageInterface(GridInterface):
                      for kdim in dataset.kdims if kdim not in kdims)
 
         data = np.atleast_1d(function(dataset.data, axis=axes, **kwargs))
-        if not kdims and len(dataset.vdims) == 1:
-            if np.isscalar(data):
-                return data
+        if not kdims:
+            if len(dataset.vdims) == 1:
+                return data if np.isscalar(data) else data[0]
             else:
-                return data[0]
+                return {vd.name: v for vd, v in zip(dataset.vdims, data)}
         elif len(axes) == 1:
             return {kdims[0]: cls.values(dataset, axes[0], expanded=False),
                     dataset.vdims[0].name: data[::-1] if axes[0] else data}

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -140,13 +140,9 @@ class ImageInterface(GridInterface):
         if not any([isinstance(el, slice) for el in coords]):
             return dataset.data[dataset.sheet2matrixidx(*coords)]
 
-        # Compute new bounds
-        ys, xs = dataset.data.shape[:2]
+        # Apply slices
         xidx, yidx = coords
         l, b, r, t = dataset.bounds.lbrt()
-        xdensity, ydensity = dataset.xdensity, dataset.ydensity
-        xunit = (1./xdensity)
-        yunit = (1./ydensity)
         if isinstance(xidx, slice):
             l = l if xidx.start is None else max(l, xidx.start)
             r = r if xidx.stop is None else min(r, xidx.stop)
@@ -154,41 +150,8 @@ class ImageInterface(GridInterface):
             b = b if yidx.start is None else max(b, yidx.start)
             t = t if yidx.stop is None else min(t, yidx.stop)
         bounds = BoundingBox(points=((l, b), (r, t)))
-
-        # Apply new bounds
         slc = Slice(bounds, dataset)
         data = slc.submatrix(dataset.data)
-
-        # Apply scalar and list indices
-        l, b, r, t = slc.compute_bounds(dataset).lbrt()
-        if not isinstance(xidx, slice):
-            if not isinstance(xidx, (list, set)): xidx = [xidx]
-            if len(xidx) > 1:
-                xdensity = xdensity*(float(len(xidx))/xs)
-            idxs = []
-            ls, rs = [], []
-            for idx in xidx:
-                xc, _ = dataset.closest_cell_center(idx, b)
-                ls.append(xc-xunit/2)
-                rs.append(xc+xunit/2)
-                _, x = dataset.sheet2matrixidx(idx, b)
-                idxs.append(x)
-            l, r = np.min(ls), np.max(rs)
-            data = data[:, np.array(idxs)]
-        elif not isinstance(yidx, slice):
-            if not isinstance(yidx, (set, list)): yidx = [yidx]
-            if len(yidx) > 1:
-                ydensity = ydensity*(float(len(yidx))/ys)
-            idxs = []
-            bs, ts = [], []
-            for idx in yidx:
-                _, yc = dataset.closest_cell_center(l, idx)
-                bs.append(yc-yunit/2)
-                ts.append(yc+yunit/2)
-                y, _ = dataset.sheet2matrixidx(l, idx)
-                idxs.append(y)
-            b, t = np.min(bs), np.max(ts)
-            data = data[np.array(idxs), :]
         return data
 
 

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -65,7 +65,11 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def reindex(cls, columns, kdims=None, vdims=None):
-        return columns.data
+        data = columns.data
+        if vdims is not None and vdims != columns.vdims and len(columns.vdims) > 1:
+            inds = [columns.get_dimension_index(vd)-columns.ndims for vd in vdims]
+            return data[:, :, inds] if len(inds) > 1 else data[:, :, inds[0]]
+        return data
 
     @classmethod
     def range(cls, obj, dim):

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -98,8 +98,8 @@ class ImageInterface(GridInterface):
         if dim_idx in [0, 1]:
             l, b, r, t = dataset.bounds.lbrt()
             dim2, dim1 = dataset.data.shape[:2]
-            d1_half_unit = (r - l)/dim1/2.
-            d2_half_unit = (t - b)/dim2/2.
+            d1_half_unit = float(r - l)/dim1/2.
+            d2_half_unit = float(t - b)/dim2/2.
             d1lin = np.linspace(l+d1_half_unit, r-d1_half_unit, dim1)
             d2lin = np.linspace(b+d2_half_unit, t-d2_half_unit, dim2)
             if expanded:

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -130,7 +130,7 @@ class ImageInterface(GridInterface):
         coords = tuple(selection[kd.name] if kd.name in selection else slice(None)
                        for kd in dataset.kdims)
         if not any([isinstance(el, slice) for el in coords]):
-            return dataset.data[dataset.sheet2matrixidx(*coords)], {}
+            return dataset.data[dataset.sheet2matrixidx(*coords)]
 
         # Compute new bounds
         ys, xs = dataset.data.shape[:2]
@@ -152,13 +152,11 @@ class ImageInterface(GridInterface):
         data = slc.submatrix(dataset.data)
 
         # Apply scalar and list indices
-        kwargs = {}
         l, b, r, t = slc.compute_bounds(dataset).lbrt()
         if not isinstance(xidx, slice):
             if not isinstance(xidx, (list, set)): xidx = [xidx]
             if len(xidx) > 1:
                 xdensity = xdensity*(float(len(xidx))/xs)
-                kwargs['xdensity'] = xdensity
             idxs = []
             ls, rs = [], []
             for idx in xidx:
@@ -173,7 +171,6 @@ class ImageInterface(GridInterface):
             if not isinstance(yidx, (set, list)): yidx = [yidx]
             if len(yidx) > 1:
                 ydensity = ydensity*(float(len(yidx))/ys)
-                kwargs['ydensity'] = ydensity
             idxs = []
             bs, ts = [], []
             for idx in yidx:
@@ -184,8 +181,7 @@ class ImageInterface(GridInterface):
                 idxs.append(y)
             b, t = np.min(bs), np.max(ts)
             data = data[np.array(idxs), :]
-        kwargs['bounds'] = BoundingBox(points=((l, b), (r, t)))
-        return data, kwargs
+        return data
 
 
     @classmethod

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -58,7 +58,6 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        print dataset.data.shape
         return np.product(dataset.data.shape)
 
 

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -53,7 +53,14 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def shape(cls, dataset):
-        return dataset.data.shape
+        return cls.length(dataset), len(dataset.dimensions()),
+
+
+    @classmethod
+    def length(cls, dataset):
+        print dataset.data.shape
+        return np.product(dataset.data.shape)
+
 
     @classmethod
     def validate(cls, dataset):

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -28,19 +28,19 @@ class ImageInterface(GridInterface):
             vdims = eltype.vdims
 
         kwargs = {}
-        dimensions = [d.alias if isinstance(d, Dimension) else
+        dimensions = [d.name if isinstance(d, Dimension) else
                       d for d in kdims + vdims]
         if isinstance(data, tuple):
             data = dict(zip(dimensions, data))
         if isinstance(data, dict):
-            xs, ys = np.asarray(data[kdims[0].alias]), np.asarray(data[kdims[1].alias])
+            xs, ys = np.asarray(data[kdims[0].name]), np.asarray(data[kdims[1].name])
             l, r, xdensity, invertx = util.bound_range(xs, None)
             b, t, ydensity, inverty = util.bound_range(ys, None)
             kwargs['bounds'] = BoundingBox(points=((l, b), (r, t)))
             if len(vdims) == 1:
-                data = np.flipud(np.asarray(data[vdims[0].alias]))
+                data = np.flipud(np.asarray(data[vdims[0].name]))
             else:
-                data = np.dstack([np.flipud(data[vd.alias]) for vd in vdims])
+                data = np.dstack([np.flipud(data[vd.name]) for vd in vdims])
             if invertx:
                 data = data[:, ::-1]
             if inverty:
@@ -123,7 +123,7 @@ class ImageInterface(GridInterface):
         """
         selection = {k: slice(*sel) if isinstance(sel, tuple) else sel
                      for k, sel in selection.items()}
-        coords = tuple(selection[kd.alias] if kd.alias in selection else slice(None)
+        coords = tuple(selection[kd.name] if kd.name in selection else slice(None)
                        for kd in dataset.kdims)
         if not any([isinstance(el, slice) for el in coords]):
             return dataset.data[dataset.sheet2matrixidx(*coords)], {}
@@ -195,7 +195,7 @@ class ImageInterface(GridInterface):
         tuple.
         """
         if len(samples[0]) == 1:
-            return dataset.select(**{dataset.kdims[0].alias:
+            return dataset.select(**{dataset.kdims[0].name:
                                      [s[0] for s in samples]}).columns()
         else:
             return [c+(dataset.data[dataset._coord2matrix(c)],)
@@ -247,7 +247,7 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def aggregate(cls, dataset, kdims, function, **kwargs):
-        kdims = [kd.alias if isinstance(kd, Dimension) else kd for kd in kdims]
+        kdims = [kd.name if isinstance(kd, Dimension) else kd for kd in kdims]
         axes = tuple(dataset.ndims-dataset.get_dimension_index(kdim)-1
                      for kdim in dataset.kdims if kdim not in kdims)
         
@@ -256,7 +256,7 @@ class ImageInterface(GridInterface):
             return data
         elif len(axes) == 1:
             return {kdims[0]: cls.values(dataset, axes[0], expanded=False),
-                    dataset.vdims[0].alias: data}
+                    dataset.vdims[0].name: data}
 
 
 Interface.register(ImageInterface)

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -73,11 +73,20 @@ class ImageInterface(GridInterface):
         return dataset.data
 
     @classmethod
-    def reindex(cls, columns, kdims=None, vdims=None):
-        data = columns.data
-        if vdims is not None and vdims != columns.vdims and len(columns.vdims) > 1:
-            inds = [columns.get_dimension_index(vd)-columns.ndims for vd in vdims]
-            return data[:, :, inds] if len(inds) > 1 else data[:, :, inds[0]]
+    def reindex(cls, dataset, kdims=None, vdims=None):
+        data = dataset.data
+        dropped_kdims = [kd for kd in dataset.kdims if kd not in kdims]
+        constant = {}
+        for kd in dropped_kdims:
+            vals = cls.values(dataset, kd.name, expanded=False)
+            if len(vals) == 1:
+                constant[kd.name] = vals[0]
+        if dropped_kdims or constant:
+            return tuple(dataset.columns(kdims+vdims).values())
+
+        if vdims is not None and vdims != dataset.vdims and len(dataset.vdims) > 1:
+            inds = [dataset.get_dimension_index(vd)-dataset.ndims for vd in vdims]
+            return data[..., inds] if len(inds) > 1 else data[..., inds[0]]
         return data
 
     @classmethod

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -247,7 +247,7 @@ class ImageInterface(GridInterface):
             if len(dataset.vdims) == 1:
                 return data if np.isscalar(data) else data[0]
             else:
-                return {vd.name: v for vd, v in zip(dataset.vdims, data)}
+                return {vd.name: np.array([v]) for vd, v in zip(dataset.vdims, data)}
         elif len(axes) == 1:
             return {kdims[0]: cls.values(dataset, axes[0], expanded=False),
                     dataset.vdims[0].name: data[::-1] if axes[0] else data}

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -52,8 +52,11 @@ class ImageInterface(GridInterface):
 
 
     @classmethod
-    def shape(cls, dataset):
-        return cls.length(dataset), len(dataset.dimensions()),
+    def shape(cls, dataset, gridded=False):
+        if gridded:
+            return dataset.data.shape
+        else:
+            return cls.length(dataset), len(dataset.dimensions())
 
 
     @classmethod

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -60,7 +60,8 @@ class Interface(param.Parameterized):
             if data.interface.datatype in datatype:
                 data = data.data
             elif data.interface.gridded:
-                gridded = {data.dimension_values(kd.name, expanded=False) for kd in self.kdims}
+                gridded = {kd.name: data.dimension_values(kd.name, expanded=False)
+                           for kd in data.kdims}
                 for vd in data.vdims:
                     gridded[vd.name] = data.dimension_values(vd, flat=False)
                 data = gridded

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -155,7 +155,7 @@ class Interface(param.Parameterized):
         all_scalar = all((not isinstance(sel, (tuple, slice, set, list))
                           and not callable(sel)) for sel in selection.values())
         all_kdims = all(d in selected for d in dataset.kdims)
-        return all_scalar and all_kdims and len(dataset.vdims) == 1
+        return all_scalar and all_kdims
 
 
     @classmethod

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -152,8 +152,8 @@ class Interface(param.Parameterized):
         boolean to indicate whether a scalar value has been indexed.
         """
         selected = list(selection.keys())
-        all_scalar = all(not isinstance(sel, (tuple, slice, set, list))
-                         for sel in selection.values())
+        all_scalar = all((not isinstance(sel, (tuple, slice, set, list))
+                          and not callable(sel)) for sel in selection.values())
         all_kdims = all(d in selected for d in dataset.kdims)
         return all_scalar and all_kdims and len(dataset.vdims) == 1
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -2,6 +2,7 @@ import param
 import numpy as np
 
 from ..element import Element, NdElement
+from ..ndmapping import OrderedDict
 from .. import util
 
 
@@ -60,13 +61,13 @@ class Interface(param.Parameterized):
             if data.interface.datatype in datatype:
                 data = data.data
             elif data.interface.gridded:
-                gridded = {kd.name: data.dimension_values(kd.name, expanded=False)
-                           for kd in data.kdims}
+                gridded = OrderedDict([(kd.name, data.dimension_values(kd.name, expanded=False))
+                                       for kd in data.kdims])
                 for vd in data.vdims:
                     gridded[vd.name] = data.dimension_values(vd, flat=False)
-                data = gridded
+                data = tuple(gridded.values())
             else:
-                data = data.columns()
+                data = tuple(data.columns())
         elif isinstance(data, Element):
             data = tuple(data.dimension_values(d) for d in kdims+vdims)
         elif isinstance(data, util.generator_types):
@@ -85,7 +86,7 @@ class Interface(param.Parameterized):
             try:
                 (data, dims, extra_kws) = interface.init(eltype, data, kdims, vdims)
                 break
-            except:
+            except Exception as e:
                 pass
         else:
             raise ValueError("None of the available storage backends "

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -67,7 +67,7 @@ class Interface(param.Parameterized):
                     gridded[vd.name] = data.dimension_values(vd, flat=False)
                 data = tuple(gridded.values())
             else:
-                data = tuple(data.columns())
+                data = tuple(data.columns().values())
         elif isinstance(data, Element):
             data = tuple(data.dimension_values(d) for d in kdims+vdims)
         elif isinstance(data, util.generator_types):

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -116,7 +116,7 @@ class CubeInterface(GridInterface):
         if vdims is None:
             vdims = [Dimension(data.name(), unit=str(data.units))]
 
-        return data, {'kdims':kdims, 'vdims':vdims}, {'group':data.name()}
+        return data, {'kdims':kdims, 'vdims':vdims}, {}
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -76,10 +76,10 @@ class CubeInterface(GridInterface):
             kdims = eltype.kdims
             kdim_names = [kd.name for kd in eltype.kdims]
 
-        if vdims is None:
-            vdims = eltype.vdims
 
         if not isinstance(data, iris.cube.Cube):
+            if vdims is None:
+                vdims = eltype.vdims
             ndims = len(kdim_names)
             kdims = [kd if isinstance(kd, Dimension) else Dimension(kd)
                      for kd in kdims]
@@ -201,7 +201,8 @@ class CubeInterface(GridInterface):
             constraint = iris.Constraint(**dict(zip(constraints, key)))
             extracted = dataset.data.extract(constraint)
             if drop_dim:
-                extracted = group_type(extracted, kdims=slice_dims).columns()
+                extracted = group_type(extracted, kdims=slice_dims,
+                                       vdims=dataset.vdims).columns()
             cube = group_type(extracted, **group_kwargs)
             data.append((key, cube))
         if issubclass(container_type, NdMapping):

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -301,7 +301,7 @@ class CubeInterface(GridInterface):
         indexed = cls.indexed(dataset, selection)
         extracted = dataset.data.extract(constraint)
         if indexed and not extracted.dim_coords:
-            return extracted.data.item(), {}
+            return extracted.data.item()
         post_dim_coords = [c.name() for c in extracted.dim_coords]
         dropped = [c for c in pre_dim_coords if c not in post_dim_coords]
         for d in dropped:

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -306,7 +306,7 @@ class CubeInterface(GridInterface):
         dropped = [c for c in pre_dim_coords if c not in post_dim_coords]
         for d in dropped:
             extracted = iris.util.new_axis(extracted, d)
-        return extracted, {}
+        return extracted
 
 
 Interface.register(CubeInterface)

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -126,6 +126,14 @@ class CubeInterface(GridInterface):
 
 
     @classmethod
+    def shape(cls, dataset, gridded=False):
+        if gridded:
+            return dataset.data.shape
+        else:
+            return (cls.length(dataset), len(dataset.dimensions()))
+
+
+    @classmethod
     def coords(cls, dataset, dim, ordered=False, expanded=False):
         dim = dataset.get_dimension(dim, strict=True)
         if expanded:

--- a/holoviews/core/data/ndelement.py
+++ b/holoviews/core/data/ndelement.py
@@ -118,9 +118,9 @@ class NdElementInterface(Interface):
     @classmethod
     def select(cls, columns, selection_mask=None, **selection):
         if selection_mask is None:
-            return columns.data.select(**selection), {}
+            return columns.data.select(**selection)
         else:
-            return columns.data[selection_mask], {}
+            return columns.data[selection_mask]
 
     @classmethod
     def sample(cls, columns, samples=[]):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -188,8 +188,8 @@ class PandasInterface(Interface):
         indexed = cls.indexed(columns, selection)
         df = df.ix[selection_mask]
         if indexed and len(df) == 1:
-            return df[columns.vdims[0].name].iloc[0], {}
-        return df, {}
+            return df[columns.vdims[0].name].iloc[0]
+        return df
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -187,7 +187,7 @@ class PandasInterface(Interface):
             selection_mask = cls.select_mask(columns, selection)
         indexed = cls.indexed(columns, selection)
         df = df.ix[selection_mask]
-        if indexed and len(df) == 1:
+        if indexed and len(df) == 1 and len(columns.vdims) == 1:
             return df[columns.vdims[0].name].iloc[0]
         return df
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -72,7 +72,7 @@ class XArrayInterface(GridInterface):
             if vdims is None:
                 vdims = list(data.data_vars.keys())
             if kdims is None:
-                kdims = [name for name in data.dims
+                kdims = [name for name in data.indexes.keys()
                          if isinstance(data[name].data, np.ndarray)]
 
         if not isinstance(data, xr.Dataset):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -225,8 +225,8 @@ class XArrayInterface(GridInterface):
         indexed = cls.indexed(dataset, selection)
         if (indexed and len(data.data_vars) == 1 and
             len(data[dataset.vdims[0].name].shape) == 0):
-            return data[dataset.vdims[0].name].item(), {}
-        return data, {}
+            return data[dataset.vdims[0].name].item()
+        return data
 
     @classmethod
     def length(cls, dataset):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -216,16 +216,18 @@ class XArrayInterface(GridInterface):
         data = dataset.data.sel(**validated)
 
         # Restore constant dimensions
+        indexed = cls.indexed(dataset, selection)
         dropped = {d.name: np.atleast_1d(data[d.name])
                    for d in dataset.kdims
                    if not data[d.name].data.shape}
-        if dropped:
+        if dropped and not indexed:
             data = data.assign_coords(**dropped)
 
-        indexed = cls.indexed(dataset, selection)
         if (indexed and len(data.data_vars) == 1 and
             len(data[dataset.vdims[0].name].shape) == 0):
             return data[dataset.vdims[0].name].item()
+        elif indexed:
+            return np.array([data[vd.name].item() for vd in dataset.vdims])
         return data
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -191,6 +191,16 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def reindex(cls, dataset, kdims=None, vdims=None):
+        dropped_kdims = [kd for kd in dataset.kdims if kd not in kdims]
+        constant = {}
+        for kd in dropped_kdims:
+            vals = cls.values(dataset, kd.name, expanded=False)
+            if len(vals) == 1:
+                constant[kd.name] = vals[0]
+        if len(constant) == len(dropped_kdims):
+            return dataset.data.sel(**constant)
+        elif dropped_kdims:
+            return tuple(dataset.columns(kdims+vdims).values())
         return dataset.data
 
     @classmethod

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -320,7 +320,7 @@ class HoloMap(UniformNdMapping, Overlayable):
                 ysamples = [(ly+uy)/2.0 for ly,uy in zip(yedges[:-1], yedges[1:])]
 
                 Y,X = np.meshgrid(ysamples, xsamples)
-                linsamples = zip(X.flat, Y.flat)
+                linsamples = list(zip(X.flat, Y.flat))
             else:
                 raise NotImplementedError("Regular sampling not implemented "
                                           "for high-dimensional Views.")

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -327,7 +327,8 @@ class HoloMap(UniformNdMapping, Overlayable):
 
             samples = list(util.unique_iterator(self.last.closest(linsamples)))
 
-        sampled = self.clone([(k, view.sample(samples, **sample_values))
+        sampled = self.clone([(k, view.sample(samples, closest=False,
+                                              **sample_values))
                               for k, view in self.data.items()])
         return sampled.table()
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1220,10 +1220,8 @@ def bound_range(vals, density):
     """
     low, high = vals.min(), vals.max()
     invert = False
-    diff = np.diff(vals)
-    if diff.max() < 0:
+    if vals[0] > vals[1]:
         invert = True
-        diff = -diff
     if not density:
         density = round(1./((high-low)/(len(vals)-1)), sys.float_info.dig)
     halfd = 0.5/density

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1214,9 +1214,9 @@ def is_nan(x):
 
 def bound_range(vals, density):
     """
-    Computes a bounding range from a number of evenly spaced samples.
-    Will raise an error if samples are not evenly spaced within
-    tolerance.
+    Computes a bounding range and density from a number of samples
+    assumed to be evenly spaced. Density is rounded to machine precision
+    using significant digits reported by sys.float_info.dig.
     """
     low, high = vals.min(), vals.max()
     invert = False

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1219,11 +1219,15 @@ def bound_range(vals, density, TOL=10e-9):
     tolerance.
     """
     low, high = vals.min(), vals.max()
+    invert = False
+    diff = np.diff(vals)
+    if diff.max() < 0:
+        invert = True
+        diff = -diff
     if not density:
-        diff = np.diff(vals)
         unit = np.unique(np.round(diff/TOL).astype(int))*TOL
         if len(unit) > 1:
             raise ValueError('Data is not sampled on a grid.')
         density = 1./unit[0]
     halfd = 0.5/density
-    return low-halfd, high+halfd, density
+    return low-halfd, high+halfd, density, invert

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1212,7 +1212,7 @@ def is_nan(x):
         return False
 
 
-def bound_range(vals, density, TOL=10e-9):
+def bound_range(vals, density):
     """
     Computes a bounding range from a number of evenly spaced samples.
     Will raise an error if samples are not evenly spaced within
@@ -1225,9 +1225,6 @@ def bound_range(vals, density, TOL=10e-9):
         invert = True
         diff = -diff
     if not density:
-        unit = np.unique(np.round(diff/TOL).astype(int))*TOL
-        if len(unit) > 1:
-            raise ValueError('Data is not sampled on a grid.')
-        density = 1./unit[0]
+        density = 1./((high-low)/(len(vals)-1))
     halfd = 0.5/density
     return low-halfd, high+halfd, density, invert

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1217,9 +1217,8 @@ def bound_range(vals, density, TOL=10e-8):
     if not density:
         diff = np.diff(vals)
         unit = np.unique(np.floor(diff/TOL).astype(int))*TOL
-        print vals, unit
         if len(unit) > 1:
             raise ValueError('Data is not sampled on a grid.')
         density = 1./unit[0]
     halfd = 0.5/density
-    return low-halfd, high+halfd
+    return low-halfd, high+halfd, density

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1225,6 +1225,6 @@ def bound_range(vals, density):
         invert = True
         diff = -diff
     if not density:
-        density = 1./((high-low)/(len(vals)-1))
+        density = round(1./((high-low)/(len(vals)-1)), sys.float_info.dig)
     halfd = 0.5/density
     return low-halfd, high+halfd, density, invert

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1212,11 +1212,16 @@ def is_nan(x):
         return False
 
 
-def bound_range(vals, density, TOL=10e-8):
+def bound_range(vals, density, TOL=10e-9):
+    """
+    Computes a bounding range from a number of evenly spaced samples.
+    Will raise an error if samples are not evenly spaced within
+    tolerance.
+    """
     low, high = vals.min(), vals.max()
     if not density:
         diff = np.diff(vals)
-        unit = np.unique(np.floor(diff/TOL).astype(int))*TOL
+        unit = np.unique(np.round(diff/TOL).astype(int))*TOL
         if len(unit) > 1:
             raise ValueError('Data is not sampled on a grid.')
         density = 1./unit[0]

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -32,17 +32,6 @@ class Surface(Image, Element3D):
         Image.__init__(self, data, extents=extents, **params)
 
 
-    def range(self, dim, data_range=True):
-        dim_idx = self.get_dimension_index(dim)
-        if dim_idx in [0, 1]:
-            l, b, r, t = self.bounds.lbrt()
-            if dim_idx == 0:
-                return (l, r)
-            elif dim_idx == 1:
-                return (b, t)
-        return super(Image, self).range(dim, data_range=data_range)
-
-
 
 class Trisurface(Element3D, Scatter):
     """

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -25,7 +25,7 @@ from numpy.testing import assert_array_equal, assert_array_almost_equal
 from . import *    # noqa (All Elements need to support comparison)
 from ..core import (Element, Empty, AdjointLayout, Overlay, Dimension,
                     HoloMap, Dimensioned, Layout, NdLayout, NdOverlay,
-                    GridSpace, DynamicMap, GridMatrix)
+                    GridSpace, DynamicMap, GridMatrix, OrderedDict)
 from ..core.options import Options, Cycle
 from ..interface.pandas import DFrame as PandasDFrame
 from ..interface.pandas import DataFrameView
@@ -105,7 +105,8 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[np.float64] =   cls.compare_floats
 
         #Dictionary comparisons
-        cls.equality_type_funcs[dict] =        cls.compare_dictionaries
+        cls.equality_type_funcs[dict] =         cls.compare_dictionaries
+        cls.equality_type_funcs[OrderedDict] =  cls.compare_dictionaries
 
         # Numpy array comparison
         cls.equality_type_funcs[np.ndarray] =   cls.compare_arrays

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -104,8 +104,9 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[np.float32] =   cls.compare_floats
         cls.equality_type_funcs[np.float64] =   cls.compare_floats
 
-        # List comparisons
+        # List and tuple comparisons
         cls.equality_type_funcs[list] =         cls.compare_lists
+        cls.equality_type_funcs[tuple] =        cls.compare_tuples
 
         #Dictionary comparisons
         cls.equality_type_funcs[dict] =         cls.compare_dictionaries
@@ -214,6 +215,13 @@ class Comparison(ComparisonInterface):
     @classmethod
     def compare_lists(cls, l1, l2, msg='Lists'):
         cls.assertEqual(len(l1), len(l2), "list lengths mismatched")
+        for v1, v2 in zip(l1, l2):
+            cls.assertEqual(v1, v2)
+
+
+    @classmethod
+    def compare_tuples(cls, l1, l2, msg='Tuples'):
+        cls.assertEqual(len(l1), len(l2), "tuple lengths mismatched")
         for v1, v2 in zip(l1, l2):
             cls.assertEqual(v1, v2)
 

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -104,6 +104,9 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[np.float32] =   cls.compare_floats
         cls.equality_type_funcs[np.float64] =   cls.compare_floats
 
+        # List comparisons
+        cls.equality_type_funcs[list] =         cls.compare_lists
+
         #Dictionary comparisons
         cls.equality_type_funcs[dict] =         cls.compare_dictionaries
         cls.equality_type_funcs[OrderedDict] =  cls.compare_dictionaries
@@ -206,6 +209,14 @@ class Comparison(ComparisonInterface):
             raise cls.failureException(msg)
         for k in keys:
             cls.assertEqual(d1[k], d2[k])
+
+
+    @classmethod
+    def compare_lists(cls, l1, l2, msg='Lists'):
+        cls.assertEqual(len(l1), len(l2), "list lengths mismatched")
+        for v1, v2 in zip(l1, l2):
+            cls.assertEqual(v1, v2)
+
 
     #=====================#
     # Literal comparisons #

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -106,6 +106,8 @@ class Comparison(ComparisonInterface):
 
         # List and tuple comparisons
         cls.equality_type_funcs[list] =         cls.compare_lists
+        cls.equality_type_funcs[tuple] =        cls.compare_tuples
+
 
         #Dictionary comparisons
         cls.equality_type_funcs[dict] =         cls.compare_dictionaries
@@ -213,16 +215,22 @@ class Comparison(ComparisonInterface):
 
     @classmethod
     def compare_lists(cls, l1, l2, msg='Lists'):
-        cls.assertEqual(len(l1), len(l2), "list lengths mismatched")
-        for v1, v2 in zip(l1, l2):
-            cls.assertEqual(v1, v2)
+        try:
+            cls.assertEqual(len(l1), len(l2))
+            for v1, v2 in zip(l1, l2):
+                cls.assertEqual(v1, v2)
+        except AssertionError:
+            raise AssertionError('%s != %s' % (repr(l1), repr(l2)))
 
 
     @classmethod
-    def compare_tuples(cls, l1, l2, msg='Tuples'):
-        cls.assertEqual(len(l1), len(l2), "tuple lengths mismatched")
-        for v1, v2 in zip(l1, l2):
-            cls.assertEqual(v1, v2)
+    def compare_tuples(cls, t1, t2, msg='Tuples'):
+        try:
+            cls.assertEqual(len(t1), len(t2))
+            for i1, i2 in zip(t1, t2):
+                cls.assertEqual(i1, i2)
+        except AssertionError:
+            raise AssertionError('%s != %s' % (repr(t1), repr(t2)))
 
 
     #=====================#

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -106,7 +106,6 @@ class Comparison(ComparisonInterface):
 
         # List and tuple comparisons
         cls.equality_type_funcs[list] =         cls.compare_lists
-        cls.equality_type_funcs[tuple] =        cls.compare_tuples
 
         #Dictionary comparisons
         cls.equality_type_funcs[dict] =         cls.compare_dictionaries

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -553,21 +553,22 @@ class Comparison(ComparisonInterface):
 
     @classmethod
     def compare_image(cls, el1, el2, msg='Image'):
-        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
+        cls.compare_dataset(el1, el2, msg)
 
     @classmethod
     def compare_rgb(cls, el1, el2, msg='RGB'):
-        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
+        cls.compare_dataset(el1, el2, msg)
 
     @classmethod
     def compare_hsv(cls, el1, el2, msg='HSV'):
-        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
+        cls.compare_dataset(el1, el2, msg)
 
     @classmethod
     def compare_surface(cls, el1, el2, msg='Surface'):
+        cls.bounds_check(el1,el2)
         cls.compare_dataset(el1, el2, msg)
 
 

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -549,31 +549,26 @@ class Comparison(ComparisonInterface):
 
     @classmethod
     def compare_heatmap(cls, el1, el2, msg='HeatMap'):
-        cls.compare_dimensioned(el1, el2)
-        cls.compare_arrays(el1.data, el2.data, msg)
+        cls.compare_dataset(el1, el2, msg)
 
     @classmethod
     def compare_image(cls, el1, el2, msg='Image'):
-        cls.compare_dimensioned(el1, el2)
-        cls.compare_arrays(el1.data, el2.data, msg)
+        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
 
     @classmethod
     def compare_rgb(cls, el1, el2, msg='RGB'):
-        cls.compare_dimensioned(el1, el2)
-        cls.compare_arrays(el1.data, el2.data, msg=msg)
+        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
 
     @classmethod
     def compare_hsv(cls, el1, el2, msg='HSV'):
-        cls.compare_dimensioned(el1, el2)
-        cls.compare_arrays(el1.data, el2.data, msg=msg)
+        cls.compare_dataset(el1, el2, msg)
         cls.bounds_check(el1,el2)
 
     @classmethod
     def compare_surface(cls, el1, el2, msg='Surface'):
-        cls.compare_dimensioned(el1, el2)
-        cls.compare_arrays(el1.data, el2.data, msg=msg)
+        cls.compare_dataset(el1, el2, msg)
 
 
     #========#

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -232,12 +232,11 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         Dataset.__init__(self, data, extents=extents, bounds=None, **params)
 
         (dim2, dim1) = self.interface.shape(self)[:2]
-        l, r = self.range(0)
-        b, t = self.range(1)
         if self.bounds is not None:
             bounds = self.bounds
-        elif bounds is None and None in (l, b, r, t):
+        elif bounds is None and isinstance(data, np.ndarray):
             bounds = BoundingBox()
+
         if bounds is None:
             xvals = self.dimension_values(0, False)
             l, r, xdensity, _ = util.bound_range(xvals, xdensity)
@@ -259,6 +258,10 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             if self.shape[2] != len(self.vdims):
                 raise ValueError("Input array has shape %r but %d value dimensions defined"
                                  % (self.shape, len(self.vdims)))
+
+    def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):
+        agg = super(Image, self).aggregate(dimensions, function, spreadfn, **kwargs)
+        return Curve(agg) if isinstance(agg, Dataset) else agg
 
 
     def select(self, selection_specs=None, **selection):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -382,6 +382,11 @@ class RGB(Image):
                 raise ValueError("Ranges must be defined on all the value dimensions of all the Images")
             arrays = [(im.data - r[0]) / (r[1] - r[0]) for r,im in zip(ranges, images)]
             data = np.dstack(arrays)
+        vdims = list(params.get('vdims', self.vdims))
+        if isinstance(data, np.ndarray):
+            if data.shape[-1] == 4 and len(vdims) == 3:
+                vdims.append(self.alpha_dimension)
+                params['vdims'] = vdims
         super(RGB, self).__init__(data, **params)
 
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -36,7 +36,7 @@ class Raster(Dataset, Element2D, SheetCoordinateSystem):
     specified.
     """
 
-    datatype = param.List(default=['image', 'grid', 'xarray'])
+    datatype = param.List(default=['image', 'grid', 'xarray', 'dataframe', 'dictionary'])
 
     bounds = param.ClassSelector(class_=BoundingRegion, default=None, doc="""
        The bounding region in sheet coordinates containing the data.""")
@@ -90,7 +90,7 @@ class Raster(Dataset, Element2D, SheetCoordinateSystem):
     def _wrap_data(self, data, bounds):
         if isinstance(data, np.ndarray):
             coords = [np.arange(s) for s in data.shape[::-1]]
-            data = tuple(coords + [data])
+            data = tuple(coords + [np.flipud(data)])
             return data, None
         return data, bounds
 
@@ -204,6 +204,20 @@ class Raster(Dataset, Element2D, SheetCoordinateSystem):
             return getter(self.closest_cell_center(*coords))
         else:
             return [getter(self.closest_cell_center(*el)) for el in coords]
+
+
+    def table(self, datatype=None):
+        """
+        Converts the data Element to a Table, optionally may
+        specify a supported data type. The default data types
+        are 'numpy' (for homogeneous data), 'dataframe', and
+        'dictionary'.
+        """
+        if datatype and not isinstance(datatype, list):
+            datatype = [datatype]
+        from ..element import Table
+        return self.clone(self.columns(), new_type=Table,
+                          **(dict(datatype=datatype) if datatype else {}))
 
 
 class Image(Raster):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -232,7 +232,11 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         if data is None: data = np.array([[0]])
         Dataset.__init__(self, data, extents=extents, bounds=None, **params)
 
-        (dim2, dim1) = self.interface.shape(self)[:2]
+        if isinstance(data, np.ndarray):
+            dim2, dim1 = data.shape[:2]
+        else:
+            dim1, dim2 = tuple([len(self.dimension_values(kd, expanded=False))
+                                  for kd in self.kdims])
         if self.bounds is not None:
             bounds = self.bounds
         elif bounds is None and isinstance(data, np.ndarray):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -22,7 +22,7 @@ except ImportError:
     PandasInterface = None
 
 
-class Raster(Element2D):
+class Raster(Dataset, Element2D, SheetCoordinateSystem):
     """
     Raster is a basic 2D element type for presenting either numpy or
     dask arrays as two dimensional raster images.
@@ -36,378 +36,6 @@ class Raster(Element2D):
     specified.
     """
 
-    group = param.String(default='Raster', constant=True)
-
-    kdims = param.List(default=[Dimension('x'), Dimension('y')],
-                       bounds=(2, 2), constant=True, doc="""
-        The label of the x- and y-dimension of the Raster in form
-        of a string or dimension object.""")
-
-    vdims = param.List(default=[Dimension('z')], bounds=(1, 1), doc="""
-        The dimension description of the data held in the data array.""")
-
-    def __init__(self, data, extents=None, **params):
-        if extents is None:
-            (d1, d2) = data.shape[:2]
-            extents = (0, 0, d2, d1)
-        super(Raster, self).__init__(data, extents=extents, **params)
-
-
-    @property
-    def _zdata(self):
-        return self.data
-
-
-    def __getitem__(self, slices):
-        if slices in self.dimensions(): return self.dimension_values(slices)
-        slices = util.process_ellipses(self,slices)
-        if not isinstance(slices, tuple):
-            slices = (slices, slice(None))
-        elif len(slices) > (2 + self.depth):
-            raise KeyError("Can only slice %d dimensions" % 2 + self.depth)
-        elif len(slices) == 3 and slices[-1] not in [self.vdims[0].name, slice(None)]:
-            raise KeyError("%r is the only selectable value dimension" % self.vdims[0].name)
-
-        slc_types = [isinstance(sl, slice) for sl in slices[:2]]
-        data = self.data.__getitem__(slices[:2][::-1])
-        if all(slc_types):
-            return self.clone(data, extents=None)
-        elif not any(slc_types):
-            return toarray(data, index_value=True)
-        else:
-            return self.clone(np.expand_dims(data, axis=slc_types.index(True)),
-                              extents=None)
-
-
-    def _coord2matrix(self, coord):
-        return int(round(coord[1])), int(round(coord[0]))
-
-
-    @classmethod
-    def collapse_data(cls, data_list, function, kdims=None, **kwargs):
-        if isinstance(function, np.ufunc):
-            return function.reduce(data_list)
-        else:
-            return function(np.dstack(data_list), axis=-1, **kwargs)
-
-
-    def sample(self, samples=[], **sample_values):
-        """
-        Sample the Raster along one or both of its dimensions,
-        returning a reduced dimensionality type, which is either
-        a ItemTable, Curve or Scatter. If two dimension samples
-        and a new_xaxis is provided the sample will be the value
-        of the sampled unit indexed by the value in the new_xaxis
-        tuple.
-        """
-        if isinstance(samples, tuple):
-            X, Y = samples
-            samples = zip(X, Y)
-        params = dict(self.get_param_values(onlychanged=True),
-                      vdims=self.vdims)
-        params.pop('extents', None)
-        params.pop('bounds', None)
-        if len(sample_values) == self.ndims or len(samples):
-            if not len(samples):
-                samples = zip(*[c if isinstance(c, list) else [c] for _, c in
-                               sorted([(self.get_dimension_index(k), v) for k, v in
-                                       sample_values.items()])])
-            table_data = [c+(self._zdata[self._coord2matrix(c)],)
-                          for c in samples]
-            params['kdims'] = self.kdims
-            return Table(table_data, **params)
-        else:
-            dimension, sample_coord = list(sample_values.items())[0]
-            if isinstance(sample_coord, slice):
-                raise ValueError(
-                    'Raster sampling requires coordinates not slices,'
-                    'use regular slicing syntax.')
-            # Indices inverted for indexing
-            sample_ind = self.get_dimension_index(dimension)
-            if sample_ind is None:
-                raise Exception("Dimension %s not found during sampling" % dimension)
-            other_dimension = [d for i, d in enumerate(self.kdims) if
-                               i != sample_ind]
-
-            # Generate sample slice
-            sample = [slice(None) for i in range(self.ndims)]
-            coord_fn = (lambda v: (v, 0)) if not sample_ind else (lambda v: (0, v))
-            sample[sample_ind] = self._coord2matrix(coord_fn(sample_coord))[abs(sample_ind-1)]
-
-            # Sample data
-            x_vals = self.dimension_values(other_dimension[0].name, False)
-            ydata = self._zdata[sample[::-1]]
-            if hasattr(self, 'bounds') and sample_ind == 0: ydata = ydata[::-1]
-            data = list(zip(x_vals, ydata))
-            params['kdims'] = other_dimension
-            return Curve(data, **params)
-
-
-    def reduce(self, dimensions=None, function=None, **reduce_map):
-        """
-        Reduces the Raster using functions provided via the
-        kwargs, where the keyword is the dimension to be reduced.
-        Optionally a label_prefix can be provided to prepend to
-        the result Element label.
-        """
-        function, dims = self._reduce_map(dimensions, function, reduce_map)
-        if len(dims) == self.ndims:
-            if isinstance(function, np.ufunc):
-                return function.reduce(self.data, axis=None)
-            else:
-                return function(self.data)
-        else:
-            dimension = dims[0]
-            other_dimension = [d for d in self.kdims if d.name != dimension]
-            oidx = self.get_dimension_index(other_dimension[0])
-            x_vals = self.dimension_values(other_dimension[0].name, False)
-            reduced = function(self._zdata, axis=oidx)
-            if oidx and hasattr(self, 'bounds'):
-                reduced = reduced[::-1]
-            data = zip(x_vals, reduced)
-            params = dict(dict(self.get_param_values(onlychanged=True)),
-                          kdims=other_dimension, vdims=self.vdims)
-            params.pop('bounds', None)
-            params.pop('extents', None)
-            return Table(data, **params)
-
-
-    def dimension_values(self, dim, expanded=True, flat=True):
-        """
-        The set of samples available along a particular dimension.
-        """
-        dim_idx = self.get_dimension_index(dim)
-        if not expanded and dim_idx == 0:
-            return np.array(range(self.data.shape[1]))
-        elif not expanded and dim_idx == 1:
-            return np.array(range(self.data.shape[0]))
-        elif dim_idx in [0, 1]:
-            values = np.mgrid[0:self.data.shape[1], 0:self.data.shape[0]][dim_idx]
-            return values.flatten() if flat else values
-        elif dim_idx == 2:
-            arr = toarray(self.data.T)
-            return arr.flatten() if flat else arr
-        else:
-            return super(Raster, self).dimension_values(dim)
-
-
-    @property
-    def depth(self):
-        return 1 if len(self.data.shape) == 2 else self.data.shape[2]
-
-
-    @property
-    def mode(self):
-        """
-        Mode specifying the color space for visualizing the array data
-        and is a function of the depth. For a depth of one, a colormap
-        is used as determined by the style. If the depth is 3 or 4,
-        the mode is 'rgb' or 'rgba' respectively.
-        """
-        if   self.depth == 1:  return 'cmap'
-        elif self.depth == 3:  return 'rgb'
-        elif self.depth == 4:  return 'rgba'
-        else:
-            raise Exception("Mode cannot be determined from the depth")
-
-
-
-class QuadMesh(Raster):
-    """
-    QuadMesh is a Raster type to hold x- and y- bin values
-    with associated values. The x- and y-values of the QuadMesh
-    may be supplied either as the edges of each bin allowing
-    uneven sampling or as the bin centers, which will be converted
-    to evenly sampled edges.
-
-    As a secondary but less supported mode QuadMesh can contain
-    a mesh of quadrilateral coordinates that is not laid out in
-    a grid. The data should then be supplied as three separate
-    2D arrays for the x-/y-coordinates and grid values.
-    """
-
-    group = param.String(default="QuadMesh", constant=True)
-
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
-
-    vdims = param.List(default=[Dimension('z')], bounds=(1,1))
-
-    def __init__(self, data, **params):
-        data = self._process_data(data)
-        Element2D.__init__(self, data, **params)
-        self.data = self._validate_data(self.data)
-        self._grid = self.data[0].ndim == 1
-
-
-    @property
-    def depth(self): return 1
-
-    def _process_data(self, data):
-        if isinstance(data, GridImage):
-            x = data.dimension_values(0, expanded=False)
-            y = data.dimension_values(1, expanded=False)
-            zarray = data.dimension_values(2, flat=False)
-        else:
-            data = tuple(np.array(el) for el in data)
-            x, y, zarray = data
-        ys, xs = zarray.shape
-        if x.ndim == 1 and len(x) == xs:
-            x = compute_edges(x)
-        if y.ndim == 1 and len(y) == ys:
-            y = compute_edges(y)
-        return (x, y, zarray)
-
-
-    @property
-    def _zdata(self):
-        return self.data[2]
-
-
-    def _validate_data(self, data):
-        x, y, z = data
-        if not z.ndim == 2:
-            raise ValueError("Z-values must be 2D array")
-
-        ys, xs = z.shape
-        shape_errors = []
-        if x.ndim == 1 and xs+1 != len(x):
-            shape_errors.append('x')
-        if x.ndim == 1 and ys+1 != len(y):
-            shape_errors.append('y')
-        if shape_errors:
-            raise ValueError("%s-edges must match shape of z-array." %
-                             '/'.join(shape_errors))
-        return data
-
-
-    def __getitem__(self, slices):
-        if slices in self.dimensions(): return self.dimension_values(slices)
-        slices = util.process_ellipses(self,slices)
-        if not self._grid:
-            raise KeyError("Indexing of non-grid based QuadMesh"
-                             "currently not supported")
-        if len(slices) > (2 + self.depth):
-            raise KeyError("Can only slice %d dimensions" % (2 + self.depth))
-        elif len(slices) == 3 and slices[-1] not in [self.vdims[0].name, slice(None)]:
-            raise KeyError("%r is the only selectable value dimension" % self.vdims[0].name)
-        slices = slices[:2]
-        if not isinstance(slices, tuple): slices = (slices, slice(None))
-        slc_types = [isinstance(sl, slice) for sl in slices]
-        if not any(slc_types):
-            indices = []
-            for idx, data in zip(slices, self.data[:self.ndims]):
-                indices.append(np.digitize([idx], data)-1)
-            return self.data[2][tuple(indices[::-1])]
-        else:
-            sliced_data, indices = [], []
-            for slc, data in zip(slices, self.data[:self.ndims]):
-                if isinstance(slc, slice):
-                    low, high = slc.start, slc.stop
-                    lidx = ([None] if low is None else
-                            max((np.digitize([low], data)-1, 0)))[0]
-                    hidx = ([None] if high is None else
-                            np.digitize([high], data))[0]
-                    sliced_data.append(data[lidx:hidx])
-                    indices.append(slice(lidx, (hidx if hidx is None else hidx-1)))
-                else:
-                    index = (np.digitize([slc], data)-1)[0]
-                    sliced_data.append(data[index:index+2])
-                    indices.append(index)
-            z = np.atleast_2d(self.data[2][tuple(indices[::-1])])
-            if not all(slc_types) and not slc_types[0]:
-                z = z.T
-            return self.clone(tuple(sliced_data+[z]))
-
-
-    @classmethod
-    def collapse_data(cls, data_list, function, kdims=None, **kwargs):
-        """
-        Allows collapsing the data of a number of QuadMesh
-        Elements with a function.
-        """
-        if not all(data[0].ndim == 1 for data in data_list):
-            raise Exception("Collapsing of non-grid based QuadMesh"
-                            "currently not supported")
-        xs, ys, zs = zip(data_list)
-        if isinstance(function, np.ufunc):
-            z = function.reduce(zs)
-        else:
-            z = function(np.dstack(zs), axis=-1, **kwargs)
-        return xs[0], ys[0], z
-
-
-    def _coord2matrix(self, coord):
-        return tuple((np.digitize([coord[i]], self.data[i])-1)[0]
-                     for i in [1, 0])
-
-
-    def range(self, dimension, data_range=True):
-        idx = self.get_dimension_index(dimension)
-        if data_range and idx in [0, 1]:
-            data = self.data[idx]
-            return np.min(data), np.max(data)
-        elif data_range and idx == 2:
-            data = self.data[idx]
-            return np.nanmin(data), np.nanmax(data)
-        super(QuadMesh, self).range(dimension)
-
-
-    def dimension_values(self, dimension, expanded=True, flat=True):
-        idx = self.get_dimension_index(dimension)
-        data = self.data[idx]
-        if idx in [0, 1]:
-            if not self._grid:
-                return data.flatten()
-            odim = self.data[2].shape[idx] if expanded else 1
-            vals = np.tile(np.convolve(data, np.ones((2,))/2, mode='valid'), odim)
-            if idx:
-                return np.sort(vals)
-            else:
-                return vals
-        elif idx == 2:
-            return data.flatten() if flat else data
-        else:
-            return super(QuadMesh, self).dimension_values(idx)
-
-
-class HeatMap(Dataset, Element2D):
-    """
-    HeatMap is an atomic Element used to visualize two dimensional
-    parameter spaces. It supports sparse or non-linear spaces, dynamically
-    upsampling them to a dense representation, which can be visualized.
-
-    A HeatMap can be initialized with any dict or NdMapping type with
-    two-dimensional keys.
-    """
-
-    group = param.String(default='HeatMap', constant=True)
-
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
-
-    vdims = param.List(default=[Dimension('z')])
-
-    def __init__(self, data, **params):
-        super(HeatMap, self).__init__(data, **params)
-        self.gridded = categorical_aggregate2d(self)
-
-    @property
-    def raster(self):
-        self.warning("The .raster attribute on HeatMap is deprecated, "
-                     "the 2D aggregate is now computed dynamically "
-                     "during plotting.")
-        return self.gridded.dimension_values(2, flat=False)
-
-
-class Image(Dataset, Element2D, SheetCoordinateSystem):
-    """
-    Image is the atomic unit as which 2D data is stored, along with
-    its bounds object. The input data may be a numpy.matrix object or
-    a two-dimensional numpy array.
-
-    Allows slicing operations of the data in sheet coordinates or direct
-    access to the data, via the .data attribute.
-    """
-
     datatype = param.List(default=['image', 'grid', 'xarray'])
 
     bounds = param.ClassSelector(class_=BoundingRegion, default=None, doc="""
@@ -418,13 +46,14 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         The label of the x- and y-dimension of the Raster in form
         of a string or dimension object.""")
 
-    group = param.String(default='Image', constant=True)
+    group = param.String(default='Raster', constant=True)
 
     vdims = param.List(default=[Dimension('z')],
                        bounds=(1, 1), doc="""
         The dimension description of the data held in the matrix.""")
 
     def __init__(self, data, bounds=None, extents=None, xdensity=None, ydensity=None, **params):
+        data, bounds = self._wrap_data(data, bounds)
         extents = extents if extents else (None, None, None, None)
         if data is None: data = np.array([[0]])
         Dataset.__init__(self, data, extents=extents, bounds=None, **params)
@@ -458,6 +87,13 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
                 raise ValueError("Input array has shape %r but %d value dimensions defined"
                                  % (self.shape, len(self.vdims)))
 
+    def _wrap_data(self, data, bounds):
+        if isinstance(data, np.ndarray):
+            coords = [np.arange(s) for s in data.shape[::-1]]
+            data = tuple(coords + [data])
+            return data, None
+        return data, bounds
+
 
     def select(self, selection_specs=None, **selection):
         """
@@ -481,12 +117,6 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
                               ydensity=self.ydensity, **kwargs)
 
 
-    def groupby(self, dimensions=[], container_type=HoloMap, group_type=Dataset,
-                dynamic=False, **kwargs):
-        return super(Image, self).groupby(dimensions, container_type, group_type,
-                                          dynamic, **kwargs)
-
-
     def sample(self, samples=[], **kwargs):
         """
         Allows sampling of Dataset as an iterator of coordinates
@@ -504,6 +134,16 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         elif kwargs:
             return self.clone(self.select(**kwargs).columns(), new_type=Dataset)
         return self.clone(self.interface.sample(self, samples), new_type=Dataset)
+
+
+    def groupby(self, dimensions=[], container_type=HoloMap, group_type=Dataset,
+                dynamic=False, **kwargs):
+        return super(Raster, self).groupby(dimensions, container_type, group_type,
+                                          dynamic, **kwargs)
+
+    @property
+    def depth(self):
+        return len(self.vdims)
 
 
     def _coord2matrix(self, coord):
@@ -547,49 +187,24 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         else:
             return [getter(self.closest_cell_center(*el)) for el in coords]
 
-    @property
-    def depth(self):
-        return len(self.vdims)
 
-
-class GridImage(Dataset, Element2D):
+class Image(Raster):
     """
-    Grid interface based version of an Image, which will
-    eventually supercede the original Image implementation.
+    Image is the atomic unit as which 2D data is stored, along with
+    its bounds object. The input data may be a numpy.matrix object or
+    a two-dimensional numpy array.
+
+    Allows slicing operations of the data in sheet coordinates or direct
+    access to the data, via the .data attribute.
     """
 
-    group = param.String(default='GridImage', constant=True)
+    group = param.String(default='Image', constant=True)
 
-    kdims = param.List(default=[Dimension('x'), Dimension('y')],
-                       bounds=(2, 2))
+    def _wrap_data(self, data, bounds):
+        return data, bounds
 
-    vdims = param.List(default=[Dimension('z')], bounds=(1, 1))
 
-    def __init__(self, data, **params):
-        super(GridImage, self).__init__(data, **params)
-        (l, r), (b, t) = self.interface.range(self, 0), self.interface.range(self, 1)
-        (ys, xs) = self.dimension_values(2, flat=False).shape
-        xsampling = (float(r-l)/(xs-1))/2.
-        ysampling = (float(t-b)/(ys-1))/2.
-        l, r = l-xsampling, r+xsampling
-        b, t = b-ysampling, t+ysampling
-        self.bounds = BoundingBox(points=((l, b), (r, t)))
-
-    def range(self, dim, data_range=True):
-        dim_idx = dim if isinstance(dim, int) else self.get_dimension_index(dim)
-        dim = self.get_dimension(dim_idx)
-        if dim.range != (None, None):
-            return dim.range
-        elif dim_idx in [0, 1]:
-            l, b, r, t = self.bounds.lbrt()
-            if dim_idx:
-                drange = (b, t)
-            else:
-                drange = (l, r)
-            return drange
-        else:
-            return self.interface.range(self, dim)
-
+GridImage = Image
 
 
 class RGB(Image):
@@ -666,17 +281,6 @@ class RGB(Image):
         rgb = cls(data, bounds=bounds, **kwargs)
         if bare: rgb = rgb(plot=dict(xaxis=None, yaxis=None))
         return rgb
-
-
-    def dimension_values(self, dim, expanded=True, flat=True):
-        """
-        The set of samples available along a particular dimension.
-        """
-        dim_idx = self.get_dimension_index(dim)
-        if self.ndims <= dim_idx < len(self.dimensions()):
-            data = np.flipud(self.data[:,:,dim_idx-self.ndims]).T
-            return data.flatten() if flat else data
-        return super(RGB, self).dimension_values(dim, expanded, flat)
 
 
     def __init__(self, data, **params):
@@ -777,3 +381,185 @@ class HSV(RGB):
 
         return RGB(np.dstack(hsv), bounds=self.bounds,
                    group=self.group, label=self.label)
+
+
+class QuadMesh(Element2D):
+    """
+    QuadMesh is a Raster type to hold x- and y- bin values
+    with associated values. The x- and y-values of the QuadMesh
+    may be supplied either as the edges of each bin allowing
+    uneven sampling or as the bin centers, which will be converted
+    to evenly sampled edges.
+
+    As a secondary but less supported mode QuadMesh can contain
+    a mesh of quadrilateral coordinates that is not laid out in
+    a grid. The data should then be supplied as three separate
+    2D arrays for the x-/y-coordinates and grid values.
+    """
+
+    group = param.String(default="QuadMesh", constant=True)
+
+    kdims = param.List(default=[Dimension('x'), Dimension('y')])
+
+    vdims = param.List(default=[Dimension('z')], bounds=(1,1))
+
+    def __init__(self, data, **params):
+        data = self._process_data(data)
+        Element2D.__init__(self, data, **params)
+        self.data = self._validate_data(self.data)
+        self._grid = self.data[0].ndim == 1
+
+
+    @property
+    def depth(self): return 1
+
+    def _process_data(self, data):
+        data = tuple(np.array(el) for el in data)
+        x, y, zarray = data
+        ys, xs = zarray.shape
+        if x.ndim == 1 and len(x) == xs:
+            x = compute_edges(x)
+        if y.ndim == 1 and len(y) == ys:
+            y = compute_edges(y)
+        return (x, y, zarray)
+
+
+    @property
+    def _zdata(self):
+        return self.data[2]
+
+
+    def _validate_data(self, data):
+        x, y, z = data
+        if not z.ndim == 2:
+            raise ValueError("Z-values must be 2D array")
+
+        ys, xs = z.shape
+        shape_errors = []
+        if x.ndim == 1 and xs+1 != len(x):
+            shape_errors.append('x')
+        if x.ndim == 1 and ys+1 != len(y):
+            shape_errors.append('y')
+        if shape_errors:
+            raise ValueError("%s-edges must match shape of z-array." %
+                             '/'.join(shape_errors))
+        return data
+
+
+    def __getitem__(self, slices):
+        if slices in self.dimensions(): return self.dimension_values(slices)
+        slices = util.process_ellipses(self,slices)
+        if not self._grid:
+            raise KeyError("Indexing of non-grid based QuadMesh"
+                             "currently not supported")
+        if len(slices) > (2 + self.depth):
+            raise KeyError("Can only slice %d dimensions" % (2 + self.depth))
+        elif len(slices) == 3 and slices[-1] not in [self.vdims[0].name, slice(None)]:
+            raise KeyError("%r is the only selectable value dimension" % self.vdims[0].name)
+        slices = slices[:2]
+        if not isinstance(slices, tuple): slices = (slices, slice(None))
+        slc_types = [isinstance(sl, slice) for sl in slices]
+        if not any(slc_types):
+            indices = []
+            for idx, data in zip(slices, self.data[:self.ndims]):
+                indices.append(np.digitize([idx], data)-1)
+            return self.data[2][tuple(indices[::-1])]
+        else:
+            sliced_data, indices = [], []
+            for slc, data in zip(slices, self.data[:self.ndims]):
+                if isinstance(slc, slice):
+                    low, high = slc.start, slc.stop
+                    lidx = ([None] if low is None else
+                            max((np.digitize([low], data)-1, 0)))[0]
+                    hidx = ([None] if high is None else
+                            np.digitize([high], data))[0]
+                    sliced_data.append(data[lidx:hidx])
+                    indices.append(slice(lidx, (hidx if hidx is None else hidx-1)))
+                else:
+                    index = (np.digitize([slc], data)-1)[0]
+                    sliced_data.append(data[index:index+2])
+                    indices.append(index)
+            z = np.atleast_2d(self.data[2][tuple(indices[::-1])])
+            if not all(slc_types) and not slc_types[0]:
+                z = z.T
+            return self.clone(tuple(sliced_data+[z]))
+
+
+    @classmethod
+    def collapse_data(cls, data_list, function, kdims=None, **kwargs):
+        """
+        Allows collapsing the data of a number of QuadMesh
+        Elements with a function.
+        """
+        if not all(data[0].ndim == 1 for data in data_list):
+            raise Exception("Collapsing of non-grid based QuadMesh"
+                            "currently not supported")
+        xs, ys, zs = zip(data_list)
+        if isinstance(function, np.ufunc):
+            z = function.reduce(zs)
+        else:
+            z = function(np.dstack(zs), axis=-1, **kwargs)
+        return xs[0], ys[0], z
+
+
+    def _coord2matrix(self, coord):
+        return tuple((np.digitize([coord[i]], self.data[i])-1)[0]
+                     for i in [1, 0])
+
+
+    def range(self, dimension):
+        idx = self.get_dimension_index(dimension)
+        if idx in [0, 1]:
+            data = self.data[idx]
+            return np.min(data), np.max(data)
+        elif idx == 2:
+            data = self.data[idx]
+            return np.nanmin(data), np.nanmax(data)
+        super(QuadMesh, self).range(dimension)
+
+
+    def dimension_values(self, dimension, expanded=True, flat=True):
+        idx = self.get_dimension_index(dimension)
+        data = self.data[idx]
+        if idx in [0, 1]:
+            if not self._grid:
+                return data.flatten()
+            odim = self.data[2].shape[idx] if expanded else 1
+            vals = np.tile(np.convolve(data, np.ones((2,))/2, mode='valid'), odim)
+            if idx:
+                return np.sort(vals)
+            else:
+                return vals
+        elif idx == 2:
+            return data.flatten() if flat else data
+        else:
+            return super(QuadMesh, self).dimension_values(idx)
+
+
+class HeatMap(Dataset, Element2D):
+    """
+    HeatMap is an atomic Element used to visualize two dimensional
+    parameter spaces. It supports sparse or non-linear spaces, dynamically
+    upsampling them to a dense representation, which can be visualized.
+
+    A HeatMap can be initialized with any dict or NdMapping type with
+    two-dimensional keys.
+    """
+
+    group = param.String(default='HeatMap', constant=True)
+
+    kdims = param.List(default=[Dimension('x'), Dimension('y')])
+
+    vdims = param.List(default=[Dimension('z')])
+
+    def __init__(self, data, **params):
+        super(HeatMap, self).__init__(data, **params)
+        self.gridded = categorical_aggregate2d(self)
+
+    @property
+    def raster(self):
+        self.warning("The .raster attribute on HeatMap is deprecated, "
+                     "the 2D aggregate is now computed dynamically "
+                     "during plotting.")
+        return self.gridded.dimension_values(2, flat=False)
+

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -6,9 +6,9 @@ import colorsys
 import param
 
 from ..core import util
-from ..core.data import ArrayInterface, DictInterface
-from ..core import (Dimension, NdMapping, Element2D,
-                    Overlay, Element, Dataset)
+from ..core.data import ArrayInterface, NdElementInterface, DictInterface
+from ..core import (Dimension, NdMapping, Element2D, HoloMap,
+                    Overlay, Element, Dataset, NdElement)
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
 from ..core.util import pd
@@ -479,6 +479,12 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         else:
             return self.clone(data, xdensity=self.xdensity,
                               ydensity=self.ydensity, **kwargs)
+
+
+    def groupby(self, dimensions=[], container_type=HoloMap, group_type=Dataset,
+                dynamic=False, **kwargs):
+        return super(Image, self).groupby(dimensions, container_type, group_type,
+                                          dynamic, **kwargs)
 
 
     def sample(self, samples=[], **kwargs):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -762,12 +762,12 @@ class HSV(RGB):
         """
         Conversion from HSV to RGB.
         """
-        hsv = self.hsv_to_rgb(self.data[:,:,0],
-                              self.data[:,:,1],
-                              self.data[:,:,2])
+        data = [self.dimension_values(d, flat=False)
+                for d in self.vdims]
+
+        hsv = self.hsv_to_rgb(*data[:2])
         if len(self.vdims) == 4:
-            hsv += (self.data[:,:,3],)
+            hsv += (data[3],)
 
         return RGB(np.dstack(hsv), bounds=self.bounds,
-                   group=self.group,
-                   label=self.label)
+                   group=self.group, label=self.label)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -67,9 +67,9 @@ class Raster(Dataset, Element2D, SheetCoordinateSystem):
             bounds = BoundingBox()
         if bounds is None:
             xvals = self.dimension_values(0, False)
-            l, r, xdensity = util.bound_range(xvals, xdensity)
+            l, r, xdensity, _ = util.bound_range(xvals, xdensity)
             yvals = self.dimension_values(0, False)
-            b, t, ydensity = util.bound_range(yvals, ydensity)
+            b, t, ydensity, _ = util.bound_range(yvals, ydensity)
             bounds = BoundingBox(points=((l, b), (r, t)))
         elif np.isscalar(bounds):
             bounds = BoundingBox(radius=bounds)
@@ -375,7 +375,7 @@ class HSV(RGB):
         data = [self.dimension_values(d, flat=False)
                 for d in self.vdims]
 
-        hsv = self.hsv_to_rgb(*data[:2])
+        hsv = self.hsv_to_rgb(*data[:3])
         if len(self.vdims) == 4:
             hsv += (data[3],)
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -266,6 +266,8 @@ class RGB(Image):
         If an alpha channel is supplied, the defined alpha_dimension
         is automatically appended to this list.""")
 
+    _vdim_reductions = {1: Image}
+
     @property
     def rgb(self):
         """

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -397,6 +397,18 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             return [getter(self.closest_cell_center(*el)) for el in coords]
 
 
+    def range(self, dim, data_range=True):
+        idx = self.get_dimension_index(dim)
+        dimension = self.get_dimension(dim)
+        rng = super(Image, self).range(dim, data_range)
+        if idx in [0, 1] and data_range and dimension.range == (None, None):
+            low, high = rng
+            density = self.ydensity if idx else self.xdensity
+            halfd = (1./density)/2.
+            return (low-halfd, high+halfd)
+        return rng
+
+
     def table(self, datatype=None):
         """
         Converts the data Element to a Table, optionally may

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -201,7 +201,7 @@ class Raster(Element2D):
 
 
 
-class Image(Dataset, Element2D, SheetCoordinateSystem):
+class Image(Dataset, Raster, SheetCoordinateSystem):
     """
     Image is the atomic unit as which 2D data is stored, along with
     its bounds object. The input data may be a numpy.matrix object or

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -6,7 +6,8 @@ import colorsys
 import param
 
 from ..core import util
-from ..core.data import ArrayInterface, NdElementInterface, DictInterface
+from ..core.data import (ArrayInterface, NdElementInterface, DictInterface,
+                         ImageInterface)
 from ..core import (Dimension, NdMapping, Element2D, HoloMap,
                     Overlay, Element, Dataset, NdElement)
 from ..core.boundingregion import BoundingRegion, BoundingBox
@@ -258,6 +259,18 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             if self.shape[2] != len(self.vdims):
                 raise ValueError("Input array has shape %r but %d value dimensions defined"
                                  % (self.shape, len(self.vdims)))
+
+
+    def __setstate__(self, state):
+        """
+        Ensures old-style unpickled Image types without an interface
+        use the ImageInterface.
+        """
+        self.__dict__ = state
+        if isinstance(self.data, np.ndarray):
+            self.interface = ImageInterface
+        super(Dataset, self).__setstate__(state)
+
 
     def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):
         agg = super(Image, self).aggregate(dimensions, function, spreadfn, **kwargs)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -481,6 +481,25 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
                               ydensity=self.ydensity, **kwargs)
 
 
+    def sample(self, samples=[], **kwargs):
+        """
+        Allows sampling of Dataset as an iterator of coordinates
+        matching the key dimensions, returning a new object containing
+        just the selected samples. Alternatively may supply kwargs
+        to sample a co-ordinate on an object.
+        """
+        if kwargs and samples:
+            raise Exception('Supply explicit list of samples or kwargs, not both.')
+        if len(kwargs) == 1 and self.ndims == 2 and self.interface.gridded:
+            dim, val = list(kwargs.items())[0]
+            kdims = [d for d in self.kdims if d != dim]
+            return Curve(self.select(**kwargs).columns(),
+                         kdims=kdims, vdims=self.vdims)
+        elif kwargs:
+            return self.clone(self.select(**kwargs).columns(), new_type=Dataset)
+        return self.clone(self.interface.sample(self, samples), new_type=Dataset)
+
+
     def _coord2matrix(self, coord):
         return self.sheet2matrixidx(*coord)
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -337,42 +337,6 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
                               ydensity=self.ydensity, bounds=bounds)
 
 
-    def sample(self, samples=[], closest=True, **kwargs):
-        """
-        Allows sampling of Dataset as an iterator of coordinates
-        matching the key dimensions, returning a new object containing
-        just the selected samples. Alternatively may supply kwargs
-        to sample a coordinate on an object.
-        """
-        if kwargs and samples:
-            raise Exception('Supply explicit list of samples or kwargs, not both.')
-        if len(kwargs) == 1 and self.ndims == 2 and self.interface.gridded:
-            dim, val = list(kwargs.items())[0]
-            kdims = [d for d in self.kdims if d != dim]
-            return Curve(self.select(**kwargs).columns(),
-                         kdims=kdims, vdims=self.vdims)
-        elif kwargs:
-            selected = self.select(**kwargs)
-            if isinstance(selected, Dataset):
-                return self.clone(selected.columns(), new_type=Dataset)
-            elif np.isscalar(selected):
-                data = [kwargs.get(d.name, kwargs.get(d.name)) for d in self.dimensions()]
-                data[self.ndims] = selected
-                return self.clone([tuple(data)], new_type=Dataset)
-        lens = {len(util.wrap_tuple(s)) for s in samples}
-        if len(lens) > 1:
-            raise IndexError('Sample coordinates must all be of the same length.')
-        if closest:
-            length = list(lens)[0]
-            if length == 1:
-                samples = self.closest(**{self.kdims[0].name: samples})
-                if np.isscalar(samples): samples = [samples]
-            else:
-                samples = self.closest(samples)
-        samples = [util.wrap_tuple(s) for s in samples]
-        return self.clone(self.interface.sample(self, samples), new_type=Dataset)
-
-
     def closest(self, coords=[], **kwargs):
         """
         Given a single coordinate or multiple coordinates as

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -278,7 +278,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
 
     def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):
         agg = super(Image, self).aggregate(dimensions, function, spreadfn, **kwargs)
-        return Curve(agg) if isinstance(agg, Dataset) else agg
+        return Curve(agg) if isinstance(agg, Dataset) and len(self.vdims) == 1 else agg
 
 
     def select(self, selection_specs=None, **selection):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -275,7 +275,7 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             return self
 
         selection = {self.get_dimension(k).name: slice(*sel) if isinstance(sel, tuple) else sel
-                     for k, sel in selection.items()}
+                     for k, sel in selection.items() if k in self.kdims}
         coords = tuple(selection[kd.name] if kd.name in selection else slice(None)
                        for kd in self.kdims)
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -91,7 +91,7 @@ class Raster(Dataset, Element2D, SheetCoordinateSystem):
     def _wrap_data(self, data, bounds):
         if isinstance(data, np.ndarray):
             coords = [np.arange(s) for s in data.shape[::-1]]
-            data = tuple(coords + [np.flipud(data)])
+            data = tuple(coords + [data])
             return data, None
         return data, bounds
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -429,7 +429,7 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
         if data is None: data = np.array([[0]])
         Dataset.__init__(self, data, extents=extents, bounds=None, **params)
 
-        (dim1, dim2) = self.shape[1], self.shape[0]
+        (dim2, dim1) = self.interface.shape(self)[:2]
         l, r = self.range(0)
         b, t = self.range(1)
         if self.bounds is not None:
@@ -438,9 +438,9 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             bounds = BoundingBox()
         if bounds is None:
             xvals = self.dimension_values(0, False)
-            l, r = util.bound_range(xvals, xdensity)
+            l, r, xdensity = util.bound_range(xvals, xdensity)
             yvals = self.dimension_values(0, False)
-            b, t = util.bound_range(yvals, ydensity)
+            b, t, ydensity = util.bound_range(yvals, ydensity)
             bounds = BoundingBox(points=((l, b), (r, t)))
         elif np.isscalar(bounds):
             bounds = BoundingBox(radius=bounds)
@@ -478,7 +478,7 @@ class Image(Dataset, Element2D, SheetCoordinateSystem):
             return data
         else:
             return self.clone(data, xdensity=self.xdensity,
-                              ydensity=self.ydensity, bounds=None, **kwargs)
+                              ydensity=self.ydensity, **kwargs)
 
 
     def _coord2matrix(self, coord):

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -260,6 +260,8 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         """
         Ensures old-style unpickled Image types without an interface
         use the ImageInterface.
+
+        Note: Deprecate as part of 2.0
         """
         self.__dict__ = state
         if isinstance(self.data, np.ndarray):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -25,17 +25,6 @@ except:
     xr = None
 
 
-def toarray(v, index_value=False):
-    """
-    Interface helper function to turn dask Arrays into numpy arrays as
-    necessary. If index_value is True, a value is returned instead of
-    an array holding a single value.
-    """
-    if dask and isinstance(v, dask.array.Array):
-        arr =  v.compute()
-        return arr[()] if index_value else arr
-    else:
-        return v
 
 def compute_edges(edges):
     """

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -4,7 +4,9 @@ import param
 import numpy as np
 
 from ..core import Dataset, OrderedDict
+from ..core.boundingregion import BoundingBox
 from ..core.operation import ElementOperation
+from ..core.sheetcoords import Slice
 from ..core.util import (is_nan, sort_topologically, one_to_one,
                          cartesian_product, is_cyclic)
 
@@ -39,6 +41,54 @@ def compute_edges(edges):
         raise ValueError('Centered bins have to be of equal width.')
     edges -= width/2.
     return np.concatenate([edges, [edges[-1]+width]])
+
+
+def compute_slice_bounds(slices, scs, shape):
+    """
+    Given a 2D selection consisting of slices/coordinates, a
+    SheetCoordinateSystem and the shape of the array returns a new
+    BoundingBox representing the sliced region.
+    """
+    xidx, yidx = slices
+    ys, xs = shape
+    l, b, r, t = scs.bounds.lbrt()
+    xdensity, ydensity = scs.xdensity, scs.ydensity
+    xunit = (1./xdensity)
+    yunit = (1./ydensity)
+    if isinstance(xidx, slice):
+        l = l if xidx.start is None else max(l, xidx.start)
+        r = r if xidx.stop is None else min(r, xidx.stop)
+    if isinstance(yidx, slice):
+        b = b if yidx.start is None else max(b, yidx.start)
+        t = t if yidx.stop is None else min(t, yidx.stop)
+    bounds = BoundingBox(points=((l, b), (r, t)))
+
+    # Apply new bounds
+    slc = Slice(bounds, scs)
+
+    # Apply scalar and list indices
+    l, b, r, t = slc.compute_bounds(scs).lbrt()
+    if not isinstance(xidx, slice):
+        if not isinstance(xidx, (list, set)): xidx = [xidx]
+        if len(xidx) > 1:
+            xdensity = xdensity*(float(len(xidx))/xs)
+        ls, rs = [], []
+        for idx in xidx:
+            xc, _ = scs.closest_cell_center(idx, b)
+            ls.append(xc-xunit/2)
+            rs.append(xc+xunit/2)
+        l, r = np.min(ls), np.max(rs)
+    elif not isinstance(yidx, slice):
+        if not isinstance(yidx, (set, list)): yidx = [yidx]
+        if len(yidx) > 1:
+            ydensity = ydensity*(float(len(yidx))/ys)
+        bs, ts = [], []
+        for idx in yidx:
+            _, yc = scs.closest_cell_center(l, idx)
+            bs.append(yc-yunit/2)
+            ts.append(yc+yunit/2)
+        b, t = np.min(bs), np.max(ts)
+    return BoundingBox(points=((l, b), (r, t)))
 
 
 def reduce_fn(x):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -430,11 +430,11 @@ class contours(ElementOperation):
         else:
             contour_fn = plt.contour
             contour_type = Contours
+
         if type(element) is Raster:
             data = [np.flipud(element.data)]
-        elif isinstance(element, Raster):
-            data = [element.data]
-        
+        elif isinstance(element, Image):
+            data = [np.flipud(element.dimension_values(2, flat=False))]
         elif isinstance(element, QuadMesh):
             data = (element.dimension_values(0, False),
                     element.dimension_values(1, False),

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -322,7 +322,7 @@ class gradient(ElementOperation):
 
         matrix_dim = matrix.vdims[0]
 
-        data = matrix.data
+        data = np.flipud(matrix.dimension_values(matrix_dim, flat=False))
         r, c = data.shape
 
         if  matrix_dim.cyclic and (None in matrix_dim.range):
@@ -382,8 +382,9 @@ class convolve(ElementOperation):
 
         k = kernel.data if self.p.kernel_roi == (0,0,0,0) else kernel[xslice, yslice].data
 
-        fft1 = np.fft.fft2(target.data)
-        fft2 = np.fft.fft2(k, s= target.data.shape)
+        data = np.flipud(target.dimension_values(2, flat=False))
+        fft1 = np.fft.fft2(data)
+        fft2 = np.fft.fft2(k, s=data.shape)
         convolved_raw = np.fft.ifft2(fft1 * fft2).real
 
         k_rows, k_cols = k.shape

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -25,7 +25,7 @@ from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideSpikesPlot, AreaPlot, VectorFieldPlot)
 from .path import PathPlot, PolygonPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
-from .raster import (RasterPlot, ImagePlot, RGBPlot, HeatmapPlot,
+from .raster import (RasterPlot, RGBPlot, HeatmapPlot,
                      HSVPlot, QuadMeshPlot)
 from .renderer import BokehRenderer
 from .tabular import TablePlot
@@ -53,8 +53,8 @@ associations = {Overlay: OverlayPlot,
                 VectorField: VectorFieldPlot,
 
                 # Rasters
-                Image: ImagePlot,
-                GridImage: ImagePlot,
+                Image: RasterPlot,
+                GridImage: RasterPlot,
                 RGB: RGBPlot,
                 HSV: HSVPlot,
                 Raster: RasterPlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -53,7 +53,7 @@ associations = {Overlay: OverlayPlot,
                 VectorField: VectorFieldPlot,
 
                 # Rasters
-                Image: RasterPlot,
+                Image: ImagePlot,
                 GridImage: ImagePlot,
                 RGB: RGBPlot,
                 HSV: HSVPlot,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -6,8 +6,7 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         RGB, Histogram, Spread, HeatMap, Contours, Bars,
                         Box, Bounds, Ellipse, Polygons, BoxWhisker,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
-                        Table, ItemTable, Area, HSV, QuadMesh, GridImage,
-                        VectorField)
+                        Table, ItemTable, Area, HSV, QuadMesh, VectorField)
 from ...core.options import Options, Cycle
 
 try:
@@ -54,7 +53,6 @@ associations = {Overlay: OverlayPlot,
 
                 # Rasters
                 Image: RasterPlot,
-                GridImage: RasterPlot,
                 RGB: RGBPlot,
                 HSV: HSVPlot,
                 Raster: RasterPlot,

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -34,24 +34,21 @@ class RasterPlot(ColorbarPlot):
 
 
     def get_data(self, element, ranges=None, empty=False):
-        img = element.data
-        if isinstance(element, Image):
-            l, b, r, t = element.bounds.lbrt()
-        else:
-            l, b, r, t = element.extents
-        dh = t-b
-        if type(element) is Raster:
-            b = t
-
+        img = element.dimension_values(2, flat=False)
         if img.dtype.kind == 'b':
             img = img.astype(np.int8)
 
+        l, b, r, t = element.bounds.lbrt()
+        if type(element) is Raster:
+            b = t
+
+        dh, dw = t-b, r-l
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:
             data = dict(image=[], x=[], y=[], dw=[], dh=[])
         else:
-            data = dict(image=[np.flipud(img)], x=[l],
-                        y=[b], dw=[r-l], dh=[dh])
+            data = dict(image=[img], x=[l],
+                        y=[b], dw=[dw], dh=[dh])
         return (data, mapping)
 
 
@@ -66,24 +63,6 @@ class RasterPlot(ColorbarPlot):
 
 
 
-class ImagePlot(RasterPlot):
-
-    def get_data(self, element, ranges=None, empty=False):
-        img = element.dimension_values(2, flat=False)
-        if img.dtype.kind == 'b':
-            img = img.astype(np.int8)
-
-        l, b, r, t = element.bounds.lbrt()
-        dh, dw = t-b, r-l
-        mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
-        if empty:
-            data = dict(image=[], x=[], y=[], dw=[], dh=[])
-        else:
-            data = dict(image=[img], x=[l],
-                        y=[b], dw=[dw], dh=[dh])
-        return (data, mapping)
-
-
 class RGBPlot(RasterPlot):
 
     style_opts = []
@@ -93,7 +72,7 @@ class RGBPlot(RasterPlot):
         l, b, r, t = element.bounds.lbrt()
         dh, dw = t-b, r-l
 
-        img = np.dstack([element.dimension_values(d, flat=False).T
+        img = np.dstack([element.dimension_values(d, flat=False)
                          for d in element.vdims])
         if img.ndim == 3:
             if img.shape[2] == 3: # alpha channel not included
@@ -122,8 +101,7 @@ class RGBPlot(RasterPlot):
 class HSVPlot(RGBPlot):
 
     def get_data(self, element, ranges=None, empty=False):
-        rgb = RGB(hsv_to_rgb(element.data))
-        return super(HSVPlot, self).get_data(rgb, ranges, empty)
+        return super(HSVPlot, self).get_data(element.rgb, ranges, empty)
 
 
 class HeatmapPlot(ColorbarPlot):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -41,7 +41,8 @@ class RasterPlot(ColorbarPlot):
         l, b, r, t = element.bounds.lbrt()
         dh, dw = t-b, r-l
         if type(element) is Raster:
-            b = t
+            t, b = b, t
+            img = np.flipud(img)
 
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -38,14 +38,14 @@ class RasterPlot(ColorbarPlot):
         if img.dtype.kind == 'b':
             img = img.astype(np.int8)
 
-        if type(element) is Raster:
+        if isinstance(element, Image):
+            l, b, r, t = element.bounds.lbrt()
+        else:
             img = np.flipud(img.T)
             l, b, r, t = element.extents
-        else:
-            l, b, r, t = element.bounds.lbrt()
-        if self.invert_yaxis:
-            b, t = t, b
         dh, dw = t-b, r-l
+        if type(element) is Raster:
+            b, t = t, b
 
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -39,10 +39,10 @@ class RasterPlot(ColorbarPlot):
             img = img.astype(np.int8)
 
         l, b, r, t = element.bounds.lbrt()
+        dh, dw = t-b, r-l
         if type(element) is Raster:
             b = t
 
-        dh, dw = t-b, r-l
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:
             data = dict(image=[], x=[], y=[], dw=[], dh=[])

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -38,11 +38,14 @@ class RasterPlot(ColorbarPlot):
         if img.dtype.kind == 'b':
             img = img.astype(np.int8)
 
-        l, b, r, t = element.bounds.lbrt()
-        dh, dw = t-b, r-l
         if type(element) is Raster:
-            t, b = b, t
-            img = np.flipud(img)
+            img = np.flipud(img.T)
+            l, b, r, t = element.extents
+        else:
+            l, b, r, t = element.bounds.lbrt()
+        if self.invert_yaxis:
+            b, t = t, b
+        dh, dw = t-b, r-l
 
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -141,7 +141,7 @@ Store.register({Curve: CurvePlot,
                 Image: RasterPlot,
                 RGB: RasterPlot,
                 HSV: RasterPlot,
-                GridImage: ImagePlot,
+                GridImage: RasterPlot,
 
                 # Annotation plots
                 VLine: VLinePlot,

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -141,7 +141,6 @@ Store.register({Curve: CurvePlot,
                 Image: RasterPlot,
                 RGB: RasterPlot,
                 HSV: RasterPlot,
-                GridImage: RasterPlot,
 
                 # Annotation plots
                 VLine: VLinePlot,

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -59,7 +59,6 @@ class RasterPlot(ColorbarPlot):
         if isinstance(element, RGB):
             style.pop('cmap', None)
 
-        data = element.data
         if isinstance(element, Image):
             l, b, r, t = element.bounds.lbrt()
         else:
@@ -68,7 +67,11 @@ class RasterPlot(ColorbarPlot):
             b, t = t, b
 
         if isinstance(element, RGB):
-            data = element.rgb.data
+            rgb = element.rgb
+            data = np.dstack([np.flipud(rgb.dimension_values(d, flat=False).T)
+                              for d in rgb.vdims])
+        else:
+            data = np.flipud(element.dimension_values(2, flat=False))
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)
         style['extent'] = [l, r, b, t]

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -59,9 +59,12 @@ class RasterPlot(ColorbarPlot):
         if isinstance(element, RGB):
             style.pop('cmap', None)
 
-        l, b, r, t = element.bounds.lbrt()
-        if self.invert_yaxis and type(element) is Raster:
-            b, t = t, b
+        if type(element) is Raster:
+            l, b, r, t = element.extents
+            if self.invert_yaxis:
+                b, t = t, b
+        else:
+            l, b, r, t = element.bounds.lbrt()
 
         if isinstance(element, RGB):
             rgb = element.rgb
@@ -69,7 +72,9 @@ class RasterPlot(ColorbarPlot):
                               for d in rgb.vdims])
         else:
             data = element.dimension_values(2, flat=False)
-            if not type(element) is Raster:
+            if type(element) is Raster:
+                data = data.T
+            else:
                 data = np.flipud(data)
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -68,7 +68,9 @@ class RasterPlot(ColorbarPlot):
             data = np.dstack([np.flipud(rgb.dimension_values(d, flat=False))
                               for d in rgb.vdims])
         else:
-            data = np.flipud(element.dimension_values(2, flat=False))
+            data = element.dimension_values(2, flat=False)
+            if not type(element) is Raster:
+                data = np.flipud(data)
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)
         style['extent'] = [l, r, b, t]

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -12,7 +12,7 @@ from ...core.util import match_spec, max_range, unique_iterator, unique_array, i
 from ...element.raster import Image, Raster, RGB
 from .element import ColorbarPlot, OverlayPlot
 from .plot import MPLPlot, GridPlot, mpl_rc_context
-from .util import get_raster_data
+from .util import get_raster_array
 
 
 class RasterPlot(ColorbarPlot):
@@ -67,7 +67,7 @@ class RasterPlot(ColorbarPlot):
         else:
             l, b, r, t = element.bounds.lbrt()
 
-        data = get_raster_data(element)
+        data = get_raster_array(element)
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)
         style['extent'] = [l, r, b, t]
@@ -345,7 +345,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
                 pane = vmap.select(**{d.name: val for d, val in zip(self.dimensions, key)
                                     if d in vmap.kdims})
                 pane = vmap.last.values()[-1] if issubclass(vmap.type, CompositeOverlay) else vmap.last
-                data = get_raster_data(pane) if pane else None
+                data = get_raster_array(pane) if pane else None
                 ranges = self.compute_ranges(vmap, key, ranges)
                 opts = self.lookup_options(pane, 'style')[self.cyclic_index]
                 plot = self.handles['axis'].imshow(data, extent=(x,x+w, y, y+h), **opts)
@@ -377,7 +377,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
                 if element:
                     plot.set_visible(True)
                     img = element.values()[0] if isinstance(element, CompositeOverlay) else element
-                    data = get_raster_data(img)
+                    data = get_raster_array(img)
                     plot.set_data(data)
                 else:
                     plot.set_visible(False)

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -7,6 +7,7 @@ from matplotlib import ticker
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 
 from ...core.util import basestring
+from ...element import Raster, RGB
 
 
 def wrap_formatter(formatter):
@@ -164,3 +165,20 @@ def get_tight_bbox(fig, bbox_extra_artists=[], pad=None):
         bbox_extra = TransformedBbox(_bbox, trans)
         bbox_inches = Bbox.union([bbox_inches, bbox_extra])
     return bbox_inches.padded(pad) if pad else bbox_inches
+
+
+def get_raster_data(image):
+    """
+    Return the array data from any Raster or Image type
+    """
+    if isinstance(image, RGB):
+        rgb = image.rgb
+        data = np.dstack([np.flipud(rgb.dimension_values(d, flat=False))
+                          for d in rgb.vdims])
+    else:
+        data = image.dimension_values(2, flat=False)
+        if type(image) is Raster:
+            data = data.T
+        else:
+            data = np.flipud(data)
+    return data

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -167,7 +167,7 @@ def get_tight_bbox(fig, bbox_extra_artists=[], pad=None):
     return bbox_inches.padded(pad) if pad else bbox_inches
 
 
-def get_raster_data(image):
+def get_raster_array(image):
     """
     Return the array data from any Raster or Image type
     """

--- a/tests/testaliases.py
+++ b/tests/testaliases.py
@@ -53,4 +53,4 @@ class TestAliases(ComparisonTestCase):
         self.assertEqual(im.kdims[0].label, '$\Lambda$')
         self.assertEqual(im.kdims[1].label, 'Energy ($J$)')
         sliced = im.select(Lambda=(-0.2, 0.2), Joules=(-0.3, 0.3))
-        self.assertEqual(sliced.shape, (6,4))
+        self.assertEqual(sliced.shape, (24,3))

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -76,7 +76,7 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         try:
             self.assertEqual(self.dimension4, self.dimension8)
         except AssertionError as e:
-            self.assertEqual(str(e), "Dimension parameter 'values' mismatched: list lengths mismatched")
+            self.assertEqual(str(e), "Dimension parameter 'values' mismatched: [] != ['a', 'b']")
 
     def test_dimension_comparison_types_unequal(self):
         try:

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -76,7 +76,7 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         try:
             self.assertEqual(self.dimension4, self.dimension8)
         except AssertionError as e:
-            self.assertEqual(str(e), "Dimension parameter 'values' mismatched: [] != ['a', 'b']")
+            self.assertEqual(str(e), "Dimension parameter 'values' mismatched: list lengths mismatched")
 
     def test_dimension_comparison_types_unequal(self):
         try:

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -1012,3 +1012,6 @@ class RasterDatasetTest(GridTests, ComparisonTestCase):
         Dataset.datatype = ['image']
         self.data_instance_type = dict
         self.init_grid_data()
+
+    def tearDown(self):
+        Dataset.datatype = self.restore_datatype

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -25,16 +25,17 @@ except:
 
 class DatatypeContext(object):
 
-    def __init__(self, datatypes):
+    def __init__(self, datatypes, dataset_type=Dataset):
         self.datatypes = datatypes
+        self.dataset_type = dataset_type
         self._old_datatypes = None
 
     def __enter__(self):
-        self._old_datatypes = Dataset.datatype
-        Dataset.datatype = self.datatypes
+        self._old_datatypes = self.dataset_type.datatype
+        self.dataset_type.datatype = self.datatypes
 
     def __exit__(self, *args):
-        Dataset.datatype = self._old_datatypes
+        self.dataset_type.datatype = self._old_datatypes
 
 
 class HomogeneousColumnTypes(object):

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -816,6 +816,19 @@ class GridDatasetTest(GridTests, HomogeneousColumnTypes, ComparisonTestCase):
         self.assertEqual(table.vdims[1], 'Z')
         self.compare_arrays(table.dimension_values('Z'), np.array(list(range(1,12))))
 
+    def test_dataset_2D_columnar_shape(self):
+        array = np.random.rand(11, 11)
+        dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
+                          kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(dataset.shape, (11*11, 3))
+
+    def test_dataset_2D_gridded_shape(self):
+        array = np.random.rand(12, 11)
+        dataset = Dataset({'x':self.xs, 'y': range(12), 'z': array},
+                          kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(dataset.interface.shape(dataset, gridded=True),
+                         (12, 11))
+
     def test_dataset_2D_aggregate_partial_hm(self):
         array = np.random.rand(11, 11)
         dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},

--- a/tests/testellipsis.py
+++ b/tests/testellipsis.py
@@ -28,7 +28,7 @@ class TestEllipsisCharts(ComparisonTestCase):
         try:
             hv.Scatter(range(10))[...,'Non-existent']
         except Exception as e:
-            if str(e) != "'Non-existent' is not an available value dimension'":
+            if str(e) != "'Non-existent' is not an available value dimension":
                 raise AssertionError("Incorrect exception raised.")
 
     def test_points_ellipsis_slice_y(self):
@@ -107,7 +107,7 @@ class TestEllipsisRaster(ComparisonTestCase):
         try:
             hv.Image(data)[...,'Non-existent']
         except Exception as e:
-            if str(e) != repr("'z' is the only selectable value dimension"):
+            if str(e) != "'Non-existent' is not an available value dimension":
                 raise AssertionError("Unexpected exception.")
 
     def test_rgb_ellipsis_slice_value(self):

--- a/tests/testellipsis.py
+++ b/tests/testellipsis.py
@@ -87,14 +87,15 @@ class TestEllipsisRaster(ComparisonTestCase):
     def test_raster_ellipsis_slice_value(self):
         data = np.random.rand(10,10)
         sliced = hv.Raster(data)[...,'z']
-        self.assertEqual(sliced.data, data)
+        self.assertEqual(sliced.data, np.flipud(data))
 
     def test_raster_ellipsis_slice_value_missing(self):
         data = np.random.rand(10,10)
         try:
             hv.Raster(data)[...,'Non-existent']
         except Exception as e:
-            if str(e) != repr("'z' is the only selectable value dimension"):
+            print(e)
+            if str(e) != "'Non-existent' is not an available value dimension":
                 raise AssertionError("Unexpected exception.")
 
     def test_image_ellipsis_slice_value(self):

--- a/tests/testellipsis.py
+++ b/tests/testellipsis.py
@@ -87,15 +87,14 @@ class TestEllipsisRaster(ComparisonTestCase):
     def test_raster_ellipsis_slice_value(self):
         data = np.random.rand(10,10)
         sliced = hv.Raster(data)[...,'z']
-        self.assertEqual(sliced.data, np.flipud(data))
+        self.assertEqual(sliced.data, data)
 
     def test_raster_ellipsis_slice_value_missing(self):
         data = np.random.rand(10,10)
         try:
             hv.Raster(data)[...,'Non-existent']
         except Exception as e:
-            print(e)
-            if str(e) != "'Non-existent' is not an available value dimension":
+            if "\'z\' is the only selectable value dimension" not in str(e):
                 raise AssertionError("Unexpected exception.")
 
     def test_image_ellipsis_slice_value(self):

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -19,9 +19,7 @@ class ImageInterfaceTest(ComparisonTestCase):
 
     def init_data(self):
         self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
-        self.rgb_array = np.random.rand(10, 10, 3)
         self.image = Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
-        self.rgb = RGB(self.rgb_array, bounds=(-10, 0, 10, 10))
 
     def tearDown(self):
         self.eltype.datatype = self.restore_datatype
@@ -141,11 +139,6 @@ class ImageInterfaceTest(ComparisonTestCase):
             self.assertEqual(self.image.reduce(y=np.mean),
                              Curve((xs, zs), kdims=['x'], vdims=['z']))
 
-    def test_select_value_dimension_rgb(self):
-        self.assertEqual(self.rgb[..., 'R'],
-                         self.image.clone(self.rgb_array[:, :, 0],
-                                          vdims=[Dimension('R', range=(0, 1))]))
-
 
 
 class ImageGridInterfaceTest(ImageInterfaceTest):
@@ -161,12 +154,6 @@ class ImageGridInterfaceTest(ImageInterfaceTest):
         self.rgb = RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
                         self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
-    
-    def test_select_value_dimension_rgb(self):
-        self.assertEqual(self.rgb[..., 'R'],
-                         self.image.clone((self.xs, self.ys, self.rgb_array[:, :, 0]),
-                                          vdims=[Dimension('R', range=(0, 1))]))
-
 
 
 class ImageXArrayInterfaceTest(ImageGridInterfaceTest):
@@ -178,7 +165,6 @@ class ImageIrisInterfaceTest(ImageGridInterfaceTest):
 
     datatype = 'cube'
 
-    
     def init_data(self):
         xs = np.linspace(-9, 9, 10)
         ys = np.linspace(0.5, 9.5, 10)
@@ -194,8 +180,42 @@ class ImageIrisInterfaceTest(ImageGridInterfaceTest):
     def test_reduce_y_dimension(self):
         raise SkipTest("Not supported")
 
+
+class RGBInterfaceTest(ComparisonTestCase):
+
+    datatype = 'image'
+
+    def setUp(self):
+        self.eltype = RGB
+        self.restore_datatype = self.eltype.datatype
+        self.eltype.datatype = [self.datatype]
+        self.init_data()
+
+    def init_data(self):
+        self.rgb_array = np.random.rand(10, 10, 3)
+        self.rgb = RGB(self.rgb_array, bounds=(-10, 0, 10, 10))
+
     def test_select_value_dimension_rgb(self):
-        raise SkipTest("Not supported")
+        self.assertEqual(self.rgb[..., 'R'],
+                         Image(self.rgb_array[:, :, 0], bounds=self.rgb.bounds,
+                               vdims=[Dimension('R', range=(0, 1))]))
 
 
-        
+
+class RGBGridInterfaceTest(RGBInterfaceTest):
+
+    datatype = 'grid'
+
+    def init_data(self):
+        self.xs = np.linspace(-9, 9, 10)
+        self.ys = np.linspace(0.5, 9.5, 10)
+        self.rgb_array = np.random.rand(10, 10, 3)
+        self.rgb = RGB((self.xs, self.ys, np.flipud(self.rgb_array[:, :, 0]),
+                        np.flipud(self.rgb_array[:, :, 1]),
+                        np.flipud(self.rgb_array[:, :, 2])))
+
+
+
+class RGBXArrayInterfaceTest(RGBGridInterfaceTest):
+
+    datatype = 'xarray'

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -1,0 +1,111 @@
+from unittest import SkipTest
+
+import numpy as np
+from holoviews import Dimension, Image
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class ImageInterfaceTest(ComparisonTestCase):
+
+    datatype = 'image'
+
+    def setUp(self):
+        self.eltype = Image
+        self.restore_datatype = self.eltype.datatype
+        self.eltype.datatype = [self.datatype]
+        self.init_data()
+
+    def init_data(self):
+        self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
+        self.image = Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
+
+    def tearDown(self):
+        self.eltype.datatype = self.restore_datatype
+
+    def test_init_bounds(self):
+        self.assertEqual(self.image.bounds.lbrt(), (-10, 0, 10, 10))
+
+    def test_init_densities(self):
+        self.assertEqual(self.image.xdensity, 0.5)
+        self.assertEqual(self.image.ydensity, 1)
+
+    def test_dimension_values_xs(self):
+        self.assertEqual(self.image.dimension_values(0, expanded=False),
+                         np.linspace(-9, 9, 10))
+
+    def test_dimension_values_ys(self):
+        self.assertEqual(self.image.dimension_values(1, expanded=False),
+                         np.linspace(0.5, 9.5, 10))
+
+    def test_dimension_values_ys(self):
+        self.assertEqual(self.image.dimension_values(1, expanded=False),
+                         np.linspace(0.5, 9.5, 10))
+
+    def test_dimension_values_vdim(self):
+        self.assertEqual(self.image.dimension_values(2, flat=False),
+                         self.array)
+
+    def test_index_single_coordinate(self):
+        self.assertEqual(self.image[0.3, 5.1], 25)
+
+    def test_slice_xaxis(self):
+        sliced = self.image[0.3:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 0, 6, 10))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.array[:, 5:8])
+
+    def test_slice_yaxis(self):
+        sliced = self.image[:, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (-10, 1., 10, 5))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.array[1:5, :])
+
+    def test_slice_both_axes(self):
+        sliced = self.image[0.3:5.2, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 1., 6, 5))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.array[1:5, 5:8])
+
+    def test_slice_x_index_y(self):
+        sliced = self.image[0.3:5.2, 5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 5.0, 6.0, 6.0))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.array[5:6, 5:8])
+    
+    def test_index_x_slice_y(self):
+        sliced = self.image[3.2, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (2.0, 1.0, 4.0, 5.0))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.array[1:5, 6:7])
+
+
+
+class ImageGridInterfaceTest(ImageInterfaceTest):
+
+    datatype = 'grid'
+
+    def init_data(self):
+        xs = np.linspace(-9, 9, 10)
+        ys = np.linspace(0.5, 9.5, 10)
+        self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
+        self.image = Image((xs, ys, self.array))
+
+
+class ImageXArrayInterfaceTest(ImageGridInterfaceTest):
+
+    datatype = 'xarray'
+
+
+class ImageIrisInterfaceTest(ImageGridInterfaceTest):
+
+    datatype = 'cube'

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -93,10 +93,10 @@ class ImageInterfaceTest(ComparisonTestCase):
                          self.array[1:5, 6:7])
 
     def test_range_xdim(self):
-        self.assertEqual(self.image.range(0), (-9, 9))
+        self.assertEqual(self.image.range(0), (-10, 10))
 
     def test_range_ydim(self):
-        self.assertEqual(self.image.range(1), (0.5, 9.5))
+        self.assertEqual(self.image.range(1), (0, 10))
 
     def test_range_vdim(self):
         self.assertEqual(self.image.range(2), (0, 81))

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -1,7 +1,7 @@
 from unittest import SkipTest
 
 import numpy as np
-from holoviews import Dimension, Image, Curve, RGB
+from holoviews import Dimension, Image, Curve, RGB, Dataset
 from holoviews.element.comparison import ComparisonTestCase
 
 from .testdataset import DatatypeContext
@@ -150,9 +150,6 @@ class ImageGridInterfaceTest(ImageInterfaceTest):
         self.ys = np.linspace(0.5, 9.5, 10)
         self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
         self.image = Image((self.xs, self.ys, self.array))
-        self.rgb_array = np.random.rand(10, 10, 3)
-        self.rgb = RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
-                        self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
 
@@ -193,12 +190,108 @@ class RGBInterfaceTest(ComparisonTestCase):
 
     def init_data(self):
         self.rgb_array = np.random.rand(10, 10, 3)
-        self.rgb = RGB(self.rgb_array, bounds=(-10, 0, 10, 10))
+        self.rgb = RGB(self.rgb_array[::-1], bounds=(-10, 0, 10, 10))
+
+    def test_init_bounds(self):
+        self.assertEqual(self.rgb.bounds.lbrt(), (-10, 0, 10, 10))
+
+    def test_init_densities(self):
+        self.assertEqual(self.rgb.xdensity, 0.5)
+        self.assertEqual(self.rgb.ydensity, 1)
+
+    def test_dimension_values_xs(self):
+        self.assertEqual(self.rgb.dimension_values(0, expanded=False),
+                         np.linspace(-9, 9, 10))
+
+    def test_dimension_values_ys(self):
+        self.assertEqual(self.rgb.dimension_values(1, expanded=False),
+                         np.linspace(0.5, 9.5, 10))
+
+    def test_dimension_values_ys(self):
+        self.assertEqual(self.rgb.dimension_values(1, expanded=False),
+                         np.linspace(0.5, 9.5, 10))
+
+    def test_dimension_values_vdims(self):
+        self.assertEqual(self.rgb.dimension_values(2, flat=False),
+                         self.rgb_array[:, :, 0])
+        self.assertEqual(self.rgb.dimension_values(3, flat=False),
+                         self.rgb_array[:, :, 1])
+        self.assertEqual(self.rgb.dimension_values(4, flat=False),
+                         self.rgb_array[:, :, 2])
+
+    def test_slice_xaxis(self):
+        sliced = self.rgb[0.3:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 0, 6, 10))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.rgb_array[:, 5:8, 0])
+
+    def test_slice_yaxis(self):
+        sliced = self.rgb[:, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (-10, 1., 10, 5))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.rgb_array[1:5, :, 0])
+
+    def test_slice_both_axes(self):
+        sliced = self.rgb[0.3:5.2, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 1., 6, 5))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.rgb_array[1:5, 5:8, 0])
+
+    def test_slice_x_index_y(self):
+        sliced = self.rgb[0.3:5.2, 5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (0, 5.0, 6.0, 6.0))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.rgb_array[5:6, 5:8, 0])
+
+    def test_index_x_slice_y(self):
+        sliced = self.rgb[3.2, 1.2:5.2]
+        self.assertEqual(sliced.bounds.lbrt(), (2.0, 1.0, 4.0, 5.0))
+        self.assertEqual(sliced.xdensity, 0.5)
+        self.assertEqual(sliced.ydensity, 1)
+        self.assertEqual(sliced.dimension_values(2, flat=False),
+                         self.rgb_array[1:5, 6:7, 0])
 
     def test_select_value_dimension_rgb(self):
         self.assertEqual(self.rgb[..., 'R'],
-                         Image(self.rgb_array[:, :, 0], bounds=self.rgb.bounds,
+                         Image(np.flipud(self.rgb_array[:, :, 0]), bounds=self.rgb.bounds,
                                vdims=[Dimension('R', range=(0, 1))]))
+
+    def test_select_single_coordinate(self):
+        with DatatypeContext([self.datatype, 'columns', 'dataframe'], self.rgb):
+            self.assertEqual(self.rgb[5.2, 3.1],
+                             self.rgb.clone([tuple(self.rgb_array[3, 7])],
+                                            kdims=[], new_type=Dataset))
+
+
+    def test_reduce_to_single_values(self):
+        with DatatypeContext([self.datatype, 'columns', 'dataframe'], self.rgb):
+            self.assertEqual(self.rgb.reduce(['x', 'y'], function=np.mean),
+                             self.rgb.clone([tuple(np.mean(self.rgb_array, axis=(0, 1)))],
+                                            kdims=[], new_type=Dataset))
+
+    def test_sample_xcoord(self):
+        ys = np.linspace(0.5, 9.5, 10)
+        data = (ys,) + tuple(self.rgb_array[:, 7, i] for i in range(3))
+        with DatatypeContext([self.datatype, 'columns', 'dataframe'], self.rgb):
+            self.assertEqual(self.rgb.sample(x=5),
+                             self.rgb.clone(data, kdims=['y'],
+                                            new_type=Curve))
+
+    def test_sample_ycoord(self):
+        xs = np.linspace(-9, 9, 10)
+        data = (xs,) + tuple(self.rgb_array[4, :, i] for i in range(3))
+        with DatatypeContext([self.datatype, 'columns', 'dataframe'], self.rgb):
+            self.assertEqual(self.rgb.sample(y=5),
+                             self.rgb.clone(data, kdims=['x'],
+                                            new_type=Curve))
 
 
 
@@ -210,9 +303,8 @@ class RGBGridInterfaceTest(RGBInterfaceTest):
         self.xs = np.linspace(-9, 9, 10)
         self.ys = np.linspace(0.5, 9.5, 10)
         self.rgb_array = np.random.rand(10, 10, 3)
-        self.rgb = RGB((self.xs, self.ys, np.flipud(self.rgb_array[:, :, 0]),
-                        np.flipud(self.rgb_array[:, :, 1]),
-                        np.flipud(self.rgb_array[:, :, 2])))
+        self.rgb = RGB((self.xs, self.ys, self.rgb_array[:, :, 0],
+                        self.rgb_array[:, :, 1], self.rgb_array[:, :, 2]))
 
 
 

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -139,6 +139,19 @@ class ImageInterfaceTest(ComparisonTestCase):
             self.assertEqual(self.image.reduce(y=np.mean),
                              Curve((xs, zs), kdims=['x'], vdims=['z']))
 
+    def test_dataset_reindex_constant(self):
+        selected = Dataset(self.image.select(x=0))
+        reindexed = selected.reindex(['y'])
+        data = Dataset(selected.columns(['y', 'z']),
+                       kdims=['y'], vdims=['z'])
+        self.assertEqual(reindexed, data)
+
+    def test_dataset_reindex_non_constant(self):
+        ds = Dataset(self.image)
+        reindexed = ds.reindex(['y'])
+        data = Dataset(ds.columns(['y', 'z']),
+                       kdims=['y'], vdims=['z'])
+        self.assertEqual(reindexed, data)
 
 
 class ImageGridInterfaceTest(ImageInterfaceTest):
@@ -292,6 +305,20 @@ class RGBInterfaceTest(ComparisonTestCase):
             self.assertEqual(self.rgb.sample(y=5),
                              self.rgb.clone(data, kdims=['x'],
                                             new_type=Curve))
+
+    def test_dataset_reindex_constant(self):
+        ds = Dataset(self.rgb.select(x=0))
+        reindexed = ds.reindex(['y'], ['R'])
+        data = Dataset(ds.columns(['y', 'R']),
+                       kdims=['y'], vdims=[ds.vdims[0]])
+        self.assertEqual(reindexed, data)
+
+    def test_dataset_reindex_non_constant(self):
+        ds = Dataset(self.rgb)
+        reindexed = ds.reindex(['y'], ['R'])
+        data = Dataset(ds.columns(['y', 'R']),
+                       kdims=['y'], vdims=[ds.vdims[0]])
+        self.assertEqual(reindexed, data)
 
 
 

--- a/tests/testndmapping.py
+++ b/tests/testndmapping.py
@@ -118,7 +118,8 @@ class NdIndexableMappingTest(ComparisonTestCase):
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
         ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])
         redimmed = ndmap.redim(intdim='Integer')
-        self.assertEqual(redimmed.kdims, [Dimension('Integer'), Dimension('floatdim')])
+        self.assertEqual(redimmed.kdims, [Dimension('Integer', type=int),
+                                          Dimension('floatdim', type=float)])
 
     def test_idxmapping_add_dimension(self):
         ndmap = MultiDimensionalMapping(self.init_items_1D_list, kdims=[self.dim1])


### PR DESCRIPTION
This PR is a WIP in implementing an interface to allow ``Image`` Elements to subclass ``Dataset`` and use the other interfaces, replacing ``GridImage``. There are a few things to be settled so I'm hoping to discuss these in this PR.

1. Our Image types need bounds. When you pass in an array the bounds are required, but when using the xarray and grid interfaces, the bounds should be computed from the data. Currently I deduce the bounds by asserting that all samples must be evenly spaced with a small tolerance (10e-9). Eventually we'll have QuadMesh for non-equal spacing, but that will require some more work. Does this sound reasonable?

2. Dataset does not have an interface to access multiple value arrays at once. This makes it difficult to access RGB and HSV data. We can either accept the overhead of stacking and unstacking these arrays and provide a convenient property on RGB/HSV elements to do this for us, or come up with a general API on the interfaces to get the stacked arrays. There was also the suggestion that other interfaces could support holding stacked value dimension arrays instead of holding them as unstacked arrays per value dimension but that could happen in a later PR.