### PR TITLE
Added support for boolean arrays in bokeh ImagePlot

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -832,6 +832,8 @@ class ColorbarPlot(ElementPlot):
             else:
                 return None
         colors = self.clipping_colors
+        if isinstance(low, (bool, np.bool_)): low = int(low)
+        if isinstance(high, (bool, np.bool_)): high = int(high)
         opts = {'low': low, 'high': high}
         color_opts = [('NaN', 'nan_color'), ('max', 'high_color'), ('min', 'low_color')]
         for name, opt in color_opts:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -33,6 +33,9 @@ class RasterPlot(ColorbarPlot):
         if type(element) is Raster:
             b = t
 
+        if img.dtype.kind == 'b':
+            img = img.astype(np.int8)
+
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:
             data = dict(image=[], x=[], y=[], dw=[], dh=[])
@@ -57,6 +60,9 @@ class ImagePlot(RasterPlot):
 
     def get_data(self, element, ranges=None, empty=False):
         img = element.dimension_values(2, flat=False)
+        if img.dtype.kind == 'b':
+            img = img.astype(np.int8)
+
         l, b, r, t = element.bounds.lbrt()
         dh, dw = t-b, r-l
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -235,6 +235,15 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         fig = plot.state
         assert len(fig.legend[0].items) == 0
 
+    def test_image_boolean_array(self):
+        img = Image(np.array([[True, False], [False, True]]))
+        plot = bokeh_renderer.get_plot(img)
+        cmapper = plot.handles['color_mapper']
+        source = plot.handles['source']
+        self.assertEqual(cmapper.low, 0)
+        self.assertEqual(cmapper.high, 1)
+        self.assertEqual(source.data['image'][0],
+                         np.array([[0, 1], [1, 0]]))
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
As described in #727, the bokeh image plots do not currently support boolean arrays. This is because the color mapper does not like boolean ``low`` and ``high`` values. However since booleans cannot be serialized easily it will be more efficient to send them as ``int8`` arrays, which will be base64 encoded in an upcoming bokeh PR.