### PR TITLE
Allow disabling stream memoization

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -482,8 +482,12 @@ def dynamicmap_memoization(callable_obj, streams):
     """
     memoization_state = bool(callable_obj.memoize)
     callable_obj.memoize &= all(s.memoize or not s._triggering for s in streams)
-    yield
-    callable_obj.memoize = memoization_state
+    try:
+        yield
+    except:
+        raise
+    finally:
+        callable_obj.memoize = memoization_state
 
 
 class DynamicMap(HoloMap):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -32,20 +32,56 @@ def triggering_streams(streams):
             stream._triggering = False
 
 
+@contextmanager
+def disable_constant(parameterized):
+    """
+    Temporarily set parameters on Parameterized object to
+    constant=False.
+    """
+    params = parameterized.params().values()
+    constants = [p.constant for p in params]
+    for param in params:
+        param.constant = False
+    try:
+        yield
+    except:
+        raise
+    finally:
+        for (param, const) in zip(params, constants):
+            param.constant = const
+
 
 class Stream(param.Parameterized):
     """
     A Stream is simply a parameterized object with parameters that
-    change over time in response to update events. Parameters are
-    updated via the update method.
+    change over time in response to update events and may trigger
+    downstream events on its subscribers. The Stream parameters can be
+    updated using the update method, which will optionally trigger the
+    stream. This will notify the subscribers which may be supplied as
+    a list of callables or added later using the add_subscriber
+    method. The subscribers will be passed a dictionary mapping of the
+    parameters of the stream, which are available on the instance as
+    the ``contents``.
 
-    Streams may have one or more subscribers which are callables passed
-    the parameter dictionary when the trigger classmethod is called.
+    Depending on the plotting backend certain streams may
+    interactively subscribe to events and changes by the plotting
+    backend. For this purpose use the LinkedStream baseclass, which
+    enables the linked option by default. A source for the linking may
+    be supplied to the constructor in the form of another viewable
+    object specifying which part of a plot the data should come from.
 
-    Depending on the plotting backend certain streams may interactively
-    subscribe to events and changes by the plotting backend. For this
-    purpose use the LinkedStream baseclass, which enables the linked
-    option by default.
+    Since a Stream may represent a transient event you may disable
+    stream parameters from being memoized, indicating that each stream
+    event should trigger an update in a downstream DynamicMap callback.
+    By enabling reset in the constructor the reset method will get
+    called each time the stream is triggered, resetting all Stream
+    parameters to their defaults.
+
+    The Stream class is meant for subclassing and subclasses should
+    generally add one or more parameters but may also override the
+    transform and reset method to preprocess parameters before they
+    are passed to subscribers and reset them using custom logic
+    respectively.
     """
 
     # Mapping from a source id to a list of streams
@@ -83,19 +119,13 @@ class Stream(param.Parameterized):
                 subscriber(**dict(union))
 
         for stream in streams:
-            params = stream.params().values()
-            constants = [p.constant for p in params]
-            for param in params:
-                param.constant = False
-
-            stream.deactivate()
-
-            for (param, const) in zip(params, constants):
-                param.constant = const
+            with disable_constant(stream):
+                if stream._reset:
+                    stream.reset()
 
 
     def __init__(self, rename={}, source=None, subscribers=[], linked=False,
-                 memoize=True, **params):
+                 memoize=True, reset=False, **params):
         """
         The rename argument allows multiple streams with similar event
         state to be used by remapping parameter names.
@@ -115,6 +145,7 @@ class Stream(param.Parameterized):
         self.memoize = memoize
         self.linked = linked
         self._rename = self._validate_rename(rename)
+        self._reset = reset
 
         # Whether this stream is currently triggering its subscribers
         self._triggering = False
@@ -134,11 +165,23 @@ class Stream(param.Parameterized):
         " Property returning the subscriber list"
         return self._subscribers
 
+
     def clear(self):
         """
         Clear all subscribers registered to this stream.
         """
         self._subscribers = []
+
+
+    def reset(self):
+        """
+        Resets stream parameters to their defaults.
+        """
+        with disable_constant(self):
+            for k, p in self.params().items():
+                if k != 'name':
+                    setattr(self, k, p.default)
+
 
     def add_subscriber(self, subscriber):
         """
@@ -150,6 +193,7 @@ class Stream(param.Parameterized):
             raise TypeError('Subscriber must be a callable.')
         self._subscribers.append(subscriber)
 
+
     def _validate_rename(self, mapping):
         param_names = [k for k in self.params().keys() if k != 'name']
         for k,v in mapping.items():
@@ -159,6 +203,7 @@ class Stream(param.Parameterized):
                 raise KeyError('Cannot rename to %r as it clashes with a '
                                'stream parameter of the same name' % v)
         return mapping
+
 
     def rename(self, **mapping):
         """
@@ -172,18 +217,10 @@ class Stream(param.Parameterized):
                               source=self._source,
                               linked=self.linked, **params)
 
-
-    def deactivate(self):
-        """
-        Allows defining an action after the stream has been triggered,
-        e.g. resetting parameters on streams with transient events.
-        """
-        pass
-
-
     @property
     def source(self):
         return self._source
+
 
     @source.setter
     def source(self, source):
@@ -203,6 +240,7 @@ class Stream(param.Parameterized):
         """
         return {}
 
+
     @property
     def contents(self):
         filtered = {k:v for k,v in self.get_param_values() if k!= 'name' }
@@ -214,19 +252,8 @@ class Stream(param.Parameterized):
         Sets the stream parameters which are expected to be declared
         constant.
         """
-        params = self.params().values()
-        constants = [p.constant for p in params]
-        for param in params:
-            param.constant = False
-        try:
+        with disable_constant(self) as constant:
             self.set_param(**kwargs)
-        except Exception as e:
-            for (param, const) in zip(params, constants):
-                param.constant = const
-            raise
-
-        for (param, const) in zip(params, constants):
-            param.constant = const
 
 
     def update(self, trigger=True, **kwargs):
@@ -245,6 +272,7 @@ class Stream(param.Parameterized):
             self._set_stream_parameters(**transformed)
         if trigger:
             self.trigger([self])
+
 
     def __repr__(self):
         cls_name = self.__class__.__name__
@@ -280,8 +308,9 @@ class PositionX(LinkedStream):
     position of the mouse/trackpad cursor.
     """
 
-    x = param.ClassSelector(class_=(Number, util.basestring), default=0, doc="""
-           Position along the x-axis in data coordinates""", constant=True)
+    x = param.ClassSelector(class_=(Number, util.basestring), default=None,
+                            constant=True, doc="""
+           Position along the x-axis in data coordinates""")
 
 
 class PositionY(LinkedStream):
@@ -292,8 +321,9 @@ class PositionY(LinkedStream):
     position of the mouse/trackpad cursor.
     """
 
-    y = param.ClassSelector(class_=(Number, util.basestring), default=0, doc="""
-           Position along the y-axis in data coordinates""", constant=True)
+    y = param.ClassSelector(class_=(Number, util.basestring), default=None,
+                            constant=True, doc="""
+           Position along the y-axis in data coordinates""")
 
 
 class PositionXY(LinkedStream):
@@ -304,11 +334,13 @@ class PositionXY(LinkedStream):
     position of the mouse/trackpad cursor.
     """
 
-    x = param.ClassSelector(class_=(Number, util.basestring), default=0, doc="""
-           Position along the x-axis in data coordinates""", constant=True)
+    x = param.ClassSelector(class_=(Number, util.basestring), default=None,
+                            constant=True, doc="""
+           Position along the x-axis in data coordinates""")
 
-    y = param.ClassSelector(class_=(Number, util.basestring), default=0, doc="""
-           Position along the y-axis in data coordinates""", constant=True)
+    y = param.ClassSelector(class_=(Number, util.basestring), default=None,
+                            constant=True, doc="""
+           Position along the y-axis in data coordinates""")
 
 
 class Tap(PositionXY):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -23,9 +23,14 @@ def triggering_streams(streams):
     """
     for stream in streams:
         stream._triggering = True
-    yield
-    for stream in streams:
-        stream._triggering = False
+    try:
+        yield
+    except:
+        raise
+    finally:
+        for stream in streams:
+            stream._triggering = False
+
 
 
 class Stream(param.Parameterized):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -131,7 +131,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         mpl_renderer.get_widget(dmap1 + dmap2, 'selection')
 
     def test_dynamic_streams_refresh(self):
-        stream = PositionXY()
+        stream = PositionXY(x=0, y=0)
         dmap = DynamicMap(lambda x, y: Points([(x, y)]),
                              kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
@@ -151,7 +151,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX()
+        stream = PositionX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
         mpl_renderer(plot)
@@ -706,7 +706,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX()
+        stream = PositionX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
@@ -1298,7 +1298,7 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX()
+        stream = PositionX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = plotly_renderer.get_plot(dmap)
         plotly_renderer(plot)


### PR DESCRIPTION
Addresses https://github.com/ioam/holoviews/issues/1215, allowing disabling memoization when a specific stream is active, which forces a callback to be triggered when a new event comes in.