### PR TITLE
Bokeh selection colors

### DIFF
--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -226,7 +226,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Both the matplotlib and the bokeh backends allow plotting datetime data, if you ensure the dates array is of a datetime dtype."
+    "Both the matplotlib and the bokeh backends allow plotting datetime data, if you ensure the dates array is of a datetime dtype. Note also that the legends are interactive and can be toggled by clicking on its entries. Additionally the style of unselected curve can be controlled by setting the ``muted_alpha`` and ``muted_color`` style options."
    ]
   },
   {
@@ -239,7 +239,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Overlay [width=600 legend_position='top_left']\n",
+    "%%opts Overlay [width=600 legend_position='top_left'] Curve (muted_alpha=0.5 muted_color='black')\n",
     "try:\n",
     "    import bokeh.sampledata.stocks\n",
     "except:\n",

--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -544,7 +544,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Bokeh provides a number of tools for selecting data points including ``box_select``, ``lasso_select`` and ``poly_select``. To distinguish between selected and unselected data points we can also set the ``unselected_color``.  You can try out any of these selection tools and see how the plot is affected:"
+    "Bokeh provides a number of tools for selecting data points including ``tap``, ``box_select``, ``lasso_select`` and ``poly_select``. To distinguish between selected and unselected data points we can also control the color and alpha of the ``selection`` and ``nonselection`` points.  You can try out any of these selection tools and see how the plot is affected:"
    ]
   },
   {
@@ -558,7 +558,7 @@
    },
    "outputs": [],
    "source": [
-    "%%opts Points [tools=['box_select', 'lasso_select', 'poly_select']] (size=10 unselected_color='red' color='blue')\n",
+    "%%opts Points [tools=['box_select', 'lasso_select', 'tap']] (size=10 nonselection_color='red' color='blue')\n",
     "hv.Points(error)"
    ]
   },

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -161,6 +161,7 @@ options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,
 
 if bokeh_version >= '0.12.5':
     options.Overlay = Options('style', click_policy='mute')
+    options.NdOverlay = Options('style', click_policy='mute')
     options.Curve = Options('style', muted_line_alpha=0.2)
     options.Path = Options('style', muted_line_alpha=0.2)
     options.Scatter = Options('style', muted_fill_alpha=0.2)

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -142,7 +142,7 @@ options.Path = Options('style', color=Cycle())
 options.Box = Options('style', color='black')
 options.Bounds = Options('style', color='black')
 options.Ellipse = Options('style', color='black')
-options.Polygons = Options('style', color=Cycle())
+options.Polygons = Options('style', color=Cycle(), line_color='black')
 
 # Rasters
 options.Image = Options('style', cmap='hot')

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -29,6 +29,8 @@ from .raster import (RasterPlot, ImagePlot, RGBPlot, HeatmapPlot,
                      HSVPlot, QuadMeshPlot)
 from .renderer import BokehRenderer
 from .tabular import TablePlot
+from .util import bokeh_version
+
 
 Store.renderers['bokeh'] = BokehRenderer.instance()
 
@@ -156,3 +158,12 @@ options.VLine = Options('style', line_color=Cycle(), line_width=3, line_alpha=1)
 # Define composite defaults
 options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,
                              xaxis=None, yaxis=None)
+
+if bokeh_version >= '0.12.5':
+    options.Overlay = Options('style', click_policy='mute')
+    options.Curve = Options('style', muted_line_alpha=0.2)
+    options.Path = Options('style', muted_line_alpha=0.2)
+    options.Scatter = Options('style', muted_fill_alpha=0.2)
+    options.Points = Options('style', muted_fill_alpha=0.2)
+    options.Polygons = Options('style', muted_fill_alpha=0.2)
+

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -130,11 +130,11 @@ options.Scatter = Options('style', color=Cycle(), size=point_size, cmap='hot')
 options.Points = Options('style', color=Cycle(), size=point_size, cmap='hot')
 options.Histogram = Options('style', line_color='black', fill_color=Cycle())
 options.ErrorBars = Options('style', color='black')
-options.Spread = Options('style', fill_color=Cycle(), fill_alpha=0.6, line_color='black')
+options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
 
 options.Spikes = Options('style', color='black')
 options.Area = Options('style', color=Cycle(), line_color='black')
-options.VectorField = Options('style', line_color='black')
+options.VectorField = Options('style', color='black')
 
 # Paths
 options.Contours = Options('style', color=Cycle())
@@ -152,8 +152,8 @@ options.QuadMesh = Options('style', cmap='hot', line_alpha=0)
 options.HeatMap = Options('style', cmap='RdYlBu_r', line_alpha=0)
 
 # Annotations
-options.HLine = Options('style', line_color=Cycle(), line_width=3, line_alpha=1)
-options.VLine = Options('style', line_color=Cycle(), line_width=3, line_alpha=1)
+options.HLine = Options('style', color=Cycle(), line_width=3, alpha=1)
+options.VLine = Options('style', color=Cycle(), line_width=3, alpha=1)
 
 # Define composite defaults
 options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -162,9 +162,9 @@ options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,
 if bokeh_version >= '0.12.5':
     options.Overlay = Options('style', click_policy='mute')
     options.NdOverlay = Options('style', click_policy='mute')
-    options.Curve = Options('style', muted_line_alpha=0.2)
-    options.Path = Options('style', muted_line_alpha=0.2)
-    options.Scatter = Options('style', muted_fill_alpha=0.2)
-    options.Points = Options('style', muted_fill_alpha=0.2)
-    options.Polygons = Options('style', muted_fill_alpha=0.2)
+    options.Curve = Options('style', muted_alpha=0.2)
+    options.Path = Options('style', muted_alpha=0.2)
+    options.Scatter = Options('style', muted_alpha=0.2)
+    options.Points = Options('style', muted_alpha=0.2)
+    options.Polygons = Options('style', muted_alpha=0.2)
 

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -65,9 +65,7 @@ class LineAnnotationPlot(ElementPlot):
         """
         Returns a Bokeh glyph object.
         """
-        properties = {p: v for p, v in properties.items()
-                      if p not in ['source', 'legend']}
-        box = Span(level='overlay', **dict(mapping, **properties))
+        box = Span(level='overlay', **mapping)
         plot.renderers.append(box)
         return None, box
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -112,7 +112,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
             nvals = len(data[k][-1])
             if 'color' not in elmapping:
                 val = styles[zorder].get('color')
-                elmapping['color'] = 'color'
+                elmapping['color'] = {'field': 'color'}
                 if isinstance(val, tuple):
                     val = rgb2hex(val)
                 data['color'].append([val]*nvals)
@@ -148,7 +148,7 @@ class VectorFieldPlot(ColorbarPlot):
        Whether the lengths will be rescaled to take into account the
        smallest non-zero distance between two vectors.""")
 
-    style_opts = ['color'] + line_properties
+    style_opts = line_properties
     _plot_methods = dict(single='segment')
 
     def _get_lengths(self, element, ranges):
@@ -222,7 +222,7 @@ class CurvePlot(ElementPlot):
         default is 'linear', other options include 'steps-mid',
         'steps-pre' and 'steps-post'.""")
 
-    style_opts = ['color'] + line_properties
+    style_opts = line_properties
     _plot_methods = dict(single='line', batched='multi_line')
     _mapping = {p: p for p in ['xs', 'ys', 'color', 'line_alpha']}
 
@@ -312,7 +312,7 @@ class AreaPlot(PolygonPlot):
 
 class SpreadPlot(PolygonPlot):
 
-    style_opts = ['color'] + line_properties + fill_properties
+    style_opts = line_properties + fill_properties
 
     def get_data(self, element, ranges=None, empty=None):
         if empty:
@@ -337,7 +337,7 @@ class SpreadPlot(PolygonPlot):
 
 class HistogramPlot(ElementPlot):
 
-    style_opts = ['color'] + line_properties + fill_properties
+    style_opts = line_properties + fill_properties
     _plot_methods = dict(single='quad')
 
     def get_data(self, element, ranges=None, empty=None):
@@ -437,7 +437,7 @@ class ErrorPlot(PathPlot):
 
     horizontal = param.Boolean(default=False)
 
-    style_opts = ['color'] + line_properties
+    style_opts = line_properties
 
     def get_data(self, element, ranges=None, empty=False):
         if empty:
@@ -644,7 +644,7 @@ class BoxPlot(ChartPlot):
     percentiles.
     """
 
-    style_opts = ['color', 'whisker_color', 'marker'] + line_properties
+    style_opts = ['whisker_color', 'marker'] + line_properties
 
     def _init_chart(self, element, ranges):
         properties = self.style[self.cyclic_index]

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -46,8 +46,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
       Function applied to size values before applying scaling,
       to remove values lower than zero.""")
 
-    style_opts = (['cmap', 'palette', 'marker', 'size', 's', 'color',
-                   'unselected_color'] +
+    style_opts = (['cmap', 'palette', 'marker', 'size', 's'] +
                   line_properties + fill_properties)
 
     _plot_methods = dict(single='scatter', batched='scatter')

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -46,7 +46,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
       Function applied to size values before applying scaling,
       to remove values lower than zero.""")
 
-    style_opts = (['cmap', 'palette', 'marker', 'size', 's', 'alpha', 'color',
+    style_opts = (['cmap', 'palette', 'marker', 'size', 's', 'color',
                    'unselected_color'] +
                   line_properties + fill_properties)
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -16,7 +16,8 @@ from ...core.options import abbreviated_exception
 from ...operation import interpolate_curve
 from ..util import (compute_sizes, get_sideplot_ranges, match_spec,
                     map_colors, get_min_distance)
-from .element import ElementPlot, ColorbarPlot, LegendPlot, line_properties, fill_properties
+from .element import (ElementPlot, ColorbarPlot, LegendPlot, line_properties,
+                      fill_properties)
 from .path import PathPlot, PolygonPlot
 from .util import get_cmap, mpl_to_bokeh, update_plot, rgb2hex, bokeh_version
 
@@ -123,29 +124,6 @@ class PointPlot(LegendPlot, ColorbarPlot):
         data = {k: np.concatenate(v) for k, v in data.items()}
         return data, elmapping
 
-
-    def _init_glyph(self, plot, mapping, properties):
-        """
-        Returns a Bokeh glyph object.
-        """
-        properties = mpl_to_bokeh(properties)
-        unselect_color = properties.pop('unselected_color', None)
-        if (any(t in self.tools for t in ['box_select', 'lasso_select'])
-            and unselect_color is not None):
-            source = properties.pop('source')
-            color = properties.pop('color', None)
-            color = mapping.pop('color', color)
-            properties.pop('legend', None)
-            unselected = Circle(**dict(properties, fill_color=unselect_color, **mapping))
-            selected = Circle(**dict(properties, fill_color=color, **mapping))
-            renderer = plot.add_glyph(source, selected, selection_glyph=selected,
-                                      nonselection_glyph=unselected)
-        else:
-            plot_method = self._plot_methods.get('batched' if self.batched else 'single')
-            renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
-        if self.colorbar and 'color_mapper' in self.handles:
-            self._draw_colorbar(plot, self.handles['color_mapper'])
-        return renderer, renderer.glyph
 
 
 class VectorFieldPlot(ColorbarPlot):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -625,24 +625,18 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 glyph = getattr(renderer, glyph_type+'glyph', None)
             if not glyph or (not renderer and glyph_type):
                 continue
-            if glyph_type:
-                glyph_props = dict(properties)
-            else:
-                glyph_props = dict(merged)
+            glyph_props = dict(merged)
 
-            for prop in ('color', 'alpha'):
-                glyph_prop = merged.get(glyph_type+prop)
-                if glyph_prop and 'line_'+prop not in glyph_props:
-                    glyph_props['line_'+prop] = glyph_prop
-                if glyph_prop and 'fill_'+prop not in glyph_props:
-                    glyph_props['fill_'+prop] = glyph_prop
+            for gtype in ((glyph_type, '') if glyph_type else ('',)):
+                for prop in ('color', 'alpha'):
+                    glyph_prop = merged.get(gtype+prop)
+                    if glyph_prop and ('line_'+prop not in glyph_props or gtype):
+                        glyph_props['line_'+prop] = glyph_prop
+                    if glyph_prop and ('fill_'+prop not in glyph_props or gtype):
+                        glyph_props['fill_'+prop] = glyph_prop
 
-            glyph_props = {k[len(glyph_type):]: v for k, v in glyph_props.items()
-                           if k.startswith(glyph_type)}
-
-            if glyph_type:
-                glyph_props = dict(properties, **glyph_props)
-
+                glyph_props.update({k[len(gtype):]: v for k, v in glyph_props.items()
+                                    if k.startswith(gtype)})
             filtered = {k: v for k, v in glyph_props.items()
                         if k in allowed_properties}
             glyph.update(**filtered)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -45,9 +45,9 @@ else:
 property_prefixes = ['selection', 'nonselection', 'muted']
 
 # Define shared style properties for bokeh plots
-line_properties = ['line_color', 'line_alpha', 'color', 'line_width',
+line_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
                    'line_join', 'line_cap', 'line_dash']
-line_properties += ['_'.join([prefix, prop]) for prop in line_properties[:3]
+line_properties += ['_'.join([prefix, prop]) for prop in line_properties[:4]
                     for prefix in property_prefixes]
 
 fill_properties = ['fill_color', 'fill_alpha']
@@ -629,15 +629,15 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 glyph_props = properties
             else:
                 glyph_props = merged
-            glyph_color = merged.get(glyph_type+'color')
+            for prop in ('color', 'alpha'):
+                glyph_prop = merged.get(glyph_type+prop)
+                if glyph_prop and 'line_'+prop not in glyph_props:
+                    glyph_props['line_'+prop] = glyph_prop
+                if glyph_prop and 'fill_'+prop not in glyph_props:
+                    glyph_props['fill_'+prop] = glyph_prop
 
             glyph_props = {k[len(glyph_type):]: v for k, v in glyph_props.items()
                            if k.startswith(glyph_type)}
-
-            if glyph_color and 'line_color' not in glyph_props:
-                glyph_props['line_color'] = glyph_color
-            if glyph_color and 'fill_color' not in glyph_props:
-                glyph_props['fill_color'] = glyph_color
 
             if glyph_type:
                 glyph_props = dict(properties, **glyph_props)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -626,9 +626,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if not glyph or (not renderer and glyph_type):
                 continue
             if glyph_type:
-                glyph_props = properties
+                glyph_props = dict(properties)
             else:
-                glyph_props = merged
+                glyph_props = dict(merged)
+
             for prop in ('color', 'alpha'):
                 glyph_prop = merged.get(glyph_type+prop)
                 if glyph_prop and 'line_'+prop not in glyph_props:

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -385,6 +385,12 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         points = Points(np.random.rand(10, 4), vdims=['a', 'b'])(plot=dict(color_index=3))
         self._test_colormapping(points, 3)
 
+    def test_points_colormapping_with_nonselection(self):
+        opts = dict(plot=dict(color_index=3),
+                    style=dict(nonselection_color='red'))
+        points = Points(np.random.rand(10, 4), vdims=['a', 'b'])(**opts)
+        self._test_colormapping(points, 3)
+
     def test_points_colormapping_categorical(self):
         points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
                          vdims=['a', 'b'])(plot=dict(color_index='b'))
@@ -394,6 +400,43 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         cmapper = plot.handles['color_mapper']
         self.assertIsInstance(cmapper, CategoricalColorMapper)
         self.assertEqual(cmapper.factors, list(points['b']))
+
+    def test_points_color_selection_nonselection(self):
+        opts = dict(color='green', selection_color='red', nonselection_color='blue')
+        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+                         vdims=['a', 'b'])(style=opts)
+        plot = bokeh_renderer.get_plot(points)
+        glyph_renderer = plot.handles['glyph_renderer']
+        self.assertEqual(glyph_renderer.glyph.fill_color, '#008000')
+        self.assertEqual(glyph_renderer.glyph.line_color, '#008000')
+        self.assertEqual(glyph_renderer.selection_glyph.fill_color, '#FF0000')
+        self.assertEqual(glyph_renderer.selection_glyph.line_color, '#FF0000')
+        self.assertEqual(glyph_renderer.nonselection_glyph.fill_color, '#0000FF')
+        self.assertEqual(glyph_renderer.nonselection_glyph.line_color, '#0000FF')
+
+    def test_points_alpha_selection_nonselection(self):
+        opts = dict(alpha=0.8, selection_alpha=1.0, nonselection_alpha=0.2)
+        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+                         vdims=['a', 'b'])(style=opts)
+        plot = bokeh_renderer.get_plot(points)
+        glyph_renderer = plot.handles['glyph_renderer']
+        self.assertEqual(glyph_renderer.glyph.fill_alpha, 0.8)
+        self.assertEqual(glyph_renderer.glyph.line_alpha, 0.8)
+        self.assertEqual(glyph_renderer.selection_glyph.fill_alpha, 1)
+        self.assertEqual(glyph_renderer.selection_glyph.line_alpha, 1)
+        self.assertEqual(glyph_renderer.nonselection_glyph.fill_alpha, 1)
+        self.assertEqual(glyph_renderer.nonselection_glyph.line_alpha, 1)
+
+    def test_points_alpha_selection_partial(self):
+        opts = dict(selection_alpha=1.0, selection_fill_alpha=0.2)
+        points = Points([(i, i*2, i*3, chr(65+i)) for i in range(10)],
+                         vdims=['a', 'b'])(style=opts)
+        plot = bokeh_renderer.get_plot(points)
+        glyph_renderer = plot.handles['glyph_renderer']
+        self.assertEqual(glyph_renderer.glyph.fill_alpha, 1.0)
+        self.assertEqual(glyph_renderer.glyph.line_alpha, 1.0)
+        self.assertEqual(glyph_renderer.selection_glyph.fill_alpha, 0.2)
+        self.assertEqual(glyph_renderer.selection_glyph.line_alpha, 1)
 
     def test_image_colormapping(self):
         img = Image(np.random.rand(10, 10))(plot=dict(logz=True))

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -407,12 +407,12 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                          vdims=['a', 'b'])(style=opts)
         plot = bokeh_renderer.get_plot(points)
         glyph_renderer = plot.handles['glyph_renderer']
-        self.assertEqual(glyph_renderer.glyph.fill_color, '#008000')
-        self.assertEqual(glyph_renderer.glyph.line_color, '#008000')
-        self.assertEqual(glyph_renderer.selection_glyph.fill_color, '#FF0000')
-        self.assertEqual(glyph_renderer.selection_glyph.line_color, '#FF0000')
-        self.assertEqual(glyph_renderer.nonselection_glyph.fill_color, '#0000FF')
-        self.assertEqual(glyph_renderer.nonselection_glyph.line_color, '#0000FF')
+        self.assertEqual(glyph_renderer.glyph.fill_color, 'green')
+        self.assertEqual(glyph_renderer.glyph.line_color, 'green')
+        self.assertEqual(glyph_renderer.selection_glyph.fill_color, 'red')
+        self.assertEqual(glyph_renderer.selection_glyph.line_color, 'red')
+        self.assertEqual(glyph_renderer.nonselection_glyph.fill_color, 'blue')
+        self.assertEqual(glyph_renderer.nonselection_glyph.line_color, 'blue')
 
     def test_points_alpha_selection_nonselection(self):
         opts = dict(alpha=0.8, selection_alpha=1.0, nonselection_alpha=0.2)
@@ -424,8 +424,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(glyph_renderer.glyph.line_alpha, 0.8)
         self.assertEqual(glyph_renderer.selection_glyph.fill_alpha, 1)
         self.assertEqual(glyph_renderer.selection_glyph.line_alpha, 1)
-        self.assertEqual(glyph_renderer.nonselection_glyph.fill_alpha, 1)
-        self.assertEqual(glyph_renderer.nonselection_glyph.line_alpha, 1)
+        self.assertEqual(glyph_renderer.nonselection_glyph.fill_alpha, 0.2)
+        self.assertEqual(glyph_renderer.nonselection_glyph.line_alpha, 0.2)
 
     def test_points_alpha_selection_partial(self):
         opts = dict(selection_alpha=1.0, selection_fill_alpha=0.2)


### PR DESCRIPTION
As requested in https://github.com/ioam/holoviews/issues/1139 this adds full control over selection and unselection glyph styles letting you apply custom colors and alphas. Additionally this also adds control of a new feature in bokeh 0.12.5, which is muting glyphs with an interactive legend, this styling can also be controlled via style option but default to a ``alpha=0.2``. This means all our bokeh legends are now clickable.

- [x] Update Bokeh_Backend Tutorial unselection glyph styling examples.
- [x] Tests to check updating all the different glyphs is working correctly. 