### PR TITLE
Timeseries operations

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -103,6 +103,10 @@ class ElementOperation(Operation):
        first component is a Normalization.ranges list and the second
        component is Normalization.keys. """)
 
+    streams = param.List(default=[], doc="""
+        List of streams that are applied if dynamic=True, allowing
+        for dynamic interaction with the plot.""")
+
     def _process(self, view, key=None):
         """
         Process a single input element and outputs new single element

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -32,7 +32,7 @@ def discover(dataset):
     Allows datashader to correctly discover the dtypes of the data
     in a holoviews Element.
     """
-    return dsdiscover(PandasInterface.as_dframe(element))
+    return dsdiscover(PandasInterface.as_dframe(dataset))
 
 
 @bypixel.pipeline.register(Element)
@@ -149,7 +149,7 @@ class aggregate(ElementOperation):
             vdims = element.vdims
         elif isinstance(obj, Element):
             glyph = 'line' if isinstance(obj, Curve) else 'points'
-            paths.append(obj.data if is_df(obj) else obj.dframe())
+            paths.append(PandasInterface.as_dframe(obj))
         if len(paths) > 1:
             if glyph == 'line':
                 path = paths[0][:1]

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -647,7 +647,7 @@ class interpolate_curve(ElementOperation):
         steps[1:, 1::2] = steps[1:, 0:-2:2]
         return steps
 
-    def _process(self, element, key=None):
+    def _apply(self, element, key=None):
         INTERPOLATE_FUNCS = {'steps-pre': self.pts_to_prestep,
                              'steps-mid': self.pts_to_midstep,
                              'steps-post': self.pts_to_poststep}
@@ -657,6 +657,9 @@ class interpolate_curve(ElementOperation):
         array = INTERPOLATE_FUNCS[self.p.interpolation](x, y)
         dvals = tuple(element.dimension_values(d) for d in element.dimensions()[2:])
         return element.clone((array[0, :], array[1, :])+dvals)
+
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)
 
 
 #==================#

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -575,7 +575,7 @@ class decimate(ElementOperation):
        The x_range as a tuple of min and max y-value. Auto-ranges
        if set to None.""")
 
-    def _apply(self, element, key=None):
+    def _process_layer(self, element, key=None):
         if not isinstance(element, Dataset):
             raise ValueError("Cannot downsample non-Dataset types.")
         if element.interface not in column_interfaces:
@@ -605,7 +605,7 @@ class decimate(ElementOperation):
         return sliced
 
     def _process(self, element, key=None):
-        return element.map(self._apply, Element)
+        return element.map(self._process_layer, Element)
 
 
 class interpolate_curve(ElementOperation):
@@ -647,7 +647,7 @@ class interpolate_curve(ElementOperation):
         steps[1:, 1::2] = steps[1:, 0:-2:2]
         return steps
 
-    def _apply(self, element, key=None):
+    def _process_layer(self, element, key=None):
         INTERPOLATE_FUNCS = {'steps-pre': self.pts_to_prestep,
                              'steps-mid': self.pts_to_midstep,
                              'steps-post': self.pts_to_poststep}
@@ -659,7 +659,7 @@ class interpolate_curve(ElementOperation):
         return element.clone((array[0, :], array[1, :])+dvals)
 
     def _process(self, element, key=None):
-        return element.map(self._apply, Element)
+        return element.map(self._process_layer, Element)
 
 
 #==================#

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -575,7 +575,7 @@ class decimate(ElementOperation):
        The x_range as a tuple of min and max y-value. Auto-ranges
        if set to None.""")
 
-    def _process(self, element, key=None):
+    def _apply(self, element, key=None):
         if not isinstance(element, Dataset):
             raise ValueError("Cannot downsample non-Dataset types.")
         if element.interface not in column_interfaces:
@@ -604,7 +604,8 @@ class decimate(ElementOperation):
             sliced = element.clone(data)
         return sliced
 
-
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)
 
 
 class interpolate_curve(ElementOperation):

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -42,14 +42,37 @@ class rolling(ElementOperation):
     function = param.Callable(default=np.mean, doc="""
         The function to apply over the rolling window.""")
 
+    min_periods = param.Integer(default=None, doc="""
+       Minimum number of observations in window required to have a
+       value (otherwise result is NA).""")
+
     rolling_window = param.Integer(default=10, doc="""
         The window size over which to apply the function.""")
+
+    window_type = param.ObjectSelector(default=None,
+        objects=['boxcar', 'triang', 'blackman', 'hamming', 'bartlett',
+                 'parzen', 'bohman', 'blackmanharris', 'nuttall',
+                 'barthann', 'kaiser', 'gaussian', 'general_gaussian',
+                 'slepian'], doc="The type of the window to apply")
 
     def _apply(self, element, key=None):
         xdim = element.kdims[0].name
         df = get_df_data(element)
-        df = df.set_index(xdim).rolling(window=self.p.rolling_window, center=self.p.center)
-        return element.clone(df.apply(self.p.function).reset_index())
+        roll_kwargs = {'window': self.p.rolling_window,
+                       'center': self.p.center,
+                       'win_type': self.p.window_type,
+                       'min_periods': self.p.min_periods}
+        df = df.set_index(xdim).rolling(**roll_kwargs)
+        if roll_kwargs['window'] is None:
+            rolled = df.apply(self.p.function)
+        else:
+            if self.p.function is np.mean:
+                rolled = df.mean()
+            elif self.p.function is np.sum:
+                rolled = df.sum()
+            else:
+                raise ValueError("Rolling window function only supports mean and sum")
+        return element.clone(rolled.reset_index())
 
     def _process(self, element, key=None):
         return element.map(self._apply, Element)
@@ -60,11 +83,14 @@ class resample(ElementOperation):
     Resamples a timeseries of dates with a frequency and function
     """
 
-    edge = param.ObjectSelector(default='right', doc="""
-        The bin edge to label the bin with.""")
+    closed = param.ObjectSelector(default=None, objects=['left', 'right'],
+        doc="Which side of bin interval is closed")
 
     function = param.Callable(default=np.mean, doc="""
         The function to apply over the rolling window.""")
+
+    label = param.ObjectSelector(default='right', doc="""
+        The bin edge to label the bin with.""")
 
     rule = param.String(default='D', doc="""
         A string representing the time interval over which to apply the resampling""")
@@ -72,7 +98,9 @@ class resample(ElementOperation):
     def _apply(self, element, key=None):
         xdim = element.kdims[0].name
         df = get_df_data(element)
-        df = df.set_index(xdim).resample(rule=self.p.rule, label=self.p.edge)
+        resample_kwargs = {'rule': self.p.rule, 'label': self.p.label,
+                           'closed': self.p.closed}
+        df = df.set_index(xdim).resample(**resample_kwargs)
         return element.clone(df.apply(self.p.function).reset_index())
 
     def _process(self, element, key=None):
@@ -81,7 +109,7 @@ class resample(ElementOperation):
 
 class rolling_outlier_std(ElementOperation):
     """
-    Detect outliers for using the standard devitation within a rolling window.
+    Detect outliers using the standard deviation within a rolling window.
 
     Outliers are the array elements outside `sigma` standard deviations from
     the smoothed trend line, as calculated from the trend line residuals.
@@ -104,7 +132,7 @@ class rolling_outlier_std(ElementOperation):
 
         # Get indices of outliers
         outliers = (np.abs(residual) > std * sigma).values
-        return element[outliers].clone(new_type=Scatter, group='Outliers')
+        return element[outliers].clone(new_type=Scatter)
 
     def _process(self, element, key=None):
         return element.map(self._apply, Element)

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -6,6 +6,54 @@ from ..core.util import pd
 from ..element import Scatter
 
 
+class rolling(ElementOperation):
+    """
+    Applies a function over a rolling window.
+    """
+
+    center = param.Boolean(default=True, doc="""
+        Whether to set the x-coordinate at the center or right edge
+        of the window.""")
+
+    function = param.Callable(default=np.mean, doc="""
+        The function to apply over the rolling window.""")
+
+    rolling_window = param.Integer(default=10, doc="""
+        The window size over which to apply the function.""")
+
+    def _apply(self, element, key=None):
+        xdim = element.kdims[0].name
+        df = df.rolling(window=self.p.rolling_window, center=self.p.center, on=xdim)
+        return element.clone(df.apply(self.p.function).reset_index())
+
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)
+
+
+class resample(ElementOperation):
+    """
+    Resamples a timeseries of dates with a frequency and function
+    """
+
+    edge = param.ObjectSelector(default='right', doc="""
+        The bin edge to label the bin with.""")
+
+    function = param.Callable(default=np.mean, doc="""
+        The function to apply over the rolling window.""")
+
+    rule = param.String(default='D', doc="""
+        A string representing the time interval over which to apply the resampling""")
+
+    def _apply(self, element, key=None):
+        xdim = element.kdims[0].name
+        df = element.dframe()
+        df = df.resample(rule=self.p.rule, label=self.p.edge, on=xdim)
+        return element.clone(df.apply(self.p.function).reset_index())
+
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)
+
+
 class rolling_outlier_std(ElementOperation):
     """
     Detect outliers for using the standard devitation within a rolling window.
@@ -32,31 +80,6 @@ class rolling_outlier_std(ElementOperation):
         # Get indices of outliers
         outliers = (np.abs(residual) > std * sigma).values
         return element[outliers].clone(new_type=Scatter, group='Outliers')
-
-    def _process(self, element, key=None):
-        return element.map(self._apply, Element)
-
-
-class rolling(ElementOperation):
-    """
-    Applies a function over a rolling window.
-    """
-
-    center = param.Boolean(default=False, doc="""
-        Whether to set the x-coordinate at the center or right edge
-        of the window.""")
-
-    function = param.Callable(default=np.mean, doc="""
-        The function to apply over the rolling window.""")
-
-    rolling_window = param.Integer(default=10, doc="""
-        The window size over which to apply the function.""")
-
-    def _apply(self, element, key=None):
-        df = element.dframe().set_index(element.kdims[0].name)
-        df = df.rolling(window=self.p.rolling_window,
-                        center=self.p.center).apply(self.p.function)
-        return element.clone(df.reset_index())
 
     def _process(self, element, key=None):
         return element.map(self._apply, Element)

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -1,0 +1,62 @@
+import numpy as np
+import param
+
+from ..core import ElementOperation, Element
+from ..core.util import pd
+from ..element import Scatter
+
+
+class rolling_outlier_std(ElementOperation):
+    """
+    Detect outliers for using the standard devitation within a rolling window.
+
+    Outliers are the array elements outside `sigma` standard deviations from
+    the smoothed trend line, as calculated from the trend line residuals.
+    """
+
+    rolling_window = param.Integer(default=10, doc="""
+        The window size of which within the rolling std is computed.""")
+
+    sigma = param.Number(default=2.0, doc="""
+        Minimum sigma before a value is considered an outlier.""")
+
+    def _apply(self, element, key=None):
+        sigma, window = self.p.sigma, self.p.rolling_window
+        ys = element.dimension_values(1)
+
+        # Calculate the variation in the distribution of the residual
+        avg = pd.Series(ys).rolling(window, center=True).mean()
+        residual = ys - avg
+        std = pd.Series(residual).rolling(window, center=True).std()
+
+        # Get indices of outliers
+        outliers = (np.abs(residual) > std * sigma).values
+        return element[outliers].clone(new_type=Scatter, group='Outliers')
+
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)
+
+
+class rolling(ElementOperation):
+    """
+    Applies a function over a rolling window.
+    """
+
+    center = param.Boolean(default=False, doc="""
+        Whether to set the x-coordinate at the center or right edge
+        of the window.""")
+
+    function = param.Callable(default=np.mean, doc="""
+        The function to apply over the rolling window.""")
+
+    rolling_window = param.Integer(default=10, doc="""
+        The window size over which to apply the function.""")
+
+    def _apply(self, element, key=None):
+        df = element.dframe().set_index(element.kdims[0].name)
+        df = df.rolling(window=self.p.rolling_window,
+                        center=self.p.center).apply(self.p.function)
+        return element.clone(df.reset_index())
+
+    def _process(self, element, key=None):
+        return element.map(self._apply, Element)

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -32,9 +32,9 @@ class rolling(ElementOperation):
                  'barthann', 'kaiser', 'gaussian', 'general_gaussian',
                  'slepian'], doc="The type of the window to apply")
 
-    def _apply(self, element, key=None):
+    def _process_layer(self, element, key=None):
         xdim = element.kdims[0].name
-        df = PandasInterface.as_df(element)
+        df = PandasInterface.as_dframe(element)
         roll_kwargs = {'window': self.p.rolling_window,
                        'center': self.p.center,
                        'win_type': self.p.window_type,
@@ -53,7 +53,7 @@ class rolling(ElementOperation):
         return element.clone(rolled.reset_index())
 
     def _process(self, element, key=None):
-        return element.map(self._apply, Element)
+        return element.map(self._process_layer, Element)
 
 
 class resample(ElementOperation):
@@ -73,8 +73,8 @@ class resample(ElementOperation):
     rule = param.String(default='D', doc="""
         A string representing the time interval over which to apply the resampling""")
 
-    def _apply(self, element, key=None):
-        df = PandasInterface.as_df(element)
+    def _process_layer(self, element, key=None):
+        df = PandasInterface.as_dframe(element)
         xdim = element.kdims[0].name
         resample_kwargs = {'rule': self.p.rule, 'label': self.p.label,
                            'closed': self.p.closed}
@@ -82,7 +82,7 @@ class resample(ElementOperation):
         return element.clone(df.apply(self.p.function).reset_index())
 
     def _process(self, element, key=None):
-        return element.map(self._apply, Element)
+        return element.map(self._process_layer, Element)
 
 
 class rolling_outlier_std(ElementOperation):
@@ -99,7 +99,7 @@ class rolling_outlier_std(ElementOperation):
     sigma = param.Number(default=2.0, doc="""
         Minimum sigma before a value is considered an outlier.""")
 
-    def _apply(self, element, key=None):
+    def _process_layer(self, element, key=None):
         sigma, window = self.p.sigma, self.p.rolling_window
         ys = element.dimension_values(1)
 
@@ -113,4 +113,4 @@ class rolling_outlier_std(ElementOperation):
         return element[outliers].clone(new_type=Scatter)
 
     def _process(self, element, key=None):
-        return element.map(self._apply, Element)
+        return element.map(self._process_layer, Element)

--- a/tests/testtimeseriesoperations.py
+++ b/tests/testtimeseriesoperations.py
@@ -1,0 +1,68 @@
+import pandas as pd
+import numpy as np
+
+from holoviews import Curve, Scatter
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.operation.timeseries import (rolling, resample, rolling_outlier_std)
+
+
+class TimeseriesOperationTests(ComparisonTestCase):
+    """
+    Tests for the various timeseries operations including rolling,
+    resample and rolling_outliers_std.
+    """
+
+    def setUp(self):
+        self.dates = pd.date_range("2016-01-01", "2016-01-07", freq='D')
+        self.values = [1, 2, 3, 4, 5, 6, 7]
+        self.outliers = [1, 2, 1, 2, 10., 2, 1]
+        self.date_curve = Curve((self.dates, self.values))
+        self.int_curve = Curve(self.values)
+        self.date_outliers = Curve((self.dates, self.outliers))
+        self.int_outliers = Curve(self.outliers)
+
+    def test_roll_dates(self):
+        rolled = rolling(self.date_curve, rolling_window=2)
+        rolled_vals = [np.NaN, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
+        self.assertEqual(rolled, Curve((self.dates, rolled_vals)))
+
+    def test_roll_ints(self):
+        rolled = rolling(self.int_curve, rolling_window=2)
+        rolled_vals = [np.NaN, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5]
+        self.assertEqual(rolled, Curve(rolled_vals))
+
+    def test_roll_date_with_window_type(self):
+        rolled = rolling(self.date_curve, rolling_window=3, window_type='triang')
+        rolled_vals = [np.NaN, 2, 3, 4, 5, 6, np.NaN]
+        self.assertEqual(rolled, Curve((self.dates, rolled_vals)))
+        
+    def test_roll_ints_with_window_type(self):
+        rolled = rolling(self.int_curve, rolling_window=3, window_type='triang')
+        rolled_vals = [np.NaN, 2, 3, 4, 5, 6, np.NaN]
+        self.assertEqual(rolled, Curve(rolled_vals))
+
+    def test_resample_weekly(self):
+        resampled = resample(self.date_curve, rule='W')
+        dates = list(map(pd.Timestamp, ["2016-01-03", "2016-01-10"]))		
+        vals = [2, 5.5]
+        self.assertEqual(resampled, Curve((dates, vals)))
+
+    def test_resample_weekly_closed_left(self):
+        resampled = resample(self.date_curve, rule='W', closed='left')
+        dates = list(map(pd.Timestamp, ["2016-01-03", "2016-01-10"]))		
+        vals = [1.5, 5]
+        self.assertEqual(resampled, Curve((dates, vals)))
+
+    def test_resample_weekly_label_left(self):
+        resampled = resample(self.date_curve, rule='W', label='left')
+        dates = list(map(pd.Timestamp, ["2015-12-27", "2016-01-03"]))
+        vals = [2, 5.5]
+        self.assertEqual(resampled, Curve((dates, vals)))
+
+    def test_rolling_outliers_std_ints(self):
+        outliers = rolling_outlier_std(self.int_outliers, rolling_window=2, sigma=1)
+        self.assertEqual(outliers, Scatter([(4, 10)]))
+
+    def test_rolling_outliers_std_dates(self):
+        outliers = rolling_outlier_std(self.date_outliers, rolling_window=2, sigma=1)
+        self.assertEqual(outliers, Scatter([(pd.Timestamp("2016-01-05"), 10)]))


### PR DESCRIPTION
Some basic operations to work with timeseries, the outlier detection is very useful in combination with datashader because it lets you get hover information about the outliers. Needs tests and support for datetime types.

Until we sort out input/output specifications on operations, I'm handling unpacking of (Nd)Overlays with a .map call in the ``_process`` method. 

I've also added a ``streams`` parameter to ``ElementOperation`` by default. It was already supported API and I've found myself wanting to attach custom streams (based on paramnb) to existing ElementOperations and not being able to. Here's the pattern I'm talking about, in the following code there are two streams one for the ranges shared amongst the data loading, datashading and decimate operations, and ``self`` which is a class defined for paramnb which controls the rolling window and sigma parameters of the smoothing and outlier detection operations:

```python
stream = RangeXY()

# Define DynamicMap to load dataset based on stream parameters
dmap = hv.DynamicMap(self.load_data, kdims=[], streams=[self])

# Apply rolling mean with the window controlled by stream 
smoothed = rolling(dmap, streams=[self])

# Apply steps interpolation
smoothed = interpolate_curve(dmap)

# Datashade based on ranges
smoothed = datashade(smoothed, cmap=get_cmap('Set1'),
                     aggregator=ds.count_cat('Conf'),
                     width=675, height=300, streams=[stream])

# Compute outliers with window and sigma controlled by stream
outliers = rolling_outlier_std(dmap, streams=[self])

# Decimate outliers only based on current range
outliers = decimate(outliers, streams=[stream])

# Overlay dynamically smoothed, interpolated, datashaded timeseries
# with dynamically decimated outliers
smoothed * outliers
```