### PR TITLE
Fixed bug unpacking Overlay and Layout objects in Layout.from_values

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -344,7 +344,7 @@ class Layout(AttrTree, Dimensioned):
                     paths[paths.index(path)] = new_path
                 path = path + (int_to_roman(count),)
             else:
-                path = path[:-1] + (int_to_roman(count-1),)
+                path = path[:-1] + (int_to_roman(count),)
             counts[path[:-1]] += 1
         return path
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -338,6 +338,7 @@ class Layout(AttrTree, Dimensioned):
             path = path[:2]
             pl = len(path)
             count = counts[path[:-1]]
+            counts[path[:-1]] += 1
             if (pl == 1 and not item.label) or (pl == 2 and item.label):
                 new_path = path + (int_to_roman(count-1),)
                 if path in paths:
@@ -345,7 +346,6 @@ class Layout(AttrTree, Dimensioned):
                 path = path + (int_to_roman(count),)
             else:
                 path = path[:-1] + (int_to_roman(count),)
-            counts[path[:-1]] += 1
         return path
 
 
@@ -374,10 +374,10 @@ class Layout(AttrTree, Dimensioned):
         Recursively unpacks lists and Layout-like objects, accumulating
         into the supplied list of items.
         """
-        if isinstance(objs, cls):
+        if type(objs) is cls:
             objs = objs.values()
         for v in objs:
-            if isinstance(v, cls):
+            if type(v) is cls:
                 cls._unpack_paths(v, paths, items, counts)
                 continue
             group = group_sanitizer(v.group)

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -28,7 +28,7 @@ class Composable(object):
     """
 
     def __add__(self, obj):
-        return Layout.from_values(self) + Layout.from_values(obj)
+        return Layout.from_values([self, obj])
 
 
     def __lshift__(self, other):
@@ -213,7 +213,7 @@ class AdjointLayout(Dimensioned):
 
 
     def __add__(self, obj):
-        return Layout.from_values(self) + Layout.from_values(obj)
+        return Layout.from_values([self, obj])
 
 
     def __len__(self):
@@ -269,7 +269,7 @@ class NdLayout(UniformNdMapping):
 
 
     def __add__(self, obj):
-        return Layout.from_values(self) + Layout.from_values(obj)
+        return Layout.from_values([self, obj])
 
 
     @property

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -100,11 +100,6 @@ class Overlay(Layout, CompositeOverlay):
     Layout and CompositeOverlay.
     """
 
-    @classmethod
-    def _from_values(cls, val):
-        return reduce(lambda x,y: x*y, val).map(lambda x: x.display('auto'), [Overlay])
-
-
     def __init__(self, items=None, group=None, label=None, **params):
         view_params = ViewableElement.params().keys()
         self.__dict__['_fixed'] = False
@@ -135,11 +130,11 @@ class Overlay(Layout, CompositeOverlay):
 
 
     def __add__(self, other):
-        return Layout.from_values(self) + Layout.from_values(other)
+        return Layout.from_values([self, other])
 
 
     def __mul__(self, other):
-        if isinstance(other, UniformNdMapping):
+        if not isinstance(other, ViewableElement):
             raise NotImplementedError
         return Overlay.from_values([self, other])
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -36,10 +36,7 @@ class Overlayable(object):
             items = [(k, self * v) for (k, v) in other.items()]
             return other.clone(items)
 
-        self_item = [((self.group, self.label if self.label else 'I'), self)]
-        other_items = (other.items() if isinstance(other, Overlay)
-                       else [((other.group, other.label if other.label else 'I'), other)])
-        return Overlay(items=Overlay.relabel_item_paths(list(self_item) + list(other_items)))
+        return Overlay.from_values([self, other])
 
 
 
@@ -142,15 +139,9 @@ class Overlay(Layout, CompositeOverlay):
 
 
     def __mul__(self, other):
-        if isinstance(other, Overlay):
-            items = list(self.data.items()) + list(other.data.items())
-        elif isinstance(other, ViewableElement):
-            label = other.label if other.label else 'I'
-            items = list(self.data.items()) + [((other.group, label), other)]
-        elif isinstance(other, UniformNdMapping):
+        if isinstance(other, UniformNdMapping):
             raise NotImplementedError
-
-        return Overlay(items=self.relabel_item_paths(items)).display('all')
+        return Overlay.from_values([self, other])
 
 
     def collate(self):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -223,7 +223,7 @@ class HoloMap(UniformNdMapping):
 
 
     def __add__(self, obj):
-        return Layout.from_values(self) + Layout.from_values(obj)
+        return Layout.from_values([self, obj])
 
 
     def __lshift__(self, other):
@@ -1137,7 +1137,7 @@ class GridSpace(UniformNdMapping):
 
 
     def __add__(self, obj):
-        return Layout.from_values(self) + Layout.from_values(obj)
+        return Layout.from_values([self, obj])
 
 
     @property

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1018,8 +1018,13 @@ def get_path(item):
     sanitizers = [group_sanitizer, label_sanitizer]
     if isinstance(item, tuple):
         path, item = item
-        new_path = get_path(item)
-        path = path[:2] if item.label and path[1] == new_path[1] else path[:1]
+        if item.label:
+            if len(path) > 1 and item.label == path[1]:
+                path = path[:2]
+            else:
+                path = path[:1] + (item.label,)
+        else:
+            path = path[:1]
     else:
         path = (item.group, item.label) if item.label else (item.group,)
     return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers))

--- a/tests/testcomposites.py
+++ b/tests/testcomposites.py
@@ -126,6 +126,31 @@ class LayoutTestCase(ElementTestCase):
                                     ('Element', 'LabelA', 'III'),
                                     ('Element', 'LabelA', 'IV')])
 
+    def test_layout_from_values_with_layouts(self):
+        layout1 = self.el1 + self.el4
+        layout2 = self.el2 + self.el5
+        paths = Layout.from_values([layout1, layout2]).keys()
+        self.assertEqual(paths, [('Element', 'I'), ('ValA', 'I'),
+                                 ('Element', 'II'), ('ValB', 'I')])
+
+    def test_layout_from_values_with_mixed_types(self):
+        layout1 = self.el1 + self.el4 + self.el7
+        layout2 = self.el2 + self.el5 + self.el8
+        paths = Layout.from_values([layout1, layout2, self.el3]).keys()
+        self.assertEqual(paths, [('Element', 'I'), ('ValA', 'I'),
+                                 ('ValA', 'LabelA'), ('Element', 'II'),
+                                 ('ValB', 'I'), ('ValA', 'LabelB'),
+                                 ('Element', 'III')])
+
+    def test_layout_from_values_retains_custom_path(self):
+        layout = Layout([('Custom', self.el1)])
+        paths = Layout.from_values([layout, self.el2]).keys()
+        self.assertEqual(paths, [('Custom', 'I'), ('Element', 'I')])
+
+    def test_layout_from_values_retains_custom_path_with_label(self):
+        layout = Layout([('Custom', self.el6)])
+        paths = Layout.from_values([layout, self.el2]).keys()
+        self.assertEqual(paths, [('Custom', 'LabelA'), ('Element', 'I')])
 
 
 class OverlayTestCase(ElementTestCase):
@@ -253,6 +278,31 @@ class OverlayTestCase(ElementTestCase):
                                     ('Element', 'LabelA', 'III'),
                                     ('Element', 'LabelA', 'IV')])
 
+    def test_overlay_from_values_with_layouts(self):
+        layout1 = self.el1 + self.el4
+        layout2 = self.el2 + self.el5
+        paths = Layout.from_values([layout1, layout2]).keys()
+        self.assertEqual(paths, [('Element', 'I'), ('ValA', 'I'),
+                                 ('Element', 'II'), ('ValB', 'I')])
+
+    def test_overlay_from_values_with_mixed_types(self):
+        overlay1 = self.el1 + self.el4 + self.el7
+        overlay2 = self.el2 + self.el5 + self.el8
+        paths = Layout.from_values([overlay1, overlay2, self.el3]).keys()
+        self.assertEqual(paths, [('Element', 'I'), ('ValA', 'I'),
+                                 ('ValA', 'LabelA'), ('Element', 'II'),
+                                 ('ValB', 'I'), ('ValA', 'LabelB'),
+                                 ('Element', 'III')])
+
+    def test_overlay_from_values_retains_custom_path(self):
+        overlay = Overlay([('Custom', self.el1)])
+        paths = Overlay.from_values([overlay, self.el2]).keys()
+        self.assertEqual(paths, [('Custom', 'I'), ('Element', 'I')])
+
+    def test_overlay_from_values_retains_custom_path_with_label(self):
+        overlay = Overlay([('Custom', self.el6)])
+        paths = Overlay.from_values([overlay, self.el2]).keys()
+        self.assertEqual(paths, [('Custom', 'LabelA'), ('Element', 'I')])
 
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -16,9 +16,9 @@ except:
 
 from holoviews.core.util import (
     sanitize_identifier_fn, find_range, max_range, wrap_tuple_streams,
-    deephash, merge_dimensions
+    deephash, merge_dimensions, get_path, make_path_unique
 )
-from holoviews import Dimension
+from holoviews import Dimension, Element
 from holoviews.streams import PositionXY
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -463,3 +463,50 @@ class TestMergeDimensions(unittest.TestCase):
                                        [Dimension('A', values=[1, 2]), Dimension('B')]])
         self.assertEqual(dimensions, [Dimension('A'), Dimension('B')])
         self.assertEqual(dimensions[0].values, [0, 1, 2])
+
+
+class TestTreePathUtils(unittest.TestCase):
+
+    def test_get_path_with_label(self):
+        path = get_path(Element('Test', label='A'))
+        self.assertEqual(path, ('Element', 'A'))
+
+    def test_get_path_without_label(self):
+        path = get_path(Element('Test'))
+        self.assertEqual(path, ('Element',))
+
+    def test_get_path_with_custom_group(self):
+        path = get_path(Element('Test', group='Custom Group'))
+        self.assertEqual(path, ('Custom_Group',))
+
+    def test_get_path_with_custom_group_and_label(self):
+        path = get_path(Element('Test', group='Custom Group', label='A'))
+        self.assertEqual(path, ('Custom_Group', 'A'))
+
+    def test_get_path_from_item_with_custom_group(self):
+        path = get_path((('Custom',), Element('Test')))
+        self.assertEqual(path, ('Custom',))
+
+    def test_get_path_from_item_with_custom_group_and_label(self):
+        path = get_path((('Custom', 'Path'), Element('Test')))
+        self.assertEqual(path, ('Custom',))
+
+    def test_get_path_from_item_with_custom_group_and_matching_label(self):
+        path = get_path((('Custom', 'Path'), Element('Test', label='Path')))
+        self.assertEqual(path, ('Custom', 'Path'))
+
+    def test_make_path_unique_no_clash(self):
+        path = ('Element', 'A')
+        new_path = make_path_unique(path, {})
+        self.assertEqual(new_path, path)
+
+    def test_make_path_unique_clash_without_label(self):
+        path = ('Element',)
+        new_path = make_path_unique(path, {path: 1})
+        self.assertEqual(new_path, path+('I',))
+
+    def test_make_path_unique_clash_with_label(self):
+        path = ('Element', 'A')
+        new_path = make_path_unique(path, {path: 1})
+        self.assertEqual(new_path, path+('I',))
+


### PR DESCRIPTION
Fix for #1081, passing Layouts and Overlays to their respective constructors correctly unpacks them again after regression caused them to be nested.

```python
elements = [hv.Curve(np.random.rand(10)) * hv.HLine(0) for i in range(4)]
overlay = hv.Overlay(elements)
print(repr(overlay))
```

This now correctly produces an object with this repr:

```
:Overlay
   .Curve.I   :Curve   [x]   (y)
   .HLine.I   :HLine   [x,y]
   .Curve.II  :Curve   [x]   (y)
   .HLine.III :HLine   [x,y]
   .Curve.III :Curve   [x]   (y)
   .HLine.IV  :HLine   [x,y]
   .Curve.IV  :Curve   [x]   (y)
   .HLine.V   :HLine   [x,y]
```