### PR TITLE
Add memoization to dynamic Callable class

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -530,7 +530,6 @@ class DynamicMap(HoloMap):
 
         self.call_mode = self._validate_mode()
         self.mode = 'bounded' if self.call_mode == 'key' else 'open'
-        self._dimensionless_cache = False
 
 
     def _initial_key(self):
@@ -778,7 +777,7 @@ class DynamicMap(HoloMap):
         try:
             dimensionless = util.dimensionless_contents(get_nested_streams(self),
                                                         self.kdims, no_duplicates=False)
-            if (dimensionless and not self._dimensionless_cache):
+            if dimensionless:
                 raise KeyError('Using dimensionless streams disables DynamicMap cache')
             cache = super(DynamicMap,self).__getitem__(key)
             # Return selected cache items in a new DynamicMap

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -406,8 +406,8 @@ class Callable(param.Parameterized):
     makes it possible to traverse the graph of operations applied
     to a DynamicMap. Additionally a Callable will memoize the last
     returned value based on the arguments to the function and the
-    state of all streams on its inputs, avoiding calling the function
-    unncessarily.
+    state of all streams on its inputs, to avoid calling the function
+    unnecessarily.
     """
 
     callable_function = param.Callable(default=lambda x: x, doc="""
@@ -421,8 +421,8 @@ class Callable(param.Parameterized):
         self._memoized = {}
 
     def __call__(self, *args, **kwargs):
-        inputs = [inp for inp in self.inputs if isinstance(inp, DynamicMap)]
-        streams = [s for inp in inputs for s in get_nested_streams(inp)]
+        inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
+        streams = [s for i in inputs for s in get_nested_streams(i)]
         values = tuple(tuple(sorted(s.contents.items())) for s in streams)
         key = args + tuple(sorted(kwargs.items())) + values
 
@@ -517,7 +517,7 @@ class DynamicMap(HoloMap):
        """)
 
     def __init__(self, callback, initial_items=None, **params):
-        if not isinstance(callback, Callable) and not isinstance(callback, types.GeneratorType):
+        if not isinstance(callback, (Callable, types.GeneratorType)):
             callback = Callable(callable_function=callback)
         super(DynamicMap, self).__init__(initial_items, callback=callback, **params)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -404,7 +404,10 @@ class Callable(param.Parameterized):
     allowing their inputs (and in future outputs) to be defined.
     This makes it possible to wrap DynamicMaps with streams and
     makes it possible to traverse the graph of operations applied
-    to a DynamicMap.
+    to a DynamicMap. Additionally a Callable will memoize the last
+    returned value based on the arguments to the function and the
+    state of all streams on its inputs, avoiding calling the function
+    unncessarily.
     """
 
     callable_function = param.Callable(default=lambda x: x, doc="""

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -128,29 +128,3 @@ def hierarchical(keys):
                 store1[v2].append(v1)
         hierarchies.append(store2 if hierarchy else {})
     return hierarchies
-
-
-class dimensionless_cache(object):
-    """
-    Context manager which temporarily enables lookup of frame in the
-    cache on a DynamicMap with dimensionless streams. Allows passing
-    any Dimensioned object which might contain a DynamicMap and
-    whether to enable the cache. This allows looking up an item
-    without triggering the callback. Useful when the object is looked
-    up multiple times as part of some processing pipeline.
-    """
-
-    def __init__(self, obj, allow_cache_lookup=True):
-        self.obj = obj
-        self._allow_cache_lookup = allow_cache_lookup
-
-    def __enter__(self):
-        self.set_cache_flag(self._allow_cache_lookup)
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.set_cache_flag(False)
-
-    def set_cache_flag(self, value):
-        self.obj.traverse(lambda x: setattr(x, '_dimensionless_cache', value),
-                          ['DynamicMap'])
-

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -18,7 +18,6 @@ from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor, SkipRendering
 from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
-from ..core.traversal import dimensionless_cache
 from ..core.util import stream_parameters
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
@@ -625,8 +624,7 @@ class GenericElementPlot(DimensionedPlot):
             self.current_key = key
             return self.current_frame
         elif self.dynamic:
-            with dimensionless_cache(self.hmap, not self._force or not self.drawn):
-                key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
+            key, frame = util.get_dynamic_item(self.hmap, self.dimensions, key)
             traverse_setter(self, '_force', False)
             if not isinstance(key, tuple): key = (key,)
             key_map = dict(zip([d.name for d in self.hmap.kdims], key))
@@ -977,8 +975,7 @@ class GenericCompositePlot(DimensionedPlot):
                                     if d in item.dimensions('key')], key)
                 self.current_key = tuple(k[1] for k in dim_keys)
             elif item.traverse(lambda x: x, [DynamicMap]):
-                with dimensionless_cache(item, not self._force or not self.drawn):
-                    key, frame = util.get_dynamic_item(item, self.dimensions, key)
+                key, frame = util.get_dynamic_item(item, self.dimensions, key)
                 layout_frame[path] = frame
                 continue
             elif self.uniform:


### PR DESCRIPTION
In order to address #1049 the Callable class now memoizes the last returned value from a DynamicMap, based on the args, kwargs and nested stream values.

Needs docstrings and tests. @jordansamuels this seems to address your issue. Small example for testing:

```python
import holoviews as hv
import numpy as np
import pandas as pd
from holoviews.operation.datashader import datashade
from holoviews.streams import PositionXY

hv.notebook_extension('bokeh')

%opts RGB [width=800, height=450] VLine HLine (line_color='black' line_width=0.5)

n=100000
def f(n):
    return np.cumsum(np.random.randn(n))
df = pd.DataFrame({'t': range(n), 'y1': f(n), 'y2': f(n), 'y3' : .10 * f(n)} )

def p(y):
    return hv.Curve(df, kdims=['t'], vdims=[y])

ts = datashade(p('y1'))
ch = hv.DynamicMap(lambda x, y: hv.HLine(y) * hv.VLine(x) * hv.Text(x+0.15, y, '%.3f' % x + ", %.3f" % y),
              kdims=[], streams=[PositionXY()])
(ts * datashade(p('y2')) * ch + ts).cols(1)
```