### PR TITLE
find_file utility handles absolute path

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -758,12 +758,17 @@ def get_spec(obj):
 
 def find_file(folder, filename):
     """
-    Find a file given folder and filename.
+    Find a file given folder and filename. If the filename can be
+    resolved directly returns otherwise walks the supplied folder.
     """
     matches = []
+    if os.path.isabs(filename) and os.path.isfile(filename):
+        return filename
     for root, _, filenames in os.walk(folder):
-        for filename in fnmatch.filter(filenames, filename):
-            matches.append(os.path.join(root, filename))
+        for fn in fnmatch.filter(filenames, filename):
+            matches.append(os.path.join(root, fn))
+    if not matches:
+        raise IOError('File %s could not be found' % filename)
     return matches[-1]
 
 


### PR DESCRIPTION
Ensure the ``find_file`` utility can handle an absolute filename path passed to it. The function ensures that the default widget assets get resolved correctly but the user should be able to override these with an absolute path.  

Concretely you can now supply custom CSS to the widgets to change the layout a bit. Setting:

```
hv.plotting.widgets.SelectionWidget.css = '/Users/philippjfr/Downloads/test.css'
```

can give you something like this:

<img width="541" alt="screen shot 2016-12-18 at 7 41 20 pm" src="https://cloud.githubusercontent.com/assets/1550771/21296048/297d9480-c55a-11e6-81ea-86cf5a6054ee.png">
