### PR TITLE
Renamed conversion interface mdims argument to groupby

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -68,25 +68,37 @@ class DataConversion(object):
     def __init__(self, element):
         self._element = element
 
-    def __call__(self, new_type, kdims=None, vdims=None, mdims=None,
+    def __call__(self, new_type, kdims=None, vdims=None, groupby=None,
                  sort=False, **kwargs):
         """
         Generic conversion method for Column based types. Supply the
-        Columns based type to convert to and optionally the
-        key dimensions (kdims), value dimensions (vdims) and HoloMap
-        key dimensions (mdims). Converted Columns can be automatically
-        sorted via the sort option and kwargs can be passed through.
+        Columns based type to convert to and optionally the key
+        dimensions (kdims), value dimensions (vdims) and the
+        dimensions.  to group over. Converted Columns can be
+        automatically sorted via the sort option and kwargs can be
+        passed through.
         """
+        if 'mdims' in kwargs:
+            if groupby:
+                raise ValueError('Cannot supply both mdims and groupby')
+            else:
+                self._element.warning("mdims keyword has been renamed to "
+                                      "groupby and will be deprecated in "
+                                      "version 1.8.")
+                groupby = kwargs['mdims']
+
         if kdims is None:
             kdims = self._element.kdims
         elif kdims and not isinstance(kdims, list): kdims = [kdims]
         if vdims is None:
             vdims = self._element.vdims
         if vdims and not isinstance(vdims, list): vdims = [vdims]
-        if mdims is None:
-            mdims = [d for d in self._element.kdims if d not in kdims+vdims]
+        if groupby is None:
+            groupby = [d for d in self._element.kdims if d not in kdims+vdims]
+        elif groupby and not isinstance(groupby, list):
+            groupby = [groupby]
 
-        selected = self._element.reindex(mdims+kdims, vdims)
+        selected = self._element.reindex(groupby+kdims, vdims)
         params = {'kdims': [selected.get_dimension(kd) for kd in kdims],
                   'vdims': [selected.get_dimension(vd) for vd in vdims],
                   'label': selected.label}
@@ -96,7 +108,7 @@ class DataConversion(object):
         if len(kdims) == selected.ndims:
             element = new_type(selected, **params)
             return element.sort() if sort else element
-        group = selected.groupby(mdims, container_type=HoloMap,
+        group = selected.groupby(groupby, container_type=HoloMap,
                                  group_type=new_type, **params)
         if sort:
             return group.map(lambda x: x.sort(), [new_type])

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -82,9 +82,10 @@ class DataConversion(object):
             if groupby:
                 raise ValueError('Cannot supply both mdims and groupby')
             else:
-                self._element.warning("mdims keyword has been renamed to "
-                                      "groupby and will be deprecated in "
-                                      "version 1.8.")
+                self._element.warning("'mdims' keyword has been renamed "
+                                      "to groupby; the name mdims is "
+                                      "deprecated and will be removed "
+                                      "after version 1.7.")
                 groupby = kwargs['mdims']
 
         if kdims is None:

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -71,12 +71,12 @@ class DataConversion(object):
     def __call__(self, new_type, kdims=None, vdims=None, groupby=None,
                  sort=False, **kwargs):
         """
-        Generic conversion method for Column based types. Supply the
-        Columns based type to convert to and optionally the key
-        dimensions (kdims), value dimensions (vdims) and the
-        dimensions.  to group over. Converted Columns can be
-        automatically sorted via the sort option and kwargs can be
-        passed through.
+        Generic conversion method for Dataset based Element
+        types. Supply the Dataset Element type to convert to and
+        optionally the key dimensions (kdims), value dimensions
+        (vdims) and the dimensions.  to group over. Converted Columns
+        can be automatically sorted via the sort option and kwargs can
+        bepassed through.
         """
         if 'mdims' in kwargs:
             if groupby:

--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -15,23 +15,23 @@ class ElementConversion(DataConversion):
     types.
     """
 
-    def bars(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Bars, kdims, vdims, mdims, **kwargs)
+    def bars(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Bars, kdims, vdims, groupby, **kwargs)
 
-    def box(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(BoxWhisker, kdims, vdims, mdims, **kwargs)
+    def box(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(BoxWhisker, kdims, vdims, groupby, **kwargs)
 
-    def bivariate(self, kdims=None, vdims=None, mdims=None, **kwargs):
+    def bivariate(self, kdims=None, vdims=None, groupby=None, **kwargs):
         from ..interface.seaborn import Bivariate
-        return self(Bivariate, kdims, vdims, mdims, **kwargs)
+        return self(Bivariate, kdims, vdims, groupby, **kwargs)
 
-    def curve(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Curve, kdims, vdims, mdims, sort=True, **kwargs)
+    def curve(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Curve, kdims, vdims, groupby, sort=True, **kwargs)
 
-    def errorbars(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(ErrorBars, kdims, vdims, mdims, sort=True, **kwargs)
+    def errorbars(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(ErrorBars, kdims, vdims, groupby, sort=True, **kwargs)
 
-    def distribution(self, dim=None, mdims=[], **kwargs):
+    def distribution(self, dim=None, groupby=[], **kwargs):
         from ..interface.seaborn import Distribution
         if dim is None:
             if self._element.vdims:
@@ -39,9 +39,9 @@ class ElementConversion(DataConversion):
             else:
                 raise Exception('Must supply an explicit value dimension '
                                 'if no value dimensions are defined ')
-        if mdims:
-            reindexed = self._element.reindex(mdims, [dim])
-            return reindexed.groupby(mdims, HoloMap, Distribution, **kwargs)
+        if groupby:
+            reindexed = self._element.reindex(groupby, [dim])
+            return reindexed.groupby(groupby, HoloMap, Distribution, **kwargs)
         else:
             element = self._element
             params = dict(vdims=[element.get_dimension(dim)],
@@ -51,44 +51,44 @@ class ElementConversion(DataConversion):
             return Distribution((element.dimension_values(dim),),
                                 **dict(params, **kwargs))
 
-    def heatmap(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(HeatMap, kdims, vdims, mdims, **kwargs)
+    def heatmap(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(HeatMap, kdims, vdims, groupby, **kwargs)
 
-    def image(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(GridImage, kdims, vdims, mdims, **kwargs)
+    def image(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(GridImage, kdims, vdims, groupby, **kwargs)
 
-    def points(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Points, kdims, vdims, mdims, **kwargs)
+    def points(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Points, kdims, vdims, groupby, **kwargs)
 
-    def raster(self, kdims=None, vdims=None, mdims=None, **kwargs):
+    def raster(self, kdims=None, vdims=None, groupby=None, **kwargs):
         heatmap = self.heatmap(kdims, vdims, **kwargs)
         return Raster(heatmap.data, **dict(self._element.get_param_values(onlychanged=True)))
 
-    def regression(self, kdims=None, vdims=None, mdims=None, **kwargs):
+    def regression(self, kdims=None, vdims=None, groupby=None, **kwargs):
         from ..interface.seaborn import Regression
-        return self(Regression, kdims, vdims, mdims, **kwargs)
+        return self(Regression, kdims, vdims, groupby, **kwargs)
 
-    def scatter(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Scatter, kdims, vdims, mdims, **kwargs)
+    def scatter(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Scatter, kdims, vdims, groupby, **kwargs)
 
-    def scatter3d(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Scatter3D, kdims, vdims, mdims, **kwargs)
+    def scatter3d(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Scatter3D, kdims, vdims, groupby, **kwargs)
 
-    def spikes(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Spikes, kdims, vdims, mdims, **kwargs)
+    def spikes(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Spikes, kdims, vdims, groupby, **kwargs)
 
-    def spread(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Spread, kdims, vdims, mdims, sort=True, **kwargs)
+    def spread(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Spread, kdims, vdims, groupby, sort=True, **kwargs)
 
-    def surface(self, kdims=None, vdims=None, mdims=None, **kwargs):
+    def surface(self, kdims=None, vdims=None, groupby=None, **kwargs):
         heatmap = self.heatmap(kdims, vdims, **kwargs)
         return Surface(heatmap.data, **dict(self._table.get_param_values(onlychanged=True)))
 
-    def trisurface(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(Trisurface, kdims, vdims, mdims, **kwargs)
+    def trisurface(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Trisurface, kdims, vdims, groupby, **kwargs)
 
-    def vectorfield(self, kdims=None, vdims=None, mdims=None, **kwargs):
-        return self(VectorField, kdims, vdims, mdims, **kwargs)
+    def vectorfield(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(VectorField, kdims, vdims, groupby, **kwargs)
 
 
 Dataset._conversion_interface = ElementConversion


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/1061 renaming mdims to groupby in the conversion interface ``.to`` method is a lot clearer. This PR renames the kwarg while retaining support for the mdims argument along with a deprecation warning.