### PR TITLE
Improve hover tool behavior on Curve types

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -158,9 +158,7 @@ class CurvePlot(ElementPlot):
             dims = list(self.hmap.last.kdims)
             line_policy = 'prev'
         else:
-            dims = [(d.pprint_label, d.pprint_value(v))
-                    for d, v in self.overlay_dims.items()]
-            dims += element.dimensions()
+            dims = list(self.overlay_dims.keys())+element.dimensions()
             line_policy = 'nearest'
         return dims, dict(line_policy=line_policy)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -7,7 +7,7 @@ try:
 except:
     Bar, BokehBoxPlot = None, None
 from bokeh.models import (Circle, GlyphRenderer, ColumnDataSource,
-                          Range1d, CustomJS, FactorRange)
+                          Range1d, CustomJS, FactorRange, HoverTool)
 from bokeh.models.tools import BoxSelectTool
 
 from ...element import Raster, Points, Polygons, Spikes
@@ -148,8 +148,7 @@ class CurvePlot(ElementPlot):
         y = element.get_dimension(yidx).name
         data = {x: [] if empty else element.dimension_values(xidx),
                 y: [] if empty else element.dimension_values(yidx)}
-        if not self.batched and 'hover' in self.tools+self.default_tools:
-            self._get_hover_data(data, element, empty)
+        self._get_hover_data(data, element, empty)
         self._categorize_data(data, (x, y), element.dimensions())
         return (data, dict(x=x, y=y))
 
@@ -432,7 +431,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
             mapping['color'] = {'field': cdim.name,
                                 'transform': cmapper}
 
-        if 'hover' in self.tools+self.default_tools and not empty:
+        if any(isinstance(t, HoverTool) for t in self.state.tools):
             for d in dims:
                 data[dimension_sanitizer(d)] = element.dimension_values(d)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -148,13 +148,9 @@ class CurvePlot(ElementPlot):
         y = element.get_dimension(yidx).name
         data = {x: [] if empty else element.dimension_values(xidx),
                 y: [] if empty else element.dimension_values(yidx)}
-
-        self._categorize_data(data, (x, y), element.dimensions())
-
         if not self.batched and 'hover' in self.tools+self.default_tools:
-            for k, v in self.overlay_dims.items():
-                dim = dimension_sanitizer(k.name)
-                data[dim] = [v for _ in range(len(data.values()[0]))]
+            self._get_hover_data(data, element, empty)
+        self._categorize_data(data, (x, y), element.dimensions())
         return (data, dict(x=x, y=y))
 
     def _hover_opts(self, element):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -148,7 +148,13 @@ class CurvePlot(ElementPlot):
         y = element.get_dimension(yidx).name
         data = {x: [] if empty else element.dimension_values(xidx),
                 y: [] if empty else element.dimension_values(yidx)}
+
         self._categorize_data(data, (x, y), element.dimensions())
+
+        if not self.batched and 'hover' in self.tools+self.default_tools:
+            for k, v in self.overlay_dims.items():
+                dim = dimension_sanitizer(k.name)
+                data[dim] = [v for _ in range(len(data.values()[0]))]
         return (data, dict(x=x, y=y))
 
     def _hover_opts(self, element):
@@ -156,9 +162,9 @@ class CurvePlot(ElementPlot):
             dims = list(self.hmap.last.kdims)
             line_policy = 'prev'
         else:
-            dims = element.dimensions()+list(self.overlay_dims.keys())
+            dims = list(self.overlay_dims.keys())+element.dimensions()
             line_policy = 'nearest'
-        return dims dict(line_policy=line_policy)
+        return dims, dict(line_policy=line_policy)
 
     def get_batched_data(self, overlay, ranges=None, empty=False):
         data = defaultdict(list)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -158,7 +158,9 @@ class CurvePlot(ElementPlot):
             dims = list(self.hmap.last.kdims)
             line_policy = 'prev'
         else:
-            dims = list(self.overlay_dims.keys())+element.dimensions()
+            dims = [(d.pprint_label, d.pprint_value(v))
+                    for d, v in self.overlay_dims.items()]
+            dims += element.dimensions()
             line_policy = 'nearest'
         return dims, dict(line_policy=line_policy)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -151,11 +151,14 @@ class CurvePlot(ElementPlot):
         self._categorize_data(data, (x, y), element.dimensions())
         return (data, dict(x=x, y=y))
 
-    def _hover_tooltips(self, element):
+    def _hover_opts(self, element):
         if self.batched:
-            return list(self.hmap.last.kdims)
+            dims = list(self.hmap.last.kdims)
+            line_policy = 'prev'
         else:
-            return list(self.overlay_dims.keys())
+            dims = element.dimensions()+list(self.overlay_dims.keys())
+            line_policy = 'nearest'
+        return dims dict(line_policy=line_policy)
 
     def get_batched_data(self, overlay, ranges=None, empty=False):
         data = defaultdict(list)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -245,7 +245,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Initializes hover data based on Element dimension values.
         If empty initializes with no data.
         """
-        if 'hover' not in self.default_tools + self.tools:
+        if not any(isinstance(t, HoverTool) for t in self.state.tools):
             return
 
         for d in element.dimensions(label=True):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -254,7 +254,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         for k, v in self.overlay_dims.items():
             dim = util.dimension_sanitizer(k.name)
-            data[dim] = [v for _ in range(len(data.values()[0]))]
+            data[dim] = [v for _ in range(len(list(data.values())[0]))]
 
 
     def _axes_props(self, plots, subplots, element, ranges):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -208,8 +208,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
-            dims = [(d.pprint_label, d.pprint_value(v))
-                    for d, v in self.overlay_dims.items()]
+            dims = list(self.overlay_dims.keys())
         dims += element.dimensions()
         return dims, {}
 
@@ -252,6 +251,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         for d in element.dimensions(label=True):
             sanitized = util.dimension_sanitizer(d)
             data[sanitized] = [] if empty else element.dimension_values(d)
+
+        for k, v in self.overlay_dims.items():
+            dim = util.dimension_sanitizer(k.name)
+            data[dim] = [v for _ in range(len(data.values()[0]))]
+
 
     def _axes_props(self, plots, subplots, element, ranges):
         # Get the bottom layer and range element

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -204,21 +204,21 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             cbs.append(cb(self, cb_streams, source))
         return cbs
 
-    def _hover_tooltips(self, element):
+    def _hover_opts(self, element):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
             dims = list(self.overlay_dims.keys())
         dims += element.dimensions()
-        return dims
+        return dims, {}
 
     def _init_tools(self, element, callbacks=[]):
         """
         Processes the list of tools to be supplied to the plot.
         """
-        tooltip_dims = self._hover_tooltips(element)
+        tooltips, hover_opts = self._hover_opts(element)
         tooltips = [(d.pprint_label, '@'+util.dimension_sanitizer(d.name))
-                    for d in tooltip_dims]
+                    for d in tooltips]
 
         callbacks = callbacks+self.callbacks
         cb_tools, tool_names = [], []
@@ -227,7 +227,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 if handle and handle in known_tools:
                     tool_names.append(handle)
                     if handle == 'hover':
-                        tool = HoverTool(tooltips=tooltips)
+                        tool = HoverTool(tooltips=tooltips, **hover_opts)
                     else:
                         tool = known_tools[handle]()
                     cb_tools.append(tool)
@@ -236,7 +236,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         tools = [t for t in cb_tools + self.default_tools + self.tools
                  if t not in tool_names]
         if 'hover' in tools:
-            tools[tools.index('hover')] = HoverTool(tooltips=tooltips)
+            tools[tools.index('hover')] = HoverTool(tooltips=tooltips, **hover_opts)
         return tools
 
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -24,7 +24,8 @@ class PathPlot(ElementPlot):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
-            dims = list(self.overlay_dims.keys())
+            dims = [(d.pprint_label, d.pprint_value(v))
+                    for d, v in self.overlay_dims.items()]
         return dims, {}
 
     def get_data(self, element, ranges=None, empty=False):

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -80,7 +80,7 @@ class PolygonPlot(ColorbarPlot, PathPlot):
             mapping['fill_color'] = {'field': cdim.name,
                                      'transform': cmapper}
 
-        if 'hover' in self.tools+self.default_tools:
+        if any(isinstance(t, HoverTool) for t in self.state.tools):
             dim_name = util.dimension_sanitizer(element.vdims[0].name)
             for k, v in self.overlay_dims.items():
                 dim = util.dimension_sanitizer(k.name)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -24,8 +24,7 @@ class PathPlot(ElementPlot):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
-            dims = [(d.pprint_label, d.pprint_value(v))
-                    for d, v in self.overlay_dims.items()]
+            dims = list(self.overlay_dims.keys())
         return dims, {}
 
     def get_data(self, element, ranges=None, empty=False):

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -20,11 +20,12 @@ class PathPlot(ElementPlot):
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
 
-    def _hover_tooltips(self, element):
+    def _hover_opts(self, element):
         if self.batched:
-            return list(self.hmap.last.kdims)
+            dims = list(self.hmap.last.kdims)
         else:
-            return list(self.overlay_dims.keys())
+            dims = list(self.overlay_dims.keys())
+        return dims, {}
 
     def get_data(self, element, ranges=None, empty=False):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
@@ -56,13 +57,13 @@ class PolygonPlot(ColorbarPlot, PathPlot):
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
 
-    def _hover_tooltips(self, element):
+    def _hover_opts(self, element):
         if self.batched:
             dims = list(self.hmap.last.kdims)
         else:
             dims = list(self.overlay_dims.keys())
         dims += element.vdims
-        return dims
+        return dims, {}
 
     def get_data(self, element, ranges=None, empty=False):
         xs = [] if empty else [path[:, 0] for path in element.data]

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -1,6 +1,7 @@
 import numpy as np
 import param
 
+from bokeh.models import HoverTool
 from bokeh.models.mappers import LinearColorMapper
 try:
     from bokeh.models.mappers import LogColorMapper
@@ -158,7 +159,7 @@ class HeatmapPlot(ColorbarPlot):
                 yvals = [ydim.pprint_value(yv) for yv in yvals]
             data = {x: xvals, y: yvals, 'zvalues': zvals}
 
-        if 'hover' in self.tools+self.default_tools:
+        if any(isinstance(t, HoverTool) for t in self.state.tools):
             for vdim in element.vdims:
                 data[vdim.name] = ['-' if is_nan(v) else vdim.pprint_value(v)
                                    for v in aggregate.dimension_values(vdim)]

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -847,7 +847,7 @@ class GenericOverlayPlot(GenericElementPlot):
             else:
                 if not isinstance(key, tuple): key = (key,)
                 style_key = group_fn(vmap) + key
-                opts['overlay_dims'] = OrderedDict(zip(vmap.last.kdims, key))
+                opts['overlay_dims'] = OrderedDict(zip(self.hmap.last.kdims, key))
 
             if self.batched:
                 vtype = type(vmap.last.last)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -166,15 +166,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         extents = plot.get_extents(overlay, {})
         self.assertEqual(extents, (0, 0, 98, 98))
 
-    def _test_hover_info(self, element, tooltips):
+    def _test_hover_info(self, element, tooltips, line_policy='prev'):
         plot = bokeh_renderer.get_plot(element)
         plot.initialize_plot()
         fig = plot.state
         hover = fig.select(dict(type=HoverTool))
         self.assertTrue(len(hover))
         self.assertEqual(hover[0].tooltips, tooltips)
+        self.assertEqual(hover[0].line_policy, line_policy)
 
-    def test_curve_overlay_hover(self):
+    def test_curve_overlay_hover_batched(self):
         obj = NdOverlay({i: Curve(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']},
@@ -182,6 +183,12 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         obj = obj(plot=opts)
         self._test_hover_info(obj, [('Test', '@Test')])
 
+    def test_curve_overlay_hover(self):
+        obj = NdOverlay({i: Curve(np.random.rand(10,2)) for i in range(5)},
+                        kdims=['Test'])
+        opts = {'Curve': {'tools': ['hover']}}
+        obj = obj(plot=opts)
+        self._test_hover_info(obj, [('Test', '0'), ('x', '@x'), ('y', '@y')], 'nearest')
 
     def test_points_overlay_hover(self):
         obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},
@@ -207,7 +214,6 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                 'NdOverlay': {'legend_limit': 0}}
         obj = obj(plot=opts)
         self._test_hover_info(obj, [('Test', '@Test'), ('z', '@z')])
-
 
     def _test_colormapping(self, element, dim, log=False):
         plot = bokeh_renderer.get_plot(element)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -188,7 +188,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                         kdims=['Test'])
         opts = {'Curve': {'tools': ['hover']}}
         obj = obj(plot=opts)
-        self._test_hover_info(obj, [('Test', '0'), ('x', '@x'), ('y', '@y')], 'nearest')
+        self._test_hover_info(obj, [('Test', '@Test'), ('x', '@x'), ('y', '@y')], 'nearest')
 
     def test_points_overlay_hover(self):
         obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},


### PR DESCRIPTION
Fixes https://github.com/ioam/holoviews/issues/986. Unfortunately in batched mode the hover tool will show all the values in the curve array rather than the specific coordinate you are hovering over so I've disabled displaying curve dimensions when in batched mode.

```python
hv.NdOverlay({i: hv.Curve((range(4), (4-i,i*2, i+3, i))) for i in range(10)}, kdims=['z'])
```

Batched:


<img width="308" alt="screen shot 2017-01-31 at 3 20 38 am" src="https://cloud.githubusercontent.com/assets/1550771/22451197/47f5c4e2-e764-11e6-8209-b84345f23eb9.png">


Non-batched:

<img width="319" alt="screen shot 2017-01-31 at 3 19 21 am" src="https://cloud.githubusercontent.com/assets/1550771/22451186/2a6b1558-e764-11e6-9c12-5d61719d1a6d.png">



