### PR TITLE
Ensure old paths aren't dropped when combining Layouts

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -430,7 +430,7 @@ class Layout(AttrTree, Dimensioned):
             if type(item) is cls:
                 cls._initial_paths(item.items(), paths)
                 continue
-            paths.append(get_path(item))
+            paths.append(get_path(item) if path is None else path)
         return paths
 
 
@@ -445,9 +445,9 @@ class Layout(AttrTree, Dimensioned):
         for item in objs:
             path, obj = item if isinstance(item, tuple) else (None, item)
             if type(obj) is cls:
-                cls._unpack_paths(obj, items, counts)
+                cls._unpack_paths(obj.items(), items, counts)
                 continue
-            path = get_path(item)
+            path = get_path(item) if path is None else path
             new_path = make_path_unique(path, counts)
             items.append((new_path, obj))
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1183,17 +1183,24 @@ def get_path(item):
     return tuple(capitalize(fn(p)) for (p, fn) in zip(path, sanitizers))
 
 
-def make_path_unique(path, counts):
+def make_path_unique(path, counts, new):
     """
     Given a path, a list of existing paths and counts for each of the
     existing paths.
     """
-    while path in counts:
+    added = False
+    while any(path == c[:i] for c in counts for i in range(1, len(c)+1)):
         count = counts[path]
         counts[path] += 1
+        if (not new and len(path) > 1) or added:
+            path = path[:-1]
+        else:
+            added = True
         path = path + (int_to_roman(count),)
     if len(path) == 1:
         path = path + (int_to_roman(counts.get(path, 1)),)
+    if path not in counts:
+        counts[path] = 1
     return path
 
 

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -497,16 +497,30 @@ class TestTreePathUtils(unittest.TestCase):
 
     def test_make_path_unique_no_clash(self):
         path = ('Element', 'A')
-        new_path = make_path_unique(path, {})
+        new_path = make_path_unique(path, {}, True)
         self.assertEqual(new_path, path)
 
     def test_make_path_unique_clash_without_label(self):
         path = ('Element',)
-        new_path = make_path_unique(path, {path: 1})
+        new_path = make_path_unique(path, {path: 1}, True)
         self.assertEqual(new_path, path+('I',))
 
     def test_make_path_unique_clash_with_label(self):
         path = ('Element', 'A')
-        new_path = make_path_unique(path, {path: 1})
+        new_path = make_path_unique(path, {path: 1}, True)
         self.assertEqual(new_path, path+('I',))
 
+    def test_make_path_unique_no_clash_old(self):
+        path = ('Element', 'A')
+        new_path = make_path_unique(path, {}, False)
+        self.assertEqual(new_path, path)
+
+    def test_make_path_unique_clash_without_label_old(self):
+        path = ('Element',)
+        new_path = make_path_unique(path, {path: 1}, False)
+        self.assertEqual(new_path, path+('I',))
+
+    def test_make_path_unique_clash_with_label_old(self):
+        path = ('Element', 'A')
+        new_path = make_path_unique(path, {path: 1}, False)
+        self.assertEqual(new_path, path[:-1]+('I',))


### PR DESCRIPTION
Fixes bug encountered when adding another plot to a collated Layout. The main issue seems to be that it ignored custom paths which do not match the auto-computed paths generated by computing a path from the group and label.