### PR TITLE
Allow working with Renderers interactively outside the notebook

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -1,4 +1,6 @@
 import uuid
+import time
+import tempfile
 
 import numpy as np
 import param
@@ -6,12 +8,13 @@ from param.parameterized import bothmethod
 
 from bokeh.charts import Chart
 from bokeh.document import Document
-from bokeh.embed import notebook_div
+from bokeh.embed import notebook_div, file_html
 from bokeh.io import load_notebook, curdoc
 from bokeh.models import (Row, Column, Plot, Model, ToolbarBox,
                           WidgetBox, Div, DataTable, Tabs)
 from bokeh.plotting import Figure
 from bokeh.resources import CDN, INLINE
+from bokeh.util.browser import view as browser_view
 
 from ...core import Store, HoloMap
 from ..comms import JupyterComm, Comm
@@ -117,6 +120,19 @@ class BokehRenderer(Renderer):
         plot.document = doc
         return div
 
+    def show(self, obj, browser=None, resource=CDN):
+        """
+        Renders the supplied object and displays it using specified browser.
+        """
+        plot = self.get_plot(obj)
+        plot.initialize_plot()
+        html = file_html(plot.state, resource)
+        tf = tempfile.NamedTemporaryFile('w')
+        tf.write(html)
+        tf.seek(0)
+        browser_view(tf.name, browser)
+        time.sleep(5)
+        tf.close()
 
     def diff(self, plot, serialize=True):
         """

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -190,4 +190,6 @@ class BokehRenderer(Renderer):
         """
         Loads the bokeh notebook resources.
         """
+        import matplotlib.pyplot as plt
+        plt.switch_backend('agg')
         load_notebook(hide_banner=True, resources=INLINE if inline else CDN)

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -1,6 +1,4 @@
 import uuid
-import time
-import tempfile
 
 import numpy as np
 import param
@@ -8,13 +6,12 @@ from param.parameterized import bothmethod
 
 from bokeh.charts import Chart
 from bokeh.document import Document
-from bokeh.embed import notebook_div, file_html
+from bokeh.embed import notebook_div
 from bokeh.io import load_notebook, curdoc
 from bokeh.models import (Row, Column, Plot, Model, ToolbarBox,
                           WidgetBox, Div, DataTable, Tabs)
 from bokeh.plotting import Figure
 from bokeh.resources import CDN, INLINE
-from bokeh.util.browser import view as browser_view
 
 from ...core import Store, HoloMap
 from ..comms import JupyterComm, Comm
@@ -120,19 +117,6 @@ class BokehRenderer(Renderer):
         plot.document = doc
         return div
 
-    def show(self, obj, browser=None, resource=CDN):
-        """
-        Renders the supplied object and displays it using specified browser.
-        """
-        plot = self.get_plot(obj)
-        plot.initialize_plot()
-        html = file_html(plot.state, resource)
-        tf = tempfile.NamedTemporaryFile('w')
-        tf.write(html)
-        tf.seek(0)
-        browser_view(tf.name, browser)
-        time.sleep(5)
-        tf.close()
 
     def diff(self, plot, serialize=True):
         """
@@ -206,6 +190,4 @@ class BokehRenderer(Renderer):
         """
         Loads the bokeh notebook resources.
         """
-        import matplotlib.pyplot as plt
-        plt.switch_backend('agg')
         load_notebook(hide_banner=True, resources=INLINE if inline else CDN)

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -1,12 +1,3 @@
-
-try:
-    # Switching to 'agg' backend (may be overridden in holoviews.rc)
-    import matplotlib.pyplot as plt
-    plt.switch_backend('agg')
-except:
-    pass
-
-
 import os
 from distutils.version import LooseVersion
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -119,6 +119,12 @@ class MPLPlot(DimensionedPlot):
         if self.fig_latex:
             self.fig_rcparams['text.usetex'] = True
 
+        if self.renderer.interactive:
+            plt.ion()
+            self._close_figures = False
+        else:
+            plt.ioff()
+
         with mpl.rc_context(rc=self.fig_rcparams):
             fig, axis = self._init_axis(fig, axis)
 
@@ -130,11 +136,6 @@ class MPLPlot(DimensionedPlot):
                          'finalize_hooks, not both.')
         self.finalize_hooks = self.final_hooks
         self.handles['bbox_extra_artists'] = []
-        if self.renderer.interactive:
-            plt.ion()
-            self._close_figures = False
-        else:
-            plt.ioff()
 
 
     def _init_axis(self, fig, axis):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -130,6 +130,11 @@ class MPLPlot(DimensionedPlot):
                          'finalize_hooks, not both.')
         self.finalize_hooks = self.final_hooks
         self.handles['bbox_extra_artists'] = []
+        if self.renderer.interactive:
+            plt.ion()
+            self._close_figures = False
+        else:
+            plt.ioff()
 
 
     def _init_axis(self, fig, axis):

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -121,18 +121,23 @@ class MPLRenderer(Renderer):
         GUI backend.
         """
         if self.interactive:
+            if isinstance(obj, list):
+                return [self.get_plot(o) for o in obj]
             return self.get_plot(obj)
 
         from .plot import MPLPlot
         MPLPlot._close_figures = False
         try:
-            plot = self.get_plot(obj)
-            plt.show(plot.state)
+            plots = []
+            objects = obj if isinstance(obj, list) else [obj]
+            for o in obj:
+                plots.append(self.get_plot(o))
+            plt.show()
         except:
             MPLPlot._close_figures = True
             raise
         MPLPlot._close_figures = True
-        return plot
+        return plots[0] if len(plots) == 1 else plots
 
 
     @classmethod

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -120,16 +120,19 @@ class MPLRenderer(Renderer):
         Renders the supplied object and displays it using the active
         GUI backend.
         """
+        if self.interactive:
+            return self.get_plot(obj)
+
         from .plot import MPLPlot
         MPLPlot._close_figures = False
         try:
             plot = self.get_plot(obj)
-            plot.initialize_plot()
             plt.show(plot.state)
         except:
             MPLPlot._close_figures = True
             raise
         MPLPlot._close_figures = True
+        return plot
 
 
     @classmethod

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -53,11 +53,14 @@ class MPLRenderer(Renderer):
         Output render multi-frame (typically animated) format. If
         None, no multi-frame rendering will occur.""")
 
+    interactive = param.Boolean(default=False, doc="""
+        Whether to enable interactive plotting allowing interactive
+        plotting with explicitly calling show.""")
+
     mode = param.ObjectSelector(default='default',
                                 objects=['default', 'mpld3', 'nbagg'], doc="""
          The 'mpld3' mode uses the mpld3 library whereas the 'nbagg' uses
          matplotlib's the experimental nbagg backend. """)
-
 
     # <format name> : (animation writer, format,  anim_kwargs, extra_args)
     ANIMATION_OPTS = {
@@ -110,6 +113,23 @@ class MPLRenderer(Renderer):
         data = self._apply_post_render_hooks(data, obj, fmt)
         return data, {'file-ext':fmt,
                       'mime_type':MIME_TYPES[fmt]}
+
+
+    def show(self, obj):
+        """
+        Renders the supplied object and displays it using the active
+        GUI backend.
+        """
+        from .plot import MPLPlot
+        MPLPlot._close_figures = False
+        try:
+            plot = self.get_plot(obj)
+            plot.initialize_plot()
+            plt.show(plot.state)
+        except:
+            MPLPlot._close_figures = True
+            raise
+        MPLPlot._close_figures = True
 
 
     @classmethod
@@ -279,3 +299,11 @@ class MPLRenderer(Renderer):
                                   "matplotlib:nbagg.\nSwitching widget mode to 'live'.")
             options['widgets'] = 'live'
         return options
+
+    @classmethod
+    def load_nb(cls, inline=True):
+        """
+        Initialize matplotlib backend
+        """
+        import matplotlib.pyplot as plt
+        plt.switch_backend('agg')


### PR DESCRIPTION
Adds ``show`` methods for the bokeh and matplotlib renderers and an interactive option for the matplotlib renderer. Addresses https://github.com/ioam/holoviews/issues/1126. @thoth291 would you mind testing if this works for you?

Here's a small example:

```python
import holoviews as hv
import holoviews.plotting.mpl

r = hv.Store.renderers['matplotlib'].instance(interactive=True)

curve = hv.Curve(range(10)))
r.show(curve)
```