### PR TITLE
Added support for categorical colormapping in bokeh backend

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -893,7 +893,20 @@ class ColorbarPlot(ElementPlot):
         low, high = ranges.get(dim.name, element.range(dim.name))
         palette = mplcmap_to_palette(style.pop('cmap', 'viridis'), ncolors)
         colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
+        colormapper, opts = self._get_cmapper_opts(low, high, factors, colors)
 
+        if 'color_mapper' in self.handles:
+            cmapper = self.handles['color_mapper']
+            cmapper.palette = palette
+            cmapper.update(**opts)
+        else:
+            cmapper = colormapper(palette=palette, **opts)
+            self.handles['color_mapper'] = cmapper
+            self.handles['color_dim'] = dim
+        return cmapper
+
+
+    def _get_cmapper_opts(self, low, high, factors, colors):
         if factors is None:
             colormapper = LogColorMapper if self.logz else LinearColorMapper
             if isinstance(low, (bool, np.bool_)): low = int(low)
@@ -906,16 +919,7 @@ class ColorbarPlot(ElementPlot):
             opts = dict(factors=factors)
             if 'NaN' in colors:
                 opts['nan_color'] = colors['NaN']
-
-        if 'color_mapper' in self.handles:
-            cmapper = self.handles['color_mapper']
-            cmapper.palette = palette
-            cmapper.update(**opts)
-        else:
-            cmapper = colormapper(palette=palette, **opts)
-            self.handles['color_mapper'] = cmapper
-            self.handles['color_dim'] = dim
-        return cmapper
+        return colormapper, opts
 
 
     def _init_glyph(self, plot, mapping, properties):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -34,7 +34,8 @@ from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update, get_sources
 from .plot import BokehPlot
 from .util import (mpl_to_bokeh, convert_datetime, update_plot, get_tab_title,
-                   bokeh_version, mplcmap_to_palette, py2js_tickformatter)
+                   bokeh_version, mplcmap_to_palette, py2js_tickformatter,
+                   rgba_tuple)
 
 if bokeh_version >= '0.12':
     from bokeh.models import FuncTickFormatter
@@ -891,10 +892,7 @@ class ColorbarPlot(ElementPlot):
         ncolors = None if factors is None else len(factors)
         low, high = ranges.get(dim.name, element.range(dim.name))
         palette = mplcmap_to_palette(style.pop('cmap', 'viridis'), ncolors)
-
-        color_rgb = lambda color: [int(c*255) if i<3 else c for i, c in enumerate(color)]
-        colors = {k: color_rgb(v) if isinstance(v, tuple) else v
-                  for k, v in self.clipping_colors.items()}
+        colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
 
         if factors is None:
             colormapper = LogColorMapper if self.logz else LinearColorMapper

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -12,7 +12,7 @@ from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
 try:
     from bokeh.models import ColorBar
-    from bokeh.models.mappers import LogColorMapper
+    from bokeh.models.mappers import LogColorMapper, CategoricalColorMapper
 except ImportError:
     LogColorMapper, ColorBar = None, None
 from bokeh.models import LogTicker, BasicTicker
@@ -851,6 +851,8 @@ class ColorbarPlot(ElementPlot):
                               major_tick_line_color='black')
 
     def _draw_colorbar(self, plot, color_mapper):
+        if CategoricalColorMapper and isinstance(color_mapper, CategoricalColorMapper):
+            return
         if LogColorMapper and isinstance(color_mapper, LogColorMapper):
             ticker = LogTicker()
         else:
@@ -870,13 +872,11 @@ class ColorbarPlot(ElementPlot):
         self.handles['colorbar'] = color_bar
 
 
-    def _get_colormapper(self, dim, element, ranges, style):
+    def _get_colormapper(self, dim, element, ranges, style, factors=None):
         # The initial colormapper instance is cached the first time
         # and then only updated
         if dim is None:
             return None
-        low, high = ranges.get(dim.name, element.range(dim.name))
-        palette = mplcmap_to_palette(style.pop('cmap', 'viridis'))
         if self.adjoined:
             cmappers = self.adjoined.traverse(lambda x: (x.handles.get('color_dim'),
                                                          x.handles.get('color_mapper')))
@@ -887,25 +887,34 @@ class ColorbarPlot(ElementPlot):
                 return cmapper
             else:
                 return None
-        colors = self.clipping_colors
-        if isinstance(low, (bool, np.bool_)): low = int(low)
-        if isinstance(high, (bool, np.bool_)): high = int(high)
-        opts = {'low': low, 'high': high}
-        color_opts = [('NaN', 'nan_color'), ('max', 'high_color'), ('min', 'low_color')]
-        for name, opt in color_opts:
-            color = colors.get(name)
-            if not color:
-                continue
-            elif isinstance(color, tuple):
-                color = [int(c*255) if i<3 else c for i, c in enumerate(color)]
-            opts[opt] = color
+
+        ncolors = None if factors is None else len(factors)
+        low, high = ranges.get(dim.name, element.range(dim.name))
+        palette = mplcmap_to_palette(style.pop('cmap', 'viridis'), ncolors)
+
+        color_rgb = lambda color: [int(c*255) if i<3 else c for i, c in enumerate(color)]
+        colors = {k: color_rgb(v) if isinstance(v, tuple) else v
+                  for k, v in self.clipping_colors.items()}
+
+        if factors is None:
+            colormapper = LogColorMapper if self.logz else LinearColorMapper
+            if isinstance(low, (bool, np.bool_)): low = int(low)
+            if isinstance(high, (bool, np.bool_)): high = int(high)
+            opts = {'low': low, 'high': high}
+            color_opts = [('NaN', 'nan_color'), ('max', 'high_color'), ('min', 'low_color')]
+            opts.update({opt: colors[name] for name, opt in color_opts if name in colors})
+        else:
+            colormapper = CategoricalColorMapper
+            opts = dict(factors=factors)
+            if 'NaN' in colors:
+                opts['nan_color'] = colors['NaN']
+
         if 'color_mapper' in self.handles:
             cmapper = self.handles['color_mapper']
             cmapper.palette = palette
             cmapper.update(**opts)
         else:
-            colormapper = LogColorMapper if self.logz else LinearColorMapper
-            cmapper = colormapper(palette, **opts)
+            cmapper = colormapper(palette=palette, **opts)
             self.handles['color_mapper'] = cmapper
             self.handles['color_dim'] = dim
         return cmapper
@@ -942,15 +951,32 @@ class LegendPlot(ElementPlot):
         options. The predefined options may be customized in the
         legend_specs class attribute.""")
 
-
     legend_cols = param.Integer(default=False, doc="""
        Whether to lay out the legend as columns.""")
-
 
     legend_specs = {'right': dict(pos='right', loc=(5, -40)),
                     'left': dict(pos='left', loc=(0, -40)),
                     'top': dict(pos='above', loc=(120, 5)),
                     'bottom': dict(pos='below', loc=(60, 0))}
+
+    def _process_legend(self, plot=None):
+        plot = plot or self.handles['plot']
+        if not plot.legend:
+            return
+        legend = plot.legend[0]
+        if not self.show_legend:
+            legend.items[:] = []
+        else:
+            plot.legend.orientation = 'horizontal' if self.legend_cols else 'vertical'
+            pos = self.legend_position
+            if pos in self.legend_specs:
+                opts = self.legend_specs[pos]
+                plot.legend[:] = []
+                legend.plot = None
+                legend.location = opts['loc']
+                plot.add_layout(legend, opts['pos'])
+            else:
+                legend.location = pos
 
 
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -65,6 +65,16 @@ def rgb2hex(rgb):
     return "#{0:02x}{1:02x}{2:02x}".format(*(int(v*255) for v in rgb))
 
 
+def rgba_tuple(rgba):
+    """
+    Ensures RGB(A) tuples in the range 0-1 are scaled to 0-255.
+    """
+    if isinstance(rgba, tuple):
+        return [int(c*255) if i<3 else c for i, c in enumerate(rgba)]
+    else:
+        return rgba
+
+
 def mplcmap_to_palette(cmap, ncolors=None):
     """
     Converts a matplotlib colormap to palette of RGB hex strings."

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -65,7 +65,7 @@ def rgb2hex(rgb):
     return "#{0:02x}{1:02x}{2:02x}".format(*(int(v*255) for v in rgb))
 
 
-def mplcmap_to_palette(cmap):
+def mplcmap_to_palette(cmap, ncolors=None):
     """
     Converts a matplotlib colormap to palette of RGB hex strings."
     """
@@ -73,6 +73,8 @@ def mplcmap_to_palette(cmap):
         raise ValueError("Using cmaps on objects requires matplotlib.")
     with abbreviated_exception():
         colormap = cm.get_cmap(cmap) #choose any matplotlib colormap here
+        if ncolors:
+            return [rgb2hex(colormap(i)) for i in np.linspace(0, 1, ncolors)]
         return [rgb2hex(m) for m in colormap(np.arange(colormap.N))]
 
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -39,7 +39,8 @@ try:
         Div, ColumnDataSource, FactorRange, Range1d, Row, Column,
         ToolbarBox, Spacer
     )
-    from bokeh.models.mappers import LinearColorMapper, LogColorMapper
+    from bokeh.models.mappers import (LinearColorMapper, LogColorMapper,
+                                      CategoricalColorMapper)
     from bokeh.models.tools import HoverTool
     from bokeh.plotting import Figure
 except:
@@ -296,6 +297,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
     def test_points_colormapping(self):
         points = Points(np.random.rand(10, 4), vdims=['a', 'b'])
         self._test_colormapping(points, 3)
+
+    def test_points_colormapping_categorical(self):
+        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+                         vdims=['a', 'b'])
+        plot = bokeh_renderer.get_plot(points)
+        plot.initialize_plot()
+        fig = plot.state
+        cmapper = plot.handles['color_mapper']
+        self.assertIsInstance(cmapper, CategoricalColorMapper)
+        self.assertEqual(cmapper.factors, list(points['b']))
 
     def test_image_colormapping(self):
         img = Image(np.random.rand(10, 10))(plot=dict(logz=True))


### PR DESCRIPTION
Adds support for categorical colormapping on bokeh ``ColorbarPlot`` and implements it specifically for Points. We already have this support in matplotlib and bokeh now makes it easy with a CategoricalColorMapper. This is also already achievable with an NdOverlay of Points but this allows selections to work on a single datastructure which is a lot easier to deal with for streams.

```python
%%opts Scatter [color_index=2 toolbar='above' legend_position='right' width=600] (cmap='Set1' size=10)
hv.Scatter([('Week %d' % (i%10), np.random.rand(), chr(65+np.random.randint(5)))
           for i in range(100)], kdims=['Date'], vdims=['r2', 'Group'])
```

<img width="617" alt="screen shot 2017-02-15 at 12 33 09 am" src="https://cloud.githubusercontent.com/assets/1550771/22955840/634ff664-f316-11e6-8364-9167a21f03de.png">

