### PR TITLE
Define length on Annotation Elements

### DIFF
--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -193,15 +193,6 @@ class Element(ViewableElement, Composable, Overlayable):
         return np.column_stack(columns)
 
 
-    def __len__(self):
-        """
-        Elements must define a length, by default will simply be
-        computed from dimension values, subclasses may override this
-        for efficiency and correctness.
-        """
-        return len(self.dimension_values(0))
-
-
 
 class Tabular(Element):
     """

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -184,6 +184,15 @@ class Element(ViewableElement, Composable, Overlayable):
         return np.column_stack(columns)
 
 
+    def __len__(self):
+        """
+        Elements must define a length, by default will simply be
+        computed from dimension values, subclasses may override this
+        for efficiency and correctness.
+        """
+        return len(self.dimension_values(0))
+
+
 
 class Tabular(Element):
     """

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -63,6 +63,15 @@ class Element(ViewableElement, Composable, Overlayable):
             raise NotImplementedError("%s currently does not support getitem" %
                                       type(self).__name__)
 
+    def __nonzero__(self):
+        """
+        Subclasses may override this to signal that the Element contains
+        no data and can safely be dropped during indexing.
+        """
+        return True
+
+    __bool__ = __nonzero__
+
 
     @classmethod
     def collapse_data(cls, data, function=None, kdims=None, **kwargs):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -148,7 +148,7 @@ class Arrow(Annotation):
     def __init__(self, x, y, text='', direction='<',
                  points=40, arrowstyle='->', **params):
 
-        info = (direction.lower(), text, (x,y), points, arrowstyle)
+        info = (x, y, text, direction, points, arrowstyle)
         super(Arrow, self).__init__(info, x=x, y=y,
                                     text=text, direction=direction,
                                     points=points, arrowstyle=arrowstyle,
@@ -157,7 +157,11 @@ class Arrow(Annotation):
     # Note: This version of clone is identical in Text and path.BaseShape
     # Consider implementing a mix-in class if it is needed again.
     def clone(self, *args, **overrides):
-        settings = dict(self.get_param_values(), **overrides)
+        if len(args) == 1 and isinstance(args[0], tuple):
+            args = args[0]
+        arg_names = ['x', 'y', 'text', 'direction', 'points', 'arrowstyle']
+        settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
+                    if k not in arg_names[:len(args)]}
         return self.__class__(*args, **settings)
 
     def dimension_values(self, dimension, expanded=True, flat=True):
@@ -207,5 +211,9 @@ class Text(Annotation):
                                    halign=halign, valign=valign, **params)
 
     def clone(self, *args, **overrides):
-        settings = dict(self.get_param_values(), **overrides)
+        if len(args) == 1 and isinstance(args[0], tuple):
+            args = args[0]
+        arg_names = ['x', 'y', 'text', 'fontsize', 'halign', 'valign', 'rotation']
+        settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
+                    if k not in arg_names[:len(args)]}
         return self.__class__(*args, **settings)

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -154,6 +154,17 @@ class Arrow(Annotation):
                                     points=points, arrowstyle=arrowstyle,
                                     **params)
 
+    def __setstate__(self, d):
+        """
+        Add compatibility for unpickling old Arrow types with different
+        .data format.
+        """
+        super(Arrow, self).__setstate__(d)
+        if len(self.data) == 5:
+            direction, text, (x, y), points, arrowstyle = self.data
+            self.data = (x, y, text, direction, points, arrowstyle)
+
+
     # Note: This version of clone is identical in Text and path.BaseShape
     # Consider implementing a mix-in class if it is needed again.
     def clone(self, *args, **overrides):

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -167,7 +167,7 @@ class Arrow(Annotation):
         elif index == 1:
             return np.array([self.y])
         else:
-            return super(Text, self).dimension_values(dimension)
+            return super(Arrow, self).dimension_values(dimension)
 
 
 

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -30,6 +30,8 @@ class Annotation(Element2D):
     def __init__(self, data, **params):
         super(Annotation, self).__init__(data, **params)
 
+    def __len__(self):
+        return 1
 
     def __getitem__(self, key):
         if key in self.dimensions(): return self.dimension_values(key)

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -84,7 +84,8 @@ class ArrowPlot(AnnotationPlot):
     style_opts = sorted(set(_arrow_style_opts + _text_style_opts))
 
     def draw_annotation(self, axis, data, opts):
-        direction, text, xy, points, arrowstyle = data
+        x, y, text, direction, points, arrowstyle = data
+        direction = direction.lower()
         arrowprops = dict({'arrowstyle':arrowstyle},
                           **{k: opts[k] for k in self._arrow_style_opts if k in opts})
         textopts = {k: opts[k] for k in self._text_style_opts if k in opts}
@@ -92,7 +93,7 @@ class ArrowPlot(AnnotationPlot):
             xytext = (0, points if direction=='v' else -points)
         elif direction in ['>', '<']:
             xytext = (points if direction=='<' else -points, 0)
-        return [axis.annotate(text, xy=xy, textcoords='offset points',
+        return [axis.annotate(text, xy=(x, y), textcoords='offset points',
                               xytext=xytext, ha="center", va="center",
                               arrowprops=arrowprops, **textopts)]
 


### PR DESCRIPTION
Defining a length is part of the core API and I have run into failures which I cannot reproduce right now because the annotations do not support it. Setting length 1 is consistent with how their ``dimension_values`` methods work, which return length 1 arrays.

Edit: I threw a bug fix for a small bug on the Arrow Annotation