### PR TITLE
Allows plotting GridSpaces inside Layouts in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -284,8 +284,8 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
     def initialize_plot(self, ranges=None, plots=[]):
         ranges = self.compute_ranges(self.layout, self.keys[-1], None)
-        plots = [[] for r in range(self.cols)]
         passed_plots = list(plots)
+        plots = [[] for r in range(self.cols)]
         for i, coord in enumerate(self.layout.keys(full_grid=True)):
             r = i % self.cols
             subplot = self.subplots.get(wrap_tuple(coord), None)
@@ -421,8 +421,6 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
             subplot_opts = dict(adjoined=main_plot)
             # Options common for any subplot
-            if type(element) in (NdLayout, Layout):
-                raise SkipRendering("Cannot plot nested Layouts.")
             vtype = element.type if isinstance(element, HoloMap) else element.__class__
             plot_type = Store.registry[self.renderer.backend].get(vtype, None)
             plotopts = self.lookup_options(element, 'plot').options
@@ -468,10 +466,10 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         return subplots, adjoint_clone
 
 
-    def initialize_plot(self, ranges=None):
+    def initialize_plot(self, plots=None, ranges=None):
         ranges = self.compute_ranges(self.layout, self.keys[-1], None)
+        passed_plots = [] if plots is None else plots
         plots = [[] for _ in range(self.rows)]
-        passed_plots = []
         tab_titles = {}
         insert_rows, insert_cols = [], []
         adjoined = False

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -16,7 +16,7 @@ from ...element import Histogram
 from ..plot import DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
 from ..util import get_dynamic_mode, initialize_sampled
 from .renderer import BokehRenderer
-from .util import bokeh_version, layout_padding, pad_plots
+from .util import bokeh_version, layout_padding, pad_plots, filter_toolboxes
 
 if bokeh_version >= '0.12':
     from bokeh.layouts import gridplot
@@ -449,8 +449,6 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                 self.warning("Bokeh plotting class for %s type not found, object will "
                              "not be rendered." % vtype.__name__)
                 continue
-            if plot_type in [GridPlot, LayoutPlot]:
-                self.tabs = True
             num = num if len(self.coords) > 1 else 0
             subplot = plot_type(element, keys=self.keys,
                                 dimensions=self.dimensions,
@@ -541,6 +539,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                       if child is not None]
             layout_plot = Tabs(tabs=panels)
         elif bokeh_version >= '0.12':
+            plots = filter_toolboxes(plots)
             plots, width = pad_plots(plots)
             layout_plot = gridplot(children=plots, width=width)
         elif len(plots) == 1 and not adjoined:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -348,23 +348,28 @@ def update_plot(old, new):
             old_r.data_source.data.update(emptied)
 
 
-def pad_width(model):
+def pad_width(model, table_padding=0.85, tabs_padding=1.2):
     """
     Computes the width of a model and sets up appropriate padding
     for Tabs and DataTable types.
     """
     if isinstance(model, Row):
-        width = np.max([pad_width(child) for child in model.children])
+        vals = [pad_width(child) for child in model.children]
+        width = np.max([v for v in vals if v is not None])
     elif isinstance(model, Column):
-        width = np.sum([pad_width(child) for child in model.children])
+        vals = [pad_width(child) for child in model.children]
+        width = np.sum([v for v in vals if v is not None])
     elif isinstance(model, Tabs):
-        width = np.max([pad_width(t) for t in model.tabs])
+        vals = [pad_width(t) for t in model.tabs]
+        width = np.max([v for v in vals if v is not None])
         for model in model.tabs:
             model.width = width
             width = int(tabs_padding*width)
     elif isinstance(model, DataTable):
         width = model.width
         model.width = int(table_padding*width)
+    elif isinstance(model, WidgetBox):
+        width = model.width
     elif model:
         width = model.plot_width
     else:
@@ -372,7 +377,7 @@ def pad_width(model):
     return width
 
 
-def pad_plots(plots, table_padding=0.85, tabs_padding=1.2):
+def pad_plots(plots):
     """
     Accepts a grid of bokeh plots in form of a list of lists and
     wraps any DataTable or Tabs in a WidgetBox with appropriate

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -37,10 +37,11 @@ try:
     from holoviews.plotting.bokeh.callbacks import Callback
     from bokeh.models import (
         Div, ColumnDataSource, FactorRange, Range1d, Row, Column,
-        ToolbarBox, Figure, Spacer
+        ToolbarBox, Spacer
     )
     from bokeh.models.mappers import LinearColorMapper, LogColorMapper
     from bokeh.models.tools import HoverTool
+    from bokeh.plotting import Figure
 except:
     bokeh_renderer = None
 
@@ -676,18 +677,19 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         grid1, grid2 = grid1.children[0], grid2.children[0]
         self.assertIsInstance(grid1, Column)
         self.assertIsInstance(grid2, Column)
-        self.assertEqual(len(grid1.children), 2)
-        grow1, grow2 = grid1.children
-        self.assertIsInstance(grow1, Row)
-        self.assertIsInstance(grow2, Row)
-        self.assertEqual(len(grow1.children), 2)
-        self.assertEqual(len(grow2.children), 2)
-        gfig1, gfig2 = grow1.children
-        gfig3, gfig3 = grow2.children
-        self.assertIsInstance(grow1, Figure)
-        self.assertIsInstance(grow2, Figure)
-        self.assertIsInstance(grow3, Figure)
-        self.assertIsInstance(grow4, Figure)
+        for grid in [grid1, grid2]:
+            self.assertEqual(len(grid.children), 2)
+            grow1, grow2 = grid.children
+            self.assertIsInstance(grow1, Row)
+            self.assertIsInstance(grow2, Row)
+            self.assertEqual(len(grow1.children), 2)
+            self.assertEqual(len(grow2.children), 2)
+            gfig1, gfig2 = grow1.children
+            gfig3, gfig4 = grow2.children
+            self.assertIsInstance(gfig1, Figure)
+            self.assertIsInstance(gfig2, Figure)
+            self.assertIsInstance(gfig3, Figure)
+            self.assertIsInstance(gfig4, Figure)
 
         # Check the row of Curve and a spacer
         self.assertEqual(len(row2.children), 2)


### PR DESCRIPTION
This PR makes the bokeh ``GridPlot`` and ``LayoutPlot`` fully composable so you can now plot multiple grids together. Here's two grids and a regular element in a layout:

```python
%%opts Image [height=260]
(hv.GridSpace({(i, j): hv.Curve(range(i+j)) for i in range(1, 3) for j in range(2,4)}) +\
 hv.GridSpace({(i, j): hv.Curve(range(i+j)) for i in range(1, 3) for j in range(2,4)}) +
 hv.Image(np.random.rand(10,10)))
```

<img width="827" alt="screen shot 2017-02-05 at 11 53 08 pm" src="https://cloud.githubusercontent.com/assets/1550771/22631124/49e753a8-ebfe-11e6-8215-e410dab04719.png">

The ``Composing_Data`` tutorial now also works for both matplotlib and bokeh:

<img width="955" alt="screen shot 2017-02-06 at 2 48 12 am" src="https://cloud.githubusercontent.com/assets/1550771/22633127/c19c6740-ec16-11e6-9088-46b747ac2bd1.png">

Related: https://github.com/ioam/holoviews/issues/381