### PR TITLE
Replaced extension logo parameter with banner toggle

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -117,7 +117,8 @@ class notebook_extension(param.ParameterizedFunction):
 
     css = param.String(default='', doc="Optional CSS rule set to apply to the notebook.")
 
-    logo = param.Boolean(default=True, doc="Toggles display of HoloViews logo")
+    banner = param.Boolean(default=True, doc="""
+        Toggles display of HoloViews logo and loading message.""")
 
     inline = param.Boolean(default=True, doc="""Whether to inline JS and CSS resources,
         if disabled resources are loaded from CDN if one is available.""")
@@ -206,8 +207,8 @@ class notebook_extension(param.ParameterizedFunction):
         loaded = ', '.join(js_names[r] if r in js_names else r.capitalize()+'JS'
                            for r in resources)
 
-        load_hvjs(logo=p.logo, JS=('holoviews' in resources),
-                  message = '%s successfully loaded in this cell.' % loaded)
+        message = '' if not p.banner else '%s successfully loaded in this cell.' % loaded
+        load_hvjs(logo=p.banner, JS=('holoviews' in resources), message = message)
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
 


### PR DESCRIPTION
This simple PR replaces the ``logo`` option of the notebook extension (which only toggled the logo) with a ``banner`` switch with can suppress both the logo and the loading message. Addresses #1186.

We'll need to mention the replacement of the ``logo`` parameter in the CHANGELOG but I don't think it is a big deal - the new behavior simply extends the old behavior and I don't think the ``logo`` parameter was used much anyway.