### PR TITLE
Implemented correct Raster.range

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -12,7 +12,7 @@ from ..core import (Dimension, NdMapping, Element2D, HoloMap,
                     Overlay, Element, Dataset, NdElement)
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem
-from ..core.util import pd
+from ..core.util import pd, max_range
 from .chart import Curve
 from .tabular import Table
 from .util import compute_edges, compute_slice_bounds, categorical_aggregate2d
@@ -74,6 +74,21 @@ class Raster(Element2D):
         else:
             return self.clone(np.expand_dims(data, axis=slc_types.index(True)),
                               extents=None)
+
+
+    def range(self, dim, data_range=True):
+        idx = self.get_dimension_index(dim)
+        if data_range and idx == 2:
+            dimension = self.get_dimension(dim)
+            drange = self.data.min(), self.data.max()
+            drange = max_range([drange, dimension.soft_range])
+            if dimension.range[0] is not None:
+                return (dimension.range[0], drange[1])
+            elif dimension.range[1] is not None:
+                return (drange[0], dimension.range[1])
+            else:
+                return drange
+        return super(Raster, self).range(dim, data_range)
 
 
     def dimension_values(self, dim, expanded=True, flat=True):

--- a/tests/testraster.py
+++ b/tests/testraster.py
@@ -38,3 +38,15 @@ class TestRaster(ComparisonTestCase):
         self.assertEqual(image.sample(y=0.25),
                          Curve(np.array([(-0.333333, 0), (0, 1), (0.333333, 2)]),
                                kdims=['x'], vdims=['z']))
+
+    def test_raster_range_masked(self):
+        arr = np.random.rand(10,10)-0.5
+        arr = np.ma.masked_where(arr<=0, arr)
+        rrange = Raster(arr).range(2)
+        self.assertEqual(rrange, (np.min(arr), np.max(arr)))
+
+    def test_image_range_masked(self):
+        arr = np.random.rand(10,10)-0.5
+        arr = np.ma.masked_where(arr<=0, arr)
+        rrange = Image(arr).range(2)
+        self.assertEqual(rrange, (np.min(arr), np.max(arr)))


### PR DESCRIPTION
Fix for https://github.com/ioam/holoviews/issues/1020, it wasn't accessing the masked array directly and hence was returning inconsistent results with Image, which does.

```python
%%opts Raster Image [colorbar=True]
tmp = np.random.rand(10,10)-0.5
tmp = np.ma.masked_where(tmp<=0, tmp)

hv.Image(tmp)+hv.Raster(tmp)
```

![image](https://cloud.githubusercontent.com/assets/1550771/24832332/88e3974c-1ca5-11e7-9908-fc27f74ba45b.png)

As we can see the masked values are no longer included in the range but are still indicated via the colorbar and the behavior is now consistent between Raster and Image.