### PR TITLE
Raise warning when size_index set to non-numeric dimension

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -67,15 +67,22 @@ class PointPlot(ColorbarPlot):
         sdim = element.get_dimension(self.size_index)
         if sdim:
             map_key = 'size_' + sdim.name
-            mapping['size'] = map_key
             if empty:
                 data[map_key] = []
+                mapping['size'] = map_key
             else:
                 ms = style.get('size', np.sqrt(6))**2
                 sizes = element.dimension_values(self.size_index)
-                data[map_key] = np.sqrt(compute_sizes(sizes, self.size_fn,
-                                                      self.scaling_factor,
-                                                      self.scaling_method, ms))
+                if sizes.dtype.kind in ('i', 'f'):
+                    sizes = compute_sizes(sizes, self.size_fn,
+                                          self.scaling_factor,
+                                          self.scaling_method, ms)
+                    data[map_key] = np.sqrt(sizes)
+                    mapping['size'] = map_key
+                else:
+                    eltype = type(element).__name__
+                    self.warning('%s dimension is not numeric, cannot '
+                                 'use to scale %s size.' % (sdim, eltype))
 
         data[dims[xidx]] = [] if empty else element.dimension_values(xidx)
         data[dims[yidx]] = [] if empty else element.dimension_values(yidx)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -73,16 +73,16 @@ class PointPlot(ColorbarPlot):
             else:
                 ms = style.get('size', np.sqrt(6))**2
                 sizes = element.dimension_values(self.size_index)
-                if sizes.dtype.kind in ('i', 'f'):
-                    sizes = compute_sizes(sizes, self.size_fn,
-                                          self.scaling_factor,
-                                          self.scaling_method, ms)
-                    data[map_key] = np.sqrt(sizes)
-                    mapping['size'] = map_key
-                else:
+                sizes = compute_sizes(sizes, self.size_fn,
+                                      self.scaling_factor,
+                                      self.scaling_method, ms)
+                if sizes is None:
                     eltype = type(element).__name__
                     self.warning('%s dimension is not numeric, cannot '
                                  'use to scale %s size.' % (sdim, eltype))
+                else:
+                    data[map_key] = np.sqrt(sizes)
+                    mapping['size'] = map_key
 
         data[dims[xidx]] = [] if empty else element.dimension_values(xidx)
         data[dims[yidx]] = [] if empty else element.dimension_values(yidx)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -510,15 +510,15 @@ class PointPlot(ChartPlot, ColorbarPlot):
         sdim = element.get_dimension(self.size_index)
         if sdim:
             sizes = element.dimension_values(self.size_index)
-            if sizes.dtype.kind in ('i', 'f'):
-                style['s'] = compute_sizes(sizes, self.size_fn, self.scaling_factor,
-                                           self.scaling_method, ms)
-                ms = style.pop('s') if 's' in style else plt.rcParams['lines.markersize']
-            else:
+            ms = style['s'] if 's' in style else plt.rcParams['lines.markersize']
+            sizes = compute_sizes(sizes, self.size_fn, self.scaling_factor,
+                                  self.scaling_method, ms)
+            if sizes is None:
                 eltype = type(element).__name__
                 self.warning('%s dimension is not numeric, cannot '
                              'use to scale %s size.' % (sdim, eltype))
-
+            else:
+                style['s'] = sizes
         style['edgecolors'] = style.pop('edgecolors', 'none')
 
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -507,11 +507,18 @@ class PointPlot(ChartPlot, ColorbarPlot):
             style['c'] = color
         style['edgecolors'] = style.pop('edgecolors', style.pop('edgecolor', 'none'))
 
-        if element.get_dimension(self.size_index):
+        sdim = element.get_dimension(self.size_index)
+        if sdim:
             sizes = element.dimension_values(self.size_index)
-            ms = style.pop('s') if 's' in style else plt.rcParams['lines.markersize']
-            style['s'] = compute_sizes(sizes, self.size_fn, self.scaling_factor,
-                                       self.scaling_method, ms)
+            if sizes.dtype.kind in ('i', 'f'):
+                style['s'] = compute_sizes(sizes, self.size_fn, self.scaling_factor,
+                                           self.scaling_method, ms)
+                ms = style.pop('s') if 's' in style else plt.rcParams['lines.markersize']
+            else:
+                eltype = type(element).__name__
+                self.warning('%s dimension is not numeric, cannot '
+                             'use to scale %s size.' % (sdim, eltype))
+
         style['edgecolors'] = style.pop('edgecolors', 'none')
 
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -98,6 +98,8 @@ def compute_sizes(sizes, size_fn, scaling_factor, scaling_method, base_size):
     base size and size_fn, which will be applied before
     scaling.
     """
+    if sizes.dtype.kind not in ('i', 'f'):
+        return None
     if scaling_method == 'area':
         pass
     elif scaling_method == 'width':

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -130,7 +130,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         self.assertEqual(y, np.arange(10, 20))
 
     def test_points_non_numeric_size_warning(self):
-        data = (range(10), range(10), map(chr, range(94,104)))
+        data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
         points = Points(data, vdims=['z'])(plot=dict(size_index=2))
         with ParamLogStream() as log:
             plot = mpl_renderer.get_plot(points)
@@ -283,7 +283,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                          np.array([[0, 1], [1, 0]]))
 
     def test_points_non_numeric_size_warning(self):
-        data = (range(10), range(10), map(chr, range(94,104)))
+        data = (np.arange(10), np.arange(10), list(map(chr, range(94,104))))
         points = Points(data, vdims=['z'])(plot=dict(size_index=2))
         with ParamLogStream() as log:
             plot = bokeh_renderer.get_plot(points)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1,11 +1,14 @@
 """
 Tests of plot instantiation (not display tests, just instantiation)
 """
+from __future__ import unicode_literals
 
+import logging
 from collections import deque
 from unittest import SkipTest
-from io import BytesIO
+from io import BytesIO, StringIO
 
+import param
 import numpy as np
 from holoviews import (Dimension, Overlay, DynamicMap, Store,
                        NdOverlay, GridSpace)
@@ -39,6 +42,29 @@ try:
     plotly_renderer = Store.renderers['plotly']
 except:
     plotly_renderer = None
+
+
+class ParamLogStream(object):
+    """
+    Context manager that replaces the param logger and captures
+    log messages in a StringIO stream.
+    """
+
+    def __enter__(self):
+        self.stream = StringIO()
+        self._handler = logging.StreamHandler(self.stream)
+        self._logger = logging.getLogger('testlogger')
+        for handler in self._logger.handlers:
+            self._logger.removeHandler(handler)
+        self._logger.addHandler(self._handler)
+        self._param_logger = param.parameterized.logger
+        param.parameterized.logger = self._logger
+        return self
+
+    def __exit__(self, *args):
+        param.parameterized.logger = self._param_logger
+        self._handler.close()
+        self.stream.seek(0)
 
 
 class TestMPLPlotInstantiation(ComparisonTestCase):
@@ -102,6 +128,17 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         x, y = plot.handles['artist'].get_data()
         self.assertEqual(x, np.arange(10))
         self.assertEqual(y, np.arange(10, 20))
+
+    def test_points_non_numeric_size_warning(self):
+        data = (range(10), range(10), map(chr, range(94,104)))
+        points = Points(data, vdims=['z'])(plot=dict(size_index=2))
+        with ParamLogStream() as log:
+            plot = mpl_renderer.get_plot(points)
+        log_msg = log.stream.read()
+        warning = ('%s: z dimension is not numeric, '
+                   'cannot use to scale Points size.\n' % plot.name)
+        self.assertEqual(log_msg, warning)
+
 
 
 class TestBokehPlotInstantiation(ComparisonTestCase):
@@ -244,6 +281,18 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(cmapper.high, 1)
         self.assertEqual(source.data['image'][0],
                          np.array([[0, 1], [1, 0]]))
+
+    def test_points_non_numeric_size_warning(self):
+        data = (range(10), range(10), map(chr, range(94,104)))
+        points = Points(data, vdims=['z'])(plot=dict(size_index=2))
+        with ParamLogStream() as log:
+            plot = bokeh_renderer.get_plot(points)
+        log_msg = log.stream.read()
+        warning = ('%s: z dimension is not numeric, '
+                   'cannot use to scale Points size.\n' % plot.name)
+        self.assertEqual(log_msg, warning)
+
+
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/982 currently you get an uninformative exception when setting the size_index option to a non-numeric dimension. This raises a warning and adds unit tests to ensure the warning is raised.