### PR TITLE
Allow ElementOperation to process NdLayout types

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -11,7 +11,7 @@ except:
     pass
 
 from .dimension import ViewableElement
-from .element import Element, HoloMap, GridSpace, Collator
+from .element import Element, HoloMap, GridSpace, NdLayout, Collator
 from .layout import Layout
 from .overlay import NdOverlay, Overlay
 from .spaces import DynamicMap, Callable
@@ -132,12 +132,11 @@ class ElementOperation(Operation):
                     isinstance(element, DynamicMap))
                    or self.p.dynamic is True)
 
-        if isinstance(element, GridSpace):
+        if isinstance(element, (GridSpace, NdLayout)):
             # Initialize an empty axis layout
             grid_data = ((pos, self(cell, **params))
                          for pos, cell in element.items())
-            processed = GridSpace(grid_data, label=element.label,
-                                  kdims=element.kdims)
+            processed = element.clone(grid_data)
         elif dynamic:
             from ..util import Dynamic
             streams = getattr(self.p, 'streams', [])

--- a/tests/testoperation.py
+++ b/tests/testoperation.py
@@ -1,7 +1,7 @@
 import numpy as np
 
-from holoviews import (HoloMap, NdOverlay, Image, Contours, Polygons, Points,
-                       Histogram, Curve)
+from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
+                       Contours, Polygons, Points, Histogram, Curve)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.element import (operation, transform, threshold,
                                          gradient, contours, histogram,
@@ -17,6 +17,20 @@ class ElementOperationTests(ComparisonTestCase):
         img = Image(np.random.rand(10, 10))
         op_img = operation(img, op=lambda x, k: x.clone(x.data*2))
         self.assertEqual(op_img, img.clone(img.data*2, group='Operation'))
+
+    def test_operation_ndlayout(self):
+        ndlayout = NdLayout({i: Image(np.random.rand(10, 10)) for i in range(10)})
+        op_ndlayout = operation(ndlayout, op=lambda x, k: x.clone(x.data*2))
+        doubled = ndlayout.clone({k: v.clone(v.data*2, group='Operation')
+                                  for k, v in ndlayout.items()})
+        self.assertEqual(op_ndlayout, doubled)
+
+    def test_operation_grid(self):
+        grid = GridSpace({i: Image(np.random.rand(10, 10)) for i in range(10)}, kdims=['X'])
+        op_grid = operation(grid, op=lambda x, k: x.clone(x.data*2))
+        doubled = grid.clone({k: v.clone(v.data*2, group='Operation')
+                              for k, v in grid.items()})
+        self.assertEqual(op_grid, doubled)
 
     def test_operation_holomap(self):
         hmap = HoloMap({1: Image(np.random.rand(10, 10))})


### PR DESCRIPTION
Partial fix for https://github.com/ioam/holoviews/issues/1107, while we haven't addressed the issue about (Nd)Overlays, this is a straightforward addition that let's ElementOperations process NdLayouts just as it already handles GridSpaces.