### PR TITLE
Guard against pdf output in IPython display hooks

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -49,7 +49,12 @@ def render(obj, **kwargs):
         return render_anim(obj)
 
     backend = Store.current_backend
-    return Store.renderers[backend].html(obj, **kwargs)
+    renderer = Store.renderers[backend]
+
+    # Drop back to png if pdf selected, notebook PDF rendering is buggy
+    if renderer.fig == 'pdf':
+        renderer = renderer.instance(fig='png')
+    return renderer.html(obj, **kwargs)
 
 
 def single_frame_plot(obj):
@@ -153,7 +158,11 @@ def element_display(element, max_frames, max_branches):
     backend = Store.current_backend
     if type(element) not in Store.registry[backend]:
         return None
+
+    # Drop back to png if pdf selected, notebook PDF rendering is buggy
     renderer = Store.renderers[backend]
+    if renderer.fig == 'pdf':
+        renderer = renderer.instance(fig='png')
     return renderer.html(element, fmt=renderer.fig)
 
 

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -272,10 +272,6 @@ class MPLRenderer(Renderer):
         """
         Validates a dictionary of options set on the backend.
         """
-        if options['fig']=='pdf':
-            outputwarning.warning("PDF output is experimental, may not be supported"
-                                  "by your browser and may change in future.")
-
         if options['backend']=='matplotlib:nbagg' and options['widgets'] != 'live':
             outputwarning.warning("The widget mode must be set to 'live' for "
                                   "matplotlib:nbagg.\nSwitching widget mode to 'live'.")


### PR DESCRIPTION
Stops the display hooks from rendering to pdf when plotting in the notebook, however exported plots will still be pdf, when ``fig='pdf'`` declared. Fixes https://github.com/ioam/holoviews/issues/519.