### PR TITLE
Fixed hover tooltips for Curve and Path types

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -143,16 +143,14 @@ class CurvePlot(ElementPlot):
 
     def _hover_tooltips(self, element):
         if self.batched:
-            dims = list(self.hmap.last.kdims)
+            return list(self.hmap.last.kdims)
         else:
-            dims = list(self.overlay_dims.keys())
-        return [(d.pprint_label, '@'+dimension_sanitizer(d.name))
-                      for d in dims]
+            return list(self.overlay_dims.keys())
 
     def get_batched_data(self, overlay, ranges=None, empty=False):
         data = defaultdict(list)
         opts = ['color', 'line_alpha', 'line_color']
-        for key, el in overlay.items():
+        for key, el in overlay.data.items():
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].append(eld)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -141,24 +141,42 @@ class CurvePlot(ElementPlot):
                  y: [] if empty else element.dimension_values(yidx)},
                 dict(x=x, y=y))
 
+    def _hover_tooltips(self, element):
+        if self.batched:
+            dims = list(self.hmap.last.kdims)
+        else:
+            dims = list(self.overlay_dims.keys())
+        return [(d.pprint_label, '@'+dimension_sanitizer(d.name))
+                      for d in dims]
+
     def get_batched_data(self, overlay, ranges=None, empty=False):
         data = defaultdict(list)
+        opts = ['color', 'line_alpha', 'line_color']
         for key, el in overlay.items():
+            eldata, elmapping = self.get_data(el, ranges, empty)
+            for k, eld in eldata.items():
+                data[k].append(eld)
+
+            # Add options
             style = self.lookup_options(el, 'style')
             style = style.max_cycles(len(self.ordering))
             zorder = self.get_zorder(overlay, key, el)
-            for opt in self._mapping:
-                if opt in ['xs', 'ys']:
-                    index = {'xs': 0, 'ys': 1}[opt]
-                    val = el.dimension_values(index)
-                else:
-                    val = style[zorder].get(opt)
+            style = style[zorder]
+            for opt in opts:
+                if opt not in style:
+                    continue
+                val = style[opt]
                 if opt == 'color' and isinstance(val, tuple):
                     val = rgb2hex(val)
-                data[opt].append(val)
+                data[opt].append([val])
+
+            for d, k in zip(overlay.kdims, key):
+                sanitized = dimension_sanitizer(d.name)
+                data[sanitized].append([k])
         data = {opt: vals for opt, vals in data.items()
                 if not any(v is None for v in vals)}
-        return data, {k: k for k in data}
+        return data, dict(xs=elmapping['x'], ys=elmapping['y'],
+                          **{o: o for o in opts if o in data})
 
 
 class AreaPlot(PolygonPlot):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -201,14 +201,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             dims = list(self.overlay_dims.keys())
         dims += element.dimensions()
-        return [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
-                for d in dims]
+        return dims
 
     def _init_tools(self, element, callbacks=[]):
         """
         Processes the list of tools to be supplied to the plot.
         """
-        tooltips = self._hover_tooltips(element)
+        tooltip_dims = self._hover_tooltips(element)
+        tooltips = [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
+                    for d in tooltip_dims]
 
         callbacks = callbacks+self.callbacks
         cb_tools, tool_names = [], []

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -195,18 +195,20 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             cbs.append(cb(self, cb_streams, source))
         return cbs
 
-
-    def _init_tools(self, element, callbacks=[]):
-        """
-        Processes the list of tools to be supplied to the plot.
-        """
+    def _hover_tooltips(self, element):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
             dims = list(self.overlay_dims.keys())
         dims += element.dimensions()
-        tooltips = [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
-                    for d in dims]
+        return [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
+                for d in dims]
+
+    def _init_tools(self, element, callbacks=[]):
+        """
+        Processes the list of tools to be supplied to the plot.
+        """
+        tooltips = self._hover_tooltips(element)
 
         callbacks = callbacks+self.callbacks
         cb_tools, tool_names = [], []
@@ -233,10 +235,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Initializes hover data based on Element dimension values.
         If empty initializes with no data.
         """
-        if 'hover' in self.default_tools + self.tools:
-            for d in element.dimensions(label=True):
-                sanitized = util.dimension_sanitizer(d)
-                data[sanitized] = [] if empty else element.dimension_values(d)
+        if 'hover' not in self.default_tools + self.tools:
+            return
+
+        for d in element.dimensions(label=True):
+            sanitized = util.dimension_sanitizer(d)
+            data[sanitized] = [] if empty else element.dimension_values(d)
+        for k, v in self.overlay_dims.items():
+            dim = util.dimension_sanitizer(k.name)
+            data[dim] = [v for _ in range(len(data.values()[0]))]
 
 
     def _axes_props(self, plots, subplots, element, ranges):

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -22,11 +22,9 @@ class PathPlot(ElementPlot):
 
     def _hover_tooltips(self, element):
         if self.batched:
-            dims = list(self.hmap.last.kdims)
+            return list(self.hmap.last.kdims)
         else:
-            dims = list(self.overlay_dims.keys())
-        return [(d.pprint_label, '@'+dimension_sanitizer(d.name))
-                      for d in dims]
+            return list(self.overlay_dims.keys())
 
     def get_data(self, element, ranges=None, empty=False):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
@@ -57,6 +55,14 @@ class PolygonPlot(ColorbarPlot, PathPlot):
 
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
+
+    def _hover_tooltips(self, element):
+        if self.batched:
+            dims = list(self.hmap.last.kdims)
+        else:
+            dims = list(self.overlay_dims.keys())
+        dims += element.vdims
+        return dims
 
     def get_data(self, element, ranges=None, empty=False):
         xs = [] if empty else [path[:, 0] for path in element.data]

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -20,6 +20,14 @@ class PathPlot(ElementPlot):
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
 
+    def _hover_tooltips(self, element):
+        if self.batched:
+            dims = list(self.hmap.last.kdims)
+        else:
+            dims = list(self.overlay_dims.keys())
+        return [(d.pprint_label, '@'+dimension_sanitizer(d.name))
+                      for d in dims]
+
     def get_data(self, element, ranges=None, empty=False):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         xs = [] if empty else [path[:, xidx] for path in element.data]


### PR DESCRIPTION
Currently dimensions that shouldn't be are appearing in the hover tooltips. Additionally on ``CurvePlot`` the NdOverlay dimension information isn't supplied at all. I've also made various fixes to make color and alpha option work correctly in batched mode.