### PR TITLE
Add support for Layout/Grid titles in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -155,6 +155,11 @@ class BokehPlot(DimensionedPlot):
 
 
 class CompositePlot(BokehPlot):
+    """
+    CompositePlot is an abstract baseclass for plot types that draw
+    render multiple axes. It implements methods to add an overall title
+    to such a plot.
+    """
 
     fontsize = param.Parameter(default={'title': '16pt'}, allow_None=True,  doc="""
        Specifies various fontsizes of the displayed text.

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -3,7 +3,8 @@ import numpy as np
 
 import param
 
-from bokeh.models import ColumnDataSource, VBox, HBox, GridPlot as BokehGridPlot
+from bokeh.models import (ColumnDataSource, VBox, HBox, Column,
+                          GridPlot as BokehGridPlot, Div)
 from bokeh.models.widgets import Panel, Tabs
 
 from ...core import (OrderedDict, CompositeOverlay, Store, Layout, GridMatrix,
@@ -153,7 +154,43 @@ class BokehPlot(DimensionedPlot):
 
 
 
-class GridPlot(BokehPlot, GenericCompositePlot):
+class CompositePlot(BokehPlot):
+
+    fontsize = param.Parameter(default={'title': '16pt'}, allow_None=True,  doc="""
+       Specifies various fontsizes of the displayed text.
+
+       Finer control is available by supplying a dictionary where any
+       unmentioned keys reverts to the default sizes, e.g:
+
+          {'title': '15pt'}""")
+
+    _title_template = "<span style='font-size: {fontsize}'><b>{title}</b></font>"
+
+    def _get_title(self, key):
+        title_div = None
+        title = self._format_title(key) if self.show_title else ''
+        if title:
+            fontsize = self._fontsize('title')
+            title_tags = self._title_template.format(title=title,
+                                                     **fontsize)
+            if 'title' in self.handles:
+                title_div = self.handles['title']
+            else:
+                title_div = Div()
+            title_div.text = title_tags
+        return title_div
+
+    @property
+    def current_handles(self):
+        """
+        Should return a list of plot objects that have changed and
+        should be updated.
+        """
+        return [self.handles['title']]
+
+
+
+class GridPlot(CompositePlot, GenericCompositePlot):
     """
     Plot a group of elements in a grid layout based on a GridSpace element
     object.
@@ -256,9 +293,14 @@ class GridPlot(BokehPlot, GenericCompositePlot):
                 plots[r].append(None)
                 passed_plots.append(None)
         if bokeh_version < '0.12':
-            self.handles['plot'] = BokehGridPlot(children=plots[::-1])
+            plot = BokehGridPlot(children=plots[::-1])
         else:
-            self.handles['plot'] = gridplot(plots[::-1])
+            plot = gridplot(plots[::-1])
+        title = self._get_title(self.keys[-1])
+        if title:
+            self.handles['title'] = title
+            plot = Column(title, plot)
+        self.handles['plot'] = plot
         self.handles['plots'] = plots
         if self.shared_datasource:
             self.sync_sources()
@@ -278,10 +320,11 @@ class GridPlot(BokehPlot, GenericCompositePlot):
             subplot = self.subplots.get(coord, None)
             if subplot is not None:
                 subplot.update_frame(key, ranges)
+        self.handles['title'] = self._get_title(key)
 
 
 
-class LayoutPlot(BokehPlot, GenericLayoutPlot):
+class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
     shared_axes = param.Boolean(default=True, doc="""
         Whether axes should be shared across plots""")
@@ -505,6 +548,10 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
         else:
             layout_plot = BokehGridPlot(children=plots)
 
+        title = self._get_title(self.keys[-1])
+        if title:
+            self.handles['title'] = title
+            layout_plot = Column(title, layout_plot)
         self.handles['plot'] = layout_plot
         self.handles['plots'] = plots
         if self.shared_datasource:
@@ -526,6 +573,8 @@ class LayoutPlot(BokehPlot, GenericLayoutPlot):
             subplot = self.subplots.get((r, c), None)
             if subplot is not None:
                 subplot.update_frame(key, ranges)
+        self.handles['title'] = self._get_title(key)
+
 
 
 class AdjointLayoutPlot(BokehPlot):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -320,7 +320,9 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             subplot = self.subplots.get(coord, None)
             if subplot is not None:
                 subplot.update_frame(key, ranges)
-        self.handles['title'] = self._get_title(key)
+        title = self._get_title(key)
+        if title:
+            self.handles['title']
 
 
 
@@ -573,7 +575,9 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             subplot = self.subplots.get((r, c), None)
             if subplot is not None:
                 subplot.update_frame(key, ranges)
-        self.handles['title'] = self._get_title(key)
+        title = self._get_title(key)
+        if title:
+            self.handles['title'] = title
 
 
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -8,7 +8,7 @@ from io import BytesIO
 
 import numpy as np
 from holoviews import (Dimension, Overlay, DynamicMap, Store,
-                       NdOverlay, GridSpace)
+                       NdOverlay, GridSpace, HoloMap, Layout)
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
                                Scatter3D, Path, Polygons, Bars)
@@ -29,6 +29,7 @@ try:
     import holoviews.plotting.bokeh
     bokeh_renderer = Store.renderers['bokeh']
     from holoviews.plotting.bokeh.callbacks import Callback
+    from bokeh.models import Div
     from bokeh.models.mappers import LinearColorMapper, LogColorMapper
     from bokeh.models.tools import HoverTool
 except:
@@ -244,6 +245,64 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(cmapper.high, 1)
         self.assertEqual(source.data['image'][0],
                          np.array([[0, 1], [1, 0]]))
+
+    def test_layout_title(self):
+        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        plot = bokeh_renderer.get_plot(hmap1+hmap2)
+        title = plot.handles['title']
+        self.assertIsInstance(title, Div)
+        text = "<span style='font-size: 16pt'><b>Default: 0</b></font>"
+        self.assertEqual(title.text, text)
+
+    def test_layout_title_fontsize(self):
+        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        layout = Layout([hmap1, hmap2])(plot=dict(fontsize={'title': '12pt'}))
+        plot = bokeh_renderer.get_plot(layout)
+        title = plot.handles['title']
+        self.assertIsInstance(title, Div)
+        text = "<span style='font-size: 12pt'><b>Default: 0</b></font>"
+        self.assertEqual(title.text, text)
+
+    def test_layout_title_show_title_false(self):
+        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        layout = Layout([hmap1, hmap2])(plot=dict(show_title=False))
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertTrue('title' not in plot.handles)
+
+    def test_layout_title_update(self):
+        hmap1 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        hmap2 = HoloMap({a: Image(np.random.rand(10,10)) for a in range(3)})
+        plot = bokeh_renderer.get_plot(hmap1+hmap2)
+        plot.update(1)
+        title = plot.handles['title']
+        self.assertIsInstance(title, Div)
+        text = "<span style='font-size: 16pt'><b>Default: 1</b></font>"
+        self.assertEqual(title.text, text)
+
+    def test_grid_title(self):
+        grid = GridSpace({(i, j): HoloMap({a: Image(np.random.rand(10,10))
+                                           for a in range(3)}, kdims=['X'])
+                          for i in range(2) for j in range(3)})
+        plot = bokeh_renderer.get_plot(grid)
+        title = plot.handles['title']
+        self.assertIsInstance(title, Div)
+        text = "<span style='font-size: 16pt'><b>X: 0</b></font>"
+        self.assertEqual(title.text, text)
+
+    def test_grid_title_update(self):
+        grid = GridSpace({(i, j): HoloMap({a: Image(np.random.rand(10,10))
+                                           for a in range(3)}, kdims=['X'])
+                          for i in range(2) for j in range(3)})
+        plot = bokeh_renderer.get_plot(grid)
+        plot.update(1)
+        title = plot.handles['title']
+        self.assertIsInstance(title, Div)
+        text = "<span style='font-size: 16pt'><b>X: 1</b></font>"
+        self.assertEqual(title.text, text)
+
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
As I had suggested in #989 it is possible to add a Div as a title to a composite plot. This finally adds consistency in titles between matplotlib and bokeh backends for Layout and Grid plots.

Still needs tests.

## Examples

### Layout

<img width="1023" alt="screen shot 2016-12-11 at 10 24 55 pm" src="https://cloud.githubusercontent.com/assets/1550771/21083830/af23dd34-bff0-11e6-8d5c-5aa673b7f02d.png">

### Grid

<img width="1022" alt="screen shot 2016-12-11 at 10 27 19 pm" src="https://cloud.githubusercontent.com/assets/1550771/21083850/024715b2-bff1-11e6-8769-c2df5fa3b448.png">
