### PR TITLE
Add interpolate_curve operation and Curve interpolation plot option

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -14,6 +14,7 @@ from ...core import OrderedDict, Dimension
 from ...core.util import (match_spec, unique_iterator, safe_unicode,
                           basestring, max_range, unicode)
 from ...element import Points, Raster, Polygons, HeatMap
+from ...operation import interpolate_curve
 from ..util import compute_sizes, get_sideplot_ranges, map_colors
 from .element import ElementPlot, ColorbarPlot, LegendPlot
 from .path  import PathPlot
@@ -41,6 +42,13 @@ class CurvePlot(ChartPlot):
         Whether to let matplotlib automatically compute tick marks
         or to allow the user to control tick marks.""")
 
+    interpolation = param.ObjectSelector(objects=['linear', 'steps-mid',
+                                                  'steps-pre', 'steps-post'],
+                                         default='linear', doc="""
+        Defines how the samples of the Curve are interpolated,
+        default is 'linear', other options include 'steps-mid',
+        'steps-pre' and 'steps-post'.""")
+
     relative_labels = param.Boolean(default=False, doc="""
         If plotted quantity is cyclic and center_cyclic is enabled,
         will compute tick labels relative to the center.""")
@@ -59,6 +67,8 @@ class CurvePlot(ChartPlot):
     _plot_methods = dict(single='plot')
 
     def get_data(self, element, ranges, style):
+        if 'steps' in self.interpolation:
+            element = interpolate_curve(element, interpolation=self.interpolation)
         xs = element.dimension_values(0)
         ys = element.dimension_values(1)
         dims = element.dimensions()

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -3,6 +3,7 @@ import plotly.graph_objs as go
 from plotly.tools import FigureFactory as FF
 
 from ...core import util
+from ...operation import interpolate_curve
 from .element import ElementPlot, ColorbarPlot
 
 
@@ -41,11 +42,20 @@ class PointPlot(ScatterPlot):
 
 class CurvePlot(ElementPlot):
 
+    interpolation = param.ObjectSelector(objects=['linear', 'steps-mid',
+                                                  'steps-pre', 'steps-post'],
+                                         default='linear', doc="""
+        Defines how the samples of the Curve are interpolated,
+        default is 'linear', other options include 'steps-mid',
+        'steps-pre' and 'steps-post'.""")
+
     graph_obj = go.Scatter
 
     style_opts = ['color', 'dash', 'width']
 
     def graph_options(self, element, ranges):
+        if 'steps' in self.interpolation:
+            element = interpolate_curve(element, interpolation=self.interpolation)
         opts = super(CurvePlot, self).graph_options(element, ranges)
         opts['mode'] = 'lines'
         style = self.style[self.cyclic_index]

--- a/tests/testoperation.py
+++ b/tests/testoperation.py
@@ -1,10 +1,11 @@
 import numpy as np
 
 from holoviews import (HoloMap, NdOverlay, Image, Contours, Polygons, Points,
-                       Histogram)
+                       Histogram, Curve)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.element import (operation, transform, threshold,
-                                         gradient, contours, histogram)
+                                         gradient, contours, histogram,
+                                         interpolate_curve)
 
 class ElementOperationTests(ComparisonTestCase):
     """
@@ -83,3 +84,18 @@ class ElementOperationTests(ComparisonTestCase):
         op_hist = histogram(points, num_bins=3, weight_dimension='y', mean_weighted=True)
         hist = Histogram(([1.,  4., 7.5], [0, 3, 6, 9]), vdims=['y'])
         self.assertEqual(op_hist, hist)
+
+    def test_interpolate_curve_pre(self):
+        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-pre')
+        curve = Curve([(0, 0), (0, 0.5), (1, 0.5), (1, 1), (2, 1)])
+        self.assertEqual(interpolated, curve)
+
+    def test_interpolate_curve_mid(self):
+        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-mid')
+        curve = Curve([(0, 0), (0.5, 0), (0.5, 0.5), (1.5, 0.5), (1.5, 1), (2, 1)])
+        self.assertEqual(interpolated, curve)
+
+    def test_interpolate_curve_post(self):
+        interpolated = interpolate_curve(Curve([0, 0.5, 1]), interpolation='steps-post')
+        curve = Curve([(0, 0), (1, 0), (1, 0.5), (2, 0.5), (2, 1)])
+        self.assertEqual(interpolated, curve)


### PR DESCRIPTION
Recently I prototyped a ``Steps`` Element which would plot changes in the y-values of a Curve as discrete steps. It was pointed out this really just represents different interpolation behavior for ``Curve`` plots. I think this is a good suggestion, and I'd like to start using it for a project I'm working on. I've added ``step_curve`` as a separate operation so you can also plot steps when datashading simply by applying it to the Curve before datashading is applied. Here's what it looks like:

```python
%%opts Overlay [legend_position='right' width=600 toolbar='above']
arr = np.random.rand(10)
hv.Overlay([hv.Curve(arr, label=intp)(plot=dict(interpolation=intp))
            for intp in ['linear', 'steps-pre', 'steps-mid', 'steps-post']])
```

<img width="622" alt="screen shot 2017-02-01 at 9 11 19 pm" src="https://cloud.githubusercontent.com/assets/1550771/22526410/0f931c16-e8c3-11e6-9e56-e7eeed8cf024.png">
