### PR TITLE
Added logging output support to unittests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,8 @@
 import os, sys
+import param
+import logging
+
+from holoviews.element.comparison import ComparisonTestCase
 
 try:
     # Standardize backend due to random inconsistencies

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -61,3 +61,25 @@ class MockLoggingHandler(logging.Handler):
             raise AssertionError(msg.format(method=methods[level],
                                             last_line=repr(last_line[0]),
                                             substring=repr(substring)))
+
+
+
+class LoggingComparisonTestCase(ComparisonTestCase):
+    """
+    ComparisonTestCase with support for capturing param logging output.
+
+    Subclasses must call super setUp to make the
+    tests independent. Testing can then be done via the
+    self.log_handler.tail and self.log_handler.assertEndsWith methods.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super(LoggingComparisonTestCase, cls).setUpClass()
+        log = param.parameterized.get_logger()
+        cls.log_handler = MockLoggingHandler(level='DEBUG')
+        log.addHandler(cls.log_handler)
+
+    def setUp(self):
+        super(LoggingComparisonTestCase, self).setUp()
+        self.log_handler.reset()

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -4,6 +4,7 @@ Test cases for Dimension and Dimensioned object behaviour.
 from unittest import SkipTest
 from holoviews.core import Dimensioned, Dimension
 from holoviews.element.comparison import ComparisonTestCase
+from . import LoggingComparisonTestCase
 
 import numpy as np
 try:
@@ -11,7 +12,10 @@ try:
 except:
     pd = None
 
-class DimensionNameLabelTest(ComparisonTestCase):
+class DimensionNameLabelTest(LoggingComparisonTestCase):
+
+    def setUp(self):
+        super(DimensionNameLabelTest, self).setUp()
 
     def test_dimension_name(self):
         dim = Dimension('test')
@@ -35,8 +39,9 @@ class DimensionNameLabelTest(ComparisonTestCase):
         self.assertEqual(dim.label, 'A test')
 
     def test_dimension_label_kwarg_and_tuple(self):
-        # Should work but issue a warning
         dim = Dimension(('test', 'A test'), label='Another test')
+        substr = "Using label as supplied by keyword ('Another test'), ignoring tuple value 'A test'"
+        self.log_handler.assertEndsWith('WARNING', substr)
         self.assertEqual(dim.label, 'Another test')
 
     def test_dimension_invalid_name(self):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -399,7 +399,7 @@ class DynamicCollate(ComparisonTestCase):
         self.assertEqual(list(grid.keys()), [(i, j) for i in range(1, 3)
                                              for j in range(1, 3)])
         self.assertEqual(grid[(0, 1)][()], Image(np.array([[1, 1], [2, 3]])))
-    
+
     def test_dynamic_collate_grid_with_integer_stream_mapping(self):
         def callback():
             return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))


### PR DESCRIPTION

This PR allows us to finally check param's logging output. We have often wanted to check the output of ``param.warning`` but haven't had the infrastructure to do so. This is important as we want to improve exceptions and warnings throughout HoloViews.

This PR includes an example of how the new ``LoggingComparisonTestCase`` is used, involving a recent unit test where I wanted to check the param.warning output. 

I'll be using this new system in a number of new unit tests I am planning but I don't intend to go back and update all the existing tests right now as it would take some thought to figure out where logging output should be checked. That could be work for a future PR and could be something to do before HoloViews 2.0.

