### PR TITLE
Enabled matplotlib layout fix by default

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -698,16 +698,14 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
       Specifies the space between horizontally adjacent elements in the grid.
       Default value is set conservatively to avoid overlap of subplots.""")
 
-    vspace = param.Number(default=0.1, doc="""
+    vspace = param.Number(default=0.3, doc="""
       Specifies the space between vertically adjacent elements in the grid.
       Default value is set conservatively to avoid overlap of subplots.""")
 
     fontsize = param.Parameter(default={'title':16}, allow_None=True)
 
     # Whether to enable fix for non-square figures
-    # Will be enabled by default in v1.7
-    # If enabled default vspace should be increased to 0.3
-    v17_layout_format = False
+    v17_layout_format = True
 
     def __init__(self, layout, **params):
         super(LayoutPlot, self).__init__(layout=layout, **params)

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -1043,7 +1043,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                     cbar_plot._draw_colorbar(redraw=False)
             adjoined = self.traverse(specs=[AdjointLayoutPlot])
             for adjoined in adjoined:
-                adjoined.adjust_positions(redraw=False)
+                if len(adjoined.subplots) > 1:
+                    adjoined.adjust_positions(redraw=False)
         return self._finalize_axis(None)
 
 


### PR DESCRIPTION
It's time to enable the matplotlib layout fix by default. There will be changes to the display data, so that will have to be updated, after careful review.