### PR TITLE
Applied formatting to bokeh datetime hover tool labels

### DIFF
--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -465,6 +465,20 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(hover[0].tooltips, tooltips)
         self.assertEqual(hover[0].line_policy, line_policy)
 
+    def test_points_overlay_datetime_hover(self):
+        obj = NdOverlay({i: Points((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
+                        kdims=['Test'])
+        opts = {'Points': {'tools': ['hover']}}
+        obj = obj(plot=opts)
+        self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x_dt_strings}'), ('y', '@{y}')])
+
+    def test_curve_overlay_datetime_hover(self):
+        obj = NdOverlay({i: Curve((list(pd.date_range('2016-01-01', '2016-01-31')), range(31))) for i in range(5)},
+                        kdims=['Test'])
+        opts = {'Curve': {'tools': ['hover']}}
+        obj = obj(plot=opts)
+        self._test_hover_info(obj, [('Test', '@{Test}'), ('x', '@{x_dt_strings}'), ('y', '@{y}')])
+
     def test_points_overlay_hover_batched(self):
         obj = NdOverlay({i: Points(np.random.rand(10,2)) for i in range(5)},
                         kdims=['Test'])


### PR DESCRIPTION
As requested in #1261 datetimes in the hover tool should be formatted correctly. This has annoyed me myself a fair bit. Currently the only approach to make this work is to send the formatted strings as a column in the ColumnDataSource as outlined here, in future we can hopefully use JS datetime formatting to support this. I do think this is an important feature (it's visible in a number of my demos like the StockExplorer) and should make it into 1.7.

See https://github.com/bokeh/bokeh/issues/1239 for status of a more convenient/efficient mechanism for this.