### PR TITLE
Fixed handling of shared_axes

### DIFF
--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -939,6 +939,25 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].formatter, FuncTickFormatter)
 
+    def test_shared_axes(self):
+        curve = Curve(range(10))
+        img = Image(np.random.rand(10,10))
+        plot = bokeh_renderer.get_plot(curve+img)
+        plot = plot.subplots[(0, 1)].subplots['main']
+        x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
+        self.assertEqual((x_range.start, x_range.end), (-.5, 9))
+        self.assertEqual((y_range.start, y_range.end), (-.5, 9))
+
+    def test_shared_axes_disable(self):
+        curve = Curve(range(10))
+        img = Image(np.random.rand(10,10))(plot=dict(shared_axes=False))
+        plot = bokeh_renderer.get_plot(curve+img)
+        plot = plot.subplots[(0, 1)].subplots['main']
+        x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
+        self.assertEqual((x_range.start, x_range.end), (-.5, .5))
+        self.assertEqual((y_range.start, y_range.end), (-.5, .5))
+
+
 
 class TestPlotlyPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
The bokeh backend supports a shared axes option which allows axes with the same axis labels to be linked. The current approach taken here is not quite correct because the plot doesn't remember that an axis is shared so it will simply override extents set by a different plot. Secondly setting ``x/yaxis='bare'`` will currently disable ``shared_axes`` because it removes the axis label.

While this behavior is a lot more consistent, we might want to consider disabling it by default in some cases (e.g. on a simply ``Layout``) because it can interfere with axiswise normalization.