### PR TITLE
Add support for GridSpace axes in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -149,3 +149,7 @@ options.HeatMap = Options('style', cmap='RdYlBu_r', line_alpha=0)
 # Annotations
 options.HLine = Options('style', line_color=Cycle(), line_width=3, line_alpha=1)
 options.VLine = Options('style', line_color=Cycle(), line_width=3, line_alpha=1)
+
+# Define composite defaults
+options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,
+                             xaxis=None, yaxis=None)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -202,6 +202,19 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     object.
     """
 
+    axis_offset = param.Integer(default=50, doc="""
+        Number of pixels to adjust row and column widths and height by
+        to compensate for shared axes.""")
+
+    fontsize = param.Parameter(default={'title': '16pt'},
+                               allow_None=True,  doc="""
+       Specifies various fontsizes of the displayed text.
+
+       Finer control is available by supplying a dictionary where any
+       unmentioned keys reverts to the default sizes, e.g:
+
+          {'title': '15pt'}""")
+
     shared_xaxis = param.Boolean(default=False, doc="""
         If enabled the x-axes of the GridSpace will be drawn from the
         objects inside the Grid rather than the GridSpace dimensions.""")
@@ -261,16 +274,17 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 vtype = None
 
             # Create axes
+            offset = self.axis_offset
             kwargs = {}
             if c == 0 and r != 0:
                 kwargs['xaxis'] = None
-                kwargs['width'] = self.plot_size+50
+                kwargs['width'] = self.plot_size+offset
             if c != 0 and r == 0:
                 kwargs['yaxis'] = None
-                kwargs['height'] = self.plot_size+50
+                kwargs['height'] = self.plot_size+offset
             if c == 0 and r == 0:
-                kwargs['width'] = self.plot_size+50
-                kwargs['height'] = self.plot_size+50
+                kwargs['width'] = self.plot_size+offset
+                kwargs['height'] = self.plot_size+offset
             if r != 0 and c != 0:
                 kwargs['xaxis'] = None
                 kwargs['yaxis'] = None
@@ -359,15 +373,21 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         if self.xaxis:
             flip = self.shared_xaxis
             rotation = self.xrotation
+            lsize = self._fontsize('xlabel').get('fontsize')
+            tsize = self._fontsize('xticks', common=False).get('fontsize')
             xfactors = list(unique_iterator(self.layout.dimension_values(0)))
             x_axis = make_axis('x', width, xfactors, self.layout.kdims[0],
-                               flip=flip, rotation=rotation)
+                               flip=flip, rotation=rotation, label_size=lsize,
+                               tick_size=tsize)
         if self.yaxis and self.layout.ndims > 1:
             flip = self.shared_yaxis
             rotation = self.yrotation
+            lsize = self._fontsize('ylabel').get('fontsize')
+            tsize = self._fontsize('yticks', common=False).get('fontsize')
             yfactors = list(unique_iterator(self.layout.dimension_values(1)))
             y_axis = make_axis('y', height, yfactors, self.layout.kdims[1],
-                               flip=flip, rotation=rotation)
+                               flip=flip, rotation=rotation, label_size=lsize,
+                               tick_size=tsize)
         if x_axis and y_axis:
             plot = filter_toolboxes(plot)
             r1, r2 = ([y_axis, plot], [None, x_axis])

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -280,7 +280,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             if 'height' not in kwargs or not self.shared_xaxis:
                 kwargs['height'] = self.plot_size
             if 'border' not in kwargs:
-                kwargs['border'] = 0
+                kwargs['border'] = 3
 
             if not self.shared_xaxis:
                 kwargs['xaxis'] = None

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -210,13 +210,13 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         If enabled the x-axes of the GridSpace will be drawn from the
         objects inside the Grid rather than the GridSpace dimensions.""")
 
-    xaxis = param.ObjectSelector(default='bottom',
-                                 objects=['bottom', 'top', None], doc="""
+    xaxis = param.ObjectSelector(default=True,
+                                 objects=['bottom', 'top', None, True, False], doc="""
         Whether and where to display the xaxis, supported options are
         'bottom', 'top' and None.""")
 
-    yaxis = param.ObjectSelector(default='left',
-                                 objects=['left', 'right', None], doc="""
+    yaxis = param.ObjectSelector(default=True,
+                                 objects=['left', 'right', None, True, False], doc="""
         Whether and where to display the yaxis, supported options are
         'left', 'right' and None.""")
 
@@ -263,17 +263,17 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             # Create axes
             kwargs = {}
             if c == 0 and r != 0:
-                kwargs['xaxis'] = 'bottom-bare'
-                kwargs['width'] = self.plot_size+40
+                kwargs['xaxis'] = None
+                kwargs['width'] = self.plot_size+50
             if c != 0 and r == 0:
-                kwargs['yaxis'] = 'left-bare'
-                kwargs['height'] = self.plot_size+40
+                kwargs['yaxis'] = None
+                kwargs['height'] = self.plot_size+50
             if c == 0 and r == 0:
-                kwargs['width'] = self.plot_size+40
-                kwargs['height'] = self.plot_size+40
+                kwargs['width'] = self.plot_size+50
+                kwargs['height'] = self.plot_size+50
             if r != 0 and c != 0:
-                kwargs['xaxis'] = 'bottom-bare'
-                kwargs['yaxis'] = 'left-bare'
+                kwargs['xaxis'] = None
+                kwargs['yaxis'] = None
 
             if 'width' not in kwargs or not self.shared_yaxis:
                 kwargs['width'] = self.plot_size
@@ -283,10 +283,10 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                 kwargs['border'] = 0
 
             if not self.shared_xaxis:
-                kwargs['xaxis'] = 'bottom-bare'
+                kwargs['xaxis'] = None
 
             if not self.shared_yaxis:
-                kwargs['yaxis'] = 'left-bare'
+                kwargs['yaxis'] = None
 
             if isinstance(layout, GridMatrix):
                 if view.traverse(lambda x: x, [Histogram]):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -296,6 +296,8 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             if 'border' not in kwargs:
                 kwargs['border'] = 3
 
+            kwargs['show_legend'] = False
+
             if not self.shared_xaxis:
                 kwargs['xaxis'] = None
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -162,6 +162,7 @@ def layout_padding(plots, renderer):
 
 def make_axis(axis, size, factors, dim, flip=False, rotation=0):
     factors = list(map(dim.pprint_value, factors))
+    nchars = np.max([len(f) for f in factors])
     ranges = FactorRange(factors=factors)
     ranges2 = Range1d(start=0, end=1)
     axis_label = dim_axis_label(dim)
@@ -170,14 +171,14 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0):
     if axis == 'x':
         align = 'center'
         # Adjust height to compensate for label rotation
-        height = int(50 + np.abs(np.sin(rotation)) * 30)
+        height = int(50 + np.abs(np.sin(rotation)) * (nchars*8))
         opts = dict(x_axis_type='auto', x_axis_label=axis_label,
                     x_range=ranges, y_range=ranges2, plot_height=height,
                     plot_width=size)
     else:
         # Adjust width to compensate for label rotation
         align = 'left' if flip else 'right'
-        width = int(80 - np.abs(np.sin(rotation)) * 30)
+        width = int(50 + np.abs(np.cos(rotation)) * (nchars*8))
         opts = dict(y_axis_label=axis_label, x_range=ranges2,
                     y_range=ranges, plot_width=width, plot_height=size)
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -131,10 +131,7 @@ def mpl_to_bokeh(properties):
 
 def layout_padding(plots, renderer):
     """
-    Temporary workaround to allow empty plots in a
-    row of a bokeh GridPlot type. Should be removed
-    when https://github.com/bokeh/bokeh/issues/2891
-    is resolved.
+    Pads Nones in a list of lists of plots with empty plots.
     """
     widths, heights = defaultdict(int), defaultdict(int)
     for r, row in enumerate(plots):

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -168,6 +168,7 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0):
 
     rotation = np.radians(rotation)
     if axis == 'x':
+        align = 'center'
         # Adjust height to compensate for label rotation
         height = int(50 + np.abs(np.sin(rotation)) * 30)
         opts = dict(x_axis_type='auto', x_axis_label=axis_label,
@@ -175,6 +176,7 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0):
                     plot_width=size)
     else:
         # Adjust width to compensate for label rotation
+        align = 'left' if flip else 'right'
         width = int(80 - np.abs(np.sin(rotation)) * 30)
         opts = dict(y_axis_label=axis_label, x_range=ranges2,
                     y_range=ranges, plot_width=width, plot_height=size)
@@ -198,6 +200,8 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0):
             p.left = []
             p.yaxis[:] = p.right
     axis.major_label_orientation = rotation
+    axis.major_label_text_align = align
+    axis.major_label_text_baseline = 'middle'
     return p
 
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -796,6 +796,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
             self.assertIsInstance(grow2, Row)
             self.assertEqual(len(grow1.children), 2)
             self.assertEqual(len(grow2.children), 2)
+            ax_row, grid_row = grow1.children
+            grow1, grow2 = grid_row.children[0].children
             gfig1, gfig2 = grow1.children
             gfig3, gfig4 = grow2.children
             self.assertIsInstance(gfig1, Figure)

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -205,7 +205,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (418, 410))
+        self.assertEqual((w, h), (422, 418))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -205,7 +205,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (440, 410))
+        self.assertEqual((w, h), (418, 410))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -205,7 +205,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (360, 360))
+        self.assertEqual((w, h), (440, 410))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])


### PR DESCRIPTION
Creates outer dimension axes for GridSpaces, like we support in matplotlib:

<img width="505" alt="screen shot 2017-02-25 at 2 21 52 pm" src="https://cloud.githubusercontent.com/assets/1550771/23331834/d40b6b34-fb65-11e6-9866-0cd0c1459c27.png">
