### PR TITLE
Fixed python widget key precision to match JS

### DIFF
--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -18,7 +18,7 @@ def escape_vals(vals, escape_numerics=True):
     unicode for safety.
     """
     # Ints formatted as floats to disambiguate with counter mode
-    ints, floats = "%.1f", "%.11f"
+    ints, floats = "%.1f", "%.10f"
 
     escaped = []
     for v in vals:

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -143,9 +143,8 @@ SelectionWidget.prototype.get_key = function(current_vals) {
     {
         val = this.current_vals[i];
         if (!(typeof val === 'string')) {
-            if (val % 1 === 0) { var fixed = 1;}
-            else { var fixed = 10;}
-            val = val.toFixed(fixed)
+            if (val % 1 === 0) { val = val.toFixed(1); }
+            else { val = val.toFixed(10); val = val.slice(0, val.length-1);}
         }
         key += "'" + val + "'";
         if(i != this.slider_ids.length-1) { key += ', ';}


### PR DESCRIPTION
So this is pretty strange, as revealed in https://github.com/ioam/holoviews/issues/1052, it turns out the precision the widget keys are set to in Python does not match the precision specified by the widgets. It seems I changed the value as part of a fix for DynamicMap. Will have to investigate what that was about before merging this.