### PR TITLE
Matplotlib aspect fixes

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -200,7 +200,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 self._set_axis_limits(axis, element, subplots, ranges)
 
             # Apply aspects
-            self._set_aspect(axis, self.aspect)
+            if self.aspect is not None and self.projection != 'polar':
+                self._set_aspect(axis, self.aspect)
 
         if not subplots and not self.drawn:
             self._finalize_artist(key)
@@ -295,9 +296,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         """
         Set the aspect on the axes based on the aspect setting.
         """
-        if aspect is None:
-            return
-        elif isinstance(aspect, util.basestring) and aspect != 'square':
+        if isinstance(aspect, util.basestring) and aspect != 'square':
             axes.set_aspect(aspect)
             return
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -200,8 +200,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                     self._finalize_ticks(axis, dimensions, xticks, yticks, zticks)
 
             # Apply aspects
-            if not (self.logx or self.logy):
-                self._set_aspect(axis, self.aspect)
+            self._set_aspect(axis, self.aspect)
 
         if not subplots and not self.drawn:
             self._finalize_artist(key)
@@ -296,13 +295,22 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         """
         Set the aspect on the axes based on the aspect setting.
         """
-        if aspect and aspect == 'square':
-            axes.set_aspect((1./axes.get_data_ratio()))
-        elif aspect not in [None, 'square']:
-            if isinstance(aspect, util.basestring):
-                axes.set_aspect(aspect)
-            else:
-                axes.set_aspect(((1./axes.get_data_ratio()))/aspect)
+        if aspect is None:
+            return
+        elif isinstance(aspect, util.basestring) and aspect != 'square':
+            axes.set_aspect(aspect)
+            return
+
+        (x0, x1), (y0, y1) = axes.get_xlim(), axes.get_ylim()
+        xsize = np.log(x1) - np.log(x0) if self.logx else x1-x0
+        ysize = np.log(y1) - np.log(y0) if self.logy else y1-y0
+        xsize = max(abs(xsize), 1e-30)
+        ysize = max(abs(ysize), 1e-30)
+        data_ratio = 1./(ysize/xsize)
+        if aspect == 'square':
+            axes.set_aspect(data_ratio)
+        else:
+            ax.set_aspect(data_ratio/aspect)
 
 
     def _set_axis_limits(self, axis, view, subplots, ranges):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -174,9 +174,6 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 if dimensions:
                     self._set_labels(axis, dimensions, xlabel, ylabel, zlabel)
 
-                # Set axes limits
-                self._set_axis_limits(axis, element, subplots, ranges)
-
                 if not subplots:
                     legend = axis.get_legend()
                     if legend:
@@ -198,6 +195,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 # Apply ticks
                 if self.apply_ticks:
                     self._finalize_ticks(axis, dimensions, xticks, yticks, zticks)
+
+                # Set axes limits
+                self._set_axis_limits(axis, element, subplots, ranges)
 
             # Apply aspects
             self._set_aspect(axis, self.aspect)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -307,10 +307,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         xsize = max(abs(xsize), 1e-30)
         ysize = max(abs(ysize), 1e-30)
         data_ratio = 1./(ysize/xsize)
-        if aspect == 'square':
-            axes.set_aspect(data_ratio)
-        else:
-            ax.set_aspect(data_ratio/aspect)
+        if aspect != 'square':
+            data_ratio = data_ratio/aspect
+        axes.set_aspect(data_ratio)
 
 
     def _set_axis_limits(self, axis, view, subplots, ranges):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -984,8 +984,6 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
                 own_params = self.get_param_values(onlychanged=True)
                 sublabel_opts = {k: v for k, v in own_params
                                  if 'sublabel_' in k}
-                if not isinstance(view, GridSpace):
-                    override_opts = dict(aspect='square')
             elif pos == 'right':
                 right_opts = dict(invert_axes=True,
                                   xaxis=None)


### PR DESCRIPTION
Fixes https://github.com/ioam/holoviews/issues/199, https://github.com/ioam/holoviews/issues/996 and https://github.com/ioam/holoviews/issues/1144. Plots in Layouts are no longer forced to square, semilog/loglog plots correctly apply aspects, and axis ranges are set after ticks.