### PR TITLE
Fixed comm creation and stream subscriber attachment

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -27,7 +27,7 @@ from ...core import util
 from ...element import RGB
 from ...streams import Stream, RangeXY, RangeX, RangeY
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import dynamic_update, get_sources
+from ..util import dynamic_update, get_sources, attach_streams
 from .plot import BokehPlot, TOOLS
 from .util import (mpl_to_bokeh, convert_datetime, update_plot, get_tab_title,
                    bokeh_version, mplcmap_to_palette, py2js_tickformatter,

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -285,13 +285,17 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     plot_size = param.Integer(default=120, doc="""
         Defines the width and height of each plot in the grid""")
 
-    def __init__(self, layout, ranges=None, layout_num=1, **params):
+    def __init__(self, layout, ranges=None, layout_num=1, keys=None, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
         super(GridPlot, self).__init__(layout=layout, layout_num=layout_num,
-                                       ranges=ranges, **params)
+                                       ranges=ranges, keys=keys, **params)
         self.cols, self.rows = layout.shape
         self.subplots, self.layout = self._create_subplots(layout, ranges)
+        top_level = keys is None
+        if top_level:
+            self.comm = self.init_comm()
+            self.traverse(lambda x: setattr(x, 'comm', self.comm))
 
 
     def _create_subplots(self, layout, ranges):
@@ -478,9 +482,13 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
 
-    def __init__(self, layout, **params):
-        super(LayoutPlot, self).__init__(layout, **params)
+    def __init__(self, layout, keys=None, **params):
+        super(LayoutPlot, self).__init__(layout, keys=keys, **params)
         self.layout, self.subplots, self.paths = self._init_layout(layout)
+        top_level = keys is None
+        if top_level:
+            self.comm = self.init_comm()
+            self.traverse(lambda x: setattr(x, 'comm', self.comm))
 
 
     def _init_layout(self, layout):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -296,11 +296,11 @@ class GridPlot(CompositePlot):
         Rotation angle of the yticks.""")
 
     def __init__(self, layout, axis=None, create_axes=True, ranges=None,
-                 layout_num=1, **params):
+                 layout_num=1, keys=None, **params):
         if not isinstance(layout, GridSpace):
             raise Exception("GridPlot only accepts GridSpace.")
         super(GridPlot, self).__init__(layout, layout_num=layout_num,
-                                       ranges=ranges, **params)
+                                       ranges=ranges, keys=keys, **params)
         # Compute ranges layoutwise
         grid_kwargs = {}
         if axis is not None:
@@ -316,6 +316,10 @@ class GridPlot(CompositePlot):
         with mpl.rc_context(rc=self.fig_rcparams):
             self.subplots, self.subaxes, self.layout = self._create_subplots(layout, axis,
                                                                              ranges, create_axes)
+        top_level = keys is None
+        if top_level:
+            self.comm = self.init_comm()
+            self.traverse(lambda x: setattr(x, 'comm', self.comm))
 
 
     def _get_size(self):
@@ -729,10 +733,14 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
     # Whether to enable fix for non-square figures
     v17_layout_format = True
 
-    def __init__(self, layout, **params):
-        super(LayoutPlot, self).__init__(layout=layout, **params)
+    def __init__(self, layout, keys=None, **params):
+        super(LayoutPlot, self).__init__(layout=layout, keys=keys, **params)
         with mpl.rc_context(rc=self.fig_rcparams):
             self.subplots, self.subaxes, self.layout = self._compute_gridspec(layout)
+        top_level = keys is None
+        if top_level:
+            self.comm = self.init_comm()
+            self.traverse(lambda x: setattr(x, 'comm', self.comm))
 
 
     def _compute_gridspec(self, layout):

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -287,7 +287,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
             dimensions, keys = traversal.unique_dimkeys(layout)
         MPLPlot.__init__(self, dimensions=dimensions, keys=keys, **params)
         if top_level:
-            self.comm = self.init_comm(layout)
+            self.comm = self.init_comm()
 
         self.layout = layout
         self.cyclic_index = 0

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -306,7 +306,8 @@ def attach_streams(plot, obj):
     """
     def append_refresh(dmap):
         for stream in get_nested_streams(dmap):
-            stream.add_subscriber(plot.refresh)
+            if plot.refresh not in stream._subscribers:
+                stream.add_subscriber(plot.refresh)
     return obj.traverse(append_refresh, [DynamicMap])
 
 


### PR DESCRIPTION
Previously the top_level plot attached itself as a subscriber to all the streams found on the plot. Apart from being inefficient because any change to a stream would trigger replotting of the whole Layout, this could cause issues with one plot triggering range updates on another even though the second plot hadn't changed at all. 

In this PR each subplot is given access to the comm which means each subplot can be responsible for updating themselves.