### PR TITLE
Update bokeh ColumnDataSource in one update

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -93,8 +93,7 @@ class BokehPlot(DimensionedPlot):
         """
         Update datasource with data for a new frame.
         """
-        for k, v in data.items():
-            source.data[k] = v
+        source.data.update(data)
 
     @property
     def state(self):


### PR DESCRIPTION
In bokeh 0.12.4 a warning is raised when column lengths do not match therefore all columns on a data source should be updated at once. 