### PR TITLE
Implement dropping dimensions in gridded groupby

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -102,7 +102,7 @@ class DataConversion(object):
         elif groupby and not isinstance(groupby, list):
             groupby = [groupby]
 
-        if new_type._1d:
+        if self._element.interface.gridded:
             selected = self._element
         else:
             selected = self._element.reindex(groupby+kdims, vdims)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -89,7 +89,10 @@ class DataConversion(object):
                 groupby = kwargs.pop('mdims')
 
         if kdims is None:
-            kdims = self._element.kdims
+            kd_filter = groupby or []
+            if not isinstance(kd_filter, list):
+                kd_filter = [groupby]
+            kdims = [kd for kd in self._element.kdims if kd not in kd_filter]
         elif kdims and not isinstance(kdims, list): kdims = [kdims]
         if vdims is None:
             vdims = self._element.vdims

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -99,7 +99,10 @@ class DataConversion(object):
         elif groupby and not isinstance(groupby, list):
             groupby = [groupby]
 
-        selected = self._element.reindex(groupby+kdims, vdims)
+        if new_type._1d:
+            selected = self._element
+        else:
+            selected = self._element.reindex(groupby+kdims, vdims)
         params = {'kdims': [selected.get_dimension(kd, strict=True) for kd in kdims],
                   'vdims': [selected.get_dimension(vd, strict=True) for vd in vdims],
                   'label': selected.label}

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -83,10 +83,10 @@ class DataConversion(object):
                 raise ValueError('Cannot supply both mdims and groupby')
             else:
                 self._element.warning("'mdims' keyword has been renamed "
-                                      "to groupby; the name mdims is "
+                                      "to 'groupby'; the name mdims is "
                                       "deprecated and will be removed "
                                       "after version 1.7.")
-                groupby = kwargs['mdims']
+                groupby = kwargs.pop('mdims')
 
         if kdims is None:
             kdims = self._element.kdims

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -869,6 +869,14 @@ class GridDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
             partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y')
         self.assertEqual(partial.last['Val'], array[:, -1, :].T.flatten())
 
+    def test_dataset_groupby_drop_dims_dynamic(self):
+        array = np.random.rand(3, 20, 10)
+        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+                     kdims=['x', 'y', 'z'], vdims=['Val'])
+        with DatatypeContext([self.datatype, 'columns', 'dataframe']):
+            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y', dynamic=True)
+            self.assertEqual(partial[19]['Val'], array[:, -1, :].T.flatten())
+
 
 class IrisDatasetTest(GridDatasetTest):
     """

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -23,6 +23,20 @@ except:
     dd = None
 
 
+class DatatypeContext(object):
+
+    def __init__(self, datatypes):
+        self.datatypes = datatypes
+        self._old_datatypes = None
+
+    def __enter__(self):
+        self._old_datatypes = Dataset.datatype
+        Dataset.datatype = self.datatypes
+
+    def __exit__(self, *args):
+        Dataset.datatype = self._old_datatypes
+
+
 class HomogeneousColumnTypes(object):
     """
     Tests for data formats that require all dataset to have the same
@@ -593,6 +607,8 @@ class GridDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
     Test of the Grid array interface
     """
 
+    datatype = 'grid'
+
     def setUp(self):
         self.restore_datatype = Dataset.datatype
         Dataset.datatype = ['grid']
@@ -845,11 +861,21 @@ class GridDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
         for c, d in keys:
             self.assertEqual(grouped[c, d], dataset.select(c=c, d=d).reindex(['a', 'b']))
 
+    def test_dataset_groupby_drop_dims(self):
+        array = np.random.rand(3, 20, 10)
+        ds = Dataset({'x': range(10), 'y': range(20), 'z': range(3), 'Val': array},
+                     kdims=['x', 'y', 'z'], vdims=['Val'])
+        with DatatypeContext([self.datatype, 'columns', 'dataframe']):
+            partial = ds.to(Dataset, kdims=['x'], vdims=['Val'], groupby='y')
+        self.assertEqual(partial.last['Val'], array[:, -1, :].T.flatten())
+
 
 class IrisDatasetTest(GridDatasetTest):
     """
     Tests for Iris interface
     """
+
+    datatype = 'cube'
 
     def setUp(self):
         import iris
@@ -900,6 +926,8 @@ class XArrayDatasetTest(GridDatasetTest):
     """
     Tests for Iris interface
     """
+
+    datatype = 'xarray'
 
     def setUp(self):
         import xarray


### PR DESCRIPTION
When using the ``.to`` method to convert a gridded dataset into lower dimensional views it is possible to drop dimensions, e.g. to visualize the distribution of values in some space. Think for example of a 3D cube of temperatures (lat * lon * altitude) . I want to view the distribution of values for each altitude, dropping the lat and lon dimensions. Previously we supported this in some limited cases but there's a simple solution to the problem, when applying a groupby on a gridded dataset which drops certain dimensions we simply convert to a columnar format. This will only affect the ``.to`` method which is meant specifically to convert high-dimensional data into a lower dimensional view so I think it's consistent with the overall semantics.