### PR TITLE
Properly close js and css files after opening

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -407,10 +407,15 @@ class Renderer(Exporter):
 
         # Join all the js widget code into one string
         path = os.path.dirname(os.path.abspath(__file__))
-        widgetjs = '\n'.join(open(find_file(path, f), 'r').read()
-                             for f in basejs + extensionjs
-                             if f is not None )
-        widgetcss = '\n'.join(open(find_file(path, f), 'r').read()
+
+        def open_and_read(path, f):
+            with open(find_file(path, f), 'r') as f:
+                txt = f.read()
+            return txt
+
+        widgetjs = '\n'.join(open_and_read(path, f)
+                             for f in basejs + extensionjs if f is not None)
+        widgetcss = '\n'.join(open_and_read(path, f) 
                               for f in css if f is not None)
 
         dependencies = {}


### PR DESCRIPTION
I often get warnings like:
```
/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/renderer.py:412: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/widgets/widgets.js' mode='r' encoding='UTF-8'>
  if f is not None )
/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/renderer.py:412: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/mpl/mplwidgets.js' mode='r' encoding='UTF-8'>
  if f is not None )
/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/renderer.py:414: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/tinkerer/Dropbox/Work/holoviews/holoviews/plotting/widgets/jsslider.css' mode='r' encoding='UTF-8'>
  for f in css if f is not None)
```

This PR should fix this.