### PR TITLE
Added small section on Options inheritance to tutorial

### DIFF
--- a/doc/Tutorials/Options.ipynb
+++ b/doc/Tutorials/Options.ipynb
@@ -642,6 +642,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Option inheritance\n",
+    "\n",
+    "Since HoloViews objects nest in a variety of ways and you do not want to keep changing the options specification when you compose your object into an ``Overlay`` or ``NdOverlay``, certain ``plot`` options are inherited. This includes all plot options which control the appearance of the axes, but not those that are specific to the Element. As a simple example let us combine the ``Image`` from above with some ``Bounds``. Even though we apply the ``xrotation`` and ``yticks`` options to the ``Image`` they are inherited by the ``Overlay`` of the ``Image`` and ``Bounds``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Image [xrotation=90 yticks=[-0.5, 0., 0.5]]\n",
+    "image * hv.Bounds((-.25, -.25, .25, .25))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
+   "source": [
     "## Separating data and visualization options"
    ]
   },


### PR DESCRIPTION
Adds a small bit of documentation explaining option inheritance to the Options Tutorial as requested in https://github.com/ioam/holoviews/issues/638.