### PR TITLE
Temporary fix for RasterGridPlot

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -309,6 +309,9 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         width, height, _, _, _, _ = self.border_extents
         if self.aspect == 'equal':
             self.aspect = float(width/height)
+        # Note that streams are not supported on RasterGridPlot
+        # until that is implemented this stub is needed
+        self.streams = []
 
     def _finalize_artist(self, key):
         pass


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/976 RasterGridPlot currently fails because it has no streams attribute. This is because it's a very atypical plot type that does not currently support streams, making streams and comms work with it will be some effort. Once this has been merged we should open an issue to add that support.