### PR TITLE
Made sorting on NdMapping optional

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -582,7 +582,6 @@ class Dimensioned(LabelledData):
        A string describing the data wrapped by the object.""")
 
     __abstract = True
-    _sorted = False
     _dim_groups = ['kdims', 'vdims', 'cdims', 'ddims']
     _dim_aliases = dict(key_dimensions='kdims', value_dimensions='vdims',
                         constant_dimensions='cdims', deep_dimensions='ddims')

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -439,7 +439,8 @@ class NdElement(NdMapping, Tabular):
         if not by: by = range(self.ndims)
         indexes = [self.get_dimension_index(d) for d in by]
         return self.clone(dimension_sort(self.data, self.kdims, self.vdims,
-                                         False, indexes, self._cached_index_values))
+                                         False, indexes, self._cached_index_values),
+                          sort=False)
 
 
     def sample(self, samples=[]):

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -269,8 +269,10 @@ class NdElement(NdMapping, Tabular):
         Note: String values may be supplied in the constructor which
         will then be promoted to Dimension objects.""")
 
+    sort = param.Boolean(default=False, doc="""
+        Whether the items should be sorted in the constructor.""")
+
     _deep_indexable = False
-    _sorted = False
 
     def __init__(self, data=None, **params):
         self.warning('NdElement will be deprecated in v2.0 and should '

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -109,6 +109,10 @@ class MultiDimensionalMapping(Dimensioned):
         self._cached_categorical = any(d.values for d in self.kdims)
 
         if initial_items is None: initial_items = []
+        if type(initial_items) is dict and not sort:
+            raise ValueError('If sort=False the data must define a fixed '
+                             'ordering, please supply a list of items or '
+                             'an OrderedDict, not a regular dictionary.')
         if isinstance(initial_items, tuple):
             self._add_item(initial_items[0], initial_items[1])
         elif not self._check_items:

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -97,14 +97,9 @@ class MultiDimensionalMapping(Dimensioned):
     _check_items = True
 
     def __init__(self, initial_items=None, **params):
-        if isinstance(initial_items, NdMapping):
-            map_type = type(initial_items)
-            own_params = self.params()
-            new_params = dict(initial_items.get_param_values(onlychanged=True))
-            if new_params.get('group') == map_type.__name__:
-                new_params.pop('group')
-            params = dict({name: value for name, value in new_params.items()
-                           if name in own_params}, **params)
+        if isinstance(initial_items, MultiDimensionalMapping):
+            params = dict(util.get_param_values(initial_items),
+                          **dict({'sort': self.sort}, **params))
         super(MultiDimensionalMapping, self).__init__(OrderedDict(), **params)
 
         self._next_ind = 0
@@ -282,7 +277,7 @@ class MultiDimensionalMapping(Dimensioned):
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
         with item_check(False):
             return util.ndmapping_groupby(self, dimensions, container_type,
-                                          group_type, sort=not self.sort, **kwargs)
+                                          group_type, sort=True, **kwargs)
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -282,7 +282,7 @@ class MultiDimensionalMapping(Dimensioned):
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
         with item_check(False):
             return util.ndmapping_groupby(self, dimensions, container_type,
-                                          group_type, sort=False, **kwargs)
+                                          group_type, sort=not self.sort, **kwargs)
 
 
     def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -467,7 +467,7 @@ class DynamicMap(HoloMap):
     mode. Bounded mode only applied to callables where all the key
     dimensions are fully bounded.
     """
-    _sorted = False
+
     # Declare that callback is a positional parameter (used in clone)
     __pos_params = ['callback']
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -125,7 +125,7 @@ class NdWidget(param.Parameterized):
             self.renderer = renderer
         # Create mock NdMapping to hold the common dimensions and keys
         self.mock_obj = NdMapping([(k, None) for k in self.keys],
-                                  kdims=self.dimensions)
+                                  kdims=self.dimensions, sort=False)
 
         NdWidget.widgets[self.id] = self
 

--- a/tests/testndmapping.py
+++ b/tests/testndmapping.py
@@ -88,6 +88,23 @@ class NdIndexableMappingTest(ComparisonTestCase):
         nested_ndmap[1.5] = ndmap3
         self.assertEquals(list(nested_ndmap[1.5].values()), ['e', 'f'])
 
+    def test_idxmapping_unsorted(self):
+        data = [('B', 1), ('C', 2), ('A', 3)]
+        ndmap = MultiDimensionalMapping(data, sort=False)
+        self.assertEquals(ndmap.keys(), ['B', 'C', 'A'])
+
+    def test_idxmapping_unsorted_clone(self):
+        data = [('B', 1), ('C', 2), ('A', 3)]
+        ndmap = MultiDimensionalMapping(data, sort=False).clone()
+        self.assertEquals(ndmap.keys(), ['B', 'C', 'A'])
+
+    def test_idxmapping_groupby_unsorted(self):
+        data = [(('B', 2), 1), (('C', 2), 2), (('A', 1), 3)]
+        grouped = MultiDimensionalMapping(data, sort=False, kdims=['X', 'Y']).groupby('Y')
+        self.assertEquals(grouped.keys(), [1, 2])
+        self.assertEquals(grouped.values()[0].keys(), ['A'])
+        self.assertEquals(grouped.last.keys(), ['B', 'C'])
+
     def test_idxmapping_reindex(self):
         data = [((0, 0.5), 'a'), ((1, 0.5), 'b')]
         ndmap = MultiDimensionalMapping(data, kdims=[self.dim1, self.dim2])


### PR DESCRIPTION
Let's users provide an explicitly sorted NdMapping. Still need to add a warning when a regular dict and sort=False are supplied since sort order is nondeterministic in that case.

~~Edit: Widgets are currently assuming sorted keys and NdElement seems to have been sorting in some cases.~~

Addresses: https://github.com/ioam/holoviews/issues/1216

Fixes: https://github.com/ioam/holoviews/issues/1042