### PR TITLE
Consistent handing of axis label and tick fontsize

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -384,7 +384,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             opts = dict(text=title, text_color='black')
             title_font = self._fontsize('title').get('fontsize')
             if title_font:
-                opts['title_text_font_size'] = value(title_font)
+                opts['text_font_size'] = value(title_font)
             return opts
 
     def _init_axes(self, plot):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -381,10 +381,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             title_font = self._fontsize('title', 'title_text_font_size')
             return dict(title=title, title_text_color='black', **title_font)
         else:
-            title_font = self._fontsize('title', 'text_font_size')
-            title_font['text_font_size'] = value(title_font['text_font_size'])
-            return dict(text=title, text_color='black', **title_font)
-
+            opts = dict(text=title, text_color='black')
+            title_font = self._fontsize('title').get('fontsize')
+            if title_font:
+                opts['title_text_font_size'] = value(title_font)
+            return opts
 
     def _init_axes(self, plot):
         if self.xaxis is None:
@@ -420,6 +421,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             axis_props['major_tick_line_color'] = None
             axis_props['minor_tick_line_color'] = None
         else:
+            labelsize = self._fontsize('%slabel' % axis).get('fontsize')
+            if labelsize:
+                axis_props['axis_label_text_font_size'] = labelsize
+            ticksize = self._fontsize('%sticks' % axis, common=False).get('fontsize')
+            if ticksize:
+                axis_props['major_label_text_font_size'] = value(ticksize)
             rotation = self.xrotation if axis == 'x' else self.yrotation
             if rotation:
                 axis_props['major_label_orientation'] = np.radians(rotation)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -248,8 +248,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             self._set_axis_ticks(axis.zaxis, zticks, log=self.logz,
                                  rotation=self.zrotation)
 
-        tick_fontsize = self._fontsize('ticks','labelsize',common=False)
-        if tick_fontsize: axis.tick_params(**tick_fontsize)
+        for ax, ax_obj in zip('xy', [axis.xaxis, axis.yaxis]):
+            tick_fontsize = self._fontsize('%sticks' % ax,'labelsize',common=False)
+            if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 
 
     def _finalize_artist(self, element):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -453,9 +453,9 @@ class GridPlot(CompositePlot):
             layout_axis.set_position(self.position)
         layout_axis.patch.set_visible(False)
 
-        for ax, ax_obj in zip('xy', [layout_axis.xaxis, layout_axis.yaxis]):
-            tick_fontsize = self._fontsize('%ticks' % ax,'labelsize',common=False)
-            if tick_fontsize: ax_obj.tick_params(**tick_fontsize)
+        for ax, ax_obj in zip(['x', 'y'], [layout_axis.xaxis, layout_axis.yaxis]):
+            tick_fontsize = self._fontsize('%sticks' % ax,'labelsize', common=False)
+            if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 
         # Set labels
         layout_axis.set_xlabel(str(layout.kdims[0]),

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -453,8 +453,9 @@ class GridPlot(CompositePlot):
             layout_axis.set_position(self.position)
         layout_axis.patch.set_visible(False)
 
-        tick_fontsize = self._fontsize('ticks','labelsize',common=False)
-        if tick_fontsize: layout_axis.tick_params(**tick_fontsize)
+        for ax, ax_obj in zip('xy', [layout_axis.xaxis, layout_axis.yaxis]):
+            tick_fontsize = self._fontsize('%ticks' % ax,'labelsize',common=False)
+            if tick_fontsize: ax_obj.tick_params(**tick_fontsize)
 
         # Set labels
         layout_axis.set_xlabel(str(layout.kdims[0]),

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -158,7 +158,8 @@ class DimensionedPlot(Plot):
 
     #Allowed fontsize keys
     _fontsize_keys = ['xlabel','ylabel', 'labels', 'ticks',
-                      'title', 'legend', 'legend_title']
+                      'title', 'legend', 'legend_title', 'xticks',
+                      'yticks']
 
     show_title = param.Boolean(default=True, doc="""
         Whether to display the plot title.""")
@@ -298,6 +299,8 @@ class DimensionedPlot(Plot):
             return {label:self.fontsize[key]}
         elif key in ['ylabel', 'xlabel'] and 'labels' in self.fontsize:
             return {label:self.fontsize['labels']}
+        elif key in ['xticks', 'yticks'] and 'ticks' in self.fontsize:
+            return {label:self.fontsize['ticks']}
         else:
             return {}
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -695,6 +695,54 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(plot.handles['x_range'].start, np.datetime64(dt.datetime(2016, 1, 1)))
         self.assertEqual(plot.handles['x_range'].end, np.datetime64(dt.datetime(2016, 1, 13)))
 
+    def test_curve_fontsize_xlabel(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'xlabel': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['xaxis'].axis_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_ylabel(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'ylabel': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['yaxis'].axis_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_both_labels(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'labels': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['xaxis'].axis_label_text_font_size,
+                         {'value': '14pt'})
+        self.assertEqual(plot.handles['yaxis'].axis_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_xticks(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'xticks': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_yticks(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'yticks': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['yaxis'].major_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_both_ticks(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'ticks': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
+                         {'value': '14pt'})
+        self.assertEqual(plot.handles['yaxis'].major_label_text_font_size,
+                         {'value': '14pt'})
+
+    def test_curve_fontsize_xticks_and_both_ticks(self):
+        curve = Curve(range(10))(plot=dict(fontsize={'xticks': '18pt', 'ticks': '14pt'}))
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.handles['xaxis'].major_label_text_font_size,
+                         {'value': '18pt'})
+        self.assertEqual(plot.handles['yaxis'].major_label_text_font_size,
+                         {'value': '14pt'})
+
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
                              for j in range(2,4)}) +


### PR DESCRIPTION
Also adds support for setting xticks and yticks size independently the same way xlabel and ylabel can be set independently. The bokeh backend wasn't respecting the axis label and tick font sizes previously.