### PR TITLE
Gridmatrix diagonal types

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -144,7 +144,7 @@ class Dataset(Element):
 
     # In the 1D case the interfaces should not automatically add x-values
     # to supplied data
-    _1d = False
+    _auto_indexable_1d = True
 
     # Define a class used to transform Datasets into other Element types
     _conversion_interface = DataConversion

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -55,10 +55,10 @@ class ArrayInterface(Interface):
         if data is None or data.ndim > 2 or data.dtype.kind in ['S', 'U', 'O']:
             raise ValueError("ArrayInterface interface could not handle input type.")
         elif data.ndim == 1:
-            if eltype._1d:
-                data = np.atleast_2d(data).T
-            else:
+            if eltype._auto_indexable_1d:
                 data = np.column_stack([np.arange(len(data)), data])
+            else:
+                data = np.atleast_2d(data).T
 
         if kdims is None:
             kdims = eltype.kdims

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -49,10 +49,10 @@ class DictInterface(Interface):
             data = {d: data[d] for d in dimensions}
         elif isinstance(data, np.ndarray):
             if data.ndim == 1:
-                if eltype._1d:
-                    data = np.atleast_2d(data).T
-                else:
+                if eltype._auto_indexable_1d:
                     data = np.column_stack([np.arange(len(data)), data])
+                else:
+                    data = np.atleast_2d(data).T
             data = {k: data[:,i] for i,k in enumerate(dimensions)}
         elif isinstance(data, list) and np.isscalar(data[0]):
             data = {dimensions[0]: np.arange(len(data)), dimensions[1]: data}

--- a/holoviews/core/data/ndelement.py
+++ b/holoviews/core/data/ndelement.py
@@ -34,10 +34,10 @@ class NdElementInterface(Interface):
             data = tuple(data.get(d) for d in dimensions)
         elif isinstance(data, np.ndarray):
             if data.ndim == 1:
-                if eltype._1d:
-                    data = np.atleast_2d(data).T
-                else:
+                if eltype._auto_indexable_1d:
                     data = (np.arange(len(data)), data)
+                else:
+                    data = np.atleast_2d(data).T
             else:
                 data = tuple(data[:, i]  for i in range(data.shape[1]))
         elif isinstance(data, list) and np.isscalar(data[0]):

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -61,10 +61,10 @@ class PandasInterface(Interface):
                 data = cyODict(((c, col) for c, col in zip(columns, column_data)))
             elif isinstance(data, np.ndarray):
                 if data.ndim == 1:
-                    if eltype._1d:
-                        data = np.atleast_2d(data).T
-                    else:
+                    if eltype._auto_indexable_1d:
                         data = (range(len(data)), data)
+                    else:
+                        data = np.atleast_2d(data).T
                 else:
                     data = tuple(data[:, i] for i in range(data.shape[1]))
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -617,11 +617,6 @@ class Dimensioned(LabelledData):
                                   for d in params.pop(group)]
                 params[group] = dimensions
         super(Dimensioned, self).__init__(data, **params)
-        duplicates = [vd for vd in self.vdims if vd in self.kdims]
-        if duplicates:
-            duplicates = ', '.join([d.name for d in duplicates])
-            raise ValueError('Dimension(s) %s cannot be both key and '
-                             'value dimensions' % duplicates)
         self.ndims = len(self.kdims)
         cdims = [(d.name, val) for d, val in self.cdims.items()]
         self._cached_constants = OrderedDict(cdims)

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -148,7 +148,7 @@ class BoxWhisker(Chart):
 
     vdims = param.List(default=[Dimension('y')], bounds=(1,1))
 
-    _1d = True
+    _auto_indexable_1d = False
 
 
 class Histogram(Element2D):
@@ -371,7 +371,7 @@ class Spikes(Chart):
 
     vdims = param.List(default=[])
 
-    _1d = True
+    _auto_indexable_1d = False
 
 
 class Area(Curve):

--- a/holoviews/interface/seaborn.py
+++ b/holoviews/interface/seaborn.py
@@ -99,7 +99,7 @@ class Distribution(Chart):
 
     vdims = param.List(default=[Dimension('Value')])
 
-    _1d = True
+    _auto_indexable_1d = False
 
 
 class Regression(Scatter):

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -758,12 +758,12 @@ class gridmatrix(param.ParameterizedFunction):
         for d1, d2 in permuted_dims:
             if d1 == d2:
                 if p.diagonal_type is not None:
-                    if p.diagonal_type._1d:
-                        values = element.dimension_values(d1)
-                        el = p.diagonal_type(values, vdims=[d1])
-                    else:
+                    if p.diagonal_type._auto_indexable_1d:
                         el = p.diagonal_type(el_data, kdims=[d1], vdims=[d2],
                                              datatype=['dataframe', 'dictionary'])
+                    else:
+                        values = element.dimension_values(d1)
+                        el = p.diagonal_type(values, vdims=[d1])
                 elif p.diagonal_operation is histogram or isinstance(p.diagonal_operation, histogram):
                     bin_range = ranges.get(d1.name, element.range(d1))
                     opts = dict(axiswise=True, framewise=True)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -758,8 +758,12 @@ class gridmatrix(param.ParameterizedFunction):
         for d1, d2 in permuted_dims:
             if d1 == d2:
                 if p.diagonal_type is not None:
-                    values = element.dimension_values(d1)
-                    el = p.diagonal_type(values, vdims=[d1])
+                    if p.diagonal_type._1d:
+                        values = element.dimension_values(d1)
+                        el = p.diagonal_type(values, vdims=[d1])
+                    else:
+                        el = p.diagonal_type(el_data, kdims=[d1], vdims=[d2],
+                                             datatype=['dataframe', 'dictionary'])
                 elif p.diagonal_operation is histogram or isinstance(p.diagonal_operation, histogram):
                     bin_range = ranges.get(d1.name, element.range(d1))
                     opts = dict(axiswise=True, framewise=True)


### PR DESCRIPTION
Allowed different types along the diagonal of a gridmatrix. Also lifted the restriction on duplicate dimensions on a Dimensioned object.  While I can sort of see why we did that, plotting a variable against itself can be a valid thing to do, e.g. to see the distribution of a variable as shown along the diagonal here (which is now also a holoviews-contrib gallery example):

http://bokeh.pydata.org/en/latest/docs/gallery/iris_splom.html
