### PR TITLE
Add consistent support for categorical axes in bokeh

### DIFF
--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -255,6 +255,61 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Categorical axes\n",
+    "\n",
+    "A number of Elements will also support categorical (i.e. string types) as dimension values, these include ``HeatMap``, ``Points``, ``Scatter``, ``Curve``, ``ErrorBar`` and ``Text`` types.\n",
+    "\n",
+    "Here we create a set of points indexed by ascending alphabetical x- and y-coordinates and values multiplying the integer index of each coordinate. We then overlay a ``HeatMap`` of the points with the points themselves enabling the hover tool for both and scaling the point size by the 'z' coordines."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Points [size_index='z' tools=['hover']] HeatMap [toolbar='above' tools=['hover']]\n",
+    "points = hv.Points([(chr(i+65), chr(j+65), i*j) for i in range(10) for j in range(10)], vdims=['z'])\n",
+    "hv.HeatMap(points) * points"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the example above both axes are categorical because a HeatMap by definition represents 2D categorical coordinates (unlike Image and Raster types). Other Element types will automatically infer a categorical dimension if the coordinates along that dimension include string types.\n",
+    "\n",
+    "Here we will generate random samples indexed by categories from 'A' to 'E' using the Scatter Element and overlay them.\n",
+    "Secondly we compute the mean and standard deviation for each category and finally we overlay these two elements with a curve representing the mean value and a text element specifying the global mean. All these Elements respect the categorical index, providing us a view of the distribution of values in each category:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Overlay [show_legend=False height=400 width=600] ErrorBars (line_width=5) Scatter(alpha=0.2 size=6)\n",
+    "\n",
+    "overlay = hv.NdOverlay({group: hv.Scatter(([group]*100, np.random.randn(100)*(i+1)+i))\n",
+    "                        for i, group in enumerate(['A', 'B', 'C', 'D', 'E'])})\n",
+    "\n",
+    "errorbars = hv.ErrorBars([(k, el.reduce(function=np.mean), el.reduce(function=np.std))\n",
+    "                          for k, el in overlay.items()])\n",
+    "\n",
+    "global_mean = hv.Text('A', 12, 'Global mean: %.3f' % overlay.dimension_values('y').mean())\n",
+    "\n",
+    "errorbars * overlay * hv.Curve(errorbars) * global_mean"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "focus": false,
     "id": "85e1ed20-1e12-4194-822e-c2fe0810ce41"

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -872,12 +872,12 @@ class Dimensioned(LabelledData):
         if None not in dimension.range:
             return dimension.range
         elif data_range:
-            if dimension in self.kdims or dimension in self.vdims:
+            if dimension in self.kdims+self.vdims:
                 dim_vals = self.dimension_values(dimension.name)
                 drange = find_range(dim_vals)
             else:
                 dname = dimension.name
-                match_fn = lambda x: dname in x.dimensions(['key', 'value'], True)
+                match_fn = lambda x: dname in x.kdims + x.vdims
                 range_fn = lambda x: x.range(dname)
                 ranges = self.traverse(range_fn, [match_fn])
                 drange = max_range(ranges)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -458,7 +458,7 @@ def max_range(ranges):
             if pd and all(isinstance(v, pd.tslib.Timestamp) for r in values for v in r):
                 values = [(v1.to_datetime64(), v2.to_datetime64()) for v1, v2 in values]
             arr = np.array(values)
-            if arr.dtype.kind in 'OS':
+            if arr.dtype.kind in 'OSU':
                 arr = np.sort([v for v in arr.flat if not is_nan(v)])
                 return arr[0], arr[-1]
             if arr.dtype.kind in 'M':

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -458,6 +458,9 @@ def max_range(ranges):
             if pd and all(isinstance(v, pd.tslib.Timestamp) for r in values for v in r):
                 values = [(v1.to_datetime64(), v2.to_datetime64()) for v1, v2 in values]
             arr = np.array(values)
+            if arr.dtype.kind in 'OS':
+                arr = np.sort([v for v in arr.flat if not is_nan(v)])
+                return arr[0], arr[-1]
             if arr.dtype.kind in 'M':
                 return arr[:, 0].min(), arr[:, 1].max()
             return (np.nanmin(arr[:, 0]), np.nanmax(arr[:, 1]))
@@ -492,10 +495,14 @@ def max_extents(extents, zrange=False):
             upper = [v for v in arr[uidx] if v is not None]
             if lower and isinstance(lower[0], np.datetime64):
                 extents[lidx] = np.min(lower)
+            elif any(isinstance(l, basestring) for l in lower):
+                extents[lidx] = np.sort(lower)[0]
             elif lower:
                 extents[lidx] = np.nanmin(lower)
             if upper and isinstance(upper[0], np.datetime64):
                 extents[uidx] = np.max(upper)
+            elif any(isinstance(u, basestring) for u in upper):
+                extents[uidx] = np.sort(upper)[-1]
             elif upper:
                 extents[uidx] = np.nanmax(upper)
     return tuple(extents)

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -156,9 +156,9 @@ class Text(Annotation):
     fontsize, alignment and rotation.
     """
 
-    x = param.Number(default=0, doc="The x-position of the text.")
+    x = param.Parameter(default=0, doc="The x-position of the text.")
 
-    y = param.Number(default=0, doc="The y-position of text.")
+    y = param.Parameter(default=0, doc="The y-position of text.")
 
     text = param.String(default='', doc="The text to be displayed.")
 

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -45,12 +45,12 @@ class Annotation(Element2D):
         return self.clone(self.data, extents=(xstart, ystart, xstop, ystop))
 
 
-    def dimension_values(self, dimension):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         index = self.get_dimension_index(dimension)
         if index == 0:
-            return [self.data if np.isscalar(self.data) else self.data[index]]
+            return np.array([self.data if np.isscalar(self.data) else self.data[index]])
         elif index == 1:
-            return [] if np.isscalar(self.data) else [self.data[1]]
+            return [] if np.isscalar(self.data) else np.array([self.data[1]])
         else:
             return super(Annotation, self).dimension_values(dimension)
 
@@ -97,10 +97,10 @@ class Spline(Annotation):
         super(Spline, self).__init__(spline_points, **params)
 
 
-    def dimension_values(self, dimension):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         index = self.get_dimension_index(dimension)
         if index in [0, 1]:
-            return [point[index] for point in self.data[0]]
+            return np.array([point[index] for point in self.data[0]])
         else:
             return super(Spline, self).dimension_values(dimension)
 

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -149,6 +149,16 @@ class Arrow(Annotation):
         settings = dict(self.get_param_values(), **overrides)
         return self.__class__(*args, **settings)
 
+    def dimension_values(self, dimension, expanded=True, flat=True):
+        index = self.get_dimension_index(dimension)
+        if index == 0:
+            return np.array([self.x])
+        elif index == 1:
+            return np.array([self.y])
+        else:
+            return super(Text, self).dimension_values(dimension)
+
+
 
 class Text(Annotation):
     """

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -103,7 +103,10 @@ class categorical_aggregate2d(ElementOperation):
                     p1, p2 = vals[i:i+2]
                     orderings[p1] = [p2]
             if sort:
-                sort = (np.diff(vals)>=0).all()
+                if vals.dtype.kind in ('i', 'f'):
+                    sort = (np.diff(vals)>=0).all()
+                else:
+                    sort = np.array_equal(np.sort(vals), vals)
         if sort or one_to_one(orderings, ycoords):
             ycoords = np.sort(ycoords)
         elif not is_cyclic(orderings):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -93,15 +93,18 @@ class categorical_aggregate2d(ElementOperation):
         grouped = obj.groupby(xdim, container_type=OrderedDict,
                               group_type=Dataset).values()
         orderings = OrderedDict()
+        sort = True
         for group in grouped:
-            vals = group.dimension_values(ydim)
+            vals = group.dimension_values(ydim, False)
             if len(vals) == 1:
                 orderings[vals[0]] = [vals[0]]
             else:
                 for i in range(len(vals)-1):
                     p1, p2 = vals[i:i+2]
                     orderings[p1] = [p2]
-        if one_to_one(orderings, ycoords):
+            if sort:
+                sort = (np.diff(vals)>=0).all()
+        if sort or one_to_one(orderings, ycoords):
             ycoords = np.sort(ycoords)
         elif not is_cyclic(orderings):
             ycoords = list(itertools.chain(*sort_topologically(orderings)))

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -20,6 +20,7 @@ class TextPlot(ElementPlot):
             data = dict(x=[element.y], y=[element.x])
         else:
             data = dict(x=[element.x], y=[element.y])
+        self._clean_data(data, ('x', 'y'), element.dimensions())
         data['text'] = [element.text]
         return (data, mapping)
 

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -20,7 +20,7 @@ class TextPlot(ElementPlot):
             data = dict(x=[element.y], y=[element.x])
         else:
             data = dict(x=[element.x], y=[element.y])
-        self._clean_data(data, ('x', 'y'), element.dimensions())
+        self._categorize_data(data, ('x', 'y'), element.dimensions())
         data['text'] = [element.text]
         return (data, mapping)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -7,7 +7,7 @@ try:
 except:
     Bar, BokehBoxPlot = None, None
 from bokeh.models import (Circle, GlyphRenderer, ColumnDataSource,
-                          Range1d, CustomJS)
+                          Range1d, CustomJS, FactorRange)
 from bokeh.models.tools import BoxSelectTool
 
 from ...element import Raster, Points, Polygons, Spikes
@@ -84,8 +84,10 @@ class PointPlot(ColorbarPlot):
                     data[map_key] = np.sqrt(sizes)
                     mapping['size'] = map_key
 
-        data[dims[xidx]] = [] if empty else element.dimension_values(xidx)
-        data[dims[yidx]] = [] if empty else element.dimension_values(yidx)
+        xdim, ydim = dims[xidx], dims[yidx]
+        data[xdim] = [] if empty else element.dimension_values(xidx)
+        data[ydim] = [] if empty else element.dimension_values(yidx)
+        self._clean_data(data, (xdim, ydim), element.dimensions())
         self._get_hover_data(data, element, empty)
         return data, mapping
 
@@ -144,9 +146,10 @@ class CurvePlot(ElementPlot):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         x = element.get_dimension(xidx).name
         y = element.get_dimension(yidx).name
-        return ({x: [] if empty else element.dimension_values(xidx),
-                 y: [] if empty else element.dimension_values(yidx)},
-                dict(x=x, y=y))
+        data = {x: [] if empty else element.dimension_values(xidx),
+                y: [] if empty else element.dimension_values(yidx)}
+        self._clean_data(data, (x, y), element.dimensions())
+        return (data, dict(x=x, y=y))
 
     def _hover_tooltips(self, element):
         if self.batched:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -371,6 +371,7 @@ class ErrorPlot(PathPlot):
             data = dict(xs=err_ys, ys=err_xs)
         else:
             data = dict(xs=err_xs, ys=err_ys)
+        self._clean_data(data, ('xs', 'ys'), element.dimensions())
         return (data, dict(self._mapping))
 
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -87,7 +87,7 @@ class PointPlot(ColorbarPlot):
         xdim, ydim = dims[xidx], dims[yidx]
         data[xdim] = [] if empty else element.dimension_values(xidx)
         data[ydim] = [] if empty else element.dimension_values(yidx)
-        self._clean_data(data, (xdim, ydim), element.dimensions())
+        self._categorize_data(data, (xdim, ydim), element.dimensions())
         self._get_hover_data(data, element, empty)
         return data, mapping
 
@@ -148,7 +148,7 @@ class CurvePlot(ElementPlot):
         y = element.get_dimension(yidx).name
         data = {x: [] if empty else element.dimension_values(xidx),
                 y: [] if empty else element.dimension_values(yidx)}
-        self._clean_data(data, (x, y), element.dimensions())
+        self._categorize_data(data, (x, y), element.dimensions())
         return (data, dict(x=x, y=y))
 
     def _hover_tooltips(self, element):
@@ -371,7 +371,7 @@ class ErrorPlot(PathPlot):
             data = dict(xs=err_ys, ys=err_xs)
         else:
             data = dict(xs=err_xs, ys=err_ys)
-        self._clean_data(data, ('xs', 'ys'), element.dimensions())
+        self._categorize_data(data, ('xs', 'ys'), element.dimensions())
         return (data, dict(self._mapping))
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1180,8 +1180,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 xfs, yfs = sp._get_factors(el)
                 xfactors.append(xfs)
                 yfactors.append(yfs)
-        xfactors = np.concatenate(xfactors)
-        yfactors = np.concatenate(yfactors)
+        if xfactors:
+            xfactors = np.concatenate(xfactors)
+        if yfactors:
+            yfactors = np.concatenate(yfactors)
         return util.unique_array(xfactors), util.unique_array(yfactors)
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -523,21 +523,27 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 offset = abs(l*0.1 if l else 0.5)
                 l -= offset
                 r += offset
+
+            if self.invert_xaxis: l, r = r, l
             if isinstance(l, np.datetime64) or np.isfinite(l): plot.x_range.start = l
             if isinstance(r, np.datetime64) or np.isfinite(r): plot.x_range.end   = r
         elif isinstance(x_range, FactorRange):
-            x_range.factors = list(xfactors)
+            xfactors = list(xfactors)
+            if self.invert_xaxis: xfactors = xfactors[::-1]
+            x_range.factors = xfactors
 
         if isinstance(plot.y_range, Range1d):
             if b == t:
                 offset = abs(b*0.1 if b else 0.5)
                 b -= offset
                 t += offset
+            if self.invert_yaxis: b, t = t, b
             if isinstance(l, np.datetime64) or np.isfinite(b): plot.y_range.start = b
             if isinstance(l, np.datetime64) or np.isfinite(t): plot.y_range.end   = t
         elif isinstance(y_range, FactorRange):
-            y_range.factors = list(yfactors)
-
+            yfactors = list(yfactors)
+            if self.invert_yaxis: yfactors = yfactors[::-1]
+            y_range.factors = yfactors
 
     def _clean_data(self, data, cols, dims):
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -550,7 +550,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         ranges = [self.handles['%s_range' % ax] for ax in 'xy']
         for i, col in enumerate(cols):
             column = data[col]
-            if isinstance(ranges[i], FactorRange) and column.dtype.kind not in 'iO':
+            if (isinstance(ranges[i], FactorRange) and
+                (isinstance(column, list) or column.dtype.kind not in 'iOS')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -570,7 +570,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for i, col in enumerate(cols):
             column = data[col]
             if (isinstance(ranges[i], FactorRange) and
-                (isinstance(column, list) or column.dtype.kind not in 'iSU')):
+                (isinstance(column, list) or column.dtype.kind not in 'SU')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
 
@@ -581,8 +581,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xdim, ydim = element.dimensions()[:2]
         xvals, yvals = [element.dimension_values(i, False)
                         for i in range(2)]
-        coords = ([x if xvals.dtype.kind in 'iSU' else xdim.pprint_value(x) for x in xvals],
-                  [y if yvals.dtype.kind in 'iSU' else ydim.pprint_value(y) for y in yvals])
+        coords = ([x if xvals.dtype.kind in 'SU' else xdim.pprint_value(x) for x in xvals],
+                  [y if yvals.dtype.kind in 'SU' else ydim.pprint_value(y) for y in yvals])
         if self.invert_axes: coords = coords[::-1]
         return coords
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -768,6 +768,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if bokeh_version >= '0.12':
             handles.append(plot.title)
 
+        for ax in 'xy':
+            key = '%s_range' % ax
+            if isinstance(self.handles[key], FactorRange):
+                handles.append(self.handles[key])
+
         if self.current_frame:
             if not self.apply_ranges:
                 rangex, rangey = False, False

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -325,7 +325,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if y_axis_type == 'datetime':
                     low = convert_datetime(low)
                     high = convert_datetime(high)
-                elif not (util.is_number(low) and util.is_number(high)):
+                elif any(isinstance(y, util.basestring) for y in (low, high)):
                     plot_ranges['y_range'] = FactorRange()
                     categorical = True
                 elif low == high and low is not None:
@@ -551,7 +551,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for i, col in enumerate(cols):
             column = data[col]
             if (isinstance(ranges[i], FactorRange) and
-                (isinstance(column, list) or column.dtype.kind not in 'iOS')):
+                (isinstance(column, list) or column.dtype.kind not in 'iOSU')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
 
@@ -563,9 +563,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xvals, yvals = [element.dimension_values(i, False)
                         for i in range(2)]
         if self.invert_yaxis: yvals = yvals[::-1]
-        return ([x if xvals.dtype.kind in 'iOS' else xdim.pprint_value(x) for x in xvals],
-                [y if yvals.dtype.kind in 'iOS' else ydim.pprint_value(y) for y in yvals])
-
+        coords =  ([x if xvals.dtype.kind in 'iOSU' else xdim.pprint_value(x) for x in xvals],
+                   [y if yvals.dtype.kind in 'iOSU' else ydim.pprint_value(y) for y in yvals])
+        if self.invert_axes: coords = coords[::-1]
+        return coords
 
     def _process_legend(self):
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -555,10 +555,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if self.invert_yaxis: yfactors = yfactors[::-1]
             y_range.factors = yfactors
 
-    def _clean_data(self, data, cols, dims):
+
+    def _categorize_data(self, data, cols, dims):
         """
-        Cleans the data before instantiating the datasource to handle
-        categorical axes correctly.
+        Transforms non-string or integer types in datasource if the
+        axis to be plotted on is categorical. Accepts the column data
+        sourcec data, the columns corresponding to the axes and the
+        dimensions for each axis, changing the data inplace.
         """
         if self.invert_axes:
             cols = cols[::-1]
@@ -567,7 +570,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for i, col in enumerate(cols):
             column = data[col]
             if (isinstance(ranges[i], FactorRange) and
-                (isinstance(column, list) or column.dtype.kind not in 'iOSU')):
+                (isinstance(column, list) or column.dtype.kind not in 'iSU')):
                 data[col] = [dims[i].pprint_value(v) for v in column]
 
 
@@ -578,8 +581,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xdim, ydim = element.dimensions()[:2]
         xvals, yvals = [element.dimension_values(i, False)
                         for i in range(2)]
-        coords = ([x if xvals.dtype.kind in 'iOSU' else xdim.pprint_value(x) for x in xvals],
-                  [y if yvals.dtype.kind in 'iOSU' else ydim.pprint_value(y) for y in yvals])
+        coords = ([x if xvals.dtype.kind in 'iSU' else xdim.pprint_value(x) for x in xvals],
+                  [y if yvals.dtype.kind in 'iSU' else ydim.pprint_value(y) for y in yvals])
         if self.invert_axes: coords = coords[::-1]
         return coords
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -457,7 +457,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                                 layout_dimensions=layout_dimensions,
                                 ranges=ranges, subplot=True,
                                 uniform=self.uniform, layout_num=num,
-                                **plotopts)
+                                **dict({'shared_axes': self.shared_axes},
+                                       **plotopts))
             subplots[pos] = subplot
             if isinstance(plot_type, type) and issubclass(plot_type, GenericCompositePlot):
                 adjoint_clone[pos] = subplots[pos].layout

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -152,9 +152,9 @@ class HeatmapPlot(ColorbarPlot):
         else:
             xdim, ydim = aggregate.dimensions()[:2]
             xvals, yvals, zvals = (aggregate.dimension_values(i) for i in range(3))
-            if xvals.dtype.kind not in 'iOSU':
+            if xvals.dtype.kind not in 'iSU':
                 xvals = [xdim.pprint_value(xv) for xv in xvals]
-            if yvals.dtype.kind not in 'iOSU':
+            if yvals.dtype.kind not in 'iSU':
                 yvals = [ydim.pprint_value(yv) for yv in yvals]
             data = {x: xvals, y: yvals, 'zvalues': zvals}
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -152,9 +152,9 @@ class HeatmapPlot(ColorbarPlot):
         else:
             xdim, ydim = aggregate.dimensions()[:2]
             xvals, yvals, zvals = (aggregate.dimension_values(i) for i in range(3))
-            if xvals.dtype.kind not in 'iSU':
+            if xvals.dtype.kind not in 'SU':
                 xvals = [xdim.pprint_value(xv) for xv in xvals]
-            if yvals.dtype.kind not in 'iSU':
+            if yvals.dtype.kind not in 'SU':
                 yvals = [ydim.pprint_value(yv) for yv in yvals]
             data = {x: xvals, y: yvals, 'zvalues': zvals}
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -136,8 +136,7 @@ class HeatmapPlot(ColorbarPlot):
     _plot_methods = dict(single='rect')
     style_opts = ['cmap', 'color'] + line_properties + fill_properties
 
-    _update_handles = ['color_mapper', 'source', 'glyph', 'colorbar',
-                        'xaxis', 'yaxis', 'x_range', 'y_range']
+    _update_handles = ['color_mapper', 'source', 'glyph', 'colorbar']
     _categorical = True
 
     def _get_factors(self, element):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -140,13 +140,7 @@ class HeatmapPlot(ColorbarPlot):
     _categorical = True
 
     def _get_factors(self, element):
-        xdim, ydim = element.dimensions()[:2]
-        xvals, yvals = [element.gridded.dimension_values(i, False)
-                        for i in range(2)]
-        if self.invert_yaxis: yvals = yvals[::-1]
-        return ([x if xvals.dtype.kind in 'iOS' else xdim.pprint_value(x) for x in xvals],
-                [y if yvals.dtype.kind in 'iOS' else ydim.pprint_value(y) for y in yvals])
-
+        return super(HeatmapPlot, self)._get_factors(element.gridded)
 
     def get_data(self, element, ranges=None, empty=False):
         x, y, z = element.dimensions(label=True)[:3]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -159,9 +159,9 @@ class HeatmapPlot(ColorbarPlot):
         else:
             xdim, ydim = aggregate.dimensions()[:2]
             xvals, yvals, zvals = (aggregate.dimension_values(i) for i in range(3))
-            if xvals.dtype.kind not in 'iO':
+            if xvals.dtype.kind not in 'iOS':
                 xvals = [xdim.pprint_value(xv) for xv in xvals]
-            if yvals.dtype.kind not in 'iO':
+            if yvals.dtype.kind not in 'iOS':
                 yvals = [ydim.pprint_value(yv) for yv in yvals]
             data = {x: xvals, y: yvals, 'zvalues': zvals}
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -152,9 +152,9 @@ class HeatmapPlot(ColorbarPlot):
         else:
             xdim, ydim = aggregate.dimensions()[:2]
             xvals, yvals, zvals = (aggregate.dimension_values(i) for i in range(3))
-            if xvals.dtype.kind not in 'iOS':
+            if xvals.dtype.kind not in 'iOSU':
                 xvals = [xdim.pprint_value(xv) for xv in xvals]
-            if yvals.dtype.kind not in 'iOS':
+            if yvals.dtype.kind not in 'iOSU':
                 yvals = [ydim.pprint_value(yv) for yv in yvals]
             data = {x: xvals, y: yvals, 'zvalues': zvals}
 

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -27,7 +27,7 @@ class BokehRenderer(Renderer):
     mode_formats = {'fig': {'default': ['html', 'json', 'auto']},
                     'holomap': {'default': ['widgets', 'scrubber', 'auto', None]}}
 
-    webgl = param.Boolean(default=True, doc="""Whether to render plots with WebGL
+    webgl = param.Boolean(default=False, doc="""Whether to render plots with WebGL
         if bokeh version >=0.10""")
 
     widgets = {'scrubber': BokehScrubberWidget,

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -42,16 +42,17 @@ markers = {'s': {'marker': 'square'},
 # and can therefore be safely ignored. Axes currently fail saying
 # LinearAxis.computed_bounds cannot be updated
 IGNORED_MODELS = ['LinearAxis', 'LogAxis', 'DatetimeAxis', 'DatetimeTickFormatter',
-                  'CategoricalAxis', 'BasicTicker', 'BasicTickFormatter',
-                  'FixedTicker', 'FuncTickFormatter', 'LogTickFormatter',
+                  'BasicTicker', 'BasicTickFormatter', 'FixedTicker',
+                  'FuncTickFormatter', 'LogTickFormatter',
                   'CategoricalTickFormatter']
 
 # List of attributes that can safely be dropped from the references
-IGNORED_ATTRIBUTES = ['data', 'palette', 'image', 'x', 'y']
+IGNORED_ATTRIBUTES = ['data', 'palette', 'image', 'x', 'y', 'factors']
 
 # Model priority order to ensure some types are updated before others
 MODEL_PRIORITY = ['Range1d', 'Title', 'Image', 'LinearColorMapper',
-                  'Plot', 'Range1d', 'LinearAxis', 'ColumnDataSource']
+                  'Plot', 'Range1d', 'FactorRange', 'CategoricalAxis',
+                  'LinearAxis', 'ColumnDataSource']
 
 
 def rgb2hex(rgb):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -705,8 +705,12 @@ class GenericElementPlot(DimensionedPlot):
                 extents = util.max_extents(extent_list, self.projection == '3d')
         else:
             extents = (np.NaN,) * num
-        return tuple(l1 if l2 is None or not np.isfinite(l2) else
-                     l2 for l1, l2 in zip(range_extents, extents))
+
+        if getattr(self, 'shared_axes', False) and self.subplot:
+            return util.max_extents([range_extents, extents], self.projection == '3d')
+        else:
+            return tuple(l1 if l2 is None or not np.isfinite(l2) else
+                         l2 for l1, l2 in zip(range_extents, extents))
 
 
     def _get_axis_labels(self, dimensions, xlabel=None, ylabel=None, zlabel=None):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -14,7 +14,7 @@ from holoviews import (Dimension, Overlay, DynamicMap, Store,
                        NdOverlay, GridSpace, HoloMap, Layout)
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
-                               Scatter3D, Path, Polygons, Bars)
+                               Scatter3D, Path, Polygons, Bars, Text)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import PositionXY, PositionX
 from holoviews.plotting import comms
@@ -32,7 +32,7 @@ try:
     import holoviews.plotting.bokeh
     bokeh_renderer = Store.renderers['bokeh']
     from holoviews.plotting.bokeh.callbacks import Callback
-    from bokeh.models import Div
+    from bokeh.models import Div, FactorRange, Range1d
     from bokeh.models.mappers import LinearColorMapper, LogColorMapper
     from bokeh.models.tools import HoverTool
 except:
@@ -360,6 +360,117 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                    'cannot use to scale Points size.\n' % plot.name)
         self.assertEqual(log_msg, warning)
 
+    def test_curve_categorical_xaxis(self):
+        curve = Curve((['A', 'B', 'C'], [1,2,3]))
+        plot = bokeh_renderer.get_plot(curve)
+        x_range = plot.handles['x_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C'])
+
+    def test_curve_categorical_xaxis_invert_axes(self):
+        curve = Curve((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(curve)
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B', 'C'])
+
+    def test_points_categorical_xaxis(self):
+        points = Points((['A', 'B', 'C'], (1,2,3)))
+        plot = bokeh_renderer.get_plot(points)
+        x_range = plot.handles['x_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C'])
+
+    def test_points_categorical_xaxis_invert_axes(self):
+        points = Points((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(points)
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B', 'C'])
+
+    def test_points_overlay_categorical_xaxis(self):
+        points = Points((['A', 'B', 'C'], (1,2,3)))
+        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        plot = bokeh_renderer.get_plot(points*points2)
+        x_range = plot.handles['x_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D'])
+
+    def test_points_overlay_categorical_xaxis_invert_axes(self):
+        points = Points((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_axes=True))
+        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        plot = bokeh_renderer.get_plot(points*points2)
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D'])
+
+    def test_heatmap_categorical_axes_string_int(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)])
+        plot = bokeh_renderer.get_plot(hmap)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B'])
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, [1, 2])
+
+    def test_heatmap_categorical_axes_string_int_inverted(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(hmap)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, [1, 2])
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B'])
+
+    def test_heatmap_points_categorical_axes_string_int(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)])
+        points = Points([('A', 2), ('B', 1),  ('C', 3)])
+        plot = bokeh_renderer.get_plot(hmap*points)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C'])
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, [1, 2, 3])
+
+    def test_heatmap_points_categorical_axes_string_int_inverted(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=dict(invert_axes=True))
+        points = Points([('A', 2), ('B', 1),  ('C', 3)])
+        plot = bokeh_renderer.get_plot(hmap*points)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, [1, 2, 3])
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B', 'C'])
+
+    def test_points_errorbars_text_ndoverlay_categorical_xaxis(self):
+        overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))
+                             for i in range(5)})
+        error = ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
+                           for el in overlay])
+        text = Text('C', 0, 'Test')
+        plot = bokeh_renderer.get_plot(overlay*error*text)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D', 'E'])
+        self.assertIsInstance(y_range, Range1d)
+
+    def test_points_errorbars_text_ndoverlay_categorical_xaxis_invert_axes(self):
+        overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))
+                             for i in range(5)})
+        error = ErrorBars([(el['x'][0], np.mean(el['y']), np.std(el['y']))
+                           for el in overlay])(plot=dict(invert_axes=True))
+        text = Text('C', 0, 'Test')
+        plot = bokeh_renderer.get_plot(overlay*error*text)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, Range1d)
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D', 'E'])
 
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -396,6 +396,14 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, FactorRange)
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D'])
 
+    def test_points_overlay_categorical_xaxis_invert_axis(self):
+        points = Points((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_xaxis=True))
+        points2 = Points((['B', 'C', 'D'], (1,2,3)))
+        plot = bokeh_renderer.get_plot(points*points2)
+        x_range = plot.handles['x_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D'][::-1])
+
     def test_points_overlay_categorical_xaxis_invert_axes(self):
         points = Points((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_axes=True))
         points2 = Points((['B', 'C', 'D'], (1,2,3)))
@@ -413,6 +421,17 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(x_range.factors, ['A', 'B'])
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, [1, 2])
+
+    def test_heatmap_categorical_axes_string_int_invert_xyaxis(self):
+        opts = dict(invert_xaxis=True, invert_yaxis=True)
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=opts)
+        plot = bokeh_renderer.get_plot(hmap)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, ['A', 'B'][::-1])
+        self.assertIsInstance(y_range, FactorRange)
+        self.assertEqual(y_range.factors, [1, 2][::-1])
 
     def test_heatmap_categorical_axes_string_int_inverted(self):
         hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=dict(invert_axes=True))

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -381,6 +381,13 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, FactorRange)
         self.assertEqual(x_range.factors, ['A', 'B', 'C'])
 
+    def test_points_categorical_xaxis_mixed_type(self):
+        points = Points(range(10))
+        points2 = Points((['A', 'B', 'C', 1, 2.0], (1, 2, 3, 4, 5)))
+        plot = bokeh_renderer.get_plot(points*points2)
+        x_range = plot.handles['x_range']
+        self.assertIsInstance(x_range, FactorRange)
+        self.assertEqual(x_range.factors, list(map(str, range(10))) + ['A', 'B', 'C', '2.0'])
     def test_points_categorical_xaxis_invert_axes(self):
         points = Points((['A', 'B', 'C'], (1,2,3)))(plot=dict(invert_axes=True))
         plot = bokeh_renderer.get_plot(points)
@@ -420,7 +427,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, FactorRange)
         self.assertEqual(x_range.factors, ['A', 'B'])
         self.assertIsInstance(y_range, FactorRange)
-        self.assertEqual(y_range.factors, [1, 2])
+        self.assertEqual(y_range.factors, ['1', '2'])
 
     def test_heatmap_categorical_axes_string_int_invert_xyaxis(self):
         opts = dict(invert_xaxis=True, invert_yaxis=True)
@@ -431,7 +438,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, FactorRange)
         self.assertEqual(x_range.factors, ['A', 'B'][::-1])
         self.assertIsInstance(y_range, FactorRange)
-        self.assertEqual(y_range.factors, [1, 2][::-1])
+        self.assertEqual(y_range.factors, ['1', '2'][::-1])
 
     def test_heatmap_categorical_axes_string_int_inverted(self):
         hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=dict(invert_axes=True))
@@ -439,7 +446,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
         self.assertIsInstance(x_range, FactorRange)
-        self.assertEqual(x_range.factors, [1, 2])
+        self.assertEqual(x_range.factors, ['1', '2'])
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, ['A', 'B'])
 
@@ -452,7 +459,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, FactorRange)
         self.assertEqual(x_range.factors, ['A', 'B', 'C'])
         self.assertIsInstance(y_range, FactorRange)
-        self.assertEqual(y_range.factors, [1, 2, 3])
+        self.assertEqual(y_range.factors, ['1', '2', '3'])
 
     def test_heatmap_points_categorical_axes_string_int_inverted(self):
         hmap = HeatMap([('A',1, 1), ('B', 2, 2)])(plot=dict(invert_axes=True))
@@ -461,7 +468,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
         self.assertIsInstance(x_range, FactorRange)
-        self.assertEqual(x_range.factors, [1, 2, 3])
+        self.assertEqual(x_range.factors, ['1', '2', '3'])
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, ['A', 'B', 'C'])
 


### PR DESCRIPTION
Previously categorical axes weren't really handled in bokeh causing issues when trying to Overlay HeatMaps or other categorical Elements. We can now update categorical axes with new factors which makes it possible to animate HeatMaps with varying density:

![heatmap_animated](https://cloud.githubusercontent.com/assets/1550771/22400089/f1648c24-e5a3-11e6-9ab1-736d6fd75f4b.gif)

We can also specify and overlay categorical curves and points:

```python
hv.Curve((['A', 'B', 'C'], (1,2, 3))) *\
hv.Curve((['A', 'B', 'C'], (3,2, 1))) *\
hv.Points((['B', 'C', 'D'], (2.5, 2, 3)))
```

<img width="220" alt="screen shot 2017-01-29 at 2 05 05 pm" src="https://cloud.githubusercontent.com/assets/1550771/22404599/f9da23ea-e62b-11e6-801f-e40df88f70d3.png">


And we can also overlay on top of a HeatMap:

```python
hv.HeatMap([('A',1, 1), ('B', 2, 2)]) * hv.Points([('A', 2), ('B', 1),  ('C', 3)])
```

<img width="226" alt="screen shot 2017-01-29 at 2 12 05 pm" src="https://cloud.githubusercontent.com/assets/1550771/22404634/f0e5c680-e62c-11e6-8e03-d5c02282f788.png">

And:

<img width="247" alt="screen shot 2017-01-29 at 2 04 30 pm" src="https://cloud.githubusercontent.com/assets/1550771/22404597/e84e6aa0-e62b-11e6-9e7f-bbecfac85922.png">

Note that ``webgl`` does not play well with this. There are now so many issues I've encountered with webgl that I would suggest disabling it by default.

Elements that can use categorical axes:

- [x] Bars
- [x] BoxWhisker
- [x] Points/Scatter
- [x] Curve
- [x] Text
- [x] ErrorBars