### PR TITLE
Dropped 'ls' as matplotlib 'linestyle' alias

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -81,9 +81,9 @@ Palette.colormaps.update({cm: plt.get_cmap(cm) for cm in plt.cm.datad})
 
 style_aliases = {'edgecolor': ['ec', 'ecolor'], 'facecolor': ['fc'],
                  'linewidth': ['lw'], 'edgecolors': ['ec', 'edgecolor'],
-                 'linestyle': ['ls'], 'size': ['s'], 'color': ['c'],
-                 'markeredgecolor': ['mec'], 'markeredgewidth': ['mew'],
-                 'markerfacecolor': ['mfc'], 'markersize': ['ms']}
+                 'size': ['s'], 'color': ['c'], 'markeredgecolor': ['mec'],
+                 'markeredgewidth': ['mew'], 'markerfacecolor': ['mfc'],
+                 'markersize': ['ms']}
 
 Store.renderers['matplotlib'] = MPLRenderer.instance()
 


### PR DESCRIPTION
It is not consistently supported as shown in: https://github.com/ioam/holoviews/issues/551