### PR TITLE
Allow casting from GridImage to QuadMesh

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -243,8 +243,13 @@ class QuadMesh(Raster):
     def depth(self): return 1
 
     def _process_data(self, data):
-        data = tuple(np.array(el) for el in data)
-        x, y, zarray = data
+        if isinstance(data, GridImage):
+            x = data.dimension_values(0, expanded=False)
+            y = data.dimension_values(1, expanded=False)
+            zarray = data.dimension_values(2, flat=False)
+        else:
+            data = tuple(np.array(el) for el in data)
+            x, y, zarray = data
         ys, xs = zarray.shape
         if x.ndim == 1 and len(x) == xs:
             x = compute_edges(x)


### PR DESCRIPTION
Useful now and will continue working just fine in the future when the image interface has been added. Let's you do something like this to get hover information from a datashaded plot:

```python
%%opts QuadMesh (fill_alpha=0) [tools=['hover']]
points = hv.Points(np.random.multivariate_normal((0,0), [[0.1, 0.1], [0.1, 1.0]], (1000000,)))
datashade(points, width=400, height=400) * hv.util.Dynamic(aggregate(points, width=100, height=100),
                                                           operation=lambda x: hv.QuadMesh(x))
```

![hover](https://cloud.githubusercontent.com/assets/1550771/24252582/bccd675e-0fd5-11e7-8224-6e1ebf4421eb.gif)
