### PR TITLE
Fixed reraising of plotting exceptions

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -136,9 +136,12 @@ def display_hook(fn):
             return "<b>{name}</b>{msg}<br>{message}".format(msg=msg, **info)
 
         except Exception as e:
+            t, v, tb = sys.exc_info()
             try: option_state(element, state=optstate)
-            except: pass
-            raise
+            except Exception: pass
+            if sys.version_info[0] < 3:
+                raise (t, v, tb)
+            raise v.with_traceback(tb)
     return wrapped
 
 


### PR DESCRIPTION
This has been plaguing me for a long time. In python2 I **always** get these exceptions when there's an issue with the options. I think this is due to the nested try/excepts. Reraising an exception in this way differs slightly between py2 and py3 hence extra conditional. 

```
TypeError: exceptions must be old-style classes or derived from BaseException, not NoneType
```