### PR TITLE
Temporarily pin dask on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh=0.12.3 pandas jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy numpy freetype nose bokeh=0.12.3 pandas jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader dask=0.13
   - source activate test-environment
   - conda install -c conda-forge  -c scitools iris sip=4.18 plotly flexx
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then


### PR DESCRIPTION
Currently tests are failing because dask 0.14 no longer supports the ``sort`` argument to groupby. I've pinged the person responsible on the dask team, so we can clarify whether sort can be supported as it seemingly was in dask 0.13.0 or whether the removal of it was deliberate and it can't be supported. In the meantime pinning it will ensure our tests pass.