### PR TITLE
Defined option_state context manager

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -107,11 +107,15 @@ def dynamic_optstate(element, state=None):
 @contextmanager
 def option_state(element):
     optstate = dynamic_optstate(element)
+    raised_exception = False
     try:
         yield
     except Exception:
-        dynamic_optstate(element, state=optstate)
+        raised_exception = True
         raise
+    finally:
+        if raised_exception:
+            dynamic_optstate(element, state=optstate)
 
 def display_hook(fn):
     @wraps(fn)


### PR DESCRIPTION
This PR defines an ``option_state`` context manager in ``display_hooks.py``. It fixes the tracebacks and I think this is a better approach than what we had before.

What I don't know is whether it fixes the exception about not inheriting from None or something other than object. I don't quite remember what the reported message was as I've never been able to reproduce that particular issue myself!