### PR TITLE
Fix for datetime support on bokeh BoxPlot

### DIFF
--- a/holoviews/core/__init__.py
+++ b/holoviews/core/__init__.py
@@ -25,6 +25,11 @@ Dimension.type_formatters[np.float32] = "%.5g"
 Dimension.type_formatters[np.float64] = "%.5g"
 Dimension.type_formatters[np.datetime64] = '%Y-%m-%d %H:%M:%S'
 
+try:
+    import pandas as pd
+    Dimension.type_formatters[pd.tslib.Timestamp] = "%Y-%m-%d %H:%M:%S"
+except:
+    pass
 
 def public(obj):
     if not isinstance(obj, type): return False

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -562,24 +562,29 @@ class BoxPlot(ChartPlot):
     """
     BoxPlot generates a box and whisker plot from a BoxWhisker
     Element. This allows plotting the median, mean and various
-    percentiles. Displaying outliers is currently not supported
-    as they cannot be consistently updated.
+    percentiles.
     """
 
-    style_opts = ['color', 'whisker_color'] + line_properties
+    style_opts = ['color', 'whisker_color', 'marker'] + line_properties
 
     def _init_chart(self, element, ranges):
         properties = self.style[self.cyclic_index]
-        dframe = element.dframe()
         label = element.dimensions('key', True)
-        if len(element.dimensions()) == 1:
+        dframe = element.dframe()
+
+        # Fix for displaying datetimes which are not handled by bokeh
+        for kd in element.kdims:
+            col = dframe[kd.name]
+            if col.dtype.kind in ('M',):
+                dframe[kd.name] = [kd.pprint_value(v).replace(':', ';')
+                                   for v in col]
+
+        if not element.kdims:
             dframe[''] = ''
             label = ['']
-        plot = BokehBoxPlot(dframe, label=label,
-                            values=element.dimensions('value', True)[0],
-                            **properties)
 
-        return plot
+        return BokehBoxPlot(dframe, label=label, values=element.vdims[0].name,
+                            **properties)
 
 
 class BarPlot(ChartPlot):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -4,6 +4,7 @@ Tests of plot instantiation (not display tests, just instantiation)
 from __future__ import unicode_literals
 
 import logging
+import datetime as dt
 from collections import deque
 from unittest import SkipTest
 from io import BytesIO, StringIO
@@ -14,7 +15,7 @@ from holoviews import (Dimension, Overlay, DynamicMap, Store,
                        NdOverlay, GridSpace, HoloMap, Layout)
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
-                               Scatter3D, Path, Polygons, Bars)
+                               Scatter3D, Path, Polygons, Bars, BoxWhisker)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import PositionXY, PositionX
 from holoviews.plotting import comms
@@ -32,7 +33,7 @@ try:
     import holoviews.plotting.bokeh
     bokeh_renderer = Store.renderers['bokeh']
     from holoviews.plotting.bokeh.callbacks import Callback
-    from bokeh.models import Div
+    from bokeh.models import Div, ColumnDataSource
     from bokeh.models.mappers import LinearColorMapper, LogColorMapper
     from bokeh.models.tools import HoverTool
 except:
@@ -360,6 +361,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                    'cannot use to scale Points size.\n' % plot.name)
         self.assertEqual(log_msg, warning)
 
+    def test_box_whisker_datetime(self):
+        times = np.arange(dt.datetime(2017,1,1), dt.datetime(2017,2,1),
+                          dt.timedelta(days=1))
+        box = BoxWhisker((times, np.random.rand(len(times))), kdims=['Date'])
+        plot = bokeh_renderer.get_plot(box)
+        formatted = [box.kdims[0].pprint_value(t).replace(':', ';') for t in times]
+        self.assertTrue(all('Date' in cds.data for cds in
+                            plot.state.select(ColumnDataSource)))
+        self.assertTrue(cds.data['Date'][0] in formatted for cds in
+                        plot.state.select(ColumnDataSource))
 
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):


### PR DESCRIPTION
Bokeh does not currently handle datetimes on their boxwhisker chart implementation, in the meantime this PR simply casts the datetimes to strings, replacing any colons with semi-colons because those are also not supported. I'll file an issue about it on the bokeh repo, but since the charts API may get deprecated it may not get addressed.