### PR TITLE
Filter spectral cmaps from palette to avoid warning

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -68,7 +68,10 @@ def get_color_cycle():
     return mpl.rcParams['axes.color_cycle']
 
 Cycle.default_cycles.update({'default_colors': get_color_cycle()})
-Palette.colormaps.update({cm: plt.get_cmap(cm) for cm in plt.cm.datad})
+
+# Filter spectral colormaps to avoid warning in mpl 2.0
+Palette.colormaps.update({cm: plt.get_cmap(cm) for cm in plt.cm.datad
+                          if cm not in ['spectral', 'spectral_r']})
 
 style_aliases = {'edgecolor': ['ec', 'ecolor'], 'facecolor': ['fc'],
                  'linewidth': ['lw'], 'edgecolors': ['ec', 'edgecolor'],


### PR DESCRIPTION
Didn't catch this one because it was py3 only. Just need to filter these, afaik they are dropped from ``plt.cm.datad`` in matplotlib master.