### PR TITLE
Fixed bugs in mpl colorbar arrows and Image.range

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -519,7 +519,7 @@ class Image(SheetCoordinateSystem, Raster):
     def range(self, dim, data_range=True):
         dim_idx = dim if isinstance(dim, int) else self.get_dimension_index(dim)
         dim = self.get_dimension(dim_idx)
-        if dim.range != (None, None):
+        if None not in dim.range:
             return dim.range
         elif dim_idx in [0, 1]:
             l, b, r, t = self.bounds.lbrt()
@@ -532,13 +532,14 @@ class Image(SheetCoordinateSystem, Raster):
             data = np.atleast_3d(self.data)[:, :, dim_idx]
             drange = (np.nanmin(data), np.nanmax(data))
         if data_range:
-            soft_range = [sr for sr in dim.soft_range if sr is not None]
+            soft_range = [np.NaN if sr is None else sr for sr in dim.soft_range]
             if soft_range:
-                return util.max_range([drange, soft_range])
-            else:
-                return drange
+                drange = util.max_range([drange, soft_range])
+            ranges = zip(drange, dim.range)
         else:
-            return dim.soft_range
+            ranges = zip(dim.soft_range, dim.range)
+        return tuple(datar if dimr is None else dimr
+                     for datar, dimr in ranges)
 
 
     def _coord2matrix(self, coord):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -211,6 +211,46 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         plot = mpl_renderer.get_plot(curve_dt*curve_dt64*curve_pd)
         self.assertEqual(plot.handles['axis'].get_xlim(), (735964.0, 735976.0))
 
+    def test_image_cbar_extend_both(self):
+        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1,2)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True)))
+        self.assertEqual(plot.handles['cbar'].extend, 'both')
+
+    def test_image_cbar_extend_min(self):
+        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(1, None)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True)))
+        self.assertEqual(plot.handles['cbar'].extend, 'min')
+
+    def test_image_cbar_extend_max(self):
+        img = Image(np.array([[0, 1], [2, 3]])).redim(z=dict(range=(None, 2)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True)))
+        self.assertEqual(plot.handles['cbar'].extend, 'max')
+
+    def test_image_cbar_extend_clime(self):
+        img = Image(np.array([[0, 1], [2, 3]]))(style=dict(clim=(None, None)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True, color_index=1)))
+        self.assertEqual(plot.handles['cbar'].extend, 'neither')
+
+    def test_points_cbar_extend_both(self):
+        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(1,2)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True, color_index=1)))
+        self.assertEqual(plot.handles['cbar'].extend, 'both')
+
+    def test_points_cbar_extend_min(self):
+        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(1, None)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True, color_index=1)))
+        self.assertEqual(plot.handles['cbar'].extend, 'min')
+
+    def test_points_cbar_extend_max(self):
+        img = Points(([0, 1], [0, 3])).redim(y=dict(range=(None, 2)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True, color_index=1)))
+        self.assertEqual(plot.handles['cbar'].extend, 'max')
+
+    def test_points_cbar_extend_clime(self):
+        img = Points(([0, 1], [0, 3]))(style=dict(clim=(None, None)))
+        plot = mpl_renderer.get_plot(img(plot=dict(colorbar=True, color_index=1)))
+        self.assertEqual(plot.handles['cbar'].extend, 'neither')
+
     def test_layout_instantiate_subplots(self):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))


### PR DESCRIPTION
In fixing a bug in the colorbars (https://github.com/ioam/holoviews/issues/1109) I found a bug in handling partially bounded Dimension.range settings, e.g.:

```
hv.Image(np.array([[0, 1], [2, 3]]).redim(z=dict(range=(None, 2))).range('z')
```

Would report ``(0, 3)`` when all our other Elements respect explicitly set ranges. I'll probably open another PR to add an argument to the range method to ignore the ``soft_range`` and ``range`` on the Dimension. Knowing the actual data range is perhaps more useful and we should consider returning that by default and only returning ``Dimension.range`` when requested, which all the plotting code could do.