### PR TITLE
Preprocessor refactor

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -10,17 +10,6 @@ from collections import defaultdict
 from .core import util
 
 
-class Preprocessor(param.Parameterized):
-    """
-    A Preprocessor is a callable that takes a dictionary as an argument
-    and returns a dictionary. Where possible, Preprocessors should have
-    valid reprs that can be evaluated.
-    """
-
-    def __call__(self, params):
-        return params
-
-
 class Stream(param.Parameterized):
     """
     A Stream is simply a parameterized object with parameters that

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -64,8 +64,8 @@ class Stream(param.Parameterized):
     def __init__(self, rename={}, source=None, subscribers=[],
                  linked=True, **params):
         """
-        Mapping allows multiple streams with similar event state to be
-        used by remapping parameter names.
+        The rename argument allows multiple streams with similar event
+        state to be used by remapping parameter names.
 
         Source is an optional argument specifying the HoloViews
         datastructure that the stream receives events from, as supported
@@ -100,6 +100,12 @@ class Stream(param.Parameterized):
         return mapping
 
     def rename(self, **mapping):
+        """
+        The rename method allows stream parameters to be allocated to
+        new names to avoid clashes with other stream parameters of the
+        same name. Returns a new clone of the stream instance with the
+        specified name mapping.
+        """
         params = {k:v for k,v in self.get_param_values() if k != 'name'}
         return self.__class__(rename=mapping,
                               source=self._source,

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -72,7 +72,7 @@ class Stream(param.Parameterized):
             stream.deactivate()
 
 
-    def __init__(self, preprocessors=[], source=None, subscribers=[],
+    def __init__(self, source=None, subscribers=[],
                  linked=True, **params):
         """
         Mapping allows multiple streams with similar event state to be
@@ -87,7 +87,6 @@ class Stream(param.Parameterized):
         """
         self._source = source
         self.subscribers = subscribers
-        self.preprocessors = preprocessors
         self._hidden_subscribers = []
         self.linked = linked
 
@@ -124,8 +123,6 @@ class Stream(param.Parameterized):
     @property
     def contents(self):
         remapped = {k:v for k,v in self.get_param_values() if k!= 'name' }
-        for preprocessor in self.preprocessors:
-            remapped = preprocessor(remapped)
         return remapped
 
 
@@ -153,10 +150,7 @@ class Stream(param.Parameterized):
         cls_name = self.__class__.__name__
         kwargs = ','.join('%s=%r' % (k,v)
                           for (k,v) in self.get_param_values() if k != 'name')
-        if not self.preprocessors:
-            return '%s(%s)' % (cls_name, kwargs)
-        else:
-            return '%s(%r, %s)' % (cls_name, self.preprocessors, kwargs)
+        return '%s(%s)' % (cls_name, kwargs)
 
 
     def __str__(self):
@@ -310,9 +304,6 @@ class ParamValues(Stream):
                                for k in self._obj.params().keys() if k!= 'name'}
         else:
             remapped={k:v for k,v in self._obj.get_param_values() if k!= 'name'}
-
-        for preprocessor in self.preprocessors:
-            remapped = preprocessor(remapped)
         return remapped
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -314,7 +314,7 @@ class Selection1D(Stream):
     A stream representing a 1D selection of objects by their index.
     """
 
-    index = param.List(default=[], doc="""
+    index = param.List(default=[], constant=True, doc="""
         Indices into a 1D datastructure.""")
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -127,10 +127,19 @@ class Stream(param.Parameterized):
         self.registry[id(source)].append(self)
 
 
+    def preprocess(self, param_values):
+        """
+        Method that can be overwritten by subclasses to process the
+        parameter values before the renaming step. Allows transformation
+        of parameter values as a function of other parameter values.
+        """
+        return param_values
+
     @property
     def contents(self):
         filtered = {k:v for k,v in self.get_param_values() if k!= 'name' }
-        return {self._rename.get(k,k):v for (k,v) in filtered.items()}
+        processed = self.preprocess(filtered)
+        return {self._rename.get(k,k):v for (k,v) in processed.items()}
 
 
     def update(self, trigger=True, **kwargs):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -15,53 +15,10 @@ class Preprocessor(param.Parameterized):
     A Preprocessor is a callable that takes a dictionary as an argument
     and returns a dictionary. Where possible, Preprocessors should have
     valid reprs that can be evaluated.
-
-    Preprocessors are used to set the contents of a stream based on the
-    parameter values. They may be used for debugging purposes or to
-    remap or repack parameter values before they are passed onto to the
-    subscribers.
     """
 
     def __call__(self, params):
         return params
-
-
-
-class Rename(Preprocessor):
-    """
-    A preprocessor used to rename parameter values.
-    """
-
-    mapping = param.Dict(default={}, doc="""
-      The mapping from the parameter names to the designated names""")
-
-    def __init__(self, **mapping):
-        super(Rename, self).__init__(mapping=mapping)
-
-    def __call__(self, params):
-        return {self.mapping.get(k,k):v for (k,v) in params.items()}
-
-    def __repr__(self):
-        keywords = ','.join('%s=%r' % (k,v) for (k,v) in sorted(self.mapping.items()))
-        return 'Rename(%s)' % keywords
-
-
-
-class Group(Preprocessor):
-    """
-    A preprocessor that keeps the parameter dictionary together,
-    supplying it as a value associated with the given key.
-    """
-
-    def __init__(self, key):
-        super(Group, self).__init__(key=key)
-
-    def __call__(self, params):
-        return {self.key:params}
-
-    def __repr__(self):
-        return 'Group(%r)' % self.key
-
 
 
 class Stream(param.Parameterized):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -89,7 +89,7 @@ class Stream(param.Parameterized):
         self.subscribers = subscribers
         self._hidden_subscribers = []
         self.linked = linked
-        self._rename = rename
+        self._rename = self._validate_rename(rename)
 
         # The metadata may provide information about the currently
         # active event, i.e. the source of the stream values may
@@ -99,6 +99,16 @@ class Stream(param.Parameterized):
         super(Stream, self).__init__(**params)
         if source:
             self.registry[id(source)].append(self)
+
+    def _validate_rename(self, mapping):
+        param_names = [k for k in self.params().keys() if k != 'name']
+        for k,v in mapping.items():
+            if k not in param_names:
+                raise KeyError('Cannot rename %r as it is not a stream parameter' % k)
+            if v in param_names:
+                raise KeyError('Cannot rename to %r as it clashes with a '
+                               'stream parameter of the same name' % v)
+        return mapping
 
     def rename(self, **mapping):
         params = {k:v for k,v in self.get_param_values() if k != 'name'}

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -256,9 +256,16 @@ class PlotSize(Stream):
     Returns the dimensions of a plot once it has been displayed.
     """
 
-    width = param.Integer(300, doc="The width of the plot in pixels")
+    width = param.Integer(300, constant=True, doc="The width of the plot in pixels")
 
-    height = param.Integer(300, doc="The height of the plot in pixels")
+    height = param.Integer(300, constant=True, doc="The height of the plot in pixels")
+
+    scale = param.Number(default=1.0, constant=True, doc="""
+       Scale factor to scale width and height values reported by the stream""")
+
+    def transform(self):
+        return {'width':  int(self.width * self.scale),
+                'height': int(self.width * self.scale)}
 
 
 class RangeXY(Stream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -265,7 +265,7 @@ class PlotSize(Stream):
 
     def transform(self):
         return {'width':  int(self.width * self.scale),
-                'height': int(self.width * self.scale)}
+                'height': int(self.height * self.scale)}
 
 
 class RangeXY(Stream):

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -3,8 +3,16 @@ Unit test of the streams system
 """
 import param
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import Stream, PositionX, PositionY, PositionXY, ParamValues
+from holoviews.streams import * # noqa (Test all available streams)
 
+def test_all_stream_parameters_constant():
+    all_stream_cls = [v for v in globals().values() if
+                      isinstance(v, type) and issubclass(v, Stream)]
+    for stream_cls in all_stream_cls:
+        for name, param in stream_cls.params().items():
+            if param.constant != True:
+                raise TypeError('Parameter %s of stream %s not declared constant'
+                                % (name, stream_cls.__name__))
 
 class TestSubscriber(object):
 

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -4,7 +4,6 @@ Unit test of the streams system
 import param
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import Stream, PositionX, PositionY, PositionXY, ParamValues
-from holoviews.streams import Rename, Group
 
 
 class TestSubscriber(object):
@@ -136,14 +135,3 @@ class TestSubscribers(ComparisonTestCase):
 
         self.assertEqual(subscriber2.kwargs, dict(x=50, y=100))
         self.assertEqual(subscriber2.call_count, 1)
-
-
-class TestPreprocessors(ComparisonTestCase):
-
-    def test_rename_preprocessor(self):
-        position = PositionXY([Rename(x='x1',y='y1')], x=1, y=3)
-        self.assertEqual(position.contents, dict(x1=1, y1=3))
-
-    def test_group_preprocessor(self):
-        position = PositionXY([Group('mygroup')], x=1, y=3)
-        self.assertEqual(position.contents, dict(mygroup={'x':1,'y':3}))

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -177,3 +177,25 @@ class TestParameterRenaming(ComparisonTestCase):
         with self.assertRaises(KeyError) as cm:
             renamed = xy.rename(x='xtest', y='x')
             self.assertEqual(str(cm).endswith('parameter of the same name'), True)
+
+
+class TestPlotSizeTransform(ComparisonTestCase):
+
+    def test_plotsize_initial_contents_1(self):
+        plotsize = PlotSize(width=300, height=400, scale=0.5)
+        self.assertEqual(plotsize.contents, {'width':300, 'height':400, 'scale':0.5})
+
+    def test_plotsize_update_1(self):
+        plotsize = PlotSize(scale=0.5)
+        plotsize.update(width=300, height=400)
+        self.assertEqual(plotsize.contents, {'width':150, 'height':200, 'scale':0.5})
+
+    def test_plotsize_initial_contents_2(self):
+        plotsize = PlotSize(width=600, height=100, scale=2)
+        self.assertEqual(plotsize.contents, {'width':600, 'height':100, 'scale':2})
+
+    def test_plotsize_update_2(self):
+        plotsize = PlotSize(scale=2)
+        plotsize.update(width=600, height=100)
+        self.assertEqual(plotsize.contents, {'width':1200, 'height':200, 'scale':2})
+

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -143,3 +143,37 @@ class TestSubscribers(ComparisonTestCase):
 
         self.assertEqual(subscriber2.kwargs, dict(x=50, y=100))
         self.assertEqual(subscriber2.call_count, 1)
+
+
+class TestParameterRenaming(ComparisonTestCase):
+
+    def test_simple_rename_constructor(self):
+        xy = PositionXY(rename={'x':'xtest', 'y':'ytest'}, x=0, y=4)
+        self.assertEqual(xy.contents, {'xtest':0, 'ytest':4})
+
+    def test_invalid_rename_constructor(self):
+        with self.assertRaises(KeyError) as cm:
+            PositionXY(rename={'x':'xtest', 'z':'ytest'}, x=0, y=4)
+            self.assertEqual(str(cm).endswith('is not a stream parameter'), True)
+
+    def test_clashing_rename_constructor(self):
+        with self.assertRaises(KeyError) as cm:
+            PositionXY(rename={'x':'xtest', 'y':'x'}, x=0, y=4)
+            self.assertEqual(str(cm).endswith('parameter of the same name'), True)
+
+    def test_simple_rename_method(self):
+        xy = PositionXY(x=0, y=4)
+        renamed = xy.rename(x='xtest', y='ytest')
+        self.assertEqual(renamed.contents, {'xtest':0, 'ytest':4})
+
+    def test_invalid_rename_method(self):
+        xy = PositionXY(x=0, y=4)
+        with self.assertRaises(KeyError) as cm:
+            renamed = xy.rename(x='xtest', z='ytest')
+            self.assertEqual(str(cm).endswith('is not a stream parameter'), True)
+
+    def test_clashing_rename_method(self):
+        xy = PositionXY(x=0, y=4)
+        with self.assertRaises(KeyError) as cm:
+            renamed = xy.rename(x='xtest', y='x')
+            self.assertEqual(str(cm).endswith('parameter of the same name'), True)


### PR DESCRIPTION
This PR addressed #1224 by greatly simplifying how stream parameters can be renamed and how stream preprocessing is implemented (when necessary).

The ``rename`` suggestion from that issue has been implemented exactly as suggested but after discussion with @philippjfr and @jbednar, it was decided that we don't really need explicit preprocessor hooks. Instead, the streams that require it can implement the ``preprocess`` method (which occurs before stream renaming) so transform the stream values as necessary.

I would still like a better name than ``rename`` and although I personally like ``remap`` more, I know this isn't the majority opinion. Consider

```python
PositionXY(rename={'x':'x1', 'y':'y1'}, x=2)
```

and 

```python
PositionXY(remap={'x':'x1', 'y':'y1'}, x=2)
```

I feel the latter conveys the idea that ``x`` will be called ``x1`` on the output better. Any other suggestions?

Action items:

- [x] Remove old preprocessor system
- [x] Offer new simplified means of preprocessing streams
- [x]  Implement ``rename`` constructor argument and method
- [x] Update ``PlotSize`` stream with a ``preprocess`` method
- [x] Add unit tests
- [x] Update tutorials **Edit: postponed till a later PR**