### PR TITLE
Dimension label fixes

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -208,9 +208,9 @@ class Dimension(param.Parameterized):
         title_format variable, including the unit string (if
         set). Numeric types are printed to the stated rounding level.
         """
-        unit = '' if self.unit is None else ' ' + self.unit
+        unit = '' if self.unit is None else ' ' + safe_unicode(self.unit)
         value = self.pprint_value(value)
-        return title_format.format(name=self.label, val=value, unit=unit)
+        return title_format.format(name=safe_unicode(self.label), val=value, unit=unit)
 
 
     def __hash__(self):

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -341,7 +341,7 @@ class SelectionWidget(NdWidget):
                 next_vals = escape_dict({k: escape_vals(v) for k, v in next_vals.items()})
 
             visibility = '' if visible else 'display: none'
-            dim_str = safe_unicode(dim.name)
+            dim_str = dim.pprint_label
             escaped_dim = dimension_sanitizer(dim_str)
             widget_data = dict(dim=escaped_dim, dim_label=dim_str,
                                dim_idx=idx, vals=dim_vals, type=widget_type,


### PR DESCRIPTION
A small unicode fix for ``Dimension.pprint_value_string`` and ensured widgets display correct label, fixing https://github.com/ioam/holoviews/issues/1160.