### PR TITLE
Raised NotImplementedError for unsupported DynamicMap methods

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1053,9 +1053,27 @@ class DynamicMap(HoloMap):
         else:
             return hist
 
+
     def reindex(self, kdims=[], force=False):
-        raise NotImplementedError('Cannot reindex a DynamicMap, '
-                                  'cast to a HoloMap first.')
+        """
+        Reindexing a DynamicMap allows reordering the dimensions but
+        not dropping an individual dimension. The force argument which
+        usually allows dropping non-constant dimensions is therefore
+        ignored and only for API consistency.
+        """
+        kdims = [self.get_dimension(kd, strict=True) for kd in kdims]
+        dropped = [kd for kd in self.kdims if kd not in kdims]
+        if dropped:
+            raise ValueError("DynamicMap does not allow dropping dimensions, "
+                             "reindex may only be used to reorder dimensions.")
+        reindexed = super(DynamicMap, self).reindex(kdims, force)
+        def reindex(*args, **kwargs):
+            keymap = {kd.name: arg for kd, arg in zip(self.kdims, args)}
+            keymap.update(kwargs)
+            args = tuple(keymap[kd.name] for kd in kdims)
+            return reindexed[args]
+        return reindexed.clone(callback=Callable(reindex, inputs=[self]))
+
 
     def drop_dimension(self, dimensions):
         raise NotImplementedError('Cannot drop dimensions from a DynamicMap, '

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1053,6 +1053,17 @@ class DynamicMap(HoloMap):
         else:
             return hist
 
+    def reindex(self, kdims=[], force=False):
+        raise NotImplementedError('Cannot reindex a DynamicMap, '
+                                  'cast to a HoloMap first.')
+
+    def drop_dimension(self, dimensions):
+        raise NotImplementedError('Cannot drop dimensions from a DynamicMap, '
+                                  'cast to a HoloMap first.')
+
+    def add_dimension(self, dimension, dim_pos, dim_val, vdim=False, **kwargs):
+        raise NotImplementedError('Cannot add dimensions to a DynamicMap, '
+                                  'cast to a HoloMap first.')
 
     # For Python 2 and 3 compatibility
     __next__ = next


### PR DESCRIPTION
As outlined in #442 the reindex, add_dimension, and drop_dimension methods on DynamicMap are simply not valid because the callback expects specific arguments which cannot be changed. Since these are inherited from ``MultiDimensionalMapping`` which is really far removed from DynamicMap it'd be a nightmare to to generate sensible baseclasses to ensure these methods don't appear at all. Therefore I'm just raising NotImplementedErrors letting the user know that they'll have to cast their DynamicMap with a cache to a HoloMap before calling the one of those methods.

Edit: Reindex does make sense as long as you're only reordering dimensions, so I've now implemented it.