### PR TITLE
Apply matplotlib rc parameters correctly throughout

### DIFF
--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -4,6 +4,7 @@ from matplotlib import patches as patches
 from ...core.util import match_spec
 from ...core.options import abbreviated_exception
 from .element import ElementPlot
+from .plot import mpl_rc_context
 
 
 class AnnotationPlot(ElementPlot):
@@ -16,6 +17,7 @@ class AnnotationPlot(ElementPlot):
         super(AnnotationPlot, self).__init__(annotation, **params)
         self.handles['annotations'] = []
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         annotation = self.hmap.last
         key = self.keys[-1]

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -24,7 +24,7 @@ from ..util import (compute_sizes, get_sideplot_ranges, map_colors,
                     get_min_distance)
 from .element import ElementPlot, ColorbarPlot, LegendPlot
 from .path  import PathPlot
-from .plot import AdjoinedPlot
+from .plot import AdjoinedPlot, mpl_rc_context
 
 
 class ChartPlot(ElementPlot):
@@ -277,6 +277,7 @@ class HistogramPlot(ChartPlot):
         self.cyclic_range = val_dim.range if val_dim.cyclic else None
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         hist = self.hmap.last
         key = self.keys[-1]
@@ -788,6 +789,7 @@ class BarPlot(LegendPlot):
             return 0, np.nanmin([vrange[0], 0]), ngroups, vrange[1]
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         element = self.hmap.last
         vdim = element.vdims[0]

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -14,7 +14,7 @@ from ...core import (OrderedDict, NdOverlay, DynamicMap,
 from ...core.options import abbreviated_exception
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update
-from .plot import MPLPlot
+from .plot import MPLPlot, mpl_rc_context
 from .util import wrap_formatter
 from distutils.version import LooseVersion
 
@@ -465,6 +465,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         self._finalize_axis(key, ranges=ranges, **(axis_kwargs if axis_kwargs else {}))
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         element = self.hmap.last
         ax = self.handles['axis']
@@ -814,6 +815,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         self.handles['legend_data'] = data
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         axis = self.handles['axis']
         key = self.keys[-1]

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -19,6 +19,16 @@ from ..util import get_dynamic_mode, initialize_sampled
 from .util import compute_ratios, fix_aspect
 
 
+def mpl_rc_context(f):
+    """
+    Applies matplotlib rc params while when method is called.
+    """
+    def wrapper(self, *args, **kwargs):
+        with mpl.rc_context(rc=self.fig_rcparams):
+            return f(self, *args, **kwargs)
+    return wrapper
+
+
 class MPLPlot(DimensionedPlot):
     """
     An MPLPlot object draws a matplotlib figure object when called or
@@ -208,6 +218,7 @@ class MPLPlot(DimensionedPlot):
         if self._close_figures: plt.close(figure)
         return anim
 
+
     def update(self, key):
         if len(self) == 1 and key == 0 and not self.drawn:
             return self.initialize_plot()
@@ -221,6 +232,7 @@ class CompositePlot(GenericCompositePlot, MPLPlot):
     subplots to form a Layout.
     """
 
+    @mpl_rc_context
     def update_frame(self, key, ranges=None):
         ranges = self.compute_ranges(self.layout, key, ranges)
         for subplot in self.subplots.values():
@@ -413,6 +425,7 @@ class GridPlot(CompositePlot):
         return subplots, subaxes, collapsed_layout
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         # Get the extent of the layout elements (not the whole layout)
         key = self.keys[-1]
@@ -586,6 +599,7 @@ class AdjointLayoutPlot(MPLPlot):
         super(AdjointLayoutPlot, self).__init__(subplots=subplots, **params)
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         """
         Plot all the views contained in the AdjointLayout Object using axes
@@ -657,6 +671,7 @@ class AdjointLayoutPlot(MPLPlot):
                 ax.set_aspect('equal')
 
 
+    @mpl_rc_context
     def update_frame(self, key, ranges=None):
         for pos in self.view_positions:
             subplot = self.subplots.get(pos)
@@ -1015,6 +1030,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         return subplots, adjoint_clone, projections
 
 
+    @mpl_rc_context
     def initialize_plot(self):
         key = self.keys[-1]
         ranges = self.compute_ranges(self.layout, key, None)

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -11,7 +11,7 @@ from ...core import traversal
 from ...core.util import match_spec, max_range, unique_iterator, unique_array, is_nan
 from ...element.raster import Image, Raster, RGB
 from .element import ColorbarPlot, OverlayPlot
-from .plot import MPLPlot, GridPlot
+from .plot import MPLPlot, GridPlot, mpl_rc_context
 
 
 class RasterPlot(ColorbarPlot):
@@ -324,6 +324,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         return GridPlot._get_frame(self, key)
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         _, _, b_w, b_h, widths, heights = self.border_extents
 

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -98,11 +98,13 @@ class MPLRenderer(Renderer):
         if isinstance(plot, tuple(self.widgets.values())):
             data = plot()
         elif fmt in ['png', 'svg', 'pdf', 'html', 'json']:
-            data = self._figure_data(plot, fmt, **({'dpi':self.dpi} if self.dpi else {}))
+            with mpl.rc_context(rc=plot.fig_rcparams):
+                data = self._figure_data(plot, fmt, **({'dpi':self.dpi} if self.dpi else {}))
         else:
             if sys.version_info[0] == 3 and mpl.__version__[:-2] in ['1.2', '1.3']:
                 raise Exception("<b>Python 3 matplotlib animation support broken &lt;= 1.3</b>")
-            anim = plot.anim(fps=self.fps)
+            with mpl.rc_context(rc=plot.fig_rcparams):
+                anim = plot.anim(fps=self.fps)
             data = self._anim_data(anim, fmt)
 
         data = self._apply_post_render_hooks(data, obj, fmt)

--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -15,7 +15,7 @@ from ...interface.seaborn import DFrame as SNSFrame
 from ...core.options import Store
 from .element import ElementPlot
 from .pandas import DFrameViewPlot
-from .plot import MPLPlot, AdjoinedPlot
+from .plot import MPLPlot, AdjoinedPlot, mpl_rc_context
 
 
 class SeabornPlot(ElementPlot):
@@ -230,6 +230,7 @@ class SNSFramePlot(DFrameViewPlot):
         super(SNSFramePlot, self).__init__(view, **params)
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         dfview = self.hmap.last
         axis = self.handles['axis']
@@ -258,6 +259,7 @@ class SNSFramePlot(DFrameViewPlot):
             raise Exception("Multiple %s plots cannot be composed."
                             % self.plot_type)
 
+    @mpl_rc_context
     def update_frame(self, key, ranges=None):
         element = self.hmap.get(key, None)
         axis = self.handles['axis']

--- a/holoviews/plotting/mpl/tabular.py
+++ b/holoviews/plotting/mpl/tabular.py
@@ -1,12 +1,12 @@
 from collections import defaultdict
 from matplotlib.font_manager import FontProperties
 from matplotlib.table import Table as mpl_Table
-from holoviews.core.util import unicode
-
 import param
 
+from ...core.util import bytes_to_unicode, unicode
 from .element import ElementPlot
-from ...core.util import bytes_to_unicode
+from .plot import mpl_rc_context
+
 
 
 class TablePlot(ElementPlot):
@@ -93,6 +93,7 @@ class TablePlot(ElementPlot):
         return cell_text
 
 
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         element = self.hmap.last
         axis = self.handles['axis']

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -274,6 +274,21 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
             if 'main' in adjoint.subplots:
                 self.assertEqual(adjoint.subplots['main'].layout_num, num)
 
+    def test_points_rcparams_do_not_persist(self):
+        opts = dict(fig_rcparams={'text.usetex': True})
+        points = Points(([0, 1], [0, 3]))(plot=opts)
+        plot = mpl_renderer.get_plot(points)
+        self.assertFalse(pyplot.rcParams['text.usetex'])
+
+    def test_points_rcparams_used(self):
+        opts = dict(fig_rcparams={'grid.color': 'red'})
+        points = Points(([0, 1], [0, 3]))(plot=opts)
+        plot = mpl_renderer.get_plot(points)
+        ax = plot.state.axes[0]
+        lines = ax.get_xgridlines()
+        self.assertEqual(lines[0].get_color(), 'red')
+
+
 
 class TestBokehPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
I've long struggled with the correct way to apply rcparams in matplotlib, I now think a decorator which is applied during axis/figure creation, for all ``initialize_plot`` and ``update_frame`` calls and during rendering is the best approach.

Fixes https://github.com/ioam/holoviews/issues/1222