### PR TITLE
Fixed bug handling rgba tuples in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -74,7 +74,7 @@ def rgba_tuple(rgba):
     Ensures RGB(A) tuples in the range 0-1 are scaled to 0-255.
     """
     if isinstance(rgba, tuple):
-        return [int(c*255) if i<3 else c for i, c in enumerate(rgba)]
+        return tuple(int(c*255) if i<3 else c for i, c in enumerate(rgba))
     else:
         return rgba
 


### PR DESCRIPTION
Bokeh accepts an rgba tuple not a list.