### PR TITLE
Remove bokeh matplotlib compatibility

### DIFF
--- a/doc/Tutorials/Bokeh_Backend.ipynb
+++ b/doc/Tutorials/Bokeh_Backend.ipynb
@@ -311,35 +311,8 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "focus": false,
-    "id": "85e1ed20-1e12-4194-822e-c2fe0810ce41"
-   },
-   "source": [
-    "### Matplotlib/Seaborn conversions\n",
-    "\n",
-    "Bokeh also allows converting a subset of existing matplotlib plot types to Bokeh. This allows us to work with some of the Seaborn plot types, including Distribution, Bivariate, and TimeSeries:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "focus": false,
-    "id": "f406d9f0-8488-4b0b-9bf2-95477aad104b"
-   },
-   "outputs": [],
-   "source": [
-    "%%opts Distribution (kde_kws=dict(shade=True))\n",
-    "d1 = np.random.randn(500) + 450\n",
-    "d2 = np.random.randn(500) + 540\n",
-    "sines = np.array([np.sin(np.linspace(0, np.pi*2, 100)) + np.random.normal(0, 1, 100) for _ in range(20)])\n",
-    "hv.Distribution(d1) + hv.Bivariate((d1, d2)) + hv.TimeSeries(sines)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
+    "deletable": true,
+    "editable": true,
     "focus": false,
     "id": "fd1916ba-13a5-404a-8115-f63487b38689"
    },

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -19,7 +19,7 @@ from ..plot import PlotSelector
 
 from .annotation import TextPlot, LineAnnotationPlot, SplinePlot
 from .callbacks import Callback # noqa (API import)
-from .element import OverlayPlot, BokehMPLWrapper
+from .element import OverlayPlot
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BoxPlot, BarPlot, SpikesPlot,
                     SideSpikesPlot, AreaPlot, VectorFieldPlot)
@@ -97,25 +97,6 @@ try:
                     Bars: BarPlot}, 'bokeh')
 except ImportError:
     pass
-
-try:
-    from ..mpl.seaborn import TimeSeriesPlot, BivariatePlot, DistributionPlot
-    from ...interface.seaborn import Bivariate, TimeSeries, Distribution
-    Store.register({Distribution: PlotSelector(lambda x: 'bokeh',
-                                               [('mpl', DistributionPlot),
-                                                ('bokeh', BokehMPLWrapper)],
-                                               True),
-                    TimeSeries: PlotSelector(lambda x: 'bokeh',
-                                             [('mpl', TimeSeriesPlot),
-                                              ('bokeh', BokehMPLWrapper)],
-                                             True),
-                    Bivariate: PlotSelector(lambda x: 'bokeh',
-                                        [('mpl', BivariatePlot),
-                                         ('bokeh', BokehMPLWrapper)], True)},
-                   'bokeh')
-except ImportError:
-    pass
-
 
 point_size = np.sqrt(6) # Matches matplotlib default
 Cycle.default_cycles['default_colors'] =  ['#30a2da', '#fc4f30', '#e5ae38',


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/1218 this removes the BokehMPLWrapper plot class and support for Distribution, Bivariate, and TimeSeries Elements. I was initially hesitant to remove this entirely in 1.7 but with the amount of warnings these currently generate and other restrictions on these plot types, I think just removing them is the correct thing to do. Hopefully we can readd Distribution and Bivariate support in 2.0 as part of the statistical elements module (https://github.com/ioam/holoviews/issues/1200).