### PR TITLE
Define Dimension formatters for numpy integer types

### DIFF
--- a/holoviews/core/__init__.py
+++ b/holoviews/core/__init__.py
@@ -14,6 +14,12 @@ archive = FileArchive()
 
 # Define default type formatters
 Dimension.type_formatters[int] = "%d"
+Dimension.type_formatters[np.uint16] = '%d'
+Dimension.type_formatters[np.int16] = '%d'
+Dimension.type_formatters[np.uint32] = '%d'
+Dimension.type_formatters[np.int32] = '%d'
+Dimension.type_formatters[np.uint64] = '%d'
+Dimension.type_formatters[np.int64] = '%d'
 Dimension.type_formatters[float] = "%.5g"
 Dimension.type_formatters[np.float32] = "%.5g"
 Dimension.type_formatters[np.float64] = "%.5g"


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/975, widgets do not correctly format integers at the moment. This is easily fixed by defining ``Dimension.type_formatters`` for the numpy integer types.