### PR TITLE
Use correct dpi in MPLRenderer.get_size

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -137,8 +137,8 @@ class MPLRenderer(Renderer):
     @bothmethod
     def get_size(self_or_cls, plot):
         w, h = plot.state.get_size_inches()
-        dpi = plot.state.dpi
-        return (w*dpi, h*dpi)
+        dpi = self_or_cls.dpi if self_or_cls.dpi else plot.state.dpi
+        return (int(w*dpi), int(h*dpi))
 
 
     def diff(self, plot):

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -135,6 +135,38 @@ class MPLRendererTest(ComparisonTestCase):
         self.assertEqual(digest_data(data),
                          '91bbc7b4efebd07b1ee595b902d9899b27f2c7e353dfc87c57c2dfd5d0404301')
 
+    def test_get_size_single_plot(self):
+        plot = self.renderer.get_plot(self.image1)
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (400, 400))
+
+    def test_get_size_row_plot(self):
+        plot = self.renderer.get_plot(self.image1+self.image2)
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (800, 355))
+
+    def test_get_size_column_plot(self):
+        plot = self.renderer.get_plot((self.image1+self.image2).cols(1))
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (400, 702))
+
+    def test_get_size_grid_plot(self):
+        grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
+        plot = self.renderer.get_plot(grid)
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (480, 480))
+
+    def test_get_size_table(self):
+        table = Table(range(10), kdims=['x'])
+        plot = self.renderer.get_plot(table)
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (400, 400))
+
+    def test_get_size_tables_in_layout(self):
+        table = Table(range(10), kdims=['x'])
+        plot = self.renderer.get_plot(table+table)
+        w, h = self.renderer.get_size(plot)
+        self.assertEqual((w, h), (800, 320))
 
 class BokehRendererTest(ComparisonTestCase):
 


### PR DESCRIPTION
Following on from #1140 it turns out the matplotlib equivalent to get the plot size in pixels is also incorrect using the wrong dpi.