### PR TITLE
Fix Dynamic utility operation parameter updates

### DIFF
--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -50,8 +50,10 @@ class Dynamic(param.ParameterizedFunction):
                 elif not isinstance(stream, Stream):
                     raise ValueError('Stream must only contain Stream '
                                      'classes or instances')
-                stream.update(**{k: self.p.operation.p.get(k, v) for k, v in
-                                 stream.contents.items()})
+                updates = {k: self.p.operation.p.get(k) for k, v in stream.contents.items()
+                           if v is None and k in self.p.operation.p}
+                if updates:
+                    stream.update(trigger=False, **updates)
                 streams.append(stream)
             return dmap.clone(streams=streams)
         return dmap


### PR DESCRIPTION
The ``Dynamic`` utility allows applying an operation dynamically. When applying an operation with a stream in this way currently the stream is updated with all the operations parameters. This is problematic for two reasons, it overrides defaults you've set on your stream and it currently triggers the stream to update which can cause bad loops.

This PR ensures that the stream only inherits parameter values which are not already defined on the stream and ensures that simply applying the dynamic operation does not trigger stream subscribers to be notified.