### PR TITLE
Tightened semantics of Dimension objects

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -231,7 +231,8 @@ class Dimension(param.Parameterized):
         settings = dict(self.get_param_values(onlychanged=True), **overrides)
         spec = spec if (spec is not None) else (overrides.get('name', self.name),
                                                 overrides.get('label', self.label))
-        return self.__class__(spec, **{k:v for k,v in settings.items() if k != 'name'})
+        return self.__class__(spec, **{k:v for k,v in settings.items()
+                                       if k not in ['name', 'label']})
 
     def __hash__(self):
         """

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -228,8 +228,16 @@ class Dimension(param.Parameterized):
         except for the supplied, explicit overrides
         """
         settings = dict(self.get_param_values(onlychanged=True), **overrides)
-        spec = spec if (spec is not None) else (overrides.get('name', self.name),
-                                                overrides.get('label', self.label))
+
+        if spec is None:
+            spec = (self.name, overrides.get('label', self.label))
+        if 'label' in overrides and isinstance(spec, basestring) :
+            spec = (spec, overrides['label'])
+        elif 'label' in overrides and isinstance(spec, tuple) :
+            self.warning('Using label as supplied by keyword ({!r}), ignoring '
+                             'tuple value {!r}'.format(overrides['label'], spec[1]))
+            spec = (spec[0],  overrides['label'])
+
         return self.__class__(spec, **{k:v for k,v in settings.items()
                                        if k not in ['name', 'label']})
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -169,6 +169,12 @@ class Dimension(param.Parameterized):
         super(Dimension, self).__init__(**all_params)
 
 
+    @property
+    def spec(self):
+        "Returns the corresponding tuple specification"
+        return (self.name, self.label)
+
+
     def pprint(self):
         spec = self.name if self.name == self.label else (self.name, self.label)
         excluded = ['name'] if self.name == self.label else ['name', 'label']

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -91,6 +91,11 @@ class Dimension(param.Parameterized):
        'weight'. Valid Python identifiers make good names, because they
        can be used conveniently as a keyword in many contexts.""")
 
+    label = param.String(doc="""
+        Unrestricted label used to describe the dimension. A label
+        should succinctly describe the dimension and may contain any
+        characters, including Unicode and LaTeX expression.""")
+
     cyclic = param.Boolean(default=False, doc="""
         Whether the range of this feature is cyclic such that the
         maximum allowed value (defined by the range parameter) is
@@ -150,7 +155,10 @@ class Dimension(param.Parameterized):
         if isinstance(name, tuple):
             name, label = name
             all_params['name'] = name
-        self.label = label
+            if 'label' in params:
+                self.warning('Using label as supplied by keyword, ignoring tuple format.')
+
+        all_params['label'] = params.get('label', label)
 
         values = params.get('values', [])
         if isinstance(values, basestring) and values == 'initial':

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -277,6 +277,18 @@ class Dimension(param.Parameterized):
                 else type(self.unit)(self.unit_format).format(unit=self.unit))
         return bytes_to_unicode(self.label) + bytes_to_unicode(unit)
 
+    def pprint(self):
+        changed = dict(self.get_param_values(onlychanged=True))
+        if len(set([changed.get(k, k) for k in ['name','label']])) == 1:
+            return 'Dimension({spec})'.format(spec=repr(self.name))
+
+        ordering = sorted( sorted(changed.keys()),
+                           key=lambda k: (- float('inf')
+                                          if self.params(k).precedence is None
+                                          else self.params(k).precedence))
+        kws = ", ".join('%s=%r' % (k, changed[k]) for k in ordering if k != 'name')
+        return 'Dimension({spec}, {kws})'.format(spec=repr(self.name), kws=kws)
+
 
     def pprint_value(self, value):
         """
@@ -298,19 +310,6 @@ class Dimension(param.Parameterized):
                 else:
                     return formatter % value
         return unicode(bytes_to_unicode(value))
-
-
-    def pprint(self):
-        changed = dict(self.get_param_values(onlychanged=True))
-        if len(set([changed.get(k, k) for k in ['name','label']])) == 1:
-            return 'Dimension({spec})'.format(spec=repr(self.name))
-
-        ordering = sorted( sorted(changed.keys()),
-                           key=lambda k: (- float('inf')
-                                          if self.params(k).precedence is None
-                                          else self.params(k).precedence))
-        kws = ", ".join('%s=%r' % (k, changed[k]) for k in ordering if k != 'name')
-        return 'Dimension({spec}, {kws})'.format(spec=repr(self.name), kws=kws)
 
     def pprint_value_string(self, value):
         """

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -63,8 +63,8 @@ def replace_dimensions(dimensions, overrides):
         elif isinstance(override, Dimension):
             replaced.append(override)
         elif isinstance(override, dict):
-            replaced.append(d(override.get('name',None),
-                              **{k:v for k,v in override.items() if k != 'name'}))
+            replaced.append(d.clone(override.get('name',None),
+                                    **{k:v for k,v in override.items() if k != 'name'}))
         else:
             raise ValueError('Dimension can only be overridden '
                              'with another dimension or a dictionary '

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -177,10 +177,10 @@ class Dimension(param.Parameterized):
         elif (spec, params.get('unit', None)) in self.presets.keys():
             preset = self.presets[(str(spec), str(params['unit']))]
             existing_params = dict(preset.get_param_values())
-        elif spec in self.presets.keys():
-            existing_params = dict(self.presets[str(spec)].get_param_values())
-        elif (spec,) in self.presets.keys():
-            existing_params = dict(self.presets[(str(spec),)].get_param_values())
+        elif spec in self.presets:
+            existing_params = dict(self.presets[spec].get_param_values())
+        elif (spec,) in self.presets:
+            existing_params = dict(self.presets[(spec,)].get_param_values())
         else:
             existing_params = {}
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -199,6 +199,11 @@ class Dimension(param.Parameterized):
             all_params['name'] = spec
             all_params['label'] = params.get('label', spec)
 
+        if all_params['name'] == '':
+            raise ValueError('Dimension name cannot be the empty string')
+        if all_params['label'] in ['', None]:
+            raise ValueError('Dimension label cannot be None or the empty string')
+
         values = params.get('values', [])
         if isinstance(values, basestring) and values == 'initial':
             self.warning("The 'initial' string for dimension values is no longer supported.")

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -79,11 +79,43 @@ class Dimension(param.Parameterized):
 
     For instance, a Dimension may specify that a set of numeric values
     actually correspond to 'Height' (dimension name), in units of
-    meters, and that allowed values must be floats greater than zero.
+    meters, with a descriptive label 'Height of adult males'.
 
-    In addition, Dimensions can be declared as cyclic, support
-    categorical data using a finite set of allowed, ordered values and
-    support a custom, pretty-printed representation.
+    All dimensions object have a name that identifies them and a label
+    containing a suitable description. If the label is not explicitly
+    specified it matches the name.
+
+    These two parameters define the core identity of the dimension
+    object and must match if two dimension objects are to be considered
+    equivalent. All other parameters are considered optional metadata
+    and are not used when testing for equality.
+
+    Unlike all the other parameters, these core parameters can be used
+    to construct a Dimension object from a tuple. This format is
+    sufficient to define an identical Dimension:
+
+    Dimension('a', label='Dimension A') == Dimension(('a', 'Dimension A'))
+
+    Everything else about a dimension is considered to reflect
+    non-semantic preferences. Examples include the default value (which
+    may be used in a visualization to set an initial slider position),
+    how the value is to rendered as text (which may be used to specify
+    the printed floating point precision) or a suitable range of values
+    to consider for a particular analysis.
+
+    Units
+    -----
+
+    Full unit support with automated conversions are on the HoloViews
+    roadmap. Once rich unit objects are supported, the unit (or more
+    specifically the type of unit) will be part of the core dimension
+    specification used to establish equality.
+
+    Until this feature is implemented, there are two auxillary
+    parameters that hold some partial information about the unit: the
+    name of the unit and whether or not it is cyclic. The name of the
+    unit is used as part of the pretty-printed representation and
+    knowing whether it is cyclic is important for certain operations.
     """
 
     name = param.String(doc="""

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -291,6 +291,14 @@ class Dimension(param.Parameterized):
         return title_format.format(name=bytes_to_unicode(self.label), val=value, unit=unit)
 
 
+    def __hash__(self):
+        """
+        The hash allows Dimension objects to be used as dictionary keys in Python 3.
+        """
+        return sum([hash(value) for _, value in self.get_param_values()
+                    if not isinstance(value, list)])
+
+
     def __setstate__(self, d):
         """
         Compatibility for pickles before alias attribute was introduced.

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -124,7 +124,7 @@ class Dimension(param.Parameterized):
        'weight'. Valid Python identifiers make good names, because they
        can be used conveniently as a keyword in many contexts.""")
 
-    label = param.String(doc="""
+    label = param.String(default=None, doc="""
         Unrestricted label used to describe the dimension. A label
         should succinctly describe the dimension and may contain any
         characters, including Unicode and LaTeX expression.""")

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -169,6 +169,22 @@ class Dimension(param.Parameterized):
         super(Dimension, self).__init__(**all_params)
 
 
+    def pprint(self):
+        spec = self.name if self.name == self.label else (self.name, self.label)
+        excluded = ['name'] if self.name == self.label else ['name', 'label']
+        changed_params = {k:v for k,v in self.get_param_values(onlychanged=True)
+                          if k not in excluded}
+        if len(changed_params) == 0:
+            return 'Dimension({spec})'.format(spec=repr(spec))
+
+        ordering = sorted( sorted(changed_params.keys()),
+                           key=lambda k: (- float('inf')
+                                          if self.params(k).precedence is None
+                                          else self.params(k).precedence))
+        kws = ", ".join('%s=%s' % (k, changed_params[k]) for k in ordering)
+        return 'Dimension({spec}, {kws})'.format(spec=repr(spec), kws=kws)
+
+
     def __call__(self, spec=None, **overrides):
         "Aliased to clone method. To be deprecated in 2.0"
         return self.clone(spec=spec, **overrides)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -87,8 +87,9 @@ class Dimension(param.Parameterized):
     """
 
     name = param.String(doc="""
-        Optional name associated with the Dimension. For instance,
-        'height' or 'weight'.""")
+       Short name associated with the Dimension, such as 'height' or
+       'weight'. Valid Python identifiers make good names, because they
+       can be used conveniently as a keyword in many contexts.""")
 
     cyclic = param.Boolean(default=False, doc="""
         Whether the range of this feature is cyclic such that the

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -18,7 +18,6 @@ from ..core.util import (basestring, sanitize_identifier,
 from .options import Store, StoreOptions
 from .pprint import PrettyPrinter
 
-
 # Alias parameter support for pickle loading
 
 ALIASES = {'key_dimensions': 'kdims', 'value_dimensions': 'vdims',
@@ -265,7 +264,7 @@ class Dimension(param.Parameterized):
         return self.name < other.name if isinstance(other, Dimension) else self.name < other
 
     def __str__(self):
-        return self.pprint_label
+        return self.name
 
     def __repr__(self):
         return self.pprint()

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -170,6 +170,11 @@ class Dimension(param.Parameterized):
 
 
     def __call__(self, name=None, **overrides):
+        "Aliased to clone method. To be deprecated in 2.0"
+        return self.clone(name=name, **overrides)
+
+
+    def clone(self, name=None, **overrides):
         """
         Derive a new Dimension that inherits existing parameters
         except for the supplied, explicit overrides

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -64,7 +64,8 @@ def replace_dimensions(dimensions, overrides):
         elif isinstance(override, Dimension):
             replaced.append(override)
         elif isinstance(override, dict):
-            replaced.append(d(**override))
+            replaced.append(d(override.get('name',None),
+                              **{k:v for k,v in override.items() if k != 'name'}))
         else:
             raise ValueError('Dimension can only be overridden '
                              'with another dimension or a dictionary '
@@ -169,6 +170,10 @@ class Dimension(param.Parameterized):
         """
         Initializes the Dimension object with the given name.
         """
+        if 'name' in params:
+            raise KeyError('Dimension name must only be passed as the positional argument')
+
+
         if isinstance(spec, Dimension):
             existing_params = dict(spec.get_param_values())
         elif (spec, params.get('unit', None)) in self.presets.keys():
@@ -238,7 +243,7 @@ class Dimension(param.Parameterized):
         settings = dict(self.get_param_values(onlychanged=True), **overrides)
         spec = spec if (spec is not None) else (overrides.get('name', self.name),
                                                 overrides.get('label', self.label))
-        return self.__class__(spec, **{k:v for k,v in settings.items() if k != ['name']})
+        return self.__class__(spec, **{k:v for k,v in settings.items() if k != 'name'})
 
 
     @property

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -295,9 +295,7 @@ class Dimension(param.Parameterized):
         """
         The hash allows Dimension objects to be used as dictionary keys in Python 3.
         """
-        return sum([hash(value) for _, value in self.get_param_values()
-                    if not isinstance(value, list)])
-
+        return hash(self.spec)
 
     def __setstate__(self, d):
         """

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -116,10 +116,10 @@ class Dimension(param.Parameterized):
         instance, the string 'm' may be used represent units of meters
         and 's' to represent units of seconds.""")
 
-    values = param.ClassSelector(class_=(str, list), default=[], doc="""
-        Optional set of allowed values for the dimension that can also
-        be used to retain a categorical ordering. Setting values to
-        'initial' indicates that the values will be added during construction.""")
+    values = param.List(default=[], doc="""
+        Optional specification of the allowed value set for the
+        dimension that may also be used to retain a categorical
+        ordering.""")
 
     # Defines default formatting by type
     type_formatters = {}
@@ -151,10 +151,12 @@ class Dimension(param.Parameterized):
             all_params['name'] = name
         self.label = label
 
-        if not isinstance(params.get('values', None), basestring):
-            all_params['values'] = sorted(list(unique_array(params.get('values', []))))
-        elif params['values'] != 'initial':
-            raise Exception("Values argument can only be set with the string 'initial'.")
+        values = params.get('values', [])
+        if isinstance(values, basestring) and values == 'initial':
+            self.warning("The 'initial' string for dimension values is no longer supported.")
+            values = []
+
+        all_params['values'] = sorted(list(unique_array(values)))
         super(Dimension, self).__init__(**all_params)
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -215,19 +215,16 @@ class Dimension(param.Parameterized):
 
 
     def pprint(self):
-        spec = self.name if self.name == self.label else (self.name, self.label)
-        excluded = ['name'] if self.name == self.label else ['name', 'label']
-        changed_params = {k:v for k,v in self.get_param_values(onlychanged=True)
-                          if k not in excluded}
-        if len(changed_params) == 0:
-            return 'Dimension({spec})'.format(spec=repr(spec))
+        changed = dict(self.get_param_values(onlychanged=True))
+        if len(set([changed.get(k, k) for k in ['name','label']])) == 1:
+            return 'Dimension({spec})'.format(spec=repr(self.name))
 
-        ordering = sorted( sorted(changed_params.keys()),
+        ordering = sorted( sorted(changed.keys()),
                            key=lambda k: (- float('inf')
                                           if self.params(k).precedence is None
                                           else self.params(k).precedence))
-        kws = ", ".join('%s=%s' % (k, changed_params[k]) for k in ordering)
-        return 'Dimension({spec}, {kws})'.format(spec=repr(spec), kws=kws)
+        kws = ", ".join('%s=%r' % (k, changed[k]) for k in ordering if k != 'name')
+        return 'Dimension({spec}, {kws})'.format(spec=repr(self.name), kws=kws)
 
 
     def __call__(self, spec=None, **overrides):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -187,7 +187,9 @@ class Dimension(param.Parameterized):
             all_params['name'] = name
             all_params['label'] = label
             if 'label' in params and (label != params['label']):
-                self.warning('Ignoring label as supplied by keyword, using tuple format.')
+                self.warning('Using label as supplied by keyword ({!r}), ignoring '
+                             'tuple value {!r}'.format(params['label'], label))
+                all_params['label'] = params['label']
         elif isinstance(spec, basestring):
             all_params['name'] = spec
             all_params['label'] = params.get('label', spec)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -291,16 +291,6 @@ class Dimension(param.Parameterized):
         return title_format.format(name=bytes_to_unicode(self.label), val=value, unit=unit)
 
 
-    def __hash__(self):
-        """
-        The hash allows two Dimension objects to be compared; if the
-        hashes are equal, all the parameters of the Dimensions are
-        also equal.
-        """
-        return sum([hash(value) for _, value in self.get_param_values()
-                    if not isinstance(value, list)])
-
-
     def __setstate__(self, d):
         """
         Compatibility for pickles before alias attribute was introduced.

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -310,16 +310,14 @@ class Dimension(param.Parameterized):
     def __str__(self):
         return self.pprint_label
 
-
     def __eq__(self, other):
         "Implements equals operator including sanitized comparison."
-        dim_matches = [self.name, self.label, dimension_sanitizer(self.label)]
-        if self is other:
-            return True
-        elif isinstance(other, Dimension):
-            return bool({other.name, other.label} & set(dim_matches))
-        else:
-            return other in dim_matches
+
+        if isinstance(other, Dimension):
+            return self.spec == other.spec
+
+        # For comparison to strings. Name may be sanitized.
+        return other in [self.name, self.label,  dimension_sanitizer(self.name)]
 
     def __ne__(self, other):
         "Implements not equal operator including sanitized comparison."

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -430,7 +430,7 @@ class MultiDimensionalMapping(Dimensioned):
                 dmin, dmax = self.range(d.name)
                 if d.value_format:
                     dmin, dmax = d.value_format(dmin), d.value_format(dmax)
-                info_str += '\t %s: %s...%s \n' % (str(d), dmin, dmax)
+                info_str += '\t %s: %s...%s \n' % (d.pprint_label, dmin, dmax)
         print(info_str)
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1016,8 +1016,7 @@ class GridSpace(UniformNdMapping):
     2D parameter spaces.
     """
 
-    kdims = param.List(default=[Dimension(name="X"), Dimension(name="Y")],
-                       bounds=(1,2))
+    kdims = param.List(default=[Dimension("X"), Dimension("Y")], bounds=(1,2))
 
     def __init__(self, initial_items=None, **params):
         super(GridSpace, self).__init__(initial_items, **params)

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -465,13 +465,13 @@ class Comparison(ComparisonInterface):
         dimension_data = [(d, el1[d], el2[d]) for d in el1.dimensions()]
         for dim, d1, d2 in dimension_data:
             if d1.dtype != d2.dtype:
-                cls.failureException("%s %s columns have different type." % (msg, dim)
+                cls.failureException("%s %s columns have different type." % (msg, dim.pprint_label)
                                      + " First has type %s, and second has type %s."
                                      % (d1, d2))
             if d1.dtype.kind in 'SUOV':
                 if list(d1) == list(d2):
                     cls.failureException("%s along dimension %s not equal." %
-                                         (msg, dim))
+                                         (msg, dim.pprint_label))
             else:
                 cls.compare_arrays(d1, d2, msg)
 

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -259,6 +259,9 @@ class Comparison(ComparisonInterface):
                                        % (set(dim1_params.keys()), set(dim2_params.keys())))
 
         for k in dim1_params.keys():
+            if (dim1.params(k).__class__.__name__ == 'Callable'
+                and dim2.params(k).__class__.__name__ == 'Callable'):
+                continue
             try:  # This is needed as two lists are not compared by contents using ==
                 cls.assertEqual(dim1_params[k], dim2_params[k], msg=None)
             except AssertionError as e:

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -251,7 +251,11 @@ class Comparison(ComparisonInterface):
         if dim1.unit != dim2.unit:
             raise cls.failureException("Dimension unit declarations mismatched: %s != %s"
                                        % (dim1.unit , dim2.unit))
-        if dim1.values != dim2.values:
+
+        # Ignoring deprecated 'initial' option
+        dim1_values = [] if dim1.values=='initial' else dim1.values
+        dim2_values = [] if dim2.values=='initial' else dim2.values
+        if dim1_values != dim2_values:
             raise cls.failureException("Dimension value declarations mismatched: %s != %s"
                                        % (dim1.values , dim2.values))
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -66,7 +66,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
             if sizes is None:
                 eltype = type(element).__name__
                 self.warning('%s dimension is not numeric, cannot '
-                             'use to scale %s size.' % (sdim, eltype))
+                             'use to scale %s size.' % (sdim.pprint_label, eltype))
             else:
                 data[map_key] = np.sqrt(sizes)
                 mapping['size'] = map_key

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -51,7 +51,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
         self.handles['source'] = source
 
         dims = element.dimensions()
-        columns = [TableColumn(field=d.name, title=str(d)) for d in dims]
+        columns = [TableColumn(field=d.name, title=d.pprint_label) for d in dims]
         properties = self.lookup_options(element, 'style')[self.cyclic_index]
         table = DataTable(source=source, columns=columns, height=self.height,
                           width=self.width, **properties)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -557,7 +557,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
             if sizes is None:
                 eltype = type(element).__name__
                 self.warning('%s dimension is not numeric, cannot '
-                             'use to scale %s size.' % (sdim, eltype))
+                             'use to scale %s size.' % (sdim.pprint_label, eltype))
             else:
                 style['s'] = sizes
         style['edgecolors'] = style.pop('edgecolors', 'none')

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -888,7 +888,7 @@ class BarPlot(LegendPlot):
                     bars[tuple(val_key)] = bar
                     prev += val if np.isfinite(val) else 0
                     labels.append(label)
-        title = [str(element.kdims[indices[cg]])
+        title = [element.kdims[indices[cg]].pprint_label
                  for cg in self.color_by if indices[cg] < ndims]
 
         if self.show_legend and any(len(l) for l in labels):

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -99,7 +99,7 @@ class Plot3D(ColorbarPlot):
 
         elif not isinstance(dim, Dimension):
             dim = element.get_dimension(dim)
-        label = str(dim)
+        label = dim.pprint_label
         cbar = fig.colorbar(artist, shrink=0.7, ax=ax)
         self.handles['cax'] = cbar.ax
         self._adjust_cbar(cbar, label, dim)

--- a/holoviews/plotting/mpl/pandas.py
+++ b/holoviews/plotting/mpl/pandas.py
@@ -108,11 +108,11 @@ class DFrameViewPlot(ElementPlot):
 
     def get_axis_kwargs(self, element):
         if element.x:
-            xlabel = str(element.get_dimension(element.x))
+            xlabel = element.get_dimension(element.x).pprint_label
         if element.x2:
-            ylabel = str(element.get_dimension(element.x2))
+            ylabel = element.get_dimension(element.x2).pprint_label
         elif element.y:
-            ylabel = str(element.get_dimension(element.y))
+            ylabel = element.get_dimension(element.y).pprint_label
         return dict(xlabel=xlabel, ylabel=ylabel)
 
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -471,10 +471,10 @@ class GridPlot(CompositePlot):
             if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 
         # Set labels
-        layout_axis.set_xlabel(str(layout.kdims[0]),
+        layout_axis.set_xlabel(layout.kdims[0].pprint_label,
                                **self._fontsize('xlabel'))
         if layout.ndims == 2:
-            layout_axis.set_ylabel(str(layout.kdims[1]),
+            layout_axis.set_ylabel(layout.kdims[1].pprint_label,
                                **self._fontsize('ylabel'))
 
         # Compute and set x- and y-ticks
@@ -486,7 +486,7 @@ class GridPlot(CompositePlot):
             layout_axis.get_yaxis().set_visible(False)
         else:
             dim1_keys, dim2_keys = zip(*keys)
-            layout_axis.set_ylabel(str(dims[1]))
+            layout_axis.set_ylabel(dims[1].pprint_label)
             layout_axis.set_aspect(float(self.rows)/self.cols)
 
         # Process ticks

--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -119,8 +119,8 @@ class TimeSeriesPlot(SeabornPlot):
         style.pop('zorder', None)
         if 'label' in style:
             style['condition'] = style.pop('label')
-        axis_kwargs = {'xlabel': str(element.kdims[0]),
-                       'ylabel': str(element.vdims[0])}
+        axis_kwargs = {'xlabel': element.kdims[0].pprint_label,
+                       'ylabel': element.vdims[0].pprint_label}
         return (element.data, element.xdata), style, axis_kwargs
 
     def init_artists(self, ax, plot_data, plot_kwargs):

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -33,15 +33,15 @@ class Chart3DPlot(ElementPlot):
         l, b, zmin, r, t, zmax = self.get_extents(element, ranges)
 
         xd, yd, zd = (element.get_dimension(i) for i in range(3))
-        xaxis = dict(range=[l, r], title=str(xd))
+        xaxis = dict(range=[l, r], title=xd.pprint_label)
         if self.logx:
             xaxis['type'] = 'log'
 
-        yaxis = dict(range=[b, t], title=str(yd))
+        yaxis = dict(range=[b, t], title=yd.pprint_label)
         if self.logy:
             yaxis['type'] = 'log'
 
-        zaxis = dict(range=[zmin, zmax], title=str(zd))
+        zaxis = dict(range=[zmin, zmax], title=zd.pprint_label)
         if self.logz:
             zaxis['type'] = 'log'
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -144,7 +144,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
     def init_graph(self, plot_args, plot_kwargs):
         return self.graph_obj(*plot_args, **plot_kwargs)
 
-    
+
     def get_data(self, element, ranges):
         return {}
 
@@ -232,7 +232,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         # Get element key and ranges for frame
         return self.generate_plot(list(self.hmap.data.keys())[0], ranges)
 
-    
+
     def generate_plot(self, key, ranges):
         element = self._get_frame(key)
 

--- a/tests/testcomparisonchart.py
+++ b/tests/testcomparisonchart.py
@@ -32,8 +32,8 @@ class BarsComparisonTest(ComparisonTestCase):
     def setUp(self):
         "Variations on the constructors in the Elements notebook"
 
-        key_dims1=[Dimension('Car occupants', values='initial')]
-        key_dims2=[Dimension('Cyclists', values='initial')]
+        key_dims1=[Dimension('Car occupants')]
+        key_dims2=[Dimension('Cyclists')]
         value_dims1=['Count']
         self.bars1 = Bars([('one',8),('two', 10), ('three', 16)],
                           kdims=key_dims1, vdims=value_dims1)

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -1,10 +1,11 @@
 """
 Test cases for Dimension and Dimensioned object comparison.
 """
-
+import sys
 from holoviews.core import Dimension, Dimensioned
 from holoviews.element.comparison import ComparisonTestCase
 
+py3 = (sys.version_info.major == 3)
 
 class DimensionsComparisonTestCase(ComparisonTestCase):
 
@@ -81,7 +82,10 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         try:
             self.assertEqual(self.dimension9, self.dimension10)
         except AssertionError as e:
-            self.assertEqual(str(e), "Dimension parameter 'type' mismatched: <type 'int'> != <type 'float'>")
+            if py3:
+                self.assertEqual(str(e), "Dimension parameter 'type' mismatched: <class 'int'> != <class 'float'>")
+            else:
+                self.assertEqual(str(e), "Dimension parameter 'type' mismatched: <type 'int'> != <type 'float'>")
 
 
     def test_dimension_comparison_value_format_unequal(self):

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -21,6 +21,8 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         self.dimension9 = Dimension('dim1', type=int)
         self.dimension10 = Dimension('dim1', type=float)
         self.dimension11 = Dimension(('dim1','Test Dimension'), range=(0,1))
+        self.dimension12 = Dimension('dim1', value_format=lambda x: x)
+        self.dimension13 = Dimension('dim1', value_format=lambda x: x)
 
     def test_dimension_comparison_equal1(self):
         self.assertEqual(self.dimension1, self.dimension1)
@@ -81,6 +83,12 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         except AssertionError as e:
             self.assertEqual(str(e), "Dimension parameter 'type' mismatched: <type 'int'> != <type 'float'>")
 
+
+    def test_dimension_comparison_value_format_unequal(self):
+        # Comparing callables is skipped
+        self.assertEqual(self.dimension12, self.dimension13)
+        self.assertNotEqual(str(self.dimension12.value_format),
+                            str(self.dimension13.value_format))
 
 
 class DimensionedComparisonTestCase(ComparisonTestCase):

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -20,6 +20,7 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         self.dimension8 = Dimension('dim1', values=['a', 'b'])
         self.dimension9 = Dimension('dim1', type=int)
         self.dimension10 = Dimension('dim1', type=float)
+        self.dimension11 = Dimension(('dim1','Test Dimension'), range=(0,1))
 
     def test_dimension_comparison_equal1(self):
         self.assertEqual(self.dimension1, self.dimension1)
@@ -37,6 +38,12 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
             self.assertEqual(self.dimension1, self.dimension2)
         except AssertionError as e:
             self.assertEqual(str(e),  'Dimension names mismatched: dim1 != dim2')
+
+    def test_dimension_comparison_labels_unequal(self):
+        try:
+            self.assertEqual(self.dimension1, self.dimension11)
+        except AssertionError as e:
+            self.assertEqual(str(e),  'Dimension labels mismatched: dim1 != Test Dimension')
 
     def test_dimension_comparison_range_unequal1(self):
         try:

--- a/tests/testcomparisondimension.py
+++ b/tests/testcomparisondimension.py
@@ -42,37 +42,37 @@ class DimensionsComparisonTestCase(ComparisonTestCase):
         try:
             self.assertEqual(self.dimension1, self.dimension3)
         except AssertionError as e:
-            self.assertEqual(str(e), 'Dimension ranges mismatched: (0, 1) != (0, 2)')
+            self.assertEqual(str(e), "Dimension parameter 'range' mismatched: (0, 1) != (0, 2)")
 
     def test_dimension_comparison_cyclic_unequal(self):
         try:
             self.assertEqual(self.dimension4, self.dimension5)
         except AssertionError as e:
-            self.assertEqual(str(e), 'Dimension cyclic declarations mismatched.')
+            self.assertEqual(str(e), "Dimension parameter 'cyclic' mismatched: False != True")
 
     def test_dimension_comparison_range_unequal2(self):
         try:
             self.assertEqual(self.dimension5, self.dimension6)
         except AssertionError as e:
-            self.assertEqual(str(e), 'Dimension ranges mismatched: (None, None) != (0, 1)')
+            self.assertEqual(str(e), "Dimension parameter 'range' mismatched: (None, None) != (0, 1)")
 
     def test_dimension_comparison_units_unequal(self):
         try:
             self.assertEqual(self.dimension6, self.dimension7)
         except AssertionError as e:
-            self.assertEqual(str(e), 'Dimension unit declarations mismatched: None != ms')
+            self.assertEqual(str(e), "Dimension parameter 'unit' mismatched: None != 'ms'")
 
     def test_dimension_comparison_values_unequal(self):
         try:
             self.assertEqual(self.dimension4, self.dimension8)
         except AssertionError as e:
-            self.assertEqual(str(e), "Dimension value declarations mismatched: [] != ['a', 'b']")
+            self.assertEqual(str(e), "Dimension parameter 'values' mismatched: [] != ['a', 'b']")
 
     def test_dimension_comparison_types_unequal(self):
         try:
             self.assertEqual(self.dimension9, self.dimension10)
         except AssertionError as e:
-            self.assertEqual(str(e)[:39], "Dimension type declarations mismatched:")
+            self.assertEqual(str(e), "Dimension parameter 'type' mismatched: <type 'int'> != <type 'float'>")
 
 
 

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -17,6 +17,11 @@ class DimensionNameLabelTest(ComparisonTestCase):
         dim = Dimension('test')
         self.assertEqual(dim.name, 'test')
 
+    def test_dimension_name_and_label(self):
+        dim = Dimension('test')
+        self.assertEqual(dim.name, 'test')
+        self.assertEqual(dim.label, 'test')
+
     def test_dimension_name_tuple(self):
         dim = Dimension(('test', 'A test'))
         self.assertEqual(dim.name, 'test')

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -107,6 +107,35 @@ class DimensionValuesTest(ComparisonTestCase):
         self.assertEqual(dim.values, self.values2)
 
 
+class DimensionCloneTest(ComparisonTestCase):
+
+    def test_simple_clone(self):
+        dim = Dimension('test')
+        self.assertEqual(dim.name, 'test')
+        self.assertEqual(dim.clone('bar').name, 'bar')
+
+    def test_simple_label_clone(self):
+        dim = Dimension('test')
+        self.assertEqual(dim.name, 'test')
+        clone = dim.clone(label='label')
+        self.assertEqual(clone.name, 'test')
+        self.assertEqual(clone.label, 'label')
+
+    def test_simple_values_clone(self):
+        dim = Dimension('test', values=[1,2,3])
+        self.assertEqual(dim.values, [1,2,3])
+        clone = dim.clone(values=[4,5,6])
+        self.assertEqual(clone.name, 'test')
+        self.assertEqual(clone.values, [4,5,6])
+
+    def test_tuple_clone(self):
+        dim = Dimension('test')
+        self.assertEqual(dim.name, 'test')
+        clone = dim.clone(('test', 'A test'))
+        self.assertEqual(clone.name, 'test')
+        self.assertEqual(clone.label, 'A test')
+
+
 class DimensionedTest(ComparisonTestCase):
 
     def test_dimensioned_init(self):

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -49,6 +49,34 @@ class DimensionNameLabelTest(ComparisonTestCase):
         with self.assertRaisesRegexp(KeyError, regexp):
             dim = Dimension(('test', 'test dimension'), name='something else')
 
+
+class DimensionReprTest(ComparisonTestCase):
+
+    def test_name_dimension_repr(self):
+        dim = Dimension('test')
+        self.assertEqual(repr(dim), "Dimension('test')")
+
+    def test_name_dimension_repr_eval_equality(self):
+        dim = Dimension('test')
+        self.assertEqual(eval(repr(dim)) == dim, True)
+
+    def test_name_dimension_repr_tuple(self):
+        dim = Dimension(('test', 'Test Dimension'))
+        self.assertEqual(repr(dim), "Dimension('test', label='Test Dimension')")
+
+    def test_name_dimension_repr_tuple_eval_equality(self):
+        dim = Dimension(('test', 'Test Dimension'))
+        self.assertEqual(eval(repr(dim)) == dim, True)
+
+    def test_name_dimension_repr_params(self):
+        dim = Dimension('test', label='Test Dimension', unit='m')
+        self.assertEqual(repr(dim), "Dimension('test', label='Test Dimension', unit='m')")
+
+    def test_name_dimension_repr_params_eval_equality(self):
+        dim = Dimension('test', label='Test Dimension', unit='m')
+        self.assertEqual(eval(repr(dim)) == dim, True)
+
+
 class DimensionValuesTest(ComparisonTestCase):
 
     def setUp(self):

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -39,6 +39,15 @@ class DimensionNameLabelTest(ComparisonTestCase):
         dim = Dimension(('test', 'A test'), label='Another test')
         self.assertEqual(dim.label, 'Another test')
 
+    def test_dimension_invalid_name(self):
+        regexp = 'Dimension name must only be passed as the positional argument'
+        with self.assertRaisesRegexp(KeyError, regexp):
+            dim = Dimension('test', name='something else')
+
+    def test_dimension_invalid_name_tuple(self):
+        regexp = 'Dimension name must only be passed as the positional argument'
+        with self.assertRaisesRegexp(KeyError, regexp):
+            dim = Dimension(('test', 'test dimension'), name='something else')
 
 class DimensionValuesTest(ComparisonTestCase):
 

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -77,6 +77,49 @@ class DimensionReprTest(ComparisonTestCase):
         self.assertEqual(eval(repr(dim)) == dim, True)
 
 
+class DimensionEqualityTest(ComparisonTestCase):
+
+    def test_simple_dim_equality(self):
+        dim1 = Dimension('test')
+        dim2 = Dimension('test')
+        self.assertEqual(dim1==dim2, True)
+
+    def test_simple_str_equality(self):
+        dim1 = Dimension('test')
+        dim2 = Dimension('test')
+        self.assertEqual(dim1==str(dim2), True)
+
+    def test_simple_dim_inequality(self):
+        dim1 = Dimension('test1')
+        dim2 = Dimension('test2')
+        self.assertEqual(dim1==dim2, False)
+
+    def test_simple_str_inequality(self):
+        dim1 = Dimension('test1')
+        dim2 = Dimension('test2')
+        self.assertEqual(dim1==str(dim2), False)
+
+    def test_label_dim_inequality(self):
+        dim1 = Dimension(('test', 'label1'))
+        dim2 = Dimension(('test', 'label2'))
+        self.assertEqual(dim1==dim2, False)
+
+    def test_label_str_equality(self):
+        dim1 = Dimension(('test', 'label1'))
+        dim2 = Dimension(('test', 'label2'))
+        self.assertEqual(dim1==str(dim2), True)
+
+    def test_weak_dim_equality(self):
+        dim1 = Dimension('test', cyclic=True, unit='m', type=float)
+        dim2 = Dimension('test', cyclic=False, unit='km', type=int)
+        self.assertEqual(dim1==dim2, True)
+
+    def test_weak_str_equality(self):
+        dim1 = Dimension('test', cyclic=True, unit='m', type=float)
+        dim2 = Dimension('test', cyclic=False, unit='km', type=int)
+        self.assertEqual(dim1==str(dim2), True)
+
+
 class DimensionValuesTest(ComparisonTestCase):
 
     def setUp(self):

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -11,8 +11,31 @@ try:
 except:
     pd = None
 
+class DimensionNameLabelTest(ComparisonTestCase):
 
-class DimensionTest(ComparisonTestCase):
+    def test_dimension_name(self):
+        dim = Dimension('test')
+        self.assertEqual(dim.name, 'test')
+
+    def test_dimension_name_tuple(self):
+        dim = Dimension(('test', 'A test'))
+        self.assertEqual(dim.name, 'test')
+
+    def test_dimension_label_tuple(self):
+        dim = Dimension(('test', 'A test'))
+        self.assertEqual(dim.label, 'A test')
+
+    def test_dimension_label_kwarg(self):
+        dim = Dimension('test', label='A test')
+        self.assertEqual(dim.label, 'A test')
+
+    def test_dimension_label_kwarg_and_tuple(self):
+        # Should work but issue a warning
+        dim = Dimension(('test', 'A test'), label='Another test')
+        self.assertEqual(dim.label, 'Another test')
+
+
+class DimensionValuesTest(ComparisonTestCase):
 
     def setUp(self):
         self.values1 = [0,1,2,3,4,5,6]

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -37,7 +37,7 @@ class DimensionNameLabelTest(ComparisonTestCase):
     def test_dimension_label_kwarg_and_tuple(self):
         # Should work but issue a warning
         dim = Dimension(('test', 'A test'), label='Another test')
-        self.assertEqual(dim.label, 'A test')
+        self.assertEqual(dim.label, 'Another test')
 
 
 class DimensionValuesTest(ComparisonTestCase):

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -155,21 +155,21 @@ class DimensionedTest(ComparisonTestCase):
             raise AssertionError("Label should be a constant parameter.")
         except TypeError: pass
 
-    def test_dimensionsed_redim_string(self):
+    def test_dimensioned_redim_string(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
         redimensioned = dimensioned.clone(kdims=['Test'])
         self.assertEqual(redimensioned, dimensioned.redim(x='Test'))
 
-    def test_dimensionsed_redim_dimension(self):
+    def test_dimensioned_redim_dimension(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
         redimensioned = dimensioned.clone(kdims=['Test'])
         self.assertEqual(redimensioned, dimensioned.redim(x=Dimension('Test')))
 
-    def test_dimensionsed_redim_dict(self):
+    def test_dimensioned_redim_dict(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
         redimensioned = dimensioned.clone(kdims=['Test'])
         self.assertEqual(redimensioned, dimensioned.redim(x={'name': 'Test'}))
 
-    def test_dimensionsed_redim_dict_range(self):
+    def test_dimensioned_redim_dict_range(self):
         redimensioned = Dimensioned('Arbitrary Data', kdims=['x']).redim(x={'range': (0, 10)})
         self.assertEqual(redimensioned.kdims[0].range, (0, 10))

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -37,7 +37,7 @@ class DimensionNameLabelTest(ComparisonTestCase):
     def test_dimension_label_kwarg_and_tuple(self):
         # Should work but issue a warning
         dim = Dimension(('test', 'A test'), label='Another test')
-        self.assertEqual(dim.label, 'Another test')
+        self.assertEqual(dim.label, 'A test')
 
 
 class DimensionValuesTest(ComparisonTestCase):


### PR DESCRIPTION
This PR aims to address issue #843 and clean-up the definition of Dimension objects generally.

It is still work in progress and I've started this PR at the first commit just so that I can see the results of the notebook tests as I progress.

**Edit**: I have copied over the action items from the issue:

- [x] Renaming the first argument from ``name`` to ``spec``.
- [x] Remove the deprecated 'initial' option from the values parameter.
- [x] Declaring ``label`` as a parameter
- [x] Allowing ``label`` to be passed as a kwarg and warning when ambiguous.
- [x] Fixing the ``__call__`` method, making it work with ``(name, label)`` tuples
- [x] Aliased ``__call__`` to ``clone``.
- [x] Implemented the ``spec`` property
- [x] Update class docstring  
- [x] Updated equality semantics
- [x] Updated comparison semantics
- [x] Add more unit tests.
