### PR TITLE
Fixed bokeh FuncTickFormater

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh pandas jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader
   - source activate test-environment
-  - conda install -c conda-forge  -c scitools iris sip=4.18 plotly
+  - conda install -c conda-forge  -c scitools iris sip=4.18 plotly flexx
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;
     fi

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -34,7 +34,7 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update, get_sources
 from .plot import BokehPlot
 from .util import (mpl_to_bokeh, convert_datetime, update_plot,
-                   bokeh_version, mplcmap_to_palette)
+                   bokeh_version, mplcmap_to_palette, py2js_tickformatter)
 
 if bokeh_version >= '0.12':
     from bokeh.models import FuncTickFormatter
@@ -450,17 +450,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if formatter:
                 msg = ('%s dimension formatter could not be '
                        'converted to tick formatter. ' % dimension.name)
-                try:
-                    formatter = FuncTickFormatter.from_py_func(formatter)
-                except RuntimeError:
-                    self.warning(msg+'Ensure Flexx is installed '
-                                 '("conda install -c bokeh flexx" or '
-                                 '"pip install flexx")')
-                except Exception as e:
-                    error = 'Pyscript raised an error: {0}'.format(e)
-                    error = error.replace('%', '%%')
-                    self.warning(msg+error)
-                else:
+                jsfunc = py2js_tickformatter(formatter, msg)
+                if jsfunc:
+                    formatter = FuncTickFormatter(code=jsfunc)
                     axis_props['formatter'] = formatter
         return axis_props
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -10,6 +10,7 @@ try:
 except ImportError:
     cm, colors = None, None
 
+import param
 import bokeh
 bokeh_version = LooseVersion(bokeh.__version__)
 from bokeh.core.enums import Palette
@@ -381,16 +382,16 @@ def py2js_tickformatter(formatter, msg=''):
     try:
         from flexx.pyscript import py2js
     except ImportError:
-        self.warning(msg+'Ensure Flexx is installed '
-                     '("conda install -c bokeh flexx" or '
-                     '"pip install flexx")')
+        param.main.warning(msg+'Ensure Flexx is installed '
+                           '("conda install -c bokeh flexx" or '
+                           '"pip install flexx")')
         return
     try:
         jscode = py2js(formatter, 'formatter')
     except Exception as e:
         error = 'Pyscript raised an error: {0}'.format(e)
         error = error.replace('%', '%%')
-        self.warning(msg+error)
+        param.main.warning(msg+error)
         return
 
     args = inspect.getargspec(formatter).args

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -1,0 +1,42 @@
+from unittest import SkipTest
+
+from holoviews.core.options import Store
+from holoviews.element.comparison import ComparisonTestCase
+
+try:
+    from holoviews.plotting.bokeh import util
+    bokeh_renderer = Store.renderers['bokeh']
+except:
+    bokeh_renderer = None
+
+
+class TestBokehUtils(ComparisonTestCase):
+
+    def setUp(self):
+        if not bokeh_renderer:
+            raise SkipTest("Bokeh required to test bokeh plot utils.")
+
+
+    def test_py2js_funcformatter_single_arg(self):
+        def test(x):  return '%s$' % x
+        jsfunc = util.py2js_tickformatter(test)
+        js_func = ('var x = tick;\nvar formatter;\nformatter = function () {\n'
+                   '    return "" + x + "$";\n};\n\nreturn formatter();\n')
+        self.assertEqual(jsfunc, js_func)
+
+
+    def test_py2js_funcformatter_two_args(self):
+        def test(x, pos):  return '%s$' % x
+        jsfunc = util.py2js_tickformatter(test)
+        js_func = ('var x = tick;\nvar formatter;\nformatter = function () {\n'
+                   '    return "" + x + "$";\n};\n\nreturn formatter();\n')
+        self.assertEqual(jsfunc, js_func)
+
+    
+    def test_py2js_funcformatter_arg_and_kwarg(self):
+        def test(x, pos=None):  return '%s$' % x
+        jsfunc = util.py2js_tickformatter(test)
+        js_func = ('var x = tick;\nvar formatter;\nformatter = function () {\n'
+                   '    pos = (pos === undefined) ? null: pos;\n    return "" '
+                   '+ x + "$";\n};\n\nreturn formatter();\n')
+        self.assertEqual(jsfunc, js_func)


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/885 in bokeh 0.12.3 the signature of python FuncTickFormatters was changed in a way that is inconsistent with formatters in holoviews. This PR adds a utility that compiles the python formatter with pyscript directly and then patches the generated JS code so the arg are made available in the namespace rather than being passed to the function. It's not exactly pretty but I don't see a way around it. I've also added some unit tests.