### PR TITLE
Fixed issue with no colorbar dimension and unicode label

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -600,9 +600,12 @@ class ColorbarPlot(ElementPlot):
 
         # Get colorbar label
         dim = element.get_dimension(dim)
-        if dim is None:
-            dim = element.vdims[0]
-        label = str(dim)
+        if dim:
+            label = dim.pprint_label
+        elif element.vdims:
+            label = element.vdims[0].pprint_label
+        elif dim is None:
+            label = ''
 
         padding = self.cbar_padding
         width = self.cbar_width


### PR DESCRIPTION
Tiny little fix that allows a colorbar to be drawn for data with no corresponding dimension (e.g. aggregated counts) and fixes a usage of ``str(dimension)`` which is not unicode safe.