### PR TITLE
Add show_frame option for bokeh plots

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -98,6 +98,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
           * timeout   - Timeout (in ms) for checking whether interactive
                         tool events are still occurring.""")
 
+    show_frame = param.Boolean(default=True, doc="""
+        Whether or not to show a complete frame around the plot.""")
+
     show_grid = param.Boolean(default=True, doc="""
         Whether to show a Cartesian grid on the plot.""")
 
@@ -341,6 +344,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         properties = dict(plot_ranges)
         properties['x_axis_label'] = xlabel if 'x' in self.labelled else ' '
         properties['y_axis_label'] = ylabel if 'y' in self.labelled else ' '
+
+        if not self.show_frame:
+            properties['outline_line_alpha'] = 0
 
         if self.show_title:
             title = self._format_title(key, separator=' ')


### PR DESCRIPTION
Currently the ``show_frame`` option that's available in matplotlib is not implemented in bokeh. This suppresses the outline by setting it to zero alpha.

``show_frame=True``

![bokeh_plot 23](https://cloud.githubusercontent.com/assets/1550771/21076392/f6743f28-bf21-11e6-973f-9b6ffab755f1.png)

``show_frame=False``

![bokeh_plot 22](https://cloud.githubusercontent.com/assets/1550771/21076393/fb4fee7a-bf21-11e6-931f-d6aec66bc703.png)
