### PR TITLE
SideHistogram supports coloring weighted average

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -300,7 +300,8 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
             data = dict(top=element.values, left=element.edges[:-1],
                         right=element.edges[1:])
 
-        dim = element.get_dimension(0)
+        color_dims = self.adjoined.traverse(lambda x: x.handles.get('color_dim'))
+        dim = color_dims[0] if color_dims else None
         cmapper = self._get_colormapper(dim, element, {}, {})
         if cmapper:
             data[dim.name] = [] if empty else element.dimension_values(dim)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -841,6 +841,8 @@ class ColorbarPlot(ElementPlot):
     def _get_colormapper(self, dim, element, ranges, style):
         # The initial colormapper instance is cached the first time
         # and then only updated
+        if dim is None:
+            return None
         low, high = ranges.get(dim.name, element.range(dim.name))
         palette = mplcmap_to_palette(style.pop('cmap', 'viridis'))
         if self.adjoined:

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -241,6 +241,36 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
         self._test_colormapping(spikes, 1)
 
+    def test_side_histogram_cmapper(self):
+        """Assert histogram shares colormapper"""
+        x,y = np.mgrid[-50:51, -50:51] * 0.1
+        img = Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
+        plot = bokeh_renderer.get_plot(img.hist())
+        plot.initialize_plot()
+        adjoint_plot = plot.subplots.values()[0]
+        main_plot = adjoint_plot.subplots['main']
+        right_plot = adjoint_plot.subplots['right']
+        self.assertIs(main_plot.handles['color_mapper'],
+                      right_plot.handles['color_mapper'])
+        self.assertEqual(main_plot.handles['color_dim'], img.vdims[0])
+
+    def test_side_histogram_cmapper_weighted(self):
+        """Assert weighted histograms share colormapper"""
+        x,y = np.mgrid[-50:51, -50:51] * 0.1
+        img = Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
+        adjoint = img.hist(dimension=['x', 'y'], weight_dimension='z',
+                           mean_weighted=True)
+        plot = bokeh_renderer.get_plot(adjoint)
+        plot.initialize_plot()
+        adjoint_plot = plot.subplots.values()[0]
+        main_plot = adjoint_plot.subplots['main']
+        right_plot = adjoint_plot.subplots['right']
+        top_plot = adjoint_plot.subplots['top']
+        self.assertIs(main_plot.handles['color_mapper'],
+                      right_plot.handles['color_mapper'])
+        self.assertIs(main_plot.handles['color_mapper'],
+                      top_plot.handles['color_mapper'])
+        self.assertEqual(main_plot.handles['color_dim'], img.vdims[0])
 
     def test_stream_callback(self):
         dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -245,7 +245,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         points = Points(np.random.rand(100, 2))
         plot = bokeh_renderer.get_plot(points.hist())
         plot.initialize_plot()
-        adjoint_plot = plot.subplots.values()[0]
+        adjoint_plot = list(plot.subplots.values())[0]
         main_plot = adjoint_plot.subplots['main']
         right_plot = adjoint_plot.subplots['right']
         self.assertTrue('color_mapper' not in main_plot.handles)
@@ -257,7 +257,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         img = Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))
         plot = bokeh_renderer.get_plot(img.hist())
         plot.initialize_plot()
-        adjoint_plot = plot.subplots.values()[0]
+        adjoint_plot = list(plot.subplots.values())[0]
         main_plot = adjoint_plot.subplots['main']
         right_plot = adjoint_plot.subplots['right']
         self.assertIs(main_plot.handles['color_mapper'],
@@ -272,7 +272,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                            mean_weighted=True)
         plot = bokeh_renderer.get_plot(adjoint)
         plot.initialize_plot()
-        adjoint_plot = plot.subplots.values()[0]
+        adjoint_plot = list(plot.subplots.values())[0]
         main_plot = adjoint_plot.subplots['main']
         right_plot = adjoint_plot.subplots['right']
         top_plot = adjoint_plot.subplots['top']

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -241,6 +241,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
         self._test_colormapping(spikes, 1)
 
+    def test_side_histogram_no_cmapper(self):
+        points = Points(np.random.rand(100, 2))
+        plot = bokeh_renderer.get_plot(points.hist())
+        plot.initialize_plot()
+        adjoint_plot = plot.subplots.values()[0]
+        main_plot = adjoint_plot.subplots['main']
+        right_plot = adjoint_plot.subplots['right']
+        self.assertTrue('color_mapper' not in main_plot.handles)
+        self.assertTrue('color_mapper' not in right_plot.handles)
+
     def test_side_histogram_cmapper(self):
         """Assert histogram shares colormapper"""
         x,y = np.mgrid[-50:51, -50:51] * 0.1


### PR DESCRIPTION
The adjoined histograms support coloring by a dimension on the main plot, but they also used to support coloring weighted histograms, which take the average in bins along the x- and y-axis. Coloring by the mean weighted value produces plots like this (matplotlib already handles this):

```python
x,y = np.mgrid[-50:51, -50:51] * 0.1

img = hv.Image(np.sin(x**2+y**2), bounds=(-1,-1,1,1))

hmap = hv.HoloMap({phase: img.clone(np.sin(0.1*x**2+0.1*y**2+phase))
                   for phase in np.linspace(0, np.pi*2, 6)}, kdims=['Phase'])
hmap.hist(num_bins=100, dimension=['x', 'y'], weight_dimension='z', mean_weighted=True)
```

![weighted_avg_hist](https://cloud.githubusercontent.com/assets/1550771/22396128/94f73b12-e549-11e6-8530-770bfa62076d.gif)
