### PR TITLE
Improved archive escaping of group and label in file/path names

### DIFF
--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -31,6 +31,9 @@ from .options import Store
 from .util import unique_iterator, group_sanitizer, label_sanitizer
 
 
+def escape(val, sep=os.sep, replacement='-sep-'):
+    return val.replace(sep, replacement)
+
 class Reference(param.Parameterized):
     """
     A Reference allows access to an object to be deferred until it is
@@ -694,8 +697,8 @@ class FileArchive(Archive):
             hashfn.update(obj_str.encode('utf-8'))
             format_values = {'timestamp': '{timestamp}',
                              'dimensions': dimensions,
-                             'group':   getattr(obj, 'group', 'no-group'),
-                             'label':   getattr(obj, 'label', 'no-label'),
+                             'group':   escape(getattr(obj, 'group', 'no-group')),
+                             'label':   escape(getattr(obj, 'label', 'no-label')),
                              'type':    obj.__class__.__name__,
                              'obj':     obj_str,
                              'SHA':     hashfn.hexdigest()}
@@ -769,7 +772,7 @@ class FileArchive(Archive):
         while (new_name, ext) in existing:
             new_name = basename+'-'+str(counter)
             counter += 1
-        return (new_name, ext)
+        return (escape(new_name), ext)
 
 
     def _truncate_name(self, basename, ext='', tail=10, join='...', maxlen=None):

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -31,7 +31,7 @@ from .options import Store
 from .util import unique_iterator, group_sanitizer, label_sanitizer
 
 
-def sanitizer(name, replacements={':':'colon_', '/':'slash_', '\\':'backslash_'}):
+def sanitizer(name, replacements={':':'_', '/':'_', '\\':'_'}):
     """
     String sanitizer to avoid problematic characters in filenames.
     """

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -31,12 +31,12 @@ from .options import Store
 from .util import unique_iterator, group_sanitizer, label_sanitizer
 
 
-def sanitizer(name, replacements={':':'_', '/':'_', '\\':'_'}):
+def sanitizer(name, replacements=[(':','_'), ('/','_'), ('\\','_')]):
     """
     String sanitizer to avoid problematic characters in filenames.
     """
-    for k,v in replacements.items():
-        name = name.replace(k,v)
+    for old,new in replacements:
+        name = name.replace(old,new)
     return name
 
 


### PR DESCRIPTION
The PR aims to address issue #1021. I now know where to implement the escaping fix as illustrated in the first commit. We should discuss how to make this prettier/more robust (I don't like the look of the escaped output yet):

![image](https://cloud.githubusercontent.com/assets/890576/21818563/3b62b690-d760-11e6-940c-082d6acc4b02.png)

I suppose that instead of using ``'-sep-'`` I should see if Python offers proper escaping of filenames/paths on Unix/Windows. As I said, this PR is still WIP!