### PR TITLE
Passed Element to mpl ElementPlot._finalize_axis

### DIFF
--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -28,7 +28,7 @@ class AnnotationPlot(ElementPlot):
         with abbreviated_exception():
             handles = self.draw_annotation(axis, annotation.data, opts)
         self.handles['annotations'] = handles
-        return self._finalize_axis(key, ranges=ranges)
+        return self._finalize_axis(key, element=annotation, ranges=ranges)
 
     def update_handles(self, key, axis, annotation, ranges, style):
         # Clear all existing annotations

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -304,7 +304,7 @@ class HistogramPlot(ChartPlot):
         ticks = self._compute_ticks(hist, edges, widths, lims)
         ax_settings = self._process_axsettings(hist, lims, ticks)
 
-        return self._finalize_axis(self.keys[-1], ranges=el_ranges, **ax_settings)
+        return self._finalize_axis(self.keys[-1], ranges=el_ranges, element=hist, **ax_settings)
 
 
     def _process_hist(self, hist):
@@ -801,7 +801,7 @@ class BarPlot(LegendPlot):
 
         self.handles['artist'], self.handles['xticks'], xdims = self._create_bars(axis, element)
         return self._finalize_axis(key, ranges=ranges, xticks=self.handles['xticks'],
-                                   dimensions=[xdims, vdim])
+                                   element=element, dimensions=[xdims, vdim])
 
 
     def _finalize_ticks(self, axis, element, xticks, yticks, zticks):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -132,7 +132,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 self.warning("Plotting hook %r could not be applied:\n\n %s" % (hook, e))
 
 
-    def _finalize_axis(self, key, title=None, dimensions=None, ranges=None, xticks=None,
+    def _finalize_axis(self, key, element=None, title=None, dimensions=None, ranges=None, xticks=None,
                        yticks=None, zticks=None, xlabel=None, ylabel=None, zlabel=None):
         """
         Applies all the axis settings before the axis or figure is returned.
@@ -141,7 +141,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         When the number of the frame is supplied as n, this method looks
         up and computes the appropriate title, axis labels and axis bounds.
         """
-        element = self._get_frame(key)
+        if element is None:
+            element = self._get_frame(key)
         self.current_frame = element
         if not dimensions and element and not self.subplots:
             el = element.traverse(lambda x: x, [Element])
@@ -462,7 +463,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         label = element.label if self.show_legend else ''
         style = dict(label=label, zorder=self.zorder, **self.style[self.cyclic_index])
         axis_kwargs = self.update_handles(key, axis, element, ranges, style)
-        self._finalize_axis(key, ranges=ranges, **(axis_kwargs if axis_kwargs else {}))
+        self._finalize_axis(key, element=element, ranges=ranges,
+                            **(axis_kwargs if axis_kwargs else {}))
 
 
     @mpl_rc_context
@@ -486,7 +488,8 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             handles = self.init_artists(ax, plot_data, plot_kwargs)
         self.handles.update(handles)
 
-        return self._finalize_axis(self.keys[-1], ranges=ranges, **axis_kwargs)
+        return self._finalize_axis(self.keys[-1], element=element, ranges=ranges,
+                                   **axis_kwargs)
 
 
     def init_artists(self, ax, plot_args, plot_kwargs):
@@ -831,7 +834,8 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         if self.show_legend:
             self._adjust_legend(element, axis)
 
-        return self._finalize_axis(key, ranges=ranges, title=self._format_title(key))
+        return self._finalize_axis(key, element=element, ranges=ranges,
+                                   title=self._format_title(key))
 
 
     def update_frame(self, key, ranges=None, element=None):
@@ -866,4 +870,4 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         if self.show_legend:
             self._adjust_legend(element, axis)
 
-        self._finalize_axis(key, ranges=ranges)
+        self._finalize_axis(key, element=element, ranges=ranges)

--- a/holoviews/plotting/mpl/pandas.py
+++ b/holoviews/plotting/mpl/pandas.py
@@ -76,7 +76,8 @@ class DFrameViewPlot(ElementPlot):
         if 'fig' in self.handles and self.handles['fig'] != plt.gcf():
             self.handles['fig'] = plt.gcf()
 
-        return self._finalize_axis(self.keys[-1], **self.get_axis_kwargs(element))
+        return self._finalize_axis(self.keys[-1], element=element,
+                                   **self.get_axis_kwargs(element))
 
 
     def _process_style(self, style):

--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -242,7 +242,7 @@ class SNSFramePlot(DFrameViewPlot):
         if 'fig' in self.handles and self.handles['fig'] != plt.gcf():
             self.handles['fig'] = plt.gcf()
 
-        return self._finalize_axis(self.keys[-1])
+        return self._finalize_axis(self.keys[-1], element=dfview)
 
 
     def _process_style(self, styles):
@@ -272,7 +272,7 @@ class SNSFramePlot(DFrameViewPlot):
 
         axis_kwargs = self.update_handles(key, axis, element, key, ranges, style)
         if axis:
-            self._finalize_axis(key, **(axis_kwargs if axis_kwargs else {}))
+            self._finalize_axis(key, element=element, **(axis_kwargs if axis_kwargs else {}))
 
 
     def _update_plot(self, axis, view, style):

--- a/holoviews/plotting/mpl/tabular.py
+++ b/holoviews/plotting/mpl/tabular.py
@@ -126,7 +126,7 @@ class TablePlot(ElementPlot):
 
         self.handles['artist'] = table
 
-        return self._finalize_axis(self.keys[-1])
+        return self._finalize_axis(self.keys[-1], element=element)
 
 
     def update_handles(self, key, axis, element, ranges, style):


### PR DESCRIPTION
In debugging another issue I found that matplotlib plots are not correctly handling DynamicMaps of overlays as ElementPlots are not passing the currently displayed Element to the ``_finalize_axis`` method. This means that the method does an additional lookup which fails when the data comes from a DynamicMap returning Overlays.