### PR TITLE
Fixes for axis options handling in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -5,7 +5,7 @@ import numpy as np
 import bokeh
 import bokeh.plotting
 from bokeh.core.properties import value
-from bokeh.models import Range, HoverTool, Renderer
+from bokeh.models import Range, HoverTool, Renderer, Range1d
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker
 from bokeh.models.widgets import Panel, Tabs
 
@@ -489,8 +489,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
 
     def _update_ranges(self, element, ranges):
-        l, b, r, t = self.get_extents(element, ranges)
         plot = self.handles['plot']
+        l, b, r, t = self.get_extents(element, ranges)
+
         if self.invert_axes:
             l, b, r, t = b, l, t, r
         if l == r:
@@ -503,10 +504,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             t += offset
 
         # Ensure that it never sets a NaN value
-        if isinstance(l, np.datetime64) or np.isfinite(l): plot.x_range.start = l
-        if isinstance(l, np.datetime64) or np.isfinite(r): plot.x_range.end   = r
-        if isinstance(l, np.datetime64) or np.isfinite(b): plot.y_range.start = b
-        if isinstance(l, np.datetime64) or np.isfinite(t): plot.y_range.end   = t
+        if isinstance(plot.x_range, Range1d):
+            if isinstance(l, np.datetime64) or np.isfinite(l): plot.x_range.start = l
+            if isinstance(l, np.datetime64) or np.isfinite(r): plot.x_range.end   = r
+        if isinstance(plot.y_range, Range1d):
+            if isinstance(l, np.datetime64) or np.isfinite(b): plot.y_range.start = b
+            if isinstance(l, np.datetime64) or np.isfinite(t): plot.y_range.end   = t
 
 
     def _process_legend(self):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -407,7 +407,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _init_axes(self, plot):
         if self.xaxis is None:
             plot.xaxis.visible = False
-        elif self.xaxis == 'top':
+        elif 'top' in self.xaxis:
             plot.above = plot.below
             plot.below = []
             plot.xaxis[:] = plot.above
@@ -416,7 +416,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if self.yaxis is None:
             plot.yaxis.visible = False
-        elif self.yaxis == 'right':
+        elif 'right' in self.yaxis:
             plot.right = plot.left
             plot.left = []
             plot.yaxis[:] = plot.right
@@ -424,7 +424,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self.handles['y_range'] = plot.y_range
 
 
-    def _axis_properties(self, axis, key, plot, dimension,
+    def _axis_properties(self, axis, key, plot, dimension=None,
                          ax_mapping={'x': 0, 'y': 1}):
         """
         Returns a dictionary of axis properties depending
@@ -474,6 +474,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         el = element.traverse(lambda x: x, [Element])
         dimensions = el[0].dimensions() if el else el.dimensions()
+        if not len(dimensions) >= 2:
+            dimensions = dimensions+[None]
         plot.update(**self._plot_properties(key, plot, element))
         props = {axis: self._axis_properties(axis, key, plot, dim)
                  for axis, dim in zip(['x', 'y'], dimensions)}

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -17,6 +17,9 @@ from .util import mplcmap_to_palette, get_cmap, hsv_to_rgb, mpl_to_bokeh
 
 class RasterPlot(ColorbarPlot):
 
+    show_grid = param.Boolean(default=True, doc="""
+        Whether to show a Cartesian grid on the plot.""")
+
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -43,7 +43,8 @@ markers = {'s': {'marker': 'square'},
 # LinearAxis.computed_bounds cannot be updated
 IGNORED_MODELS = ['LinearAxis', 'LogAxis', 'DatetimeAxis', 'DatetimeTickFormatter',
                   'CategoricalAxis', 'BasicTicker', 'BasicTickFormatter',
-                  'FixedTicker', 'FuncTickFormatter', 'LogTickFormatter']
+                  'FixedTicker', 'FuncTickFormatter', 'LogTickFormatter',
+                  'CategoricalTickFormatter']
 
 # List of attributes that can safely be dropped from the references
 IGNORED_ATTRIBUTES = ['data', 'palette', 'image', 'x', 'y']


### PR DESCRIPTION
Two small bugs here, the ``top-bare`` and ``right-bare`` options for xaxis and yaxis respectively were being ignored and secondly elements with only one dimension like Spikes do not correctly processed their axis settings.