### PR TITLE
Handle empty arrays and datashader aggregates

### DIFF
--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -118,8 +118,8 @@ class ImageInterface(GridInterface):
         if dim_idx in [0, 1]:
             l, b, r, t = dataset.bounds.lbrt()
             dim2, dim1 = dataset.data.shape[:2]
-            d1_half_unit = float(r - l)/dim1/2.
-            d2_half_unit = float(t - b)/dim2/2.
+            d1_half_unit = (1./dataset.xdensity)/2.
+            d2_half_unit = (1./dataset.ydensity)/2.
             d1lin = np.linspace(l+d1_half_unit, r-d1_half_unit, dim1)
             d2lin = np.linspace(b+d2_half_unit, t-d2_half_unit, dim2)
             if expanded:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -15,7 +15,7 @@ from .interface import Interface
 
 class XArrayInterface(GridInterface):
 
-    types = (xr.Dataset if xr else None,)
+    types = (xr.Dataset, xr.DataArray)
 
     datatype = 'xarray'
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1341,6 +1341,8 @@ def bound_range(vals, density):
     assumed to be evenly spaced. Density is rounded to machine precision
     using significant digits reported by sys.float_info.dig.
     """
+    if not len(vals):
+        return 0, 0, density or 0, False
     low, high = vals.min(), vals.max()
     invert = False
     if vals[0] > vals[1]:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -261,8 +261,15 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
             bounds = BoundingBox(points=((l, b), (r, t)))
 
         l, b, r, t = bounds.lbrt()
-        xdensity = xdensity if xdensity else dim1/float(r-l)
-        ydensity = ydensity if ydensity else dim2/float(t-b)
+        if dim1:
+            xdensity = xdensity if xdensity else dim1/float(r-l)
+        else:
+            xdensity = 1
+
+        if dim2:
+            ydensity = ydensity if ydensity else dim2/float(t-b)
+        else:
+            ydensity = 1
         SheetCoordinateSystem.__init__(self, bounds, xdensity, ydensity)
 
         if len(self.shape) == 3:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1028,7 +1028,11 @@ class ColorbarPlot(ElementPlot):
             colormapper = LogColorMapper if self.logz else LinearColorMapper
             if isinstance(low, (bool, np.bool_)): low = int(low)
             if isinstance(high, (bool, np.bool_)): high = int(high)
-            opts = {'low': low, 'high': high}
+            opts = {}
+            if np.isfinite(low):
+                opts['low'] = low
+            if np.isfinite(high):
+                opts['high'] = high
             color_opts = [('NaN', 'nan_color'), ('max', 'high_color'), ('min', 'low_color')]
             opts.update({opt: colors[name] for name, opt in color_opts if name in colors})
         else:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -47,6 +47,12 @@ class RasterPlot(ColorbarPlot):
         if type(element) is Raster:
             b, t = t, b
 
+        # Handle empty image
+        dh = dh or 1
+        dw = dw or 1
+        if img.shape == (0, 0):
+            img = np.full((1, 1), np.NaN, dtype=img.dtype)
+
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:
             data = dict(image=[], x=[], y=[], dw=[], dh=[])
@@ -89,6 +95,12 @@ class RGBPlot(RasterPlot):
             N, M, _ = img.shape
             #convert image NxM dtype=uint32
             img = img.view(dtype=np.uint32).reshape((N, M))
+
+        # Handle empty image
+        dh = dh or 1
+        dw = dw or 1
+        if img.shape == (0, 0):
+            img = np.zeros((1, 1), dtype=img.dtype)
 
         mapping = dict(image='image', x='x', y='y', dw='dw', dh='dh')
         if empty:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -667,8 +667,10 @@ class ColorbarPlot(ElementPlot):
         opts['vmax'] = clim[1]
 
         # Check whether the colorbar should indicate clipping
-        values = np.asarray(element.dimension_values(vdim))
-        if values.dtype.kind not in 'OSUM':
+        values = element.dimension_values(vdim)
+        if not len(values):
+            el_min, el_max = np.NaN, np.NaN
+        elif values.dtype.kind not in 'OSUM':
             el_min, el_max = np.nanmin(values), np.nanmax(values)
         else:
             el_min, el_max = -np.inf, np.inf


### PR DESCRIPTION
As the title says, this avoids errors when trying to aggregate empty objects and lets the plotting interfaces handle empty arrays.