### PR TITLE
Add support for bokeh event callbacks

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -8,6 +8,7 @@ from ...streams import (Stream, PositionXY, RangeXY, Selection1D, RangeX,
                         RangeY, PositionX, PositionY, Bounds, Tap,
                         DoubleTap, MouseEnter, MouseLeave, PlotDimensions)
 from ..comms import JupyterCommJS
+from .util import bokeh_version
 
 
 def attributes_js(attributes, handles):
@@ -349,10 +350,10 @@ class Callback(object):
                     cb.handle_ids[k].update(v)
 
         if not cb:
-            if self.events:
+            if self.events and bokeh_version >= '0.12.5':
                 for event in self.events:
                     handle.js_on_event(event, js_callback)
-            elif self.change:
+            elif self.change and bokeh_version >= '0.12.5':
                 for change in self.change:
                     handle.js_on_change(change, js_callback)
             else:

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -169,6 +169,8 @@ class Callback(object):
 
     _callbacks = {}
 
+    event = False
+
     def __init__(self, plot, streams, source, **params):
         self.plot = plot
         self.streams = streams
@@ -273,6 +275,11 @@ class Callback(object):
 
         attributes = attributes_js(self.attributes, references)
         code = 'var data = {};\n' + attributes + self.code + self_callback
+
+        if self.event:
+            js_callback = CustomJS(args=references, code=code)
+            handle.js_on_event(self.event, js_callback)
+            return
 
         # Merge callbacks if another callback has already been attached
         # otherwise set it

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -5,7 +5,8 @@ import numpy as np
 from bokeh.models import CustomJS
 
 from ...streams import (Stream, PositionXY, RangeXY, Selection1D, RangeX,
-                        RangeY, PositionX, PositionY, Bounds)
+                        RangeY, PositionX, PositionY, Bounds, Tap,
+                        DoubleTap, MouseEnter, MouseLeave, PlotDimensions)
 from ..comms import JupyterCommJS
 
 
@@ -363,33 +364,74 @@ class Callback(object):
 
 
 class PositionXYCallback(Callback):
+    """
+    Returns the mouse x/y-position on mousemove event.
+    """
 
-    attributes = {'x': 'cb_data.geometry.x', 'y': 'cb_data.geometry.y'}
+    attributes = {'x': 'cb_obj.event.x', 'y': 'cb_obj.event.y'}
     handles = ['plot']
     events = ['mousemove']
 
 
-class PositionXCallback(Callback):
+class PositionXCallback(PositionXYCallback):
+    """
+    Returns the mouse x-position on mousemove event.
+    """
 
-    attributes = {'x': 'cb_data.geometry.x'}
-    handles = ['plot']
-    events = ['mousemove']
+    attributes = {'x': 'cb_obj.event.x'}
 
 
-class PositionYCallback(Callback):
+class PositionYCallback(PositionXYCallback):
+    """
+    Returns the mouse x/y-position on mousemove event.
+    """
 
-    attributes = {'y': 'cb_data.geometry.y'}
-    handles = ['plot']
-    events = ['mousemove']
+    attributes = {'y': 'cb_data.event.y'}
+
+
+class TapCallback(PositionXYCallback):
+    """
+    Returns the mouse x/y-position on tap event.
+    """
+
+    events = ['tap']
+
+
+class DoubleTapCallback(PositionXYCallback):
+    """
+    Returns the mouse x/y-position on doubletap event.
+    """
+
+    events = ['doubletap']
+
+
+class MouseEnterCallback(PositionXYCallback):
+    """
+    Returns the mouse x/y-position on mouseenter event, i.e. when
+    mouse enters the plot canvas.
+    """
+
+    events = ['mouseenter']
+
+
+class MouseLeaveCallback(PositionXYCallback):
+    """
+    Returns the mouse x/y-position on mouseleave event, i.e. when
+    mouse leaves the plot canvas.
+    """
+
+    events = ['mouseleave']
 
 
 class RangeXYCallback(Callback):
+    """
+    Returns the x/y-axis ranges of a plot.
+    """
 
     attributes = {'x0': 'x_range.attributes.start',
                   'x1': 'x_range.attributes.end',
                   'y0': 'y_range.attributes.start',
                   'y1': 'y_range.attributes.end'}
-
     handles = ['x_range', 'y_range']
     change = ['start', 'end']
 
@@ -402,11 +444,13 @@ class RangeXYCallback(Callback):
         return data
 
 
-class RangeXCallback(Callback):
+class RangeXCallback(RangeXYCallback):
+    """
+    Returns the x-axis range of a plot.
+    """
 
     attributes = {'x0': 'x_range.attributes.start',
                   'x1': 'x_range.attributes.end'}
-
     handles = ['x_range']
 
     def _process_msg(self, msg):
@@ -416,11 +460,13 @@ class RangeXCallback(Callback):
             return {}
 
 
-class RangeYCallback(Callback):
+class RangeYCallback(RangeXYCallback):
+    """
+    Returns the y-axis range of a plot.
+    """
 
     attributes = {'y0': 'y_range.attributes.start',
                   'y1': 'y_range.attributes.end'}
-
     handles = ['y_range']
 
     def _process_msg(self, msg):
@@ -430,13 +476,27 @@ class RangeYCallback(Callback):
             return {}
 
 
+class PlotDimensionCallback(Callback):
+    """
+    Returns the actual width and height of a plot once the layout
+    solver has executed.
+    """
+
+    handles = ['plot']
+    attributes = {'width': 'cb_obj.inner_width',
+                  'height': 'cb_obj.inner_height'}
+    change = ['inner_width', 'inner_height']
+
+
 class BoundsCallback(Callback):
+    """
+    Returns the bounds of a box_select tool.
+    """
 
     attributes = {'x0': 'cb_data.geometry.x0',
                   'x1': 'cb_data.geometry.x1',
                   'y0': 'cb_data.geometry.y0',
                   'y1': 'cb_data.geometry.y1'}
-
     handles = ['box_select']
 
     def _process_msg(self, msg):
@@ -447,10 +507,13 @@ class BoundsCallback(Callback):
 
 
 class Selection1DCallback(Callback):
+    """
+    Returns the current selection on a ColumnDataSource.
+    """
 
-    attributes = {'index': 'source.selected.1d.indices'}
-
+    attributes = {'index': 'cb_obj.selected.1d.indices'}
     handles = ['source']
+    change = ['selected']
 
     def _process_msg(self, msg):
         if 'index' in msg:
@@ -461,11 +524,16 @@ class Selection1DCallback(Callback):
 
 callbacks = Stream._callbacks['bokeh']
 
-callbacks[PositionXY] = PositionXYCallback
-callbacks[PositionX] = PositionXCallback
-callbacks[PositionY] = PositionYCallback
-callbacks[RangeXY] = RangeXYCallback
-callbacks[RangeX] = RangeXCallback
-callbacks[RangeY] = RangeYCallback
-callbacks[Bounds] = BoundsCallback
+callbacks[PositionXY]  = PositionXYCallback
+callbacks[PositionX]   = PositionXCallback
+callbacks[PositionY]   = PositionYCallback
+callbacks[Tap]         = TapCallback
+callbacks[DoubleTap]   = DoubleTapCallback
+callbacks[MouseEnter]  = MouseEnterCallback
+callbacks[MouseLeave]  = MouseLeaveCallback
+callbacks[RangeXY]     = RangeXYCallback
+callbacks[RangeX]      = RangeXCallback
+callbacks[RangeY]      = RangeYCallback
+callbacks[Bounds]      = BoundsCallback
 callbacks[Selection1D] = Selection1DCallback
+callbacks[PlotDimensions] = PlotDimensionCallback

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -380,6 +380,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         properties['webgl'] = Store.renderers[self.renderer.backend].webgl
         with warnings.catch_warnings():
+            # Bokeh raises warnings about duplicate tools but these
+            # are not really an issue
             warnings.simplefilter('ignore', UserWarning)
             return bokeh.plotting.Figure(x_axis_type=x_axis_type,
                                          y_axis_type=y_axis_type, title=title,

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -232,7 +232,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         cb_tools, tool_names = [], []
         hover = False
         for cb in callbacks:
-            for handle in cb.handles+cb.extra_handles:
+            for handle in cb.models+cb.extra_models:
                 if handle and handle in known_tools:
                     tool_names.append(handle)
                     if handle == 'hover':

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -32,7 +32,7 @@ from ...element import RGB
 from ...streams import Stream, RangeXY, RangeX, RangeY
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update, get_sources
-from .plot import BokehPlot
+from .plot import BokehPlot, TOOLS
 from .util import (mpl_to_bokeh, convert_datetime, update_plot, get_tab_title,
                    bokeh_version, mplcmap_to_palette, py2js_tickformatter,
                    rgba_tuple)
@@ -59,10 +59,6 @@ text_properties = ['text_font', 'text_font_size', 'text_font_style', 'text_color
 
 legend_dimensions = ['label_standoff', 'label_width', 'label_height', 'glyph_width',
                      'glyph_height', 'legend_padding', 'legend_spacing', 'click_policy']
-
-
-TOOLS = {name: tool if isinstance(tool, util.basestring) else type(tool())
-         for name, tool in known_tools.items()}
 
 
 class ElementPlot(BokehPlot, GenericElementPlot):
@@ -242,7 +238,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         cb_tools, tool_names = [], []
         hover = False
         for cb in callbacks:
-            for handle in cb.handles:
+            for handle in cb.handles+cb.extra_handles:
                 if handle and handle in known_tools:
                     tool_names.append(handle)
                     if handle == 'hover':

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1255,7 +1255,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             tool = self.handles['hover_tools'].get(tuple(hover.tooltips))
             if tool:
                 tool.renderers += hover.renderers
-        elif self.batched:
+        elif self.batched and 'hover' in subplot.handles:
             self.handles['hover'] = subplot.handles['hover']
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -204,7 +204,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             streams = Stream.registry.get(id(source), [])
             registry = Stream._callbacks['bokeh']
             cb_classes |= {(registry[type(stream)], stream) for stream in streams
-                           if type(stream) in registry and stream.interactive}
+                           if type(stream) in registry and stream.linked}
         cbs = []
         sorted_cbs = sorted(cb_classes, key=lambda x: id(x[0]))
         for cb, group in groupby(sorted_cbs, lambda x: x[0]):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -204,7 +204,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             streams = Stream.registry.get(id(source), [])
             registry = Stream._callbacks['bokeh']
             cb_classes |= {(registry[type(stream)], stream) for stream in streams
-                           if type(stream) in registry and streams}
+                           if type(stream) in registry and stream.interactive}
         cbs = []
         sorted_cbs = sorted(cb_classes, key=lambda x: id(x[0]))
         for cb, group in groupby(sorted_cbs, lambda x: x[0]):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -182,10 +182,13 @@ class CompositePlot(BokehPlot):
 
     def _update_callbacks(self, plot):
         """
-        Updates any callbacks on the subplots.
+        Iterates over all subplots and updates existing CustomJS
+        callbacks with models that were replaced when compositing subplots
+        into a CompositePlot
         """
         subplots = self.traverse(lambda x: x, [GenericElementPlot])
-        merged_tools = {t: list(plot.select({'type': TOOLS[t]})) for t in self._merged_tools}
+        merged_tools = {t: list(plot.select({'type': TOOLS[t]}))
+                        for t in self._merged_tools}
         for subplot in subplots:
             for cb in subplot.callbacks:
                 for c in cb.callbacks:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -12,7 +12,8 @@ from ...core import traversal
 from ...core.options import Compositor, SkipRendering
 from ...core.util import basestring, wrap_tuple, unique_iterator
 from ...element import Histogram
-from ..plot import DimensionedPlot, GenericCompositePlot, GenericLayoutPlot
+from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
+                    GenericElementPlot)
 from ..util import get_dynamic_mode, initialize_sampled
 from .renderer import BokehRenderer
 from .util import (bokeh_version, layout_padding, pad_plots,
@@ -22,6 +23,10 @@ if bokeh_version >= '0.12':
     from bokeh.layouts import gridplot
 else:
     from bokeh.models import GridPlot as BokehGridPlot
+from bokeh.plotting.helpers import _known_tools as known_tools
+
+TOOLS = {name: tool if isinstance(tool, basestring) else type(tool())
+         for name, tool in known_tools.items()}
 
 
 class BokehPlot(DimensionedPlot):
@@ -171,6 +176,23 @@ class CompositePlot(BokehPlot):
           {'title': '15pt'}""")
 
     _title_template = "<span style='font-size: {fontsize}'><b>{title}</b></font>"
+
+    _merged_tools = ['pan', 'box_zoom', 'box_select', 'lasso_select',
+                     'poly_select', 'ypan', 'xpan']
+
+    def _update_callbacks(self, plot):
+        """
+        Updates any callbacks on the subplots.
+        """
+        subplots = self.traverse(lambda x: x, [GenericElementPlot])
+        merged_tools = {t: list(plot.select({'type': TOOLS[t]})) for t in self._merged_tools}
+        for subplot in subplots:
+            for cb in subplot.callbacks:
+                for c in cb.callbacks:
+                    for tool, objs in merged_tools.items():
+                        if tool in c.args and objs:
+                            c.args[tool] = objs[0]
+
 
     def _get_title(self, key):
         title_div = None
@@ -323,14 +345,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                                            if isinstance(subplot, GenericCompositePlot)
                                            else subplot.hmap)
                 subplots[coord] = subplot
-        self.sync_tools(subplots)
         return subplots, collapsed_layout
-
-
-    def sync_tools(self, subplots):
-        tools = list({t for p in subplots.values() for t in p.tools})
-        for plot in subplots.values():
-            plot.tools = tools
 
 
     def initialize_plot(self, ranges=None, plots=[]):
@@ -360,6 +375,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             plot = Column(title, plot)
             self.handles['title'] = title
 
+        self._update_callbacks(plot)
         self.handles['plot'] = plot
         self.handles['plots'] = plots
         if self.shared_datasource:
@@ -648,6 +664,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         if title:
             self.handles['title'] = title
             layout_plot = Column(title, layout_plot)
+
+        self._update_callbacks(layout_plot)
         self.handles['plot'] = layout_plot
         self.handles['plots'] = plots
         if self.shared_datasource:

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -24,6 +24,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
         self.handles = {} if plot is None else self.handles['plot']
         element_ids = self.hmap.traverse(lambda x: id(x), [Dataset, ItemTable])
         self.static = len(set(element_ids)) == 1 and len(self.keys) == len(self.hmap)
+        self.callbacks = [] # Callback support on tables not implemented
 
 
     def get_data(self, element, ranges=None, empty=False):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -72,6 +72,10 @@ class Stream(param.Parameterized):
 
     Streams may have one or more subscribers which are callables passed
     the parameter dictionary when the trigger classmethod is called.
+
+    Depending on the plotting backend certain streams may interactively
+    subscribe to events and changes by the plotting backend. To disable
+    this behavior instantiate the Stream with interactive=False.
     """
 
     # Mapping from a source id to a list of streams
@@ -111,7 +115,8 @@ class Stream(param.Parameterized):
             stream.deactivate()
 
 
-    def __init__(self, preprocessors=[], source=None, subscribers=[], **params):
+    def __init__(self, preprocessors=[], source=None, subscribers=[],
+                 interactive=True, **params):
         """
         Mapping allows multiple streams with similar event state to be
         used by remapping parameter names.
@@ -125,6 +130,7 @@ class Stream(param.Parameterized):
         self.preprocessors = preprocessors
         self._hidden_subscribers = []
         self._metadata = None
+        self.interactive = interactive
 
         super(Stream, self).__init__(**params)
         if source:

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -75,7 +75,7 @@ class Stream(param.Parameterized):
 
     Depending on the plotting backend certain streams may interactively
     subscribe to events and changes by the plotting backend. To disable
-    this behavior instantiate the Stream with interactive=False.
+    this behavior instantiate the Stream with linked=False.
     """
 
     # Mapping from a source id to a list of streams
@@ -116,7 +116,7 @@ class Stream(param.Parameterized):
 
 
     def __init__(self, preprocessors=[], source=None, subscribers=[],
-                 interactive=True, **params):
+                 linked=True, **params):
         """
         Mapping allows multiple streams with similar event state to be
         used by remapping parameter names.
@@ -124,12 +124,15 @@ class Stream(param.Parameterized):
         Source is an optional argument specifying the HoloViews
         datastructure that the stream receives events from, as supported
         by the plotting backend.
+
+        Some streams are configured to automatically link to the source
+        plot, to disable this set linked=False
         """
         self._source = source
         self.subscribers = subscribers
         self.preprocessors = preprocessors
         self._hidden_subscribers = []
-        self.interactive = interactive
+        self.linked = linked
 
         # The metadata may provide information about the currently
         # active event, i.e. the source of the stream values may

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -129,8 +129,12 @@ class Stream(param.Parameterized):
         self.subscribers = subscribers
         self.preprocessors = preprocessors
         self._hidden_subscribers = []
-        self._metadata = None
         self.interactive = interactive
+
+        # The metadata may provide information about the currently
+        # active event, i.e. the source of the stream values may
+        # indicate where the event originated from
+        self._metadata = {}
 
         super(Stream, self).__init__(**params)
         if source:
@@ -264,7 +268,7 @@ class MouseLeave(PositionXY):
     """
 
 
-class PlotDimensions(Stream):
+class PlotSize(Stream):
     """
     Returns the dimensions of a plot once it has been displayed.
     """

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -124,6 +124,7 @@ class Stream(param.Parameterized):
         self.subscribers = subscribers
         self.preprocessors = preprocessors
         self._hidden_subscribers = []
+        self._metadata = None
 
         super(Stream, self).__init__(**params)
         if source:

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -232,6 +232,42 @@ class PositionXY(Stream):
            Position along the y-axis in data coordinates""", constant=True)
 
 
+class Tap(PositionXY):
+    """
+    The x/y-position of a tap or click in data coordinates.
+    """
+
+
+class DoubleTap(PositionXY):
+    """
+    The x/y-position of a double-tap or -click in data coordinates.
+    """
+
+
+class MouseEnter(PositionXY):
+    """
+    The x/y-position where the mouse/cursor entered the plot area
+    in data coordinates.
+    """
+
+
+class MouseLeave(PositionXY):
+    """
+    The x/y-position where the mouse/cursor entered the plot area
+    in data coordinates.
+    """
+
+
+class PlotDimensions(Stream):
+    """
+    Returns the dimensions of a plot once it has been displayed.
+    """
+
+    width = param.Integer(300, doc="The width of the plot in pixels")
+
+    height = param.Integer(300, doc="The height of the plot in pixels")
+
+
 class RangeXY(Stream):
     """
     Axis ranges along x- and y-axis in data coordinates.

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -39,7 +39,7 @@ except:
     sns = None
 
 try:
-    import holoviews.plotting.bokeh
+    from holoviews.plotting.bokeh.util import bokeh_version
     bokeh_renderer = Store.renderers['bokeh']
     from holoviews.plotting.bokeh.callbacks import Callback
     from bokeh.models import (
@@ -499,6 +499,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(main_plot.handles['color_dim'], img.vdims[0])
 
     def test_stream_callback(self):
+        if bokeh_version < str('0.12.5'):
+            raise SkipTest("Bokeh >= 0.12.5 required to test streams")
         dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
@@ -508,17 +510,23 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(data['y'], np.array([-10]))
 
     def test_stream_callback_with_ids(self):
+        if bokeh_version < str('0.12.5'):
+            raise SkipTest("Bokeh >= 0.12.5 required to test streams")
+
         dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
-        hover = plot.state.select(type=HoverTool)[0]
-        plot.callbacks[0].on_msg({"x": {'id': hover.ref['id'], 'value': 10},
-                                  "y": {'id': hover.ref['id'], 'value': -10}})
+        model = plot.state
+        plot.callbacks[0].on_msg({"x": {'id': model.ref['id'], 'value': 10},
+                                  "y": {'id': model.ref['id'], 'value': -10}})
         data = plot.handles['source'].data
         self.assertEqual(data['x'], np.array([10]))
         self.assertEqual(data['y'], np.array([-10]))
 
     def test_stream_callback_single_call(self):
+        if bokeh_version < str('0.12.5'):
+            raise SkipTest("Bokeh >= 0.12.5 required to test streams")
+
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))


### PR DESCRIPTION
Adds support for the upcoming event callbacks in bokeh, currently being developed [here](https://github.com/jlstevens/bokeh/pull/4).

Summary of how it works
===================

1. Check if any of the ``skip_conditions`` apply, if so, skip

2. Grab all the requested ``attributes`` from the models and accumulate them in data

3. Check if there is a ``Comm`` instantiated otherwise open it and store it in a global registry

4. Check if there is a ``comm_state`` for the ``Comm`` otherwise make one defining a ``event_buffer``, a ``blocked`` flag and a ``time``

5. Check whether the comm_state is blocked or has timed out (i.e. ``Date.now()>comm_state.time+timeout``):

   a) if it's blocked put data along with ``cb_obj.event.event_name`` on top of the ``event_buffer``

   b) if it's not blocked also prepend to ``event_buffer`` but also call ``process_event`` with small timeout. The small timeout acts as a debouncing mechanism as new events can be pushed ahead of the original event in the event queue. After process_events is called set the ``comm_state`` to blocked

6. ``process_events`` will iterate over the ``event_buffer`` and filter out older duplicated events. This ensures only the latest event of each type is processed (e.g. to ensure ``panstart``, ``pan`` and ``panend`` are all processed). (Can probably be simplified)

7. In python everything does its thing and sends back a message either acknowledging execution or failure. This message also contains the ``comm_id``, with which the ``comm_state`` is looked up. If there is something on the ``event_buffer`` process it and keep the ``Comm`` blocked, otherwise unblock.

ToDo:

- [x] Update docstring
- [x] Finalize naming for Callback attributes
- [ ] Add tests to ensure callbacks reference correct handles/models
- [ ] Add documentation about defining custom Stream/Callbacks