### PR TITLE
Fixed saving to html and json in Python 3

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -361,12 +361,13 @@ class Renderer(Exporter):
             widget = obj
 
         html = self_or_cls.static_html(widget, fmt, template)
+        encoded = self_or_cls.encode((html, {'mime_type': 'text/html'}))
         if isinstance(filename, BytesIO):
-            filename.write(html)
+            filename.write(encoded)
             filename.seek(0)
         else:
             with open(filename, 'w') as f:
-                f.write(html)
+                f.write(encoded)
 
 
     @classmethod

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -50,8 +50,8 @@ MIME_TYPES = {
     'webm': 'video/webm',
     'mp4':  'video/mp4',
     'pdf':  'application/pdf',
-    'html':  None,
-    'json':  None
+    'html':  'text/html',
+    'json':  'text/json'
 }
 
 static_template = """

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -478,11 +478,11 @@ class Renderer(Exporter):
             rendered = self_or_cls(plot, fmt)
         if rendered is None: return
         (data, info) = rendered
+        encoded = self_or_cls.encode(rendered)
         if isinstance(basename, BytesIO):
-            basename.write(data)
+            basename.write(encoded)
             basename.seek(0)
         else:
-            encoded = self_or_cls.encode(rendered)
             filename ='%s.%s' % (basename, info['file-ext'])
             with open(filename, 'wb') as f:
                 f.write(encoded)

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -2,13 +2,17 @@
 """
 Test cases for rendering exporters
 """
+from __future__ import unicode_literals
+
 from io import BytesIO
 from hashlib import sha256
 from unittest import SkipTest
 import numpy as np
 
 from holoviews import HoloMap, Image, ItemTable, Store
+from holoviews.core.util import unicode
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import Renderer
 
 from nose.plugins.attrib import attr
 
@@ -31,6 +35,20 @@ def digest_data(data):
     hashfn = sha256()
     hashfn.update(data)
     return hashfn.hexdigest()
+
+
+class TestRenderer(ComparisonTestCase):
+    """
+    Test the basic serializer and deserializer (i.e. using pickle),
+    including metadata access.
+    """
+
+    def test_renderer_encode_unicode_types(self):
+        mime_types = ['image/svg+xml', 'text/html', 'text/json']
+        for mime in mime_types:
+            info = {'mime_type': mime}
+            encoded = Renderer.encode(('Testing «ταБЬℓσ»: 1<2 & 4+1>3', info))
+            self.assertTrue(isinstance(encoded, bytes))
 
 
 @attr(optional=1)
@@ -107,7 +125,7 @@ class MPLRendererTest(ComparisonTestCase):
 
     def test_static_html_gif(self):
         data = self.renderer.static_html(self.map1, fmt='gif')
-        self.assertEqual(digest_data(data),
+        self.assertEqual(digest_data(normalize(data)),
                          '9d43822e0f368f3c673b19aaf66d22252849947b7dc4a157306c610c42d319b5')
 
     def test_export_widgets(self):

--- a/tests/testwidgets.py
+++ b/tests/testwidgets.py
@@ -17,6 +17,7 @@ except:
     raise SkipTest("Matplotlib required to test widgets")
 
 from holoviews import Image, HoloMap
+from holoviews.core.util import unicode
 from holoviews.plotting.mpl import RasterPlot
 
 def digest_data(data):
@@ -32,10 +33,15 @@ filters += [re.compile('new [A-Za-z]*ScrubberWidget\([a-z0-9_, "]+')]
 filters += [re.compile('new [A-Za-z]*SelectionWidget\([a-z0-9_, "]+')]
 
 def normalize(data):
+    if isinstance(data, bytes):
+        data = data.decode('utf8')
     for f in filters:
         data = re.sub(f, '[CLEARED]', data)
     # Hack around inconsistencies in jinja between Python 2 and 3
-    return data.replace('0.0', '0').replace('1.0', '1')
+    data = data.replace('0.0', '0').replace('1.0', '1')
+    if isinstance(data, unicode):
+        data = data.encode('utf8')
+    return data
 
 @attr(optional=1)
 class TestWidgets(IPTestCase):


### PR DESCRIPTION
Fixes https://github.com/ioam/holoviews/issues/979 which ended up throwing bugs in ``Renderer.save`` in python3 when a string type was written to file. By defining the MIME type the encoding is applied correctly.

Needs some tests before merging.