### PR TITLE
Fixed output magic message when backend unavailable

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -186,7 +186,7 @@ class notebook_extension(param.ParameterizedFunction):
             ip = get_ipython() if ip is None else ip # noqa (get_ipython)
             param_ext.load_ipython_extension(ip, verbose=False)
             load_magics(ip)
-            OutputMagic.initialize()
+            OutputMagic.initialize(list( self._backends.keys()))
             set_display_hooks(ip)
             notebook_extension._loaded = True
 

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -267,10 +267,6 @@ class OutputMagic(OptionsMagic):
         else:
             raise ValueError("Backend %r does not exist" % value)
 
-
-        raise ValueError(OutputMagic.backend_list, value)
-        # raise ValueError("Backend %r not available. Has it been loaded with the notebook_extension?" % value)
-
     custom_exceptions = {'holomap':missing_dependency_exception,
                          'backend': missing_backend_exception }
 

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -260,7 +260,11 @@ class OutputMagic(OptionsMagic):
     def missing_dependency_exception(value, keyword, allowed):
         raise Exception("Format %r does not appear to be supported." % value)
 
-    custom_exceptions = {'holomap':missing_dependency_exception}
+    def missing_backend_exception(value, keyword, allowed):
+        raise ValueError("Backend %r not available. Has it been loaded with the notebook_extension?" % value)
+
+    custom_exceptions = {'holomap':missing_dependency_exception,
+                         'backend': missing_backend_exception }
 
     # Counter for nbagg figures
     nbagg_counter = 0

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -256,12 +256,20 @@ class OutputMagic(OptionsMagic):
     #==========================#
 
     last_backend = None
+    backend_list = [] # List of possible backends
 
     def missing_dependency_exception(value, keyword, allowed):
         raise Exception("Format %r does not appear to be supported." % value)
 
     def missing_backend_exception(value, keyword, allowed):
-        raise ValueError("Backend %r not available. Has it been loaded with the notebook_extension?" % value)
+        if value in OutputMagic.backend_list:
+            raise ValueError("Backend %r not available. Has it been loaded with the notebook_extension?" % value)
+        else:
+            raise ValueError("Backend %r does not exist" % value)
+
+
+        raise ValueError(OutputMagic.backend_list, value)
+        # raise ValueError("Backend %r not available. Has it been loaded with the notebook_extension?" % value)
 
     custom_exceptions = {'holomap':missing_dependency_exception,
                          'backend': missing_backend_exception }
@@ -398,7 +406,8 @@ class OutputMagic(OptionsMagic):
 
 
     @classmethod
-    def initialize(cls):
+    def initialize(cls, backend_list):
+        cls.backend_list = backend_list
         backend = cls.options.get('backend', cls.defaults['backend'])
         if backend in Store.renderers:
             cls.options = dict(cls.defaults)

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -360,7 +360,9 @@ class OutputMagic(OptionsMagic):
         prev_backend = Store.current_backend
         renderer = Store.renderers[Store.current_backend]
         prev_backend += ':%s' % renderer.mode
-        if not backend or backend == prev_backend:
+
+        available = backend in Store.renderers.keys()
+        if (not backend) or (not available) or backend == prev_backend:
             return options
 
         cls._backend_options[prev_backend] = cls.options


### PR DESCRIPTION
This PR addresses #999 regarding the inappropriate error message when trying to load an unavailable backend. Here is the old behavior:

![image](https://cloud.githubusercontent.com/assets/890576/21822342/bc439884-d76e-11e6-953c-3e4f0a4cade4.png)

And the new behavior:

![image](https://cloud.githubusercontent.com/assets/890576/21816896/b9db448a-d759-11e6-9575-b4b5abc8850f.png)

I've tried to make a minimal fix. That said, the output message might suggest how to load the backend with ``notebook_extension``...