### PR TITLE
Small fixes for hover tools

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -103,7 +103,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
 
     def get_batched_data(self, element, ranges=None, empty=False):
         data = defaultdict(list)
-        for key, el in element.items():
+        for key, el in element.data.items():
             style = self.lookup_options(el, 'style')
             style = style.max_cycles(len(self.ordering))
             self.set_param(**self.lookup_options(el, 'plot').options)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -110,13 +110,20 @@ class PointPlot(LegendPlot, ColorbarPlot):
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].append(eld)
+
+            nvals = len(data[k][-1])
             if 'color' not in elmapping:
                 zorder = self.get_zorder(element, key, el)
                 val = style[zorder].get('color')
                 elmapping['color'] = 'color'
                 if isinstance(val, tuple):
                     val = rgb2hex(val)
-                data['color'].append([val]*len(data[k][-1]))
+                data['color'].append([val]*nvals)
+
+            if any(isinstance(t, HoverTool) for t in self.state.tools):
+                for dim, k in zip(element.dimensions(), key):
+                    sanitized = dimension_sanitizer(dim.name)
+                    data[sanitized].append([k]*nvals)
         data = {k: np.concatenate(v) for k, v in data.items()}
         return data, elmapping
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -211,7 +211,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             dims = list(self.overlay_dims.keys())
         dims += element.dimensions()
-        return dims, {}
+        return list(util.unique_iterator(dims)), {}
 
     def _init_tools(self, element, callbacks=[]):
         """
@@ -249,13 +249,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if not any(isinstance(t, HoverTool) for t in self.state.tools):
             return
 
-        for d in element.dimensions(label=True):
-            sanitized = util.dimension_sanitizer(d)
-            data[sanitized] = [] if empty else element.dimension_values(d)
+        for d in element.dimensions():
+            dim = util.dimension_sanitizer(d.name)
+            if dim not in data:
+                data[dim] = element.dimension_values(d)
 
         for k, v in self.overlay_dims.items():
             dim = util.dimension_sanitizer(k.name)
-            data[dim] = [v for _ in range(len(list(data.values())[0]))]
+            if dim not in data:
+                data[dim] = [v for _ in range(len(list(data.values())[0]))]
 
 
     def _axes_props(self, plots, subplots, element, ranges):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -282,6 +282,14 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(hover[0].tooltips, tooltips)
         self.assertEqual(hover[0].line_policy, line_policy)
 
+    def test_points_overlay_hover_batched(self):
+        obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},
+                        kdims=['Test'])
+        opts = {'Points': {'tools': ['hover']},
+                'NdOverlay': {'legend_limit': 0}}
+        obj = obj(plot=opts)
+        self._test_hover_info(obj, [('Test', '@Test'), ('x', '@x'), ('y', '@y')])
+
     def test_curve_overlay_hover_batched(self):
         obj = NdOverlay({i: Curve(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])


### PR DESCRIPTION
Fixes a bug in the hover tool specification in a batched OverlayPlot of Points.

Before:

<img width="152" alt="screen shot 2017-03-06 at 7 54 55 pm" src="https://cloud.githubusercontent.com/assets/1550771/23627000/d6a81ac0-02a6-11e7-887d-2b98b6dc1e59.png">

After:

<img width="103" alt="screen shot 2017-03-06 at 7 55 45 pm" src="https://cloud.githubusercontent.com/assets/1550771/23627025/edffd2c6-02a6-11e7-937c-a06f98d886e9.png">