### PR TITLE
fix datashade import from .operation

### DIFF
--- a/holoviews/operation/__init__.py
+++ b/holoviews/operation/__init__.py
@@ -3,6 +3,7 @@ from ..core.options import Compositor
 
 from .element import *      # noqa (API import)
 from ..core import Overlay  # noqa (API import)
+from .datashader import datashade
 
 def public(obj):
     if not isinstance(obj, type): return False


### PR DESCRIPTION
This is a one-line fix to allow `from holoviews.operations import datashade` .  See also issue #1176 that mentioned the import error.