### PR TITLE
Dynamic collation

### DIFF
--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -28,8 +28,7 @@ class Overlayable(object):
             def dynamic_mul(*args, **kwargs):
                 element = other[args]
                 return self * element
-            callback = Callable(callable_function=dynamic_mul,
-                                inputs=[self, other])
+            callback = Callable(dynamic_mul, inputs=[self, other])
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -498,11 +498,17 @@ class DynamicMap(HoloMap):
         values on the key dimensions.
         """
         key = []
+        undefined = []
         for kdim in self.kdims:
             if kdim.values:
                 key.append(kdim.values[0])
             elif kdim.range:
                 key.append(kdim.range[0])
+            else:
+                undefined.append(kdim)
+        if undefined:
+            raise KeyError('dimensions do not specify a range or values, '
+                           'cannot supply initial key' % ', '.join(undefined))
         return tuple(key)
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -808,13 +808,13 @@ class DynamicMap(HoloMap):
         """
         Collation allows collapsing DynamicMaps with invalid nesting
         hierarchies. This is particularly useful when defining
-        DynamicMaps returning an (Nd)Layout. Collating will split the
-        DynamicMap into an (Nd)Layout of individual DynamicMaps. Note
-        that the Layout should be of consistent length and types for
-        this to work correctly. In order to attach a stream as a source
-        for a particular object in the Layout you may supply either
-        a dictionary or list of lists of streams corresponding to each
-        Element in the Layout.
+        DynamicMaps returning an (Nd)Layout or GridSpace
+        type. Collating will split the DynamicMap into of individual
+        DynamicMaps. Note that the composite object has to be of
+        consistent length and types for this to work
+        correctly. Associating streams with specific viewables in the
+        returned container declare a stream_mapping on the DynamicMap
+        Callable during instantiation.
         """
         # Initialize
         if self.last is not None:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -410,7 +410,9 @@ class Callable(param.Parameterized):
     inputs = param.List(default=[], doc="""
          The list of inputs the callable function is wrapping.""")
 
-    def __init__(self, **params):
+    def __init__(self, callable_function=None, **params):
+        if callable_function is not None:
+            params['callable_function'] = callable_function
         super(Callable, self).__init__(**params)
         self._memoized = {}
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -854,7 +854,7 @@ class DynamicMap(HoloMap):
             # Get stream mapping from callback
             remapped_streams = []
             streams = self.callback.stream_mapping
-            for i, (k, v) in enumerate(self.last.items()):
+            for i, (k, v) in enumerate(self.last.data.items()):
                 vstreams = streams.get(i, [])
                 if not vstreams:
                     if isinstance(self.last, Layout):
@@ -865,6 +865,11 @@ class DynamicMap(HoloMap):
                                 break
                     else:
                         vstreams = streams.get(k, [])
+                if any(s in remapped_streams for s in vstreams):
+                    raise ValueError(
+                        "The stream_mapping supplied on the Callable "
+                        "is ambiguous please supply more specific Layout "
+                        "path specs.")
                 remapped_streams += vstreams
 
                 # Define collation callback

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -821,22 +821,23 @@ class DynamicMap(HoloMap):
         """
         # Initialize
         if self.last is not None:
-            pass
+            initialized = self
         else:
-            self.clone()[self._initial_key()]
+            initialized = self.clone()
+            initialized[initialized._initial_key()]
 
-        if not isinstance(self.last, (Layout, NdLayout, GridSpace)):
+        if not isinstance(initialized.last, (Layout, NdLayout, GridSpace)):
             return self
 
-        container = self.last.clone(shared_data=False)
+        container = initialized.last.clone(shared_data=False)
 
         # Get stream mapping from callback
         remapped_streams = []
         streams = self.callback.stream_mapping
-        for i, (k, v) in enumerate(self.last.data.items()):
+        for i, (k, v) in enumerate(initialized.last.data.items()):
             vstreams = streams.get(i, [])
             if not vstreams:
-                if isinstance(self.last, Layout):
+                if isinstance(initialized.last, Layout):
                     for l in range(len(k)):
                         path = '.'.join(k[:l])
                         if path in streams:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -847,9 +847,10 @@ class DynamicMap(HoloMap):
                     vstreams = streams.get(i, [])
                 elif isinstance(streams, list):
                     vstreams = streams[i] if i < len(streams) else []
-                def collation_cb(collation_key=k, *args, **kwargs):
-                    return self[args][collation_key]
-                callback = Callable(collation_cb, inputs=[self])
+                def collation_cb(*args, **kwargs):
+                    return self[args][kwargs['collation_key']]
+                callback = Callable(partial(collation_cb, collation_key=k),
+                                    inputs=[self])
                 vdmap = self.clone(callback=callback, shared_data=False,
                                    streams=vstreams)
                 for stream in vstreams:

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -18,7 +18,7 @@ from .widgets import NdWidget, ScrubberWidget, SelectionWidget
 from .. import DynamicMap
 from . import Plot
 from .comms import JupyterComm
-from .util import displayable, collate
+from .util import displayable, collate, initialize_dynamic
 
 from param.parameterized import bothmethod
 
@@ -159,16 +159,12 @@ class Renderer(Exporter):
         """
         Given a HoloViews Viewable return a corresponding plot instance.
         """
+        # Initialize DynamicMaps with first data item
+        initialize_dynamic(obj)
+
         if not isinstance(obj, Plot) and not displayable(obj):
             obj = collate(obj)
-
-        # Initialize DynamicMaps with first data item
-        dmaps = obj.traverse(lambda x: x, specs=[DynamicMap])
-        for dmap in dmaps:
-            if dmap.sampled:
-                # Skip initialization until plotting code
-                continue
-            dmap[dmap._initial_key()]
+            initialize_dynamic(obj)
 
         if not renderer: renderer = self_or_cls.instance()
         if not isinstance(obj, Plot):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -43,12 +43,12 @@ def collate(obj):
                                 "(http://git.io/vtIQh)" % nested_type)
         return obj.collate()
     if isinstance(obj, HoloMap):
-        display_warning.warning("Nesting %ss within a HoloMap makes it difficult "
+        display_warning.warning("Nesting {0}s within a {1} makes it difficult "
                                 "to access your data or control how it appears; "
-                                "we recommend calling .collate() on the HoloMap "
+                                "we recommend calling .collate() on the {1} "
                                 "in order to follow the recommended nesting "
                                 "structure shown in the Composing Data tutorial"
-                                "(http://git.io/vtIQh)" % obj.type.__name__)
+                                "(http://git.io/vtIQh)".format(obj.type.__name__, type(obj).__name__))
         return obj.collate()
     elif isinstance(obj, (Layout, NdLayout)):
         try:
@@ -68,6 +68,19 @@ def collate(obj):
             raise Exception(undisplayable_info(obj))
     else:
         raise Exception(undisplayable_info(obj))
+
+
+def initialize_dynamic(obj):
+    """
+    Initializes all DynamicMap objects contained by the object
+    """
+    dmaps = obj.traverse(lambda x: x, specs=[DynamicMap])
+    for dmap in dmaps:
+        if dmap.sampled:
+            # Skip initialization until plotting code
+            continue
+        if not len(dmap):
+            dmap[dmap._initial_key()]
 
 
 def undisplayable_info(obj, html=False):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -42,6 +42,8 @@ def collate(obj):
                                 "structure shown in the Composing Data tutorial"
                                 "(http://git.io/vtIQh)" % nested_type)
         return obj.collate()
+    if isinstance(obj, DynamicMap):
+        return obj.collate()
     if isinstance(obj, HoloMap):
         display_warning.warning("Nesting {0}s within a {1} makes it difficult "
                                 "to access your data or control how it appears; "

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -20,8 +20,9 @@ class Stream(param.Parameterized):
     the parameter dictionary when the trigger classmethod is called.
 
     Depending on the plotting backend certain streams may interactively
-    subscribe to events and changes by the plotting backend. To disable
-    this behavior instantiate the Stream with linked=False.
+    subscribe to events and changes by the plotting backend. For this
+    purpose use the LinkedStream baseclass, which enables the linked
+    option by default.
     """
 
     # Mapping from a source id to a list of streams
@@ -60,7 +61,7 @@ class Stream(param.Parameterized):
             stream.deactivate()
 
 
-    def __init__(self, rename={}, source=None, subscribers=[], linked=True, **params):
+    def __init__(self, rename={}, source=None, subscribers=[], linked=False, **params):
         """
         The rename argument allows multiple streams with similar event
         state to be used by remapping parameter names.
@@ -222,7 +223,18 @@ class Stream(param.Parameterized):
         return repr(self)
 
 
-class PositionX(Stream):
+class LinkedStream(Stream):
+    """
+    A LinkedStream indicates is automatically linked to plot interactions
+    on a backend via a Renderer. Not all backends may support dynamically
+    supplying stream data.
+    """
+
+    def __init__(self, linked=True, **params):
+        super(LinkedStream, self).__init__(linked=linked, **params)
+
+
+class PositionX(LinkedStream):
     """
     A position along the x-axis in data coordinates.
 
@@ -234,7 +246,7 @@ class PositionX(Stream):
            Position along the x-axis in data coordinates""", constant=True)
 
 
-class PositionY(Stream):
+class PositionY(LinkedStream):
     """
     A position along the y-axis in data coordinates.
 
@@ -246,7 +258,7 @@ class PositionY(Stream):
            Position along the y-axis in data coordinates""", constant=True)
 
 
-class PositionXY(Stream):
+class PositionXY(LinkedStream):
     """
     A position along the x- and y-axes in data coordinates.
 
@@ -287,7 +299,7 @@ class MouseLeave(PositionXY):
     """
 
 
-class PlotSize(Stream):
+class PlotSize(LinkedStream):
     """
     Returns the dimensions of a plot once it has been displayed.
     """
@@ -304,7 +316,7 @@ class PlotSize(Stream):
                 'height': int(self.height * self.scale)}
 
 
-class RangeXY(Stream):
+class RangeXY(LinkedStream):
     """
     Axis ranges along x- and y-axis in data coordinates.
     """
@@ -316,7 +328,7 @@ class RangeXY(Stream):
       Range of the y-axis of a plot in data coordinates""")
 
 
-class RangeX(Stream):
+class RangeX(LinkedStream):
     """
     Axis range along x-axis in data coordinates.
     """
@@ -325,7 +337,7 @@ class RangeX(Stream):
       Range of the x-axis of a plot in data coordinates""")
 
 
-class RangeY(Stream):
+class RangeY(LinkedStream):
     """
     Axis range along y-axis in data coordinates.
     """
@@ -334,7 +346,7 @@ class RangeY(Stream):
       Range of the y-axis of a plot in data coordinates""")
 
 
-class Bounds(Stream):
+class Bounds(LinkedStream):
     """
     A stream representing the bounds of a box selection as an
     tuple of the left, bottom, right and top coordinates.
@@ -345,7 +357,7 @@ class Bounds(Stream):
         Bounds defined as (left, bottom, top, right) tuple.""")
 
 
-class Selection1D(Stream):
+class Selection1D(LinkedStream):
     """
     A stream representing a 1D selection of objects by their index.
     """

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -149,7 +149,9 @@ class Stream(param.Parameterized):
     @source.setter
     def source(self, source):
         if self._source:
-            raise Exception('source has already been defined on stream.')
+            source_list = self.registry[id(self._source)]
+            if self in source_list:
+                source_list.remove(self)
         self._source = source
         self.registry[id(source)].append(self)
 

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -83,10 +83,10 @@ class Dynamic(param.ParameterizedFunction):
                 _, el = util.get_dynamic_item(map_obj, map_obj.kdims, key)
                 return self._process(el, key)
         if isinstance(self.p.operation, ElementOperation):
-            return OperationCallable(callable_function=dynamic_operation,
-                                     inputs=[map_obj], operation=self.p.operation)
+            return OperationCallable(dynamic_operation, inputs=[map_obj],
+                                     operation=self.p.operation)
         else:
-            return Callable(callable_function=dynamic_operation, inputs=[map_obj])
+            return Callable(dynamic_operation, inputs=[map_obj])
 
 
     def _make_dynamic(self, hmap, dynamic_fn):


### PR DESCRIPTION
Implements dynamic collation as requested and described in #1188. The user can declare a stream on a ``DynamicMap`` returning a ``(Nd)Layout``, and then specify which item in the Layout should be used as the source for the stream in the collate call by either supplying a list of streams for each item or a dictionary where the key corresponds to the index of the item in the Layout. Here's a small example:

```python
%%opts Layout [shared_axes=False]

def test(x_range, y_range):
    return hv.Image(np.random.rand(10,10)) + hv.Bounds((x_range[0], y_range[0], x_range[1], y_range[1]))

stream = hv.streams.RangeXY(x_range=(0,-.5), y_range=(0,-0.5))
dmap = hv.DynamicMap(test, streams=[stream], kdims=[])

dmap.collate(streams={0: [stream]})
# OR dmap.collate(streams=[[stream]])

```

Here the RangeXY stream will be attached to the Image and the Bounds in the second subplot will reflect the zoom ranges of the first plot. Leaving out the ``streams`` declaration on the collate call will mean that the ``Stream`` gets ranges from both subplots.