### PR TITLE
Simplified how Event subscribers are handled

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -598,9 +598,14 @@ class DynamicMap(HoloMap):
         (renamed as appropriate) to be updated in an event.
         """
         stream_params = set(util.stream_parameters(self.streams))
+        for k in stream_params - set(kwargs.keys()):
+            raise KeyError('Key %r does not correspond to any stream parameter')
+
         updated_streams = []
         for stream in self.streams:
-            rkwargs = util.rename_stream_kwargs(stream, kwargs, reverse=True)
+            applicable_kws = {k:v for k,v in kwargs.items()
+                              if k in set(stream.contents.keys())}
+            rkwargs = util.rename_stream_kwargs(stream, applicable_kws, reverse=True)
             stream.update(**dict(rkwargs, trigger=False))
             updated_streams.append(stream)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -594,16 +594,15 @@ class DynamicMap(HoloMap):
 
     def event(self, trigger=True, **kwargs):
         """
-        This method allows any of the available stream parameters to be
-        updated in an event.
+        This method allows any of the available stream parameters
+        (renamed as appropriate) to be updated in an event.
         """
         stream_params = set(util.stream_parameters(self.streams))
         updated_streams = []
         for stream in self.streams:
-            overlap = set(stream.contents.keys()) & stream_params & set(kwargs.keys())
-            if overlap:
-                stream.update(**dict({k:kwargs[k] for k in overlap}, trigger=False))
-                updated_streams.append(stream)
+            rkwargs = util.rename_stream_kwargs(stream, kwargs, reverse=True)
+            stream.update(**dict(rkwargs, trigger=False))
+            updated_streams.append(stream)
 
         if updated_streams and trigger:
             updated_streams[0].trigger(updated_streams)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -600,7 +600,7 @@ class DynamicMap(HoloMap):
         stream_params = set(util.stream_parameters(self.streams))
         updated_streams = []
         for stream in self.streams:
-            overlap = set(stream.params().keys()) & stream_params & set(kwargs.keys())
+            overlap = set(stream.contents.keys()) & stream_params & set(kwargs.keys())
             if overlap:
                 stream.update(**dict({k:kwargs[k] for k in overlap}, trigger=False))
                 updated_streams.append(stream)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -914,6 +914,41 @@ def wrap_tuple(unwrapped):
     return (unwrapped if isinstance(unwrapped, tuple) else (unwrapped,))
 
 
+def stream_name_mapping(stream, exclude_params=['name'], reverse=False):
+    """
+    Return a complete dictionary mapping between stream parameter names
+    to their applicable renames, excluding parameters listed in
+    exclude_params.
+
+    If reverse is True, the mapping is from the renamed strings to the
+    original stream parameter names.
+    """
+    filtered = [k for k in stream.params().keys() if k not in exclude_params]
+    mapping = {k:stream._rename.get(k,k) for k in filtered}
+    if reverse:
+        return {v:k for k,v in mapping.items()}
+    else:
+        return mapping
+
+def rename_stream_kwargs(stream, kwargs, reverse=False):
+    """
+    Given a stream and a kwargs dictionary of parameter values, map to
+    the corresponding dictionary where the keys are substituted with the
+    appropriately renamed string.
+
+    If reverse, the output will be a dictionary using the original
+    parameter names given a dictionary using the renamed equivalents.
+    """
+    mapped_kwargs = {}
+    mapping = stream_name_mapping(stream, reverse=reverse)
+    for k,v in kwargs.items():
+        if k not in mapping:
+            msg = 'Could not map key {key} {direction} renamed equivalent'
+            direction = 'from' if reverse else 'to'
+            raise KeyError(msg.format(key=repr(k), direction=direction))
+        mapped_kwargs[mapping[k]] = v
+    return mapped_kwargs
+
 
 def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     """

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -298,7 +298,7 @@ def attach_streams(plot, obj):
     """
     def append_refresh(dmap):
         for stream in get_nested_streams(dmap):
-            stream._hidden_subscribers.append(plot.refresh)
+            stream.add_subscriber(plot.refresh)
     return obj.traverse(append_refresh, [DynamicMap])
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -61,8 +61,7 @@ class Stream(param.Parameterized):
             stream.deactivate()
 
 
-    def __init__(self, rename={}, source=None, subscribers=[],
-                 linked=True, **params):
+    def __init__(self, rename={}, source=None, linked=True, **params):
         """
         The rename argument allows multiple streams with similar event
         state to be used by remapping parameter names.
@@ -75,7 +74,7 @@ class Stream(param.Parameterized):
         plot, to disable this set linked=False
         """
         self._source = source
-        self.subscribers = subscribers
+        self._subscribers = []
         self._hidden_subscribers = []
         self.linked = linked
         self._rename = self._validate_rename(rename)
@@ -88,6 +87,20 @@ class Stream(param.Parameterized):
         super(Stream, self).__init__(**params)
         if source:
             self.registry[id(source)].append(self)
+
+
+    @property
+    def subscribers(self):
+        return self._subscribers
+
+    def clear(self):
+        self._subscribers = []
+
+    def add_subscriber(self, subscriber):
+        if callable(subscriber):
+            self._subscribers.append(subscriber)
+        else:
+            raise TypeError('Subscriber must be a callable.')
 
     def _validate_rename(self, mapping):
         param_names = [k for k in self.params().keys() if k != 'name']
@@ -109,7 +122,6 @@ class Stream(param.Parameterized):
         params = {k:v for k,v in self.get_param_values() if k != 'name'}
         return self.__class__(rename=mapping,
                               source=self._source,
-                              subscribers=self.subscribers,
                               linked=self.linked, **params)
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -95,10 +95,9 @@ class Stream(param.Parameterized):
         self._subscribers = []
 
     def add_subscriber(self, subscriber):
-        if callable(subscriber):
-            self._subscribers.append(subscriber)
-        else:
+        if not callable(subscriber):
             raise TypeError('Subscriber must be a callable.')
+        self._subscribers.append(subscriber)
 
     def _validate_rename(self, mapping):
         param_names = [k for k in self.params().keys() if k != 'name']

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -92,12 +92,21 @@ class Stream(param.Parameterized):
 
     @property
     def subscribers(self):
+        " Property returning the subscriber list"
         return self._subscribers
 
     def clear(self):
+        """
+        Clear all subscribers registered to this stream.
+        """
         self._subscribers = []
 
     def add_subscriber(self, subscriber):
+        """
+        Register a callable subscriber to this stream which will be
+        invoked either when update is called with trigger=True or when
+        this stream is passed to the trigger classmethod.
+        """
         if not callable(subscriber):
             raise TypeError('Subscriber must be a callable.')
         self._subscribers.append(subscriber)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -60,7 +60,7 @@ class Stream(param.Parameterized):
             stream.deactivate()
 
 
-    def __init__(self, rename={}, source=None, linked=True, **params):
+    def __init__(self, rename={}, source=None, subscribers=[], linked=True, **params):
         """
         The rename argument allows multiple streams with similar event
         state to be used by remapping parameter names.
@@ -74,6 +74,9 @@ class Stream(param.Parameterized):
         """
         self._source = source
         self._subscribers = []
+        for subscriber in subscribers:
+            self.add_subscriber(subscriber)
+
         self.linked = linked
         self._rename = self._validate_rename(rename)
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -51,8 +51,7 @@ class Stream(param.Parameterized):
 
         # Currently building a simple set of subscribers
         groups = [stream.subscribers for stream in streams]
-        hidden = [stream._hidden_subscribers for stream in streams]
-        subscribers = util.unique_iterator([s for subscribers in groups+hidden
+        subscribers = util.unique_iterator([s for subscribers in groups
                                             for s in subscribers])
         for subscriber in subscribers:
             subscriber(**dict(union))
@@ -75,7 +74,6 @@ class Stream(param.Parameterized):
         """
         self._source = source
         self._subscribers = []
-        self._hidden_subscribers = []
         self.linked = linked
         self._rename = self._validate_rename(rename)
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -177,9 +177,16 @@ class Stream(param.Parameterized):
         constants = [p.constant for p in params]
         for param in params:
             param.constant = False
-        self.set_param(**kwargs)
-        for (param, const) in zip(params, constants):
-            param.constant = const
+        try:
+            self.set_param(**kwargs)
+        except Exception as e:
+            for (param, const) in zip(params, constants):
+                param.constant = const
+            raise
+        else:
+            for (param, const) in zip(params, constants):
+                param.constant = const
+
 
     def update(self, trigger=True, **kwargs):
         """

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -174,28 +174,20 @@ class Stream(param.Parameterized):
 
     def update(self, trigger=True, **kwargs):
         """
-        The update method updates the stream parameters in response to
-        some event. If the stream has a custom transform method, this
-        is applied to transform the parameter values accordingly.
+        The update method updates the stream parameters (without any
+        renaming applied) in response to some event. If the stream has a
+        custom transform method, this is applied to transform the
+        parameter values accordingly.
 
         If trigger is enabled, the trigger classmethod is invoked on
         this particular Stream instance.
         """
-        reverse_map = {v:k for k,v in self._rename.items()}
-        param_kws = {}
-        for (k,v) in kwargs.items():
-            if k in reverse_map:
-               param_kws[reverse_map[k]] = v
-            else:
-                param_kws[k] = v
-
-        self._set_stream_parameters(**param_kws)
+        self._set_stream_parameters(**kwargs)
         transformed = self.transform()
         if transformed:
             self._set_stream_parameters(**transformed)
         if trigger:
             self.trigger([self])
-
 
     def __repr__(self):
         cls_name = self.__class__.__name__

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -183,9 +183,9 @@ class Stream(param.Parameterized):
             for (param, const) in zip(params, constants):
                 param.constant = const
             raise
-        else:
-            for (param, const) in zip(params, constants):
-                param.constant = const
+
+        for (param, const) in zip(params, constants):
+            param.constant = const
 
 
     def update(self, trigger=True, **kwargs):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -178,7 +178,15 @@ class Stream(param.Parameterized):
         If trigger is enabled, the trigger classmethod is invoked on
         this particular Stream instance.
         """
-        self._set_stream_parameters(**kwargs)
+        reverse_map = {v:k for k,v in self._rename.items()}
+        param_kws = {}
+        for (k,v) in kwargs.items():
+            if k in reverse_map:
+               param_kws[reverse_map[k]] = v
+            else:
+                param_kws[k] = v
+
+        self._set_stream_parameters(**param_kws)
         transformed = self.transform()
         if transformed:
             self._set_stream_parameters(**transformed)

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -242,7 +242,8 @@ class DynamicTestOverlay(ComparisonTestCase):
 
         xy = PositionXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
-        with self.assertRaises(KeyError) as cm:
+
+        regexp = '(.+?)does not correspond to any stream parameter'
+        with self.assertRaisesRegexp(KeyError, regexp):
             dmap.event(x=1, y=2)
-            self.assertEqual(str(cm).endswith('from renamed equivalent'), True)
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -226,3 +226,23 @@ class DynamicTestOverlay(ComparisonTestCase):
         self.assertEqual(overlay.Scatter.I, fn(1, 2))
         # Ensure dmap2 callback was called only once
         self.assertEqual(counter[0], 1)
+
+    def test_dynamic_event_renaming_valid(self):
+
+        def fn(x, y):
+            return Scatter([(x, y)])
+
+        xy = PositionXY(rename={'x':'x1','y':'y1'})
+        dmap = DynamicMap(fn, kdims=[], streams=[xy])
+        dmap.event(x1=1, y1=2)
+
+    def test_dynamic_event_renaming_invalid(self):
+        def fn(x, y):
+            return Scatter([(x, y)])
+
+        xy = PositionXY(rename={'x':'x1','y':'y1'})
+        dmap = DynamicMap(fn, kdims=[], streams=[xy])
+        with self.assertRaises(KeyError) as cm:
+            dmap.event(x=1, y=2)
+            self.assertEqual(str(cm).endswith('from renamed equivalent'), True)
+

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -9,8 +9,9 @@ def test_all_stream_parameters_constant():
     all_stream_cls = [v for v in globals().values() if
                       isinstance(v, type) and issubclass(v, Stream)]
     for stream_cls in all_stream_cls:
-        for name, param in stream_cls.params().items():
-            if param.constant != True:
+        for name, p in stream_cls.params().items():
+            if name == 'name': continue
+            if p.constant != True:
                 raise TypeError('Parameter %s of stream %s not declared constant'
                                 % (name, stream_cls.__name__))
 

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -178,6 +178,19 @@ class TestParameterRenaming(ComparisonTestCase):
             renamed = xy.rename(x='xtest', y='x')
             self.assertEqual(str(cm).endswith('parameter of the same name'), True)
 
+    def test_update_rename_valid(self):
+        xy = PositionXY(x=0, y=4)
+        renamed = xy.rename(x='xtest', y='ytest')
+        renamed.update(x=4, y=8)
+        self.assertEqual(renamed.contents, {'xtest':4, 'ytest':8})
+
+    def test_update_rename_invalid(self):
+        xy = PositionXY(x=0, y=4)
+        renamed = xy.rename(x='xtest', y='ytest')
+        with self.assertRaises(ValueError) as cm:
+            renamed.update(xtest=4, ytest=8)
+            self.assertEqual(str(cm).startsswith("'ytest' is not a parameter of"), True)
+
 
 class TestPlotSizeTransform(ComparisonTestCase):
 

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -153,14 +153,15 @@ class TestParameterRenaming(ComparisonTestCase):
         self.assertEqual(xy.contents, {'xtest':0, 'ytest':4})
 
     def test_invalid_rename_constructor(self):
-        with self.assertRaises(KeyError) as cm:
+        regexp = '(.+?)is not a stream parameter'
+        with self.assertRaisesRegexp(KeyError, regexp):
             PositionXY(rename={'x':'xtest', 'z':'ytest'}, x=0, y=4)
-            self.assertEqual(str(cm).endswith('is not a stream parameter'), True)
+            self.assertEqual(str(cm).endswith(), True)
 
     def test_clashing_rename_constructor(self):
-        with self.assertRaises(KeyError) as cm:
+        regexp = '(.+?)parameter of the same name'
+        with self.assertRaisesRegexp(KeyError, regexp):
             PositionXY(rename={'x':'xtest', 'y':'x'}, x=0, y=4)
-            self.assertEqual(str(cm).endswith('parameter of the same name'), True)
 
     def test_simple_rename_method(self):
         xy = PositionXY(x=0, y=4)
@@ -169,15 +170,16 @@ class TestParameterRenaming(ComparisonTestCase):
 
     def test_invalid_rename_method(self):
         xy = PositionXY(x=0, y=4)
-        with self.assertRaises(KeyError) as cm:
+        regexp = '(.+?)is not a stream parameter'
+        with self.assertRaisesRegexp(KeyError, regexp):
             renamed = xy.rename(x='xtest', z='ytest')
-            self.assertEqual(str(cm).endswith('is not a stream parameter'), True)
+
 
     def test_clashing_rename_method(self):
         xy = PositionXY(x=0, y=4)
-        with self.assertRaises(KeyError) as cm:
+        regexp = '(.+?)parameter of the same name'
+        with self.assertRaisesRegexp(KeyError, regexp):
             renamed = xy.rename(x='xtest', y='x')
-            self.assertEqual(str(cm).endswith('parameter of the same name'), True)
 
     def test_update_rename_valid(self):
         xy = PositionXY(x=0, y=4)
@@ -188,9 +190,9 @@ class TestParameterRenaming(ComparisonTestCase):
     def test_update_rename_invalid(self):
         xy = PositionXY(x=0, y=4)
         renamed = xy.rename(x='xtest', y='ytest')
-        with self.assertRaises(ValueError) as cm:
+        regexp = "ytest' is not a parameter of(.+?)"
+        with self.assertRaisesRegexp(ValueError, regexp):
             renamed.update(xtest=4, ytest=8)
-            self.assertEqual(str(cm).startsswith("'ytest' is not a parameter of"), True)
 
 
 class TestPlotSizeTransform(ComparisonTestCase):

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -189,10 +189,10 @@ class TestParameterRenaming(ComparisonTestCase):
 
     def test_update_rename_invalid(self):
         xy = PositionXY(x=0, y=4)
-        renamed = xy.rename(x='xtest', y='ytest')
+        renamed = xy.rename(y='ytest')
         regexp = "ytest' is not a parameter of(.+?)"
         with self.assertRaisesRegexp(ValueError, regexp):
-            renamed.update(xtest=4, ytest=8)
+            renamed.update(ytest=8)
 
 
 class TestPlotSizeTransform(ComparisonTestCase):


### PR DESCRIPTION
This PR offers ``clear`` and ``add_subscriber`` methods to ``Event`` and does away with ``_hidden_subscribers``. The ``subscribers`` attribute is now in fact a read-only property which means the correct way to add subscribers is with the ``add_subscribers`` method.

Outstanding items to address:

- [x] Clarify whether ``DynamicMap.event`` and ``Stream.update`` methods support names before or after renaming.
- [x] Add more unit tests
- [x] Add docstrings