### PR TITLE
Fixed unicode widget templating bug

### DIFF
--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -146,7 +146,7 @@ class NdWidget(param.Parameterized):
         name = type(self).__name__
         cached = str(self.embed).lower()
         load_json = str(self.export_json).lower()
-        mode = repr(self.renderer.mode)
+        mode = str(self.renderer.mode)
         json_path = (self.json_save_path if self.json_load_path is None
                      else self.json_load_path)
         if json_path and json_path[-1] != '/':

--- a/holoviews/plotting/widgets/jsscrubber.jinja
+++ b/holoviews/plotting/widgets/jsscrubber.jinja
@@ -32,7 +32,7 @@
 
         function create_widget() {
             setTimeout(function() {
-                anim{{ id }} = new {{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, {{ mode }}, {{ cached }}, "{{ json_path }}", {{ dynamic }});
+                anim{{ id }} = new {{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
             }, 0);
         }
 

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -235,7 +235,7 @@
     function create_widget() {
         setTimeout(function() {
             anim{{ id }} = new {{ widget_name }}(frame_data, "{{ id }}", widget_ids,
-				keyMap, dim_vals, notFound, {{ load_json }}, {{ mode }},
+				keyMap, dim_vals, notFound, {{ load_json }}, "{{ mode }}",
 				{{ cached }}, "{{ json_path}}", {{ dynamic }});
         }, 0);
     }


### PR DESCRIPTION
The mode parameter wasn't being templated correctly resulting in ``u'somestring'`` showing up in the template.