### PR TITLE
Handle batched styles consistently

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -113,9 +113,10 @@ class PointPlot(LegendPlot, ColorbarPlot):
                 data[k].append(eld)
 
             # Apply static styles
+            nvals = len(list(eldata.values())[0])
             style = styles[zorder]
             expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping)
+                                 data, elmapping, nvals)
 
             nvals = len(list(data.values()[0])[-1])
             if any(isinstance(t, HoverTool) for t in self.state.tools):
@@ -265,11 +266,11 @@ class CurvePlot(ElementPlot):
             # Apply static styles
             style = styles[zorder]
             expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping)
+                                 data, elmapping, nvals=None)
 
             for d, k in zip(overlay.kdims, key):
                 sanitized = dimension_sanitizer(d.name)
-                data[sanitized].append([k])
+                data[sanitized].append(k)
         data = {opt: vals for opt, vals in data.items()
                 if not any(v is None for v in vals)}
         mapping = {{'x': 'xs', 'y': 'ys'}.get(k, k): v

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -115,7 +115,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
             expand_batched_style(style, self._batched_style_opts,
                                  data, elmapping, nvals)
 
-            nvals = len(list(data.values()[0])[-1])
+            nvals = len(list(eldata.values())[0])
             if any(isinstance(t, HoverTool) for t in self.state.tools):
                 for dim, k in zip(element.dimensions(), key):
                     sanitized = dimension_sanitizer(dim.name)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -51,10 +51,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
                   line_properties + fill_properties)
 
     _plot_methods = dict(single='scatter', batched='scatter')
-    _batched_style_opts = ['line_color', 'fill_color', 'color',
-                           'fill_alpha', 'line_alpha', 'alpha',
-                           'size', 'line_width', 'line_dash',
-                           'line_join', 'line_cap']
+    _batched_style_opts = line_properties + fill_properties + ['size']
 
     def _get_size_data(self, element, ranges, style):
         data, mapping = {}, {}
@@ -227,8 +224,7 @@ class CurvePlot(ElementPlot):
 
     style_opts = line_properties
     _plot_methods = dict(single='line', batched='multi_line')
-    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha',
-                           'line_width', 'line_dash', 'line_join', 'line_cap']
+    _batched_style_opts = line_properties
 
     def get_data(self, element, ranges=None, empty=False):
         if 'steps' in self.interpolation:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -270,8 +270,9 @@ class CurvePlot(ElementPlot):
                 data[sanitized].append([k])
         data = {opt: vals for opt, vals in data.items()
                 if not any(v is None for v in vals)}
-        return data, dict(xs=elmapping['x'], ys=elmapping['y'],
-                          **{o: o for o in opts if o in data})
+        mapping = {{'x': 'xs', 'y': 'ys'}.get(k, k): v
+                   for k, v in elmapping.items()}
+        return data, mapping
 
 
 class AreaPlot(PolygonPlot):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -47,12 +47,14 @@ class PointPlot(LegendPlot, ColorbarPlot):
       Function applied to size values before applying scaling,
       to remove values lower than zero.""")
 
-    style_opts = (['cmap', 'palette', 'marker', 'size', 's'] +
+    style_opts = (['cmap', 'palette', 'marker', 'size'] +
                   line_properties + fill_properties)
 
     _plot_methods = dict(single='scatter', batched='scatter')
     _batched_style_opts = ['line_color', 'fill_color', 'color',
-                           'fill_alpha', 'line_alpha', 'alpha']
+                           'fill_alpha', 'line_alpha', 'alpha',
+                           'size', 'line_width', 'line_dash',
+                           'line_join', 'line_cap']
 
     def _get_size_data(self, element, ranges, style):
         data, mapping = {}, {}
@@ -224,8 +226,8 @@ class CurvePlot(ElementPlot):
 
     style_opts = line_properties
     _plot_methods = dict(single='line', batched='multi_line')
-    _mapping = {p: p for p in ['xs', 'ys', 'color', 'line_alpha']}
-    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha']
+    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha',
+                           'line_width', 'line_dash', 'line_join', 'line_cap']
 
     def get_data(self, element, ranges=None, empty=False):
         if 'steps' in self.interpolation:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -19,7 +19,8 @@ from ..util import (compute_sizes, get_sideplot_ranges, match_spec,
 from .element import (ElementPlot, ColorbarPlot, LegendPlot, line_properties,
                       fill_properties)
 from .path import PathPlot, PolygonPlot
-from .util import get_cmap, mpl_to_bokeh, update_plot, rgb2hex, bokeh_version
+from .util import (get_cmap, mpl_to_bokeh, update_plot, rgb2hex,
+                   bokeh_version, expand_batched_style)
 
 
 class PointPlot(LegendPlot, ColorbarPlot):
@@ -50,6 +51,8 @@ class PointPlot(LegendPlot, ColorbarPlot):
                   line_properties + fill_properties)
 
     _plot_methods = dict(single='scatter', batched='scatter')
+    _batched_style_opts = ['line_color', 'fill_color', 'color',
+                           'fill_alpha', 'line_alpha', 'alpha']
 
     def _get_size_data(self, element, ranges, style):
         data, mapping = {}, {}
@@ -101,25 +104,23 @@ class PointPlot(LegendPlot, ColorbarPlot):
         zorders = self._updated_zorders(element)
         styles = self.lookup_options(element.last, 'style')
         styles = styles.max_cycles(len(self.ordering))
-
         for (key, el), zorder in zip(element.data.items(), zorders):
             self.set_param(**self.lookup_options(el, 'plot').options)
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].append(eld)
 
-            nvals = len(data[k][-1])
-            if 'color' not in elmapping:
-                val = styles[zorder].get('color')
-                elmapping['color'] = {'field': 'color'}
-                if isinstance(val, tuple):
-                    val = rgb2hex(val)
-                data['color'].append([val]*nvals)
+            # Apply static styles
+            style = styles[zorder]
+            expand_batched_style(style, self._batched_style_opts,
+                                 data, elmapping)
 
+            nvals = len(list(data.values()[0])[-1])
             if any(isinstance(t, HoverTool) for t in self.state.tools):
                 for dim, k in zip(element.dimensions(), key):
                     sanitized = dimension_sanitizer(dim.name)
                     data[sanitized].append([k]*nvals)
+
         data = {k: np.concatenate(v) for k, v in data.items()}
         return data, elmapping
 
@@ -224,6 +225,7 @@ class CurvePlot(ElementPlot):
     style_opts = line_properties
     _plot_methods = dict(single='line', batched='multi_line')
     _mapping = {p: p for p in ['xs', 'ys', 'color', 'line_alpha']}
+    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha']
 
     def get_data(self, element, ranges=None, empty=False):
         if 'steps' in self.interpolation:
@@ -248,7 +250,6 @@ class CurvePlot(ElementPlot):
 
     def get_batched_data(self, overlay, ranges=None, empty=False):
         data = defaultdict(list)
-        opts = ['color', 'line_alpha', 'line_color']
 
         zorders = self._updated_zorders(overlay)
         styles = self.lookup_options(overlay.last, 'style')
@@ -259,15 +260,10 @@ class CurvePlot(ElementPlot):
             for k, eld in eldata.items():
                 data[k].append(eld)
 
-            # Add options
+            # Apply static styles
             style = styles[zorder]
-            for opt in opts:
-                if opt not in style:
-                    continue
-                val = style[opt]
-                if opt == 'color' and isinstance(val, tuple):
-                    val = rgb2hex(val)
-                data[opt].append([val])
+            expand_batched_style(style, self._batched_style_opts,
+                                 data, elmapping)
 
             for d, k in zip(overlay.kdims, key):
                 sanitized = dimension_sanitizer(d.name)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -643,8 +643,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                     if glyph_prop and ('fill_'+prop not in glyph_props or gtype):
                         glyph_props['fill_'+prop] = glyph_prop
 
-                glyph_props.update({k[len(gtype):]: v for k, v in glyph_props.items()
-                                    if k.startswith(gtype)})
+                props = {k[len(gtype):]: v for k, v in glyph_props.items()
+                         if k.startswith(gtype)}
+                if self.batched:
+                    glyph_props = dict(props, **glyph_props)
+                else:
+                    glyph_props.update(props)
             filtered = {k: v for k, v in glyph_props.items()
                         if k in allowed_properties}
             glyph.update(**filtered)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -8,7 +8,7 @@ from bokeh.models import HoverTool
 from ...core import util
 from ..util import map_colors
 from .element import ElementPlot, ColorbarPlot, line_properties, fill_properties
-from .util import get_cmap, rgb2hex
+from .util import get_cmap, rgb2hex, expand_batched_style
 
 
 class PathPlot(ElementPlot):
@@ -19,6 +19,7 @@ class PathPlot(ElementPlot):
     style_opts = ['color'] + line_properties
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
+    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha']
 
     def _hover_opts(self, element):
         if self.batched:
@@ -45,12 +46,11 @@ class PathPlot(ElementPlot):
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].extend(eld)
-            val = styles[zorder].get('color')
-            if val:
-                elmapping['line_color'] = 'color'
-                if isinstance(val, tuple):
-                    val = rgb2hex(val)
-                data['color'] += [val for _ in range(len(list(eldata.values())[0]))]
+
+            # Apply static styles
+            style = styles[zorder]
+            expand_batched_style(style, self._batched_style_opts,
+                                 data, elmapping)
         return data, elmapping
 
 
@@ -58,6 +58,8 @@ class PolygonPlot(ColorbarPlot, PathPlot):
 
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
+    _batched_style_opts = ['line_color', 'fill_color', 'color',
+                           'fill_alpha', 'line_alpha', 'alpha']
 
     def _hover_opts(self, element):
         if self.batched:
@@ -104,11 +106,11 @@ class PolygonPlot(ColorbarPlot, PathPlot):
             eldata, elmapping = self.get_data(el, ranges, empty)
             for k, eld in eldata.items():
                 data[k].extend(eld)
-            if 'color' not in elmapping:
-                val = styles[zorder].get('color')
-                elmapping['color'] = 'color'
-                if isinstance(val, tuple):
-                    val = rgb2hex(val)
-                data['color'] += [val for _ in range(len(eldata['xs']))]
+
+            # Apply static styles
+            style = styles[zorder]
+            expand_batched_style(style, self._batched_style_opts,
+                                 data, elmapping)
+
 
         return data, elmapping

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -19,7 +19,8 @@ class PathPlot(ElementPlot):
     style_opts = ['color'] + line_properties
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
-    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha']
+    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha',
+                           'line_width', 'line_dash', 'line_join', 'line_cap']
 
     def _hover_opts(self, element):
         if self.batched:
@@ -60,7 +61,8 @@ class PolygonPlot(ColorbarPlot, PathPlot):
     style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
     _batched_style_opts = ['line_color', 'fill_color', 'color',
-                           'fill_alpha', 'line_alpha', 'alpha']
+                           'fill_alpha', 'line_alpha', 'alpha', 'line_width',
+                           'line_dash', 'line_join', 'line_cap']
 
     def _hover_opts(self, element):
         if self.batched:

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -16,11 +16,10 @@ class PathPlot(ElementPlot):
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 
-    style_opts = ['color'] + line_properties
+    style_opts = line_properties
     _plot_methods = dict(single='multi_line', batched='multi_line')
     _mapping = dict(xs='xs', ys='ys')
-    _batched_style_opts = ['line_color', 'color', 'line_alpha', 'alpha',
-                           'line_width', 'line_dash', 'line_join', 'line_cap']
+    _batched_style_opts = line_properties
 
     def _hover_opts(self, element):
         if self.batched:
@@ -59,11 +58,10 @@ class PathPlot(ElementPlot):
 
 class PolygonPlot(ColorbarPlot, PathPlot):
 
-    style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
+    style_opts = ['cmap', 'palette'] + line_properties + fill_properties
     _plot_methods = dict(single='patches', batched='patches')
-    _batched_style_opts = ['line_color', 'fill_color', 'color',
-                           'fill_alpha', 'line_alpha', 'alpha', 'line_width',
-                           'line_dash', 'line_join', 'line_cap']
+    _style_opts = ['color', 'cmap', 'palette'] + line_properties + fill_properties
+    _batched_style_opts = line_properties + fill_properties
 
     def _hover_opts(self, element):
         if self.batched:

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -50,7 +50,8 @@ class PathPlot(ElementPlot):
             # Apply static styles
             style = styles[zorder]
             expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping)
+                                 data, elmapping, path=True)
+
         return data, elmapping
 
 
@@ -110,7 +111,6 @@ class PolygonPlot(ColorbarPlot, PathPlot):
             # Apply static styles
             style = styles[zorder]
             expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping)
-
+                                 data, elmapping, path=True)
 
         return data, elmapping

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -8,7 +8,8 @@ from bokeh.models import HoverTool
 from ...core import util
 from ..util import map_colors
 from .element import ElementPlot, ColorbarPlot, line_properties, fill_properties
-from .util import get_cmap, rgb2hex, expand_batched_style
+from .util import (get_cmap, rgb2hex, expand_batched_style,
+                   filter_batched_data)
 
 
 class PathPlot(ElementPlot):
@@ -50,9 +51,13 @@ class PathPlot(ElementPlot):
             # Apply static styles
             nvals = len(list(eldata.values())[0])
             style = styles[zorder]
-            expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping, nvals, multiple=True)
+            sdata, smapping = expand_batched_style(style, self._batched_style_opts,
+                                                   elmapping, nvals)
+            elmapping.update(smapping)
+            for k, v in sdata.items():
+                data[k].extend(list(v))
 
+        filter_batched_data(data, elmapping)
         return data, elmapping
 
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -49,9 +49,10 @@ class PathPlot(ElementPlot):
                 data[k].extend(eld)
 
             # Apply static styles
+            nvals = len(list(eldata.values())[0])
             style = styles[zorder]
             expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping, path=True)
+                                 data, elmapping, nvals, multiple=True)
 
         return data, elmapping
 
@@ -95,24 +96,3 @@ class PolygonPlot(ColorbarPlot, PathPlot):
             data[dim_name] = [element.level for _ in range(len(xs))]
 
         return data, mapping
-
-
-    def get_batched_data(self, element, ranges=None, empty=False):
-        data = defaultdict(list)
-        
-        zorders = self._updated_zorders(element)
-        styles = self.lookup_options(element.last, 'style')
-        styles = styles.max_cycles(len(self.ordering))
-
-        for (key, el), zorder in zip(element.data.items(), zorders):
-            self.overlay_dims = dict(zip(element.kdims, key))
-            eldata, elmapping = self.get_data(el, ranges, empty)
-            for k, eld in eldata.items():
-                data[k].extend(eld)
-
-            # Apply static styles
-            style = styles[zorder]
-            expand_batched_style(style, self._batched_style_opts,
-                                 data, elmapping, path=True)
-
-        return data, elmapping

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -547,3 +547,40 @@ def get_tab_title(key, frame, overlay):
         title = ' | '.join([d.pprint_value_string(k) for d, k in
                             zip(overlay.kdims, key)])
     return title
+
+
+def expand_batched_style(style, opts, data, mapping):
+    """
+    Expands styles applied to a batched plot by iterating over the
+    supplied list of style options and any options found in the supplied
+    style dictionary to the ColumnDataSource data and mapping.
+    """
+    nvals = len(list(data.values()[0])[-1])
+    for opt in opts:
+        if 'color' in opt:
+            alias = 'color'
+        elif 'alpha' in opt:
+            alias = 'alpha'
+        else:
+            alias = None
+        if opt not in style:
+            continue
+        elif opt == alias:
+            if alias in mapping:
+                continue
+            elif 'line_'+alias in mapping:
+                if 'fill_'+alias not in opts:
+                    continue
+                opt = 'fill_'+alias
+                val = style[alias]
+            elif 'fill_'+alias in mapping:
+                opt = 'line_'+alias
+                val = style[alias]
+            else:
+                val = style[alias]
+        else:
+            val = style[opt]
+        mapping[opt] = {'field': opt}
+        if 'color' in opt and isinstance(val, tuple):
+            val = rgb2hex(val)
+        data[opt].append([val]*nvals)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -549,13 +549,15 @@ def get_tab_title(key, frame, overlay):
     return title
 
 
-def expand_batched_style(style, opts, data, mapping):
+def expand_batched_style(style, opts, data, mapping, path=False):
     """
     Expands styles applied to a batched plot by iterating over the
     supplied list of style options and any options found in the supplied
-    style dictionary to the ColumnDataSource data and mapping.
+    style dictionary to the ColumnDataSource data and mapping. Supply
+    path=True to avoid nesting style options as required by multi_line
+    and patches glyphs.
     """
-    nvals = len(list(data.values()[0])[-1])
+    nvals = int(path) or len(list(data.values()[0])[-1])
     for opt in opts:
         if 'color' in opt:
             alias = 'color'
@@ -583,4 +585,4 @@ def expand_batched_style(style, opts, data, mapping):
         mapping[opt] = {'field': opt}
         if 'color' in opt and isinstance(val, tuple):
             val = rgb2hex(val)
-        data[opt].append([val]*nvals)
+        data[opt].append(val if path else [val]*nvals)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -27,6 +27,7 @@ if bokeh_version >= '0.12':
 
 from ...core.options import abbreviated_exception
 from ...core.overlay import Overlay
+from ...core.util import basestring
 
 from ..util import dim_axis_label
 
@@ -549,15 +550,16 @@ def get_tab_title(key, frame, overlay):
     return title
 
 
-def expand_batched_style(style, opts, data, mapping, nvals=None, multiple=False):
+def expand_batched_style(style, opts, mapping, nvals):
     """
     Computes styles applied to a batched plot by iterating over the
     supplied list of style options and expanding any options found in
-    the supplied style dictionary to the ColumnDataSource data and
-    mapping. Supplying nvals adds the style entry multiple times, added
-    as an array by default. When multiple is active multiple scalar values
-    will be added.
+    the supplied style dictionary returning a data and mapping defining
+    the data that should be added to the ColumnDataSource.
     """
+    opts = sorted(opts, key=lambda x: x in ['color', 'alpha'])
+    applied_styles = set(mapping)
+    style_data, style_mapping = {}, {}
     for opt in opts:
         if 'color' in opt:
             alias = 'color'
@@ -568,25 +570,39 @@ def expand_batched_style(style, opts, data, mapping, nvals=None, multiple=False)
         if opt not in style:
             continue
         elif opt == alias:
-            if alias in mapping:
+            if alias in applied_styles:
                 continue
-            elif 'line_'+alias in mapping:
+            elif 'line_'+alias in applied_styles:
                 if 'fill_'+alias not in opts:
                     continue
                 opt = 'fill_'+alias
                 val = style[alias]
-            elif 'fill_'+alias in mapping:
+            elif 'fill_'+alias in applied_styles:
                 opt = 'line_'+alias
                 val = style[alias]
             else:
                 val = style[alias]
         else:
             val = style[opt]
-        mapping[opt] = {'field': opt}
+        style_mapping[opt] = {'field': opt}
+        applied_styles.add(opt)
         if 'color' in opt and isinstance(val, tuple):
             val = rgb2hex(val)
-        vals = val if nvals is None else [val]*nvals
-        if multiple:
-            data[opt].extend(vals)
-        else:
-            data[opt].append(vals)
+        style_data[opt] = [val]*nvals
+    return style_data, style_mapping
+
+
+def filter_batched_data(data, mapping):
+    """
+    Iterates over the data and mapping for a ColumnDataSource and
+    replaces columns with repeating values with scalar
+    """
+    for k, v in list(mapping.items()):
+        if isinstance(v, dict) and 'field' in v:
+            v = v['field']
+        elif not isinstance(v, basestring):
+            continue
+        values = data[v]
+        if len(np.unique(values)) == 1:
+            mapping[k] = values[0]
+            del data[v]

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -549,15 +549,15 @@ def get_tab_title(key, frame, overlay):
     return title
 
 
-def expand_batched_style(style, opts, data, mapping, path=False):
+def expand_batched_style(style, opts, data, mapping, nvals=None, multiple=False):
     """
-    Expands styles applied to a batched plot by iterating over the
-    supplied list of style options and any options found in the supplied
-    style dictionary to the ColumnDataSource data and mapping. Supply
-    path=True to avoid nesting style options as required by multi_line
-    and patches glyphs.
+    Computes styles applied to a batched plot by iterating over the
+    supplied list of style options and expanding any options found in
+    the supplied style dictionary to the ColumnDataSource data and
+    mapping. Supplying nvals adds the style entry multiple times, added
+    as an array by default. When multiple is active multiple scalar values
+    will be added.
     """
-    nvals = int(path) or len(list(data.values()[0])[-1])
     for opt in opts:
         if 'color' in opt:
             alias = 'color'
@@ -585,4 +585,8 @@ def expand_batched_style(style, opts, data, mapping, path=False):
         mapping[opt] = {'field': opt}
         if 'color' in opt and isinstance(val, tuple):
             val = rgb2hex(val)
-        data[opt].append(val if path else [val]*nvals)
+        vals = val if nvals is None else [val]*nvals
+        if multiple:
+            data[opt].extend(vals)
+        else:
+            data[opt].append(vals)

--- a/tests/testbokehutils.py
+++ b/tests/testbokehutils.py
@@ -1,0 +1,85 @@
+from collections import defaultdict
+from unittest import SkipTest
+
+import numpy as np
+
+from holoviews.core import Store
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.element import Curve, Points, Path
+
+try:
+    from holoviews.plotting.bokeh.util import (
+        bokeh_version, expand_batched_style, filter_batched_data
+    )
+    bokeh_renderer = Store.renderers['bokeh']
+except:
+    bokeh_renderer = None
+
+
+class TestBokehUtilsInstantiation(ComparisonTestCase):
+
+    def setUp(self):
+        if not bokeh_renderer:
+            raise SkipTest("Bokeh required to test plot instantiation")
+
+    def test_expand_style_opts_simple(self):
+        style = {'line_width': 3}
+        opts = ['line_width']
+        data, mapping = expand_batched_style(style, opts, {}, nvals=3)
+        self.assertEqual(data['line_width'], [3, 3, 3])
+        self.assertEqual(mapping, {'line_width': {'field': 'line_width'}})
+
+    def test_expand_style_opts_multiple(self):
+        style = {'line_color': 'red', 'line_width': 4}
+        opts = ['line_color', 'line_width']
+        data, mapping = expand_batched_style(style, opts, {}, nvals=3)
+        self.assertEqual(data['line_color'], ['red', 'red', 'red'])
+        self.assertEqual(data['line_width'], [4, 4, 4])
+        self.assertEqual(mapping, {'line_color': {'field': 'line_color'},
+                                   'line_width': {'field': 'line_width'}})
+
+    def test_expand_style_opts_line_color_and_color(self):
+        style = {'fill_color': 'red', 'color': 'blue'}
+        opts = ['color', 'line_color', 'fill_color']
+        data, mapping = expand_batched_style(style, opts, {}, nvals=3)
+        self.assertEqual(data['line_color'], ['blue', 'blue', 'blue'])
+        self.assertEqual(data['fill_color'], ['red', 'red', 'red'])
+        self.assertEqual(mapping, {'line_color': {'field': 'line_color'},
+                                   'fill_color': {'field': 'fill_color'}})
+
+    def test_expand_style_opts_line_alpha_and_alpha(self):
+        style = {'fill_alpha': 0.5, 'alpha': 0.2}
+        opts = ['alpha', 'line_alpha', 'fill_alpha']
+        data, mapping = expand_batched_style(style, opts, {}, nvals=3)
+        self.assertEqual(data['line_alpha'], [0.2, 0.2, 0.2])
+        self.assertEqual(data['fill_alpha'], [0.5, 0.5, 0.5])
+        self.assertEqual(mapping, {'line_alpha': {'field': 'line_alpha'},
+                                   'fill_alpha': {'field': 'fill_alpha'}})
+
+    def test_expand_style_opts_color_predefined(self):
+        style = {'fill_color': 'red'}
+        opts = ['color', 'line_color', 'fill_color']
+        data, mapping = expand_batched_style(style, opts, {'color': 'color'}, nvals=3)
+        self.assertEqual(data['fill_color'], ['red', 'red', 'red'])
+        self.assertEqual(mapping, {'fill_color': {'field': 'fill_color'}})
+
+    def test_filter_batched_data(self):
+        data = {'line_color': ['red', 'red', 'red']}
+        mapping = {'line_color': 'line_color'}
+        filter_batched_data(data, mapping)
+        self.assertEqual(data, {})
+        self.assertEqual(mapping, {'line_color': 'red'})
+
+    def test_filter_batched_data_as_field(self):
+        data = {'line_color': ['red', 'red', 'red']}
+        mapping = {'line_color': {'field': 'line_color'}}
+        filter_batched_data(data, mapping)
+        self.assertEqual(data, {})
+        self.assertEqual(mapping, {'line_color': 'red'})
+
+    def test_filter_batched_data_heterogeneous(self):
+        data = {'line_color': ['red', 'red', 'blue']}
+        mapping = {'line_color': {'field': 'line_color'}}
+        filter_batched_data(data, mapping)
+        self.assertEqual(data, {'line_color': ['red', 'red', 'blue']})
+        self.assertEqual(mapping, {'line_color': {'field': 'line_color'}})

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -12,7 +12,7 @@ from io import BytesIO, StringIO
 import param
 import numpy as np
 from holoviews import (Dimension, Overlay, DynamicMap, Store,
-                       NdOverlay, GridSpace, HoloMap, Layout)
+                       NdOverlay, GridSpace, HoloMap, Layout, Cycle)
 from holoviews.core.util import pd
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
@@ -327,6 +327,116 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay)
         extents = plot.get_extents(overlay, {})
         self.assertEqual(extents, (0, 0, 98, 98))
+
+    def test_batched_points_size_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Points': dict(style=dict(size=Cycle(values=[1, 2])))}
+        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        size = np.array([1, 1, 2, 2])
+        color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
+                         dtype='|S7')
+        self.assertEqual(plot.handles['source'].data['color'], color)
+        self.assertEqual(plot.handles['source'].data['size'], size)
+
+    def test_batched_points_line_color_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Points': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_color = np.array(['red', 'red', 'blue', 'blue'])
+        fill_color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
+                         dtype='|S7')
+        self.assertEqual(plot.handles['source'].data['fill_color'], fill_color)
+        self.assertEqual(plot.handles['source'].data['line_color'], line_color)
+
+    def test_batched_points_alpha_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Points': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        alpha = np.array([0.5, 0.5, 1., 1.])
+        color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
+                         dtype='|S7')
+        self.assertEqual(plot.handles['source'].data['alpha'], alpha)
+        self.assertEqual(plot.handles['source'].data['color'], color)
+
+    def test_batched_points_line_width_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Points': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Points([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_width = np.array([0.5, 0.5, 1., 1.])
+        color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
+                         dtype='|S7')
+        self.assertEqual(plot.handles['source'].data['line_width'], line_width)
+        self.assertEqual(plot.handles['source'].data['color'], color)
+
+    def test_batched_curve_line_color_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_color = ['red', 'blue']
+        self.assertEqual(plot.handles['source'].data['line_color'], line_color)
+
+    def test_batched_curve_alpha_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Curve': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        alpha = [0.5, 1.]
+        color = ['#30a2da', '#fc4f30']
+        self.assertEqual(plot.handles['source'].data['alpha'], alpha)
+        self.assertEqual(plot.handles['source'].data['color'], color)
+
+    def test_batched_curve_line_width_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Curve': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Curve([(i, j) for j in range(2)])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_width = [0.5, 1.]
+        color = ['#30a2da', '#fc4f30']
+        self.assertEqual(plot.handles['source'].data['line_width'], line_width)
+        self.assertEqual(plot.handles['source'].data['color'], color)
+
+    def test_batched_path_line_color_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Path': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_color = ['red', 'blue']
+        self.assertEqual(plot.handles['source'].data['line_color'], line_color)
+
+    def test_batched_path_alpha_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Path': dict(style=dict(alpha=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        alpha = [0.5, 1.]
+        color = ['#30a2da', '#fc4f30']
+        self.assertEqual(plot.handles['source'].data['alpha'], alpha)
+        self.assertEqual(plot.handles['source'].data['color'], color)
+
+    def test_batched_path_line_width_and_color(self):
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Path': dict(style=dict(line_width=Cycle(values=[0.5, 1])))}
+        overlay = NdOverlay({i: Path([[(i, j) for j in range(2)]])
+                             for i in range(2)})(opts)
+        plot = bokeh_renderer.get_plot(overlay).subplots[()]
+        line_width = [0.5, 1.]
+        color = ['#30a2da', '#fc4f30']
+        self.assertEqual(plot.handles['source'].data['line_width'], line_width)
+        self.assertEqual(plot.handles['source'].data['color'], color)
 
     def _test_hover_info(self, element, tooltips, line_policy='prev'):
         plot = bokeh_renderer.get_plot(element)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -336,7 +336,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         size = np.array([1, 1, 2, 2])
         color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
-                         dtype='|S7')
+                         dtype='<U7')
         self.assertEqual(plot.handles['source'].data['color'], color)
         self.assertEqual(plot.handles['source'].data['size'], size)
 
@@ -348,7 +348,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_color = np.array(['red', 'red', 'blue', 'blue'])
         fill_color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
-                         dtype='|S7')
+                         dtype='<U7')
         self.assertEqual(plot.handles['source'].data['fill_color'], fill_color)
         self.assertEqual(plot.handles['source'].data['line_color'], line_color)
 
@@ -360,7 +360,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         alpha = np.array([0.5, 0.5, 1., 1.])
         color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
-                         dtype='|S7')
+                         dtype='<U7')
         self.assertEqual(plot.handles['source'].data['alpha'], alpha)
         self.assertEqual(plot.handles['source'].data['color'], color)
 
@@ -372,7 +372,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay).subplots[()]
         line_width = np.array([0.5, 0.5, 1., 1.])
         color = np.array(['#30a2da', '#30a2da', '#fc4f30', '#fc4f30'],
-                         dtype='|S7')
+                         dtype='<U7')
         self.assertEqual(plot.handles['source'].data['line_width'], line_width)
         self.assertEqual(plot.handles['source'].data['color'], color)
 


### PR DESCRIPTION
The handling of batched style options was handled differently on all the different plots. As I outlined in https://github.com/ioam/holoviews/issues/795 this should be handled consistently and this PR makes that happen.