### PR TITLE
Automatically handle different signatures in Callable

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -460,6 +460,22 @@ class Callable(param.Parameterized):
         if memoize and hashed_key in self._memoized:
             return self._memoized[hashed_key]
 
+        if self.argspec.varargs is not None:
+            # Missing information on positional argument names, cannot promote to keywords
+            pass
+        elif len(args) != 0: # Turn positional arguments into keyword arguments
+            pos_kwargs = {k:v for k,v in zip(self.argspec.args, args)}
+            ignored = range(len(self.argspec.args),len(args))
+            if len(ignored):
+                self.warning('Ignoring extra positional argument %s'
+                             % ', '.join('%s' % i for i in ignored))
+            clashes = set(pos_kwargs.keys()) & set(kwargs.keys())
+            if clashes:
+                self.warning('Positional arguments %r overriden by keywords'
+                             % list(clashes))
+            args, kwargs = (), dict(pos_kwargs, **kwargs)
+
+
         ret = self.callable(*args, **kwargs)
         if hashed_key is not None:
             self._memoized = {hashed_key : ret}

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -556,6 +556,9 @@ class DynamicMap(HoloMap):
             callback = Callable(callback)
         super(DynamicMap, self).__init__(initial_items, callback=callback, **params)
 
+        self._posarg_keys = util.validate_dynamic_argspec(self.callback.argspec,
+                                                          self.kdims,
+                                                          self.streams)
         # Set source to self if not already specified
         for stream in self.streams:
             if stream.source is None:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -647,14 +647,14 @@ class DynamicMap(HoloMap):
         kwarg_items = [s.contents.items() for s in self.streams]
         flattened = [(k,v) for kws in kwarg_items for (k,v) in kws
                      if k not in kdims]
+
+        if self._posarg_keys:
+            kwargs = dict(flattened, **dict(zip(self._posarg_keys, args)))
+            args = ()
+        else:
+            kwargs = dict(flattened)
+
         with dynamicmap_memoization(self.callback, self.streams):
-
-            if self._posarg_keys:
-                kwargs = dict(flattened, **dict(zip(self._posarg_keys, args)))
-                args = ()
-            else:
-                kwargs = dict(flattened)
-
             retval = self.callback(*args, **kwargs)
         return self._style(retval)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -648,7 +648,14 @@ class DynamicMap(HoloMap):
         flattened = [(k,v) for kws in kwarg_items for (k,v) in kws
                      if k not in kdims]
         with dynamicmap_memoization(self.callback, self.streams):
-            retval = self.callback(*args, **dict(flattened))
+
+            if self._posarg_keys:
+                kwargs = dict(flattened, **dict(zip(self._posarg_keys, args)))
+                args = ()
+            else:
+                kwargs = dict(flattened)
+
+            retval = self.callback(*args, **kwargs)
         return self._style(retval)
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -442,6 +442,10 @@ class Callable(param.Parameterized):
         super(Callable, self).__init__(callable=callable, **params)
         self._memoized = {}
 
+    @property
+    def argspec(self):
+        return util.argspec(self.callable)
+
     def __call__(self, *args, **kwargs):
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -161,7 +161,7 @@ def validate_dynamic_argspec(argspec, kdims, streams):
     kwargs = argspec.args[-len(defaults):]
 
     if argspec.keywords is None:
-        unassigned_streams = set(stream_params) - set(kwargs)
+        unassigned_streams = set(stream_params) - set(argspec.args)
         if unassigned_streams:
             raise KeyError('Callable missing keywords to accept %s stream parameters'
                            % ', '.join(unassigned_streams))
@@ -174,9 +174,13 @@ def validate_dynamic_argspec(argspec, kdims, streams):
         return posargs
     elif argspec.varargs:          # Posargs missing, passed to Callable directly
         return None
-    else:
+
+    # Handle positional arguments matching stream parameter names
+    stream_posargs = [arg for arg in posargs if arg in stream_params]
+    if len(stream_posargs) != len(posargs):
         raise Exception('Supplied callback signature does not accommodate '
                         'required kdims and stream parameters')
+    return stream_posargs
 
 
 def process_ellipses(obj, key, vdim_selection=False):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -187,7 +187,7 @@ def validate_dynamic_argspec(argspec, kdims, streams):
     elif set(kdims).issubset(set(kwargs)): # Key dims can be supplied by keyword
         return kdims
     else:
-        raise KeyError('Callback signature over {names} do not accommodate '
+        raise KeyError('Callback signature over {names} does not accommodate '
                        'required kdims {kdims}'.format(names=list(set(posargs+kwargs)),
                                                        kdims=kdims))
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -111,7 +111,12 @@ def argspec(callable_obj):
     seen by the user. In other words, the first argument which is
     conventionally called 'self' or 'cls' is omitted in these cases.
     """
-    if inspect.isfunction(callable_obj):    # functions and staticmethods
+    if (isinstance(callable_obj, type)
+        and issubclass(callable_obj, param.ParameterizedFunction)):
+        # Parameterized function.__call__ considered function in py3 but not py2
+        spec = inspect.getargspec(callable_obj.__call__)
+        args=spec.args[1:]
+    elif inspect.isfunction(callable_obj):    # functions and staticmethods
         return inspect.getargspec(callable_obj)
     elif isinstance(callable_obj, partial): # partials
         arglen = len(callable_obj.args)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -177,8 +177,8 @@ def validate_dynamic_argspec(argspec, kdims, streams):
     elif argspec.varargs:          # Posargs missing, passed to Callable directly
         return None
     else:
-        raise Exception('Callback positional arguments {posargs} do not accommodate '
-                        'required kdims {kdims}'.format(posargs=posargs, kdims=kdims))
+        raise KeyError('Callback positional arguments {posargs} do not accommodate '
+                       'required kdims {kdims}'.format(posargs=posargs, kdims=kdims))
 
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -168,7 +168,7 @@ def validate_dynamic_argspec(argspec, kdims, streams):
             raise KeyError('Callable missing keywords to accept %s stream parameters'
                            % ', '.join(unassigned_streams))
 
-    if posargs == []:              # No posargs, stream kwargs already validated
+    if kdims == []:                    # Can be no posargs, stream kwargs already validated
         return []
     if set(kdims) == set(posargs): # Posargs match, can all be passed as kwargs
         return kdims
@@ -176,9 +176,16 @@ def validate_dynamic_argspec(argspec, kdims, streams):
         return posargs
     elif argspec.varargs:          # Posargs missing, passed to Callable directly
         return None
+    elif set(posargs) - set(kdims):
+        raise KeyError('Callable accepts more positional arguments {posargs} '
+                       'than there are key dimensions {kdims}'.format(posargs=posargs,
+                                                                      kdims=kdims))
+    elif set(kdims).issubset(set(kwargs)): # Key dims can be supplied by keyword
+        return kdims
     else:
-        raise KeyError('Callback positional arguments {posargs} do not accommodate '
-                       'required kdims {kdims}'.format(posargs=posargs, kdims=kdims))
+        raise KeyError('Callback signature over {names} do not accommodate '
+                       'required kdims {kdims}'.format(names=list(set(posargs+kwargs)),
+                                                       kdims=kdims))
 
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -172,11 +172,14 @@ def validate_dynamic_argspec(argspec, kdims, streams):
         return []
     if set(kdims) == set(posargs): # Posargs match, can all be passed as kwargs
         return kdims
-    elif len(posargs) == kdims:    # Posargs match kdims length, supplying names
+    elif len(posargs) == len(kdims):    # Posargs match kdims length, supplying names
         return posargs
     elif argspec.varargs:          # Posargs missing, passed to Callable directly
         return None
-    return None                    # Use strict invocation
+    else:
+        raise Exception('Callback positional arguments {posargs} do not accommodate '
+                        'required kdims {kdims}'.format(posargs=posargs, kdims=kdims))
+
 
 
 def process_ellipses(obj, key, vdim_selection=False):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -168,13 +168,13 @@ def validate_dynamic_argspec(argspec, kdims, streams):
             raise KeyError('Callable missing keywords to accept %s stream parameters'
                            % ', '.join(unassigned_streams))
 
-    if kdims == []:                    # Can be no posargs, stream kwargs already validated
+    if kdims == []:                  # Can be no posargs, stream kwargs already validated
         return []
-    if set(kdims) == set(posargs): # Posargs match, can all be passed as kwargs
+    if set(kdims) == set(posargs):   # Posargs match exactly, can all be passed as kwargs
         return kdims
-    elif len(posargs) == len(kdims):    # Posargs match kdims length, supplying names
+    elif len(posargs) == len(kdims): # Posargs match kdims length, supplying names
         return posargs
-    elif argspec.varargs:          # Posargs missing, passed to Callable directly
+    elif argspec.varargs:            # Posargs missing, passed to Callable directly
         return None
     elif set(posargs) - set(kdims):
         raise KeyError('Callable accepts more positional arguments {posargs} '

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -173,6 +173,10 @@ def validate_dynamic_argspec(argspec, kdims, streams):
     if set(kdims) == set(posargs):   # Posargs match exactly, can all be passed as kwargs
         return kdims
     elif len(posargs) == len(kdims): # Posargs match kdims length, supplying names
+        if argspec.args[:len(kdims)] != posargs:
+            raise KeyError('Unmatched positional kdim arguments only '
+                           'allowed at the start of the signature')
+
         return posargs
     elif argspec.varargs:            # Posargs missing, passed to Callable directly
         return None

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -108,7 +108,7 @@ def argspec(callable_obj):
     methods, classmethods and partials.
 
     Note that the args list for instance and class methods are those as
-    seen by the user. In other words, the first argument with is
+    seen by the user. In other words, the first argument which is
     conventionally called 'self' or 'cls' is omitted in these cases.
     """
     if inspect.isfunction(callable_obj):    # functions and staticmethods

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -27,6 +27,8 @@ class MockLoggingHandler(logging.Handler):
     def __init__(self, *args, **kwargs):
         self.messages = {'DEBUG': [], 'INFO': [], 'WARNING': [],
                          'ERROR': [], 'CRITICAL': [], 'VERBOSE':[]}
+        self.param_methods = {'WARNING':'param.warning()', 'INFO':'param.message()',
+                              'VERBOSE':'param.verbose()', 'DEBUG':'param.debug()'}
         super(MockLoggingHandler, self).__init__(*args, **kwargs)
 
     def emit(self, record):
@@ -54,18 +56,30 @@ class MockLoggingHandler(logging.Handler):
         Assert that the last line captured at the given level ends with
         a particular substring.
         """
-        methods = {'WARNING':'param.warning()', 'INFO':'param.message()',
-                   'VERBOSE':'param.verbose()', 'DEBUG':'param.debug()'}
         msg='\n\n{method}: {last_line}\ndoes not end with:\n{substring}'
         last_line = self.tail(level, n=1)
         if len(last_line) == 0:
-            raise AssertionError('Missing {method} output: {repr(substring)}'.format(
-                method=methods[level], substring=repr(substring)))
+            raise AssertionError('Missing {method} output: {substring}'.format(
+                method=self.param_methods[level], substring=repr(substring)))
         if not last_line[0].endswith(substring):
-            raise AssertionError(msg.format(method=methods[level],
+            raise AssertionError(msg.format(method=self.param_methods[level],
                                             last_line=repr(last_line[0]),
                                             substring=repr(substring)))
 
+    def assertContains(self, level, substring):
+        """
+        Assert that the last line captured at the given level contains a
+        particular substring.
+        """
+        msg='\n\n{method}: {last_line}\ndoes not contain:\n{substring}'
+        last_line = self.tail(level, n=1)
+        if len(last_line) == 0:
+            raise AssertionError('Missing {method} output: {substring}'.format(
+                method=self.param_methods[level], substring=repr(substring)))
+        if substring not in last_line[0]:
+            raise AssertionError(msg.format(method=self.param_methods[level],
+                                            last_line=repr(last_line[0]),
+                                            substring=repr(substring)))
 
 
 class LoggingComparisonTestCase(ComparisonTestCase):

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests of the Callable object that wraps user callbacks
+"""
+import param
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.core.spaces import Callable
+from functools import partial
+
+from . import LoggingComparisonTestCase
+
+class CallableClass(object):
+
+    def __call__(self, *testargs):
+        return sum(testargs)
+
+
+class ParamFunc(param.ParameterizedFunction):
+
+    a = param.Integer(default=1)
+    b = param.Number(default=1)
+
+    def __call__(self, **params):
+        p = param.ParamOverrides(self, params)
+        return p.a * p.b
+
+
+class TestSimpleCallableInvocation(LoggingComparisonTestCase):
+
+    def setUp(self):
+        super(TestSimpleCallableInvocation, self).setUp()
+
+    def test_callable_fn(self):
+        def callback(x): return x
+        self.assertEqual(Callable(callback)(3), 3)
+
+    def test_callable_lambda(self):
+        self.assertEqual(Callable(lambda x,y: x+y)(3,5), 8)
+
+    def test_callable_lambda_extras(self):
+        substr = "Ignoring extra positional argument"
+        self.assertEqual(Callable(lambda x,y: x+y)(3,5,10), 8)
+        self.log_handler.assertContains('WARNING', substr)
+
+    def test_callable_lambda_extras_kwargs(self):
+        substr = "['x'] overriden by keywords"
+        self.assertEqual(Callable(lambda x,y: x+y)(3,5,x=10), 15)
+        self.log_handler.assertEndsWith('WARNING', substr)
+
+    def test_callable_partial(self):
+        self.assertEqual(Callable(partial(lambda x,y: x+y,x=4))(5), 9)
+
+    def test_callable_class(self):
+        self.assertEqual(Callable(CallableClass())(1,2,3,4), 10)
+
+    def test_callable_paramfunc(self):
+        self.assertEqual(Callable(ParamFunc)(a=3,b=5), 15)
+
+
+class TestCallableArgspec(ComparisonTestCase):
+
+    def test_callable_fn_argspec(self):
+        def callback(x): return x
+        self.assertEqual(Callable(callback).argspec.args, ['x'])
+        self.assertEqual(Callable(callback).argspec.keywords, None)
+
+    def test_callable_lambda_argspec(self):
+        self.assertEqual(Callable(lambda x,y: x+y).argspec.args, ['x','y'])
+        self.assertEqual(Callable(lambda x,y: x+y).argspec.keywords, None)
+
+    def test_callable_partial_argspec(self):
+        self.assertEqual(Callable(partial(lambda x,y: x+y,x=4)).argspec.args, ['y'])
+        self.assertEqual(Callable(partial(lambda x,y: x+y,x=4)).argspec.keywords, None)
+
+    def test_callable_class_argspec(self):
+        self.assertEqual(Callable(CallableClass()).argspec.args, [])
+        self.assertEqual(Callable(CallableClass()).argspec.keywords, None)
+        self.assertEqual(Callable(CallableClass()).argspec.varargs, 'testargs')
+
+    def test_callable_paramfunc_argspec(self):
+        self.assertEqual(Callable(ParamFunc).argspec.args, [])
+        self.assertEqual(Callable(ParamFunc).argspec.keywords, 'params')
+        self.assertEqual(Callable(ParamFunc).argspec.varargs, None)
+
+
+class TestKwargCallableInvocation(ComparisonTestCase):
+    """
+    Test invocation of Callable with kwargs, even for callbacks with
+    positional arguments.
+    """
+
+    def test_callable_fn(self):
+        def callback(x): return x
+        self.assertEqual(Callable(callback)(x=3), 3)
+
+    def test_callable_lambda(self):
+        self.assertEqual(Callable(lambda x,y: x+y)(x=3,y=5), 8)
+
+    def test_callable_partial(self):
+        self.assertEqual(Callable(partial(lambda x,y: x+y,x=4))(y=5), 9)
+
+    def test_callable_paramfunc(self):
+        self.assertEqual(Callable(ParamFunc)(a=3,b=5), 15)
+
+
+class TestMixedCallableInvocation(ComparisonTestCase):
+    """
+    Test mixed invocation of Callable with kwargs.
+    """
+
+    def test_callable_mixed_1(self):
+        def mixed_example(a,b, c=10, d=20):
+            return a+b+c+d
+        self.assertEqual(Callable(mixed_example)(a=3,b=5), 38)
+
+    def test_callable_mixed_2(self):
+        def mixed_example(a,b, c=10, d=20):
+            return a+b+c+d
+        self.assertEqual(Callable(mixed_example)(3,5,5), 33)

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -190,6 +190,17 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
 
+    def test_dynamic_split_mismatched_kdims_and_streams(self):
+        # Corresponds to the old style of kdims as posargs and streams
+        # as kwargs. Positional arg names don't have to match
+        def fn(B, x=1, y=2):
+            return Scatter([(x,y)], label=B)
+
+        xy = streams.PositionXY(x=1, y=2)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
+
+
     def test_dynamic_split_args_and_kwargs(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs, captured as *args and **kwargs

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -196,7 +196,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label=B)
 
         xy = streams.PositionXY(x=1, y=2)
-        regexp = "Callback signature over (.+?) do not accommodate required kdims"
+        regexp = "Callback signature over (.+?) does not accommodate required kdims"
         with self.assertRaisesRegexp(KeyError, regexp):
             DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
 

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -20,9 +20,9 @@ class ParamFunc(param.ParameterizedFunction):
     a = param.Integer(default=1)
     b = param.Number(default=1)
 
-    def __call__(self, **params):
+    def __call__(self, a, **params):
         p = param.ParamOverrides(self, params)
-        return p.a * p.b
+        return a * p.b
 
 
 class TestSimpleCallableInvocation(LoggingComparisonTestCase):
@@ -54,8 +54,10 @@ class TestSimpleCallableInvocation(LoggingComparisonTestCase):
         self.assertEqual(Callable(CallableClass())(1,2,3,4), 10)
 
     def test_callable_paramfunc(self):
-        self.assertEqual(Callable(ParamFunc)(a=3,b=5), 15)
+        self.assertEqual(Callable(ParamFunc)(3,b=5), 15)
 
+    def test_callable_paramfunc_instance(self):
+        self.assertEqual(Callable(ParamFunc.instance())(3,b=5), 15)
 
 class TestCallableArgspec(ComparisonTestCase):
 
@@ -78,10 +80,14 @@ class TestCallableArgspec(ComparisonTestCase):
         self.assertEqual(Callable(CallableClass()).argspec.varargs, 'testargs')
 
     def test_callable_paramfunc_argspec(self):
-        self.assertEqual(Callable(ParamFunc).argspec.args, [])
+        self.assertEqual(Callable(ParamFunc).argspec.args, ['a'])
         self.assertEqual(Callable(ParamFunc).argspec.keywords, 'params')
         self.assertEqual(Callable(ParamFunc).argspec.varargs, None)
 
+    def test_callable_paramfunc_instance_argspec(self):
+        self.assertEqual(Callable(ParamFunc.instance()).argspec.args, ['a'])
+        self.assertEqual(Callable(ParamFunc.instance()).argspec.keywords, 'params')
+        self.assertEqual(Callable(ParamFunc.instance()).argspec.varargs, None)
 
 class TestKwargCallableInvocation(ComparisonTestCase):
     """

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -200,7 +200,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         with self.assertRaisesRegexp(KeyError, regexp):
             DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
 
-    def test_dynamic_split_mismatched_kdims_example1(self):
+    def test_dynamic_split_mismatched_kdims(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs. Positional arg names don't have to match
         def fn(B, x=1, y=2):
@@ -210,16 +210,19 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
-    def test_dynamic_split_mismatched_kdims_example2(self):
+    def test_dynamic_split_mismatched_kdims_invalid(self):
         # Corresponds to the old style of kdims as posargs and streams
         # as kwargs. Positional arg names don't have to match and the
-        # stream parameters can be passed by position
+        # stream parameters can be passed by position but *only* if they
+        # come first
         def fn(x, y, B):
             return Scatter([(x,y)], label=B)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
-        self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
+        regexp = ("Unmatched positional kdim arguments only allowed "
+                  "at the start of the signature")
+        with self.assertRaisesRegexp(KeyError, regexp):
+            DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
 
     def test_dynamic_split_args_and_kwargs(self):
         # Corresponds to the old style of kdims as posargs and streams

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -187,16 +187,16 @@ class DynamicTestOverlay(ComparisonTestCase):
 
     def test_dynamic_event_renaming_valid(self):
 
-        def fn(x, y):
-            return Scatter([(x, y)])
+        def fn(x1, y1):
+            return Scatter([(x1, y1)])
 
         xy = PositionXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
         dmap.event(x1=1, y1=2)
 
     def test_dynamic_event_renaming_invalid(self):
-        def fn(x, y):
-            return Scatter([(x, y)])
+        def fn(x1, y1):
+            return Scatter([(x1, y1)])
 
         xy = PositionXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])


### PR DESCRIPTION

This PR aims to address #1189. The goal is to make ``Callable`` very flexible in what it accepts when it dispatches args and kwargs to the callback. This should mean that DynamicMap can accept almost any sensible callback.

## Action items

- [x] Make Callable flexible in how it dispatches arguments
- [x] Validate argspec against kdims and streams in DynamicMap 
- [x] Add more unit tests