### PR TITLE
Ensure multiple callbacks do not bleed wrong plot state

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -239,7 +239,7 @@ class Callback(object):
         handles = {}
         for plot in plots:
             for k, v in plot.handles.items():
-                if k not in handles:
+                if k not in handles and k in self.handles:
                     handles[k] = v
         return handles
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -12,13 +12,23 @@ from ..comms import JupyterCommJS
 def attributes_js(attributes, handles):
     """
     Generates JS code to look up attributes on JS objects from
-    an attributes specification dictionary.
+    an attributes specification dictionary. If the specification
+    references a plotting particular plotting handle it will also
+    generate JS code to get the ID of the object.
 
-    Example:
+    Simple example (when referencing cb_data or cb_obj):
 
     Input  : {'x': 'cb_data.geometry.x'}
 
     Output : data['x'] = cb_data['geometry']['x']
+
+    Example referencing plot handle:
+
+    Input  : {'x0': 'x_range.attributes.start'}
+
+    Output : if ((x_range !== undefined)) {
+               data['x0'] = {id: x_range['id'], value: x_range['attributes']['start']}
+             }
     """
     code = ''
     for key, attr_path in attributes.items():
@@ -31,7 +41,7 @@ def attributes_js(attributes, handles):
             assign_str = '{assign}{{id: {obj_name}["id"], value: {obj_name}{attr_getters}}};\n'.format(
                 assign=data_assign, obj_name=obj_name, attr_getters=attr_getters
             )
-            code += 'if (({obj_name} != undefined) && ({obj_name}["id"] == "{id}")) {{ {assign} }}'.format(
+            code += 'if (({obj_name} != undefined)) {{ {assign} }}'.format(
                 obj_name=obj_name, id=handles[obj_name].ref['id'], assign=assign_str
                 )
         else:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 
 import param
@@ -108,7 +107,6 @@ class Callback(object):
         }}
 
         data['comms_target'] = "{comms_target}";
-        var argstring = JSON.stringify(data);
         if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
           var comm_manager = Jupyter.notebook.kernel.comm_manager;
           var comms = HoloViewsWidget.comms["{comms_target}"];
@@ -141,9 +139,9 @@ class Callback(object):
         timeout = comm_state.timeout + {timeout};
         if ((window.Jupyter == undefined) | (Jupyter.notebook.kernel == undefined)) {{
         }} else if ((comm_state.blocked && (Date.now() < timeout))) {{
-            comm_state.event = argstring;
+            comm_state.event = data;
         }} else {{
-            comm_state.event = argstring;
+            comm_state.event = data;
             setTimeout(trigger, {debounce});
             comm_state.blocked = true;
             comm_state.timeout = Date.now()+{debounce};

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -84,11 +84,7 @@ class Callback(object):
     js_callback = """
         function on_msg(msg){{
           msg = JSON.parse(msg.content.data);
-          if ("comms_target" in msg) {{
-            comms_target = msg["comms_target"]
-          }} else {{
-            comms_target = "{comms_target}"
-          }}
+          var comms_target = msg["comms_target"]
           var comm = HoloViewsWidget.comms[comms_target];
           var comm_state = HoloViewsWidget.comm_state[comms_target];
           if (comm_state.event) {{
@@ -131,8 +127,8 @@ class Callback(object):
 
         function trigger() {{
             if (comm_state.event != undefined) {{
-               comms_target = comm_state.event["comms_target"]
-               comm = HoloViewsWidget.comms[comms_target];
+               var comms_target = comm_state.event["comms_target"]
+               var comm = HoloViewsWidget.comms[comms_target];
                comm.send(comm_state.event);
             }}
             comm_state.event = undefined;

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -188,6 +188,10 @@ class Callback(object):
 
 
     def on_msg(self, msg):
+        # For each stream check whether plot state is meant for it
+        # by checking that the IDs match the IDs of the stream's plot
+        # handles, dispatch only the part of the message meant for
+        # a particular stream
         for stream in self.streams:
             ids = self.stream_handles[stream]
             sanitized_msg = {}
@@ -230,6 +234,9 @@ class Callback(object):
         attributes = attributes_js(self.attributes, handles)
         code = 'var data = {};\n' + attributes + self.code + self_callback
 
+        # Gather the ids of the plotting handles attached to this callback
+        # This allows checking that a stream is not given the state
+        # of a plotting handle it wasn't attached to
         stream_handle_ids = defaultdict(list)
         for stream in self.streams:
             for h in self.handles:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -131,6 +131,8 @@ class Callback(object):
 
         function trigger() {{
             if (comm_state.event != undefined) {{
+               comms_target = comm_state.event["comms_target"]
+               comm = HoloViewsWidget.comms[comms_target];
                comm.send(comm_state.event);
             }}
             comm_state.event = undefined;

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -94,9 +94,9 @@ class Callback(object):
     js_callback = """
         function on_msg(msg){{
           msg = JSON.parse(msg.content.data);
-          var comms_target = msg["comms_target"]
-          var comm = HoloViewsWidget.comms[comms_target];
-          var comm_state = HoloViewsWidget.comm_state[comms_target];
+          var comm_id = msg["comm_id"]
+          var comm = HoloViewsWidget.comms[comm_id];
+          var comm_state = HoloViewsWidget.comm_state[comm_id];
           if (comm_state.event) {{
             comm.send(comm_state.event);
             comm_state.blocked = true;
@@ -112,33 +112,33 @@ class Callback(object):
           }}
         }}
 
-        data['comms_target'] = "{comms_target}";
+        data['comm_id'] = "{comm_id}";
         if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
           var comm_manager = Jupyter.notebook.kernel.comm_manager;
-          var comms = HoloViewsWidget.comms["{comms_target}"];
-          if (comms && ("{comms_target}" in comms)) {{
-            comm = comms["{comms_target}"];
+          var comms = HoloViewsWidget.comms["{comm_id}"];
+          if (comms && ("{comm_id}" in comms)) {{
+            comm = comms["{comm_id}"];
           }} else {{
-            comm = comm_manager.new_comm("{comms_target}", {{}}, {{}}, {{}});
+            comm = comm_manager.new_comm("{comm_id}", {{}}, {{}}, {{}});
             comm.on_msg(on_msg);
-            comm_manager["{comms_target}"] = comm;
-            HoloViewsWidget.comms["{comms_target}"] = comm;
+            comm_manager["{comm_id}"] = comm;
+            HoloViewsWidget.comms["{comm_id}"] = comm;
           }}
-          comm_manager["{comms_target}"] = comm;
+          comm_manager["{comm_id}"] = comm;
         }} else {{
           return
         }}
 
-        var comm_state = HoloViewsWidget.comm_state["{comms_target}"];
+        var comm_state = HoloViewsWidget.comm_state["{comm_id}"];
         if (comm_state === undefined) {{
             comm_state = {{event: undefined, blocked: false, timeout: Date.now()}}
-            HoloViewsWidget.comm_state["{comms_target}"] = comm_state
+            HoloViewsWidget.comm_state["{comm_id}"] = comm_state
         }}
 
         function trigger() {{
             if (comm_state.event != undefined) {{
-               var comms_target = comm_state.event["comms_target"]
-               var comm = HoloViewsWidget.comms[comms_target];
+               var comm_id = comm_state.event["comm_id"]
+               var comm = HoloViewsWidget.comms[comm_id];
                comm.send(comm_state.event);
             }}
             comm_state.event = undefined;
@@ -267,7 +267,7 @@ class Callback(object):
         """
 
         # Generate callback JS code to get all the requested data
-        self_callback = self.js_callback.format(comms_target=self.comm.target,
+        self_callback = self.js_callback.format(comm_id=self.comm.id,
                                                 timeout=self.timeout,
                                                 debounce=self.debounce)
 

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -61,8 +61,8 @@ class BokehRenderer(Renderer):
         doc_handler = add_to_document(plot.state)
         with doc_handler:
             doc = doc_handler._doc
-            target = plot.comm.target if plot.comm else None
-            div = notebook_div(plot.state, target)
+            comm_id = plot.comm.id if plot.comm else None
+            div = notebook_div(plot.state, comm_id)
         plot.document = doc
         doc.add_root(plot.state)
         return div

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -156,7 +156,13 @@ class JupyterComm(Comm):
 
     @classmethod
     def decode(cls, msg):
-        return json.loads(msg['content']['data'])
+        data = msg['content']['data']
+        try:
+            data = json.loads(data)
+        except ValueError as e:
+            if e.message != "No JSON object could be decoded":
+                raise
+        return data
 
 
     def send(self, data):

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -120,7 +120,7 @@ class Comm(object):
             reply = {'msg_type': "Ready", 'content': stdout}
         if 'comms_target' in msg:
             reply['comms_target'] = msg.pop('comms_target', None)
-        self.comm.send(json.dumps(reply))
+        self.send(json.dumps(reply))
 
 
 class JupyterComm(Comm):

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -123,6 +123,9 @@ class Comm(object):
         else:
             stdout = '\n\t'+'\n\t'.join(stdout) if stdout else ''
             reply = {'msg_type': "Ready", 'content': stdout}
+
+        # Returning the comms_target in an ACK message ensures that
+        # the correct comms handle is unblocked
         if 'comms_target' in msg:
             reply['comms_target'] = msg.pop('comms_target', None)
         self.send(json.dumps(reply))
@@ -161,6 +164,10 @@ class JupyterComm(Comm):
 
     @classmethod
     def decode(cls, msg):
+        """
+        Decodes messages following Jupyter messaging protocol.
+        If JSON decoding fails data is assumed to be a regular string.
+        """
         data = msg['content']['data']
         try:
             data = json.loads(data)

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -11,11 +11,6 @@ except:
 from ipykernel.comm import Comm as IPyComm
 from IPython import get_ipython
 
-if sys.version_info.major >= 3:
-    DecodeError = json.decoder.JSONDecodeError
-else:
-    DecodeError = ValueError
-
 
 class StandardOutput(list):
     """
@@ -171,7 +166,7 @@ class JupyterComm(Comm):
         data = msg['content']['data']
         try:
             data = json.loads(data)
-        except DecodeError:
+        except ValueError:
             pass
         return data
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -163,12 +163,7 @@ class JupyterComm(Comm):
         Decodes messages following Jupyter messaging protocol.
         If JSON decoding fails data is assumed to be a regular string.
         """
-        data = msg['content']['data']
-        try:
-            data = json.loads(data)
-        except ValueError:
-            pass
-        return data
+        return msg['content']['data']
 
 
     def send(self, data):

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -114,11 +114,13 @@ class Comm(object):
             if stdout:
                 stdout = '\n\t'+'\n\t'.join(stdout)
                 error = '\n'.join([stdout, error])
-            msg = {'msg_type': "Error", 'traceback': error}
+            reply = {'msg_type': "Error", 'traceback': error}
         else:
             stdout = '\n\t'+'\n\t'.join(stdout) if stdout else ''
-            msg = {'msg_type': "Ready", 'content': stdout}
-        self.comm.send(json.dumps(msg))
+            reply = {'msg_type': "Ready", 'content': stdout}
+        if 'comms_target' in msg:
+            reply['comms_target'] = msg.pop('comms_target', None)
+        self.comm.send(json.dumps(reply))
 
 
 class JupyterComm(Comm):
@@ -154,7 +156,7 @@ class JupyterComm(Comm):
 
     @classmethod
     def decode(cls, msg):
-        return msg['content']['data']
+        return json.loads(msg['content']['data'])
 
 
     def send(self, data):

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -11,6 +11,11 @@ except:
 from ipykernel.comm import Comm as IPyComm
 from IPython import get_ipython
 
+if sys.version_info.major >= 3:
+    DecodeError = json.decoder.JSONDecodeError
+else:
+    DecodeError = ValueError
+
 
 class StandardOutput(list):
     """
@@ -159,9 +164,8 @@ class JupyterComm(Comm):
         data = msg['content']['data']
         try:
             data = json.loads(data)
-        except ValueError as e:
-            if e.message != "No JSON object could be decoded":
-                raise
+        except DecodeError:
+            pass
         return data
 
 

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -46,8 +46,7 @@ class Comm(object):
 
     The template must accept three arguments:
 
-    * comms_target - A unique id to register to register as the
-                     comms target.
+    * id          -  A unique id to register to register the comm under.
     * msg_handler -  JS code which has the msg variable in scope and
                      performs appropriate action for the supplied message.
     * init_frame  -  The initial frame to render on the frontend.
@@ -55,11 +54,11 @@ class Comm(object):
 
     template = ''
 
-    def __init__(self, plot, target=None, on_msg=None):
+    def __init__(self, plot, id=None, on_msg=None):
         """
         Initializes a Comms object
         """
-        self.target = target if target else uuid.uuid4().hex
+        self.id = id if id else uuid.uuid4().hex
         self._plot = plot
         self._on_msg = on_msg
         self._comm = None
@@ -119,10 +118,10 @@ class Comm(object):
             stdout = '\n\t'+'\n\t'.join(stdout) if stdout else ''
             reply = {'msg_type': "Ready", 'content': stdout}
 
-        # Returning the comms_target in an ACK message ensures that
+        # Returning the comm_id in an ACK message ensures that
         # the correct comms handle is unblocked
-        if 'comms_target' in msg:
-            reply['comms_target'] = msg.pop('comms_target', None)
+        if 'comm_id' in msg:
+            reply['comm_id'] = msg.pop('comm_id', None)
         self.send(json.dumps(reply))
 
 
@@ -141,11 +140,11 @@ class JupyterComm(Comm):
 
       if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
         comm_manager = Jupyter.notebook.kernel.comm_manager;
-        comm_manager.register_target("{comms_target}", function(comm) {{ comm.on_msg(msg_handler);}});
+        comm_manager.register_target("{comm_id}", function(comm) {{ comm.on_msg(msg_handler);}});
       }}
     </script>
 
-    <div id="fig_{comms_target}">
+    <div id="fig_{comm_id}">
       {init_frame}
     </div>
     """
@@ -153,7 +152,7 @@ class JupyterComm(Comm):
     def init(self):
         if self._comm:
             return
-        self._comm = IPyComm(target_name=self.target, data={})
+        self._comm = IPyComm(target_name=self.id, data={})
         self._comm.on_msg(self._handle_msg)
 
 
@@ -192,23 +191,23 @@ class JupyterCommJS(JupyterComm):
 
       if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
         var comm_manager = Jupyter.notebook.kernel.comm_manager;
-        comm = comm_manager.new_comm("{comms_target}", {{}}, {{}}, {{}}, "{comms_target}");
+        comm = comm_manager.new_comm("{comm_id}", {{}}, {{}}, {{}}, "{comm_id}");
         comm.on_msg(msg_handler);
       }}
     </script>
 
-    <div id="fig_{comms_target}">
+    <div id="fig_{comm_id}">
       {init_frame}
     </div>
     """
 
-    def __init__(self, plot, target=None, on_msg=None):
+    def __init__(self, plot, id=None, on_msg=None):
         """
         Initializes a Comms object
         """
-        super(JupyterCommJS, self).__init__(plot, target, on_msg)
+        super(JupyterCommJS, self).__init__(plot, id, on_msg)
         self.manager = get_ipython().kernel.comm_manager
-        self.manager.register_target(self.target, self._handle_open)
+        self.manager.register_target(self.id, self._handle_open)
 
 
     def _handle_open(self, comm, msg):

--- a/holoviews/plotting/mpl/comms.py
+++ b/holoviews/plotting/mpl/comms.py
@@ -13,7 +13,7 @@ from ..comms import JupyterComm
 
 mpl_msg_handler = """
 /* Backend specific body of the msg_handler, updates displayed frame */
-target = $('#fig_{comms_target}');
+target = $('#fig_{comm_id}');
 img = $('<div />').html(msg);
 target.children().each(function () {{ $(this).remove() }})
 target.append(img)
@@ -21,9 +21,9 @@ target.append(img)
 
 mpld3_msg_handler = """
 /* Backend specific body of the msg_handler, updates displayed frame */
-target = $('#fig_el{comms_target}');
+target = $('#fig_el{comm_id}');
 target.children().each(function () {{ $(this).remove() }});
-mpld3.draw_figure("fig_el{comms_target}", msg);
+mpld3.draw_figure("fig_el{comm_id}", msg);
 """
 
 class NbAggCommSocket(CommSocket):
@@ -72,7 +72,7 @@ class NbAggJupyterComm(JupyterComm):
         for ax in fig.get_axes():
             if isinstance(ax, Axes3D):
                 ax.mouse_init()
-        self._comm_socket = NbAggCommSocket(target=self.target,
+        self._comm_socket = NbAggCommSocket(target=self.id,
                                             manager=self.manager)
         return self.manager
 

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -178,15 +178,15 @@ class MPLRenderer(Renderer):
             if fmt == 'json':
                 return mpld3.fig_to_dict(fig)
             else:
-                figid = "fig_el"+plot.comm.target if plot.comm else None
+                figid = "fig_el"+plot.comm.id if plot.comm else None
                 html = mpld3.fig_to_html(fig, figid=figid)
                 html = "<center>" + html + "<center/>"
                 if plot.comm:
                     comm, msg_handler = self.comms[self.mode]
-                    msg_handler = msg_handler.format(comms_target=plot.comm.target)
+                    msg_handler = msg_handler.format(comm_id=plot.comm.id)
                     return comm.template.format(init_frame=html,
                                                 msg_handler=msg_handler,
-                                                comms_target=plot.comm.target)
+                                                comm_id=plot.comm.id)
                 return html
 
         traverse_fn = lambda x: x.handles.get('bbox_extra_artists', None)

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -14,7 +14,7 @@ from .widgets import PlotlyScrubberWidget, PlotlySelectionWidget
 
 plotly_msg_handler = """
 /* Backend specific body of the msg_handler, updates displayed frame */
-var plot = $('#{comms_target}')[0];
+var plot = $('#{comm_id}')[0];
 var data = JSON.parse(msg);
 $.each(data.data, function(i, obj) {{
   $.each(Object.keys(obj), function(j, key) {{
@@ -82,7 +82,7 @@ class PlotlyRenderer(Renderer):
         figure = plot.state
         if divuuid is None:
             if plot.comm:
-                divuuid = plot.comm.target
+                divuuid = plot.comm.id
             else:
                 divuuid = uuid.uuid4().hex
 
@@ -118,10 +118,10 @@ class PlotlyRenderer(Renderer):
 
         if comm and plot.comm is not None:
             comm, msg_handler = self.comms[self.mode]
-            msg_handler = msg_handler.format(comms_target=plot.comm.target)
+            msg_handler = msg_handler.format(comm_id=plot.comm.id)
             return comm.template.format(init_frame=joined,
                                         msg_handler=msg_handler,
-                                        comms_target=plot.comm.target)
+                                        comm_id=plot.comm.id)
         return joined
 
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -283,10 +283,10 @@ class Renderer(Exporter):
         html = tag.format(src=src, mime_type=mime_type, css=css)
         if comm and plot.comm is not None:
             comm, msg_handler = self.comms[self.mode]
-            msg_handler = msg_handler.format(comms_target=plot.comm.target)
+            msg_handler = msg_handler.format(comm_id=plot.comm.id)
             return comm.template.format(init_frame=html,
                                         msg_handler=msg_handler,
-                                        comms_target=plot.comm.target)
+                                        comm_id=plot.comm.id)
         else:
             return html
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -106,7 +106,7 @@ class NdWidget(param.Parameterized):
 
     def __init__(self, plot, renderer=None, **params):
         super(NdWidget, self).__init__(**params)
-        self.id = plot.comm.target if plot.comm else uuid.uuid4().hex
+        self.id = plot.comm.id if plot.comm else uuid.uuid4().hex
         self.plot = plot
         streams = []
         for stream in plot.streams:

--- a/tests/testcomms.py
+++ b/tests/testcomms.py
@@ -10,9 +10,9 @@ class TestComm(ComparisonTestCase):
     def test_init_comm(self):
         Comm(None)
 
-    def test_init_comm_target(self):
-        comm = Comm(None, target='Test')
-        self.assertEqual(comm.target, 'Test')
+    def test_init_comm_id(self):
+        comm = Comm(None, id='Test')
+        self.assertEqual(comm.id, 'Test')
 
     def test_decode(self):
         msg = 'Test'
@@ -25,25 +25,25 @@ class TestComm(ComparisonTestCase):
             decoded = json.loads(msg)
             self.assertEqual(decoded['msg_type'], "Error")
             self.assertTrue(decoded['traceback'].endswith('Exception: Test'))
-        comm = Comm(None, target='Test', on_msg=raise_error)
+        comm = Comm(None, id='Test', on_msg=raise_error)
         comm.send = assert_error
         comm._handle_msg({})
 
     def test_handle_message_ready_reply(self):
         def assert_ready(msg):
             self.assertEqual(json.loads(msg), {'msg_type': "Ready", 'content': ''})
-        comm = Comm(None, target='Test')
+        comm = Comm(None, id='Test')
         comm.send = assert_ready
         comm._handle_msg({})
 
-    def test_handle_message_ready_reply_with_comms_target(self):
+    def test_handle_message_ready_reply_with_comm_id(self):
         def assert_ready(msg):
             decoded = json.loads(msg)
             self.assertEqual(decoded, {'msg_type': "Ready", 'content': '',
-                                       'comms_target': 'Testing target'})
-        comm = Comm(None, target='Test')
+                                       'comm_id': 'Testing id'})
+        comm = Comm(None, id='Test')
         comm.send = assert_ready
-        comm._handle_msg({'comms_target': 'Testing target'})
+        comm._handle_msg({'comm_id': 'Testing id'})
 
 
 
@@ -52,9 +52,9 @@ class TestJupyterComm(ComparisonTestCase):
     def test_init_comm(self):
         JupyterComm(None)
 
-    def test_init_comm_target(self):
-        comm = JupyterComm(None, target='Test')
-        self.assertEqual(comm.target, 'Test')
+    def test_init_comm_id(self):
+        comm = JupyterComm(None, id='Test')
+        self.assertEqual(comm.id, 'Test')
 
     def test_decode(self):
         msg = {'content': {'data': 'Test'}}
@@ -65,6 +65,6 @@ class TestJupyterComm(ComparisonTestCase):
         def raise_error(msg):
             if msg == 'Error':
                 raise Exception()
-        comm = JupyterComm(None, target='Test', on_msg=raise_error)
+        comm = JupyterComm(None, id='Test', on_msg=raise_error)
         with self.assertRaises(Exception):
             comm._handle_msg({'content': {'data': 'Error'}})

--- a/tests/testcomms.py
+++ b/tests/testcomms.py
@@ -1,3 +1,4 @@
+import json
 from nose.tools import *
 
 from holoviews.element.comparison import ComparisonTestCase
@@ -17,13 +18,33 @@ class TestComm(ComparisonTestCase):
         msg = 'Test'
         self.assertEqual(Comm.decode(msg), msg)
 
-    def test_on_msg(self):
+    def test_handle_message_error_reply(self):
         def raise_error(msg):
-            if msg == 'Error':
-                raise Exception()
+            raise Exception('Test')
+        def assert_error(msg):
+            decoded = json.loads(msg)
+            self.assertEqual(decoded['msg_type'], "Error")
+            self.assertTrue(decoded['traceback'].endswith('Exception: Test'))
         comm = Comm(None, target='Test', on_msg=raise_error)
-        with self.assertRaises(Exception):
-            comm._handle_msg('Error')
+        comm.send = assert_error
+        comm._handle_msg({})
+
+    def test_handle_message_ready_reply(self):
+        def assert_ready(msg):
+            self.assertEqual(json.loads(msg), {'msg_type': "Ready", 'content': ''})
+        comm = Comm(None, target='Test')
+        comm.send = assert_ready
+        comm._handle_msg({})
+
+    def test_handle_message_ready_reply_with_comms_target(self):
+        def assert_ready(msg):
+            decoded = json.loads(msg)
+            self.assertEqual(decoded, {'msg_type': "Ready", 'content': '',
+                                       'comms_target': 'Testing target'})
+        comm = Comm(None, target='Test')
+        comm.send = assert_ready
+        comm._handle_msg({'comms_target': 'Testing target'})
+
 
 
 class TestJupyterComm(ComparisonTestCase):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -246,7 +246,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
-        plot.callbacks[0].on_msg('{"x": 10, "y": -10}')
+        plot.callbacks[0].on_msg({"x": 10, "y": -10})
         data = plot.handles['source'].data
         self.assertEqual(data['x'], np.array([10]))
         self.assertEqual(data['y'], np.array([-10]))

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -251,6 +251,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(data['x'], np.array([10]))
         self.assertEqual(data['y'], np.array([-10]))
 
+    def test_stream_callback_with_ids(self):
+        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
+        plot = bokeh_renderer.get_plot(dmap)
+        bokeh_renderer(plot)
+        hover = plot.state.select(type=HoverTool)[0]
+        plot.callbacks[0].on_msg({"x": {'id': hover.ref['id'], 'value': 10},
+                                  "y": {'id': hover.ref['id'], 'value': -10}})
+        data = plot.handles['source'].data
+        self.assertEqual(data['x'], np.array([10]))
+        self.assertEqual(data['y'], np.array([-10]))
 
     def test_stream_callback_single_call(self):
         def history_callback(x, history=deque(maxlen=10)):


### PR DESCRIPTION
Currently there is a bug in the code that handles multiple callbacks being attached to one bokeh plot object. The issue arises when two streams are attached to one plot object, this can happen when one axis is linked between two plots. In these cases the ``RangeXY`` stream of one plot can end up with the y-range of another plot, which has a linked and therefore shared x-axis. The solution is to keep track of the IDs of the handles each stream is attached to, the frontend can send the matching ids along with the updated values and we can then check that only the appropriate data is actually forwarded to the stream.