### PR TITLE
Aliased __str__ to __repr__

### DIFF
--- a/doc/Tutorials/Columnar_Data.ipynb
+++ b/doc/Tutorials/Columnar_Data.ipynb
@@ -124,9 +124,9 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(hv.Scatter({'x': xs, 'y': ys}) +\n",
-    "           hv.Scatter(np.column_stack([xs, ys])) +\n",
-    "           hv.Scatter(pd.DataFrame({'x': xs, 'y': ys}))))"
+    "print(hv.Scatter({'x': xs, 'y': ys}) +\n",
+    "      hv.Scatter(np.column_stack([xs, ys])) +\n",
+    "      hv.Scatter(pd.DataFrame({'x': xs, 'y': ys})))"
    ]
   },
   {
@@ -146,7 +146,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(hv.Scatter(ys) + hv.Scatter((xs, ys)) + hv.Scatter(zip(xs, ys))))"
+    "print(hv.Scatter(ys) + hv.Scatter((xs, ys)) + hv.Scatter(zip(xs, ys)))"
    ]
   },
   {

--- a/doc/Tutorials/Composing_Data.ipynb
+++ b/doc/Tutorials/Composing_Data.ipynb
@@ -85,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The structure of this object can be seen in the ``repr()``:"
+    "The structure of this object can be seen using ``print()``:"
    ]
   },
   {
@@ -96,7 +96,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(layout))"
+    "print(layout)"
    ]
   },
   {
@@ -148,7 +148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Above, we have already viewed the highest level of our data structure as a Layout. Here is the repr of entire Layout object, which reflects all the levels shown in the diagram:"
+    "Above, we have already viewed the highest level of our data structure as a Layout. Here is the representation of entire Layout object, which reflects all the levels shown in the diagram:"
    ]
   },
   {
@@ -159,7 +159,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(layout))"
+    "print(layout)"
    ]
   },
   {
@@ -232,7 +232,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``repr()`` showed us that the ``HoloMap`` is composed of ``Overlay`` objects, six in this case (giving six frames to the animation above).  Let us access one of these elements, i.e. one frame of the animation above, by indexing to retrieve an ``Overlay`` associated with the key with a ``Frequency`` of *1.0*:"
+    "The printed representation showed us that the ``HoloMap`` is composed of ``Overlay`` objects, six in this case (giving six frames to the animation above).  Let us access one of these elements, i.e. one frame of the animation above, by indexing to retrieve an ``Overlay`` associated with the key with a ``Frequency`` of *1.0*:"
    ]
   },
   {
@@ -257,7 +257,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As the ``repr()`` shows, the ``Overlay`` contains a ``Points`` object and an ``NdOverlay`` object.  We can access either one of these using the attribute access supported by ``Overlay``:"
+    "As the representation shows, the ``Overlay`` contains a ``Points`` object and an ``NdOverlay`` object.  We can access either one of these using the attribute access supported by ``Overlay``:"
    ]
   },
   {

--- a/doc/Tutorials/Composing_Data.ipynb
+++ b/doc/Tutorials/Composing_Data.ipynb
@@ -306,7 +306,7 @@
    },
    "outputs": [],
    "source": [
-    "repr(l)"
+    "print(l)"
    ]
   },
   {

--- a/doc/Tutorials/Dynamic_Map.ipynb
+++ b/doc/Tutorials/Dynamic_Map.ipynb
@@ -175,7 +175,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This object is created instantly, because it doesn't generate any `hv.Image` objects initially. We can now look at the ``repr`` of this object: "
+    "This object is created instantly, because it doesn't generate any `hv.Image` objects initially. We can now look at the printed representation of this object: "
    ]
   },
   {
@@ -186,7 +186,7 @@
    },
    "outputs": [],
    "source": [
-    "repr(dmap)"
+    "print(dmap)"
    ]
   },
   {
@@ -1005,7 +1005,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, we are given only the text-based repr, to indicate that the generator is exhausted. However, as the process of iteration has populated the cache, we can still view the output as a ``HoloMap`` using ``hv.HoloMap(dmap)`` as before."
+    "Here, we are given only the text-based representation, to indicate that the generator is exhausted. However, as the process of iteration has populated the cache, we can still view the output as a ``HoloMap`` using ``hv.HoloMap(dmap)`` as before."
    ]
   },
   {

--- a/doc/Tutorials/Exporting.ipynb
+++ b/doc/Tutorials/Exporting.ipynb
@@ -447,7 +447,7 @@
     "if os.path.isfile(path):\n",
     "    o = Unpickler.load(open(path,\"r\"))\n",
     "    c = o.Image\n",
-    "print(repr(c))"
+    "print(c)"
    ]
   },
   {

--- a/doc/Tutorials/Introduction.ipynb
+++ b/doc/Tutorials/Introduction.ipynb
@@ -276,7 +276,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(channels))"
+    "print(channels)"
    ]
   },
   {
@@ -303,7 +303,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that for each item in the ``Layout``, the ``repr()`` shows us its Python type (``Image``) and the attributes needed to access it (``.Image.Blue`` in this case).  The remaining items in brackets and parentheses in the ``repr()`` will be discussed below.\n",
+    "You can see that for each item in the ``Layout``, using ``print()`` shows us its Python type (``Image``) and the attributes needed to access it (``.Image.Blue`` in this case).  The remaining items in brackets and parentheses in the printed representation will be discussed below.\n",
     "\n",
     "Since we can access the channels easily, we can recompose our data how we like, e.g. to compare the Red and Blue channels side by side:"
    ]
@@ -400,7 +400,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(chans.Channel))\n",
+    "print(chans.Channel)\n",
     "chans.Channel"
    ]
   },
@@ -450,7 +450,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(chans))"
+    "print(chans)"
    ]
   },
   {
@@ -468,7 +468,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can see that ``rgb_parrot`` is still titled with its internal label \"Macaw\", even though it's been inserted into a custom location in the ``Layout`` tree; the attributes are only used for grouping and accessing the objects from Python, not for plotting purposes, and so you can use them however you see fit to organize your own data.  The two-level structure provided by the ``+`` operator is just a useful default, and should be all many HoloViews users will need.  Note that the attributes constructed using ``+`` are sanitized --- spaces are converted to ``_``, special characters are represented specially, and so on -- just use ``[TAB]`` completion (or ``print(repr())``) to find out the correct attribute name in unusual cases.  So you can use any characters you like in the label and group, and there will still be usable names for use in attribute selection and options processing."
+    "You can see that ``rgb_parrot`` is still titled with its internal label \"Macaw\", even though it's been inserted into a custom location in the ``Layout`` tree; the attributes are only used for grouping and accessing the objects from Python, not for plotting purposes, and so you can use them however you see fit to organize your own data.  The two-level structure provided by the ``+`` operator is just a useful default, and should be all many HoloViews users will need.  Note that the attributes constructed using ``+`` are sanitized --- spaces are converted to ``_``, special characters are represented specially, and so on -- just use ``[TAB]`` completion (or ``print()``) to find out the correct attribute name in unusual cases.  So you can use any characters you like in the label and group, and there will still be usable names for use in attribute selection and options processing."
    ]
   },
   {
@@ -482,7 +482,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Apart from the attribute access and types, the other items in the ``repr()`` show the dimensions of the ``Image`` objects:"
+    "Apart from the attribute access and types, the other items in the printed representation show the dimensions of the ``Image`` objects:"
    ]
   },
   {
@@ -493,7 +493,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(chans))"
+    "print(chans)"
    ]
   },
   {
@@ -518,7 +518,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The value dimensions in parentheses in the ``repr()`` tell you what data will be returned by applying the above indexing over the key dimensions, in this case the single value for the luminance of the blue pixel at that location. The generic default name for that dimension of an ``Image`` is ``z``, but you can use another name for it if you prefer:"
+    "The value dimensions in parentheses in the ``print()`` tell you what data will be returned by applying the above indexing over the key dimensions, in this case the single value for the luminance of the blue pixel at that location. The generic default name for that dimension of an ``Image`` is ``z``, but you can use another name for it if you prefer:"
    ]
   },
   {
@@ -530,7 +530,7 @@
    "outputs": [],
    "source": [
     "chans.Channel.Blue = chans.Channel.Blue.clone(vdims=[\"Luminance\"])\n",
-    "print(repr(chans.Channel.Blue))"
+    "print(chans.Channel.Blue)"
    ]
   },
   {
@@ -548,7 +548,7 @@
    },
    "outputs": [],
    "source": [
-    "print(repr(rgb_parrot))\n",
+    "print(rgb_parrot)\n",
     "print(rgb_parrot[0,0])\n",
     "print(rgb_parrot[0,0][0])"
    ]

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -901,6 +901,9 @@ class Dimensioned(LabelledData):
         else:
             return str(reprval)
 
+    def __str__(self):
+        return repr(self)
+
     def __unicode__(self):
         return unicode(PrettyPrinter.pprint(self))
 


### PR DESCRIPTION
PR implementing the suggestion in #966. The code change is tiny (aliasing ``__str__`` to ``__repr__``) and most of this PR will be about updating the docs.

Here is the behavior before:

![image](https://cloud.githubusercontent.com/assets/890576/21822988/54019f3e-d771-11e6-9c61-72735ab0d543.png)

And after:

![image](https://cloud.githubusercontent.com/assets/890576/21822970/40cb8164-d771-11e6-8166-89b45715ed27.png)

Of course I'll make sure to put the parens around print in the notebooks for Python 3 support!