### PR TITLE
Remove links to transforming data page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Features
 * Includes a rich `library of composable elements <http://www.holoviews.org/Tutorials/Elements>`_ that can be overlaid, nested and positioned with ease.
 * Supports `rapid data exploration <http://www.holoviews.org/Tutorials/Exploring_Data>`_ that naturally develops into a `fully reproducible workflow <Tutorials/Exporting>`_.
 * You can create complex animated or interactive visualizations with minimal code.
-* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <http://www.holoviews.org/Tutorials/Transforming_Data>`_.
+* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <http://www.holoviews.org/Tutorials/Sampling_Data>`_.
 * Every parameter of every object includes easy-to-access documentation.
 * All features `available in vanilla Python 2 or 3 <http://www.holoviews.org/Tutorials/Options>`_, with minimal dependencies.
 
@@ -67,7 +67,7 @@ Features
 **Analysis and data access features**
 
 * Allows you to annotate your data with dimensions, units, labels and data ranges.
-* Easily `slice and access <http://www.holoviews.org/Tutorials/Transforming_Data>`_ regions of your data, no matter how high the dimensionality.
+* Easily `slice and access <http://www.holoviews.org/Tutorials/Sampling_Data>`_ regions of your data, no matter how high the dimensionality.
 * Apply any suitable function to collapse your data or reduce dimensionality.
 * Helpful textual representation to inform you how every level of your data may be accessed.
 * Includes small library of common operations for any scientific or engineering data.

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Or clone holoviews directly from GitHub with::
 
    git clone git://github.com/ioam/holoviews.git
 
-Please visit `our website <http://ioam.github.com/holoviews/>`_
+Please visit `our website <http://holoviews.org>`_
 for official releases, installation instructions, documentation,
 and many detailed `example notebooks and tutorials
 <http://holoviews.org/Tutorials>`_. Additional user contributed
@@ -48,12 +48,12 @@ Features
 **Overview**
 
 * Lets you build data structures that both contain and visualize your data.
-* Includes a rich `library of composable elements <http://www.holoviews.org/Tutorials/Elements>`_ that can be overlaid, nested and positioned with ease.
-* Supports `rapid data exploration <http://www.holoviews.org/Tutorials/Exploring_Data>`_ that naturally develops into a `fully reproducible workflow <Tutorials/Exporting>`_.
+* Includes a rich `library of composable elements <http://www.holoviews.org/Tutorials/Elements.html>`_ that can be overlaid, nested and positioned with ease.
+* Supports `rapid data exploration <http://www.holoviews.org/Tutorials/Exploring_Data.html>`_ that naturally develops into a `fully reproducible workflow <Tutorials/Exporting.html>`_.
 * You can create complex animated or interactive visualizations with minimal code.
-* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <http://www.holoviews.org/Tutorials/Sampling_Data>`_.
+* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <http://www.holoviews.org/Tutorials/Sampling_Data.html>`_.
 * Every parameter of every object includes easy-to-access documentation.
-* All features `available in vanilla Python 2 or 3 <http://www.holoviews.org/Tutorials/Options>`_, with minimal dependencies.
+* All features `available in vanilla Python 2 or 3 <http://www.holoviews.org/Tutorials/Options.html>`_, with minimal dependencies.
 
 **Support for maintainable, reproducible research**
   
@@ -62,12 +62,12 @@ Features
 * All HoloViews objects can be pickled and unpickled.
 * Provides comparison utilities for testing, so you know when your results have changed and why.
 * Core data structures only depend on the numpy and param libraries.
-* Provides `export and archival facilities <http://www.holoviews.org/Tutorials/Exporting>`_ for keeping track of your work throughout the lifetime of a project.
+* Provides `export and archival facilities <http://www.holoviews.org/Tutorials/Exporting.html>`_ for keeping track of your work throughout the lifetime of a project.
 
 **Analysis and data access features**
 
 * Allows you to annotate your data with dimensions, units, labels and data ranges.
-* Easily `slice and access <http://www.holoviews.org/Tutorials/Sampling_Data>`_ regions of your data, no matter how high the dimensionality.
+* Easily `slice and access <http://www.holoviews.org/Tutorials/Sampling_Data.html>`_ regions of your data, no matter how high the dimensionality.
 * Apply any suitable function to collapse your data or reduce dimensionality.
 * Helpful textual representation to inform you how every level of your data may be accessed.
 * Includes small library of common operations for any scientific or engineering data.
@@ -77,7 +77,7 @@ Features
 
 * Useful default settings make it easy to inspect data, with minimal code.
 * Powerful normalization system to make understanding your data across plots easy.
-* Build `complex animations or interactive visualizations in seconds  <http://www.holoviews.org/Tutorials/Exploring_Data>`_ instead of hours or days.
+* Build `complex animations or interactive visualizations in seconds  <http://www.holoviews.org/Tutorials/Exploring_Data.html>`_ instead of hours or days.
 * Refine the visualization of your data interactively and incrementally.
 * Separation of concerns: all visualization settings are kept separate from your data objects.
 * Support for interactive tooltips/panning/zooming, via the optional mpld3 backend.
@@ -89,11 +89,11 @@ Features
 * Exportable sliders and scrubber widgets.
 * Automatic display of animated formats in the notebook or for export, including gif, webm, and mp4.
 * Useful IPython magics for configuring global display options and for customizing objects.
-* `Automatic archival and export of notebooks <http://www.holoviews.org/Tutorials/Exporting>`_, including extracting figures as SVG, generating a static HTML copy of your results for reference, and storing your optional metadata like version control information.
+* `Automatic archival and export of notebooks <http://www.holoviews.org/Tutorials/Exporting.html>`_, including extracting figures as SVG, generating a static HTML copy of your results for reference, and storing your optional metadata like version control information.
 
 **Integration with third-party libraries**  
 
-* Flexible interface to both the `pandas and Seaborn libraries <http://www.holoviews.org/Tutorials/Pandas_Seaborn>`_
+* Flexible interface to both the `pandas and Seaborn libraries <http://www.holoviews.org/Tutorials/Pandas_Seaborn.html>`_
 * Immediately visualize pandas data as any HoloViews object.
 * Seamlessly combine and animate your Seaborn plots in HoloViews rich, compositional data-structures.
    

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ Features
 
 * Lets you build data structures that both contain and visualize your data.
 * Includes a rich `library of composable elements <http://www.holoviews.org/Tutorials/Elements.html>`_ that can be overlaid, nested and positioned with ease.
-* Supports `rapid data exploration <http://www.holoviews.org/Tutorials/Exploring_Data.html>`_ that naturally develops into a `fully reproducible workflow <Tutorials/Exporting.html>`_.
+* Supports `rapid data exploration <http://www.holoviews.org/Tutorials/Exploring_Data.html>`_ that naturally develops into a `fully reproducible workflow <http://www.holoviews.org/Tutorials/Exporting.html>`_.
 * You can create complex animated or interactive visualizations with minimal code.
 * Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <http://www.holoviews.org/Tutorials/Sampling_Data.html>`_.
 * Every parameter of every object includes easy-to-access documentation.

--- a/README.rst
+++ b/README.rst
@@ -35,9 +35,9 @@ including examples that may be run live on `mybinder.org
 
 
 For general discussion, we have a `gitter channel
-<https://gitter.im/ioam/holoviews>`_.  In addition we have a
-`wiki page
-<https://github.com/ioam/holoviews/wiki/Experimental-Features>`_
+<https://gitter.im/ioam/holoviews>`_.  In addition we have
+`a user-contributed wiki
+<https://github.com/ioam/holoviews-contrib/wiki>`_
 describing current work-in-progress and experimental features. If
 you find any bugs or have any feature suggestions please file a
 GitHub Issue or submit a pull request.

--- a/doc/features.rst
+++ b/doc/features.rst
@@ -8,7 +8,7 @@ ________
 * Includes a rich `library of composable elements <Tutorials/Elements.html>`_ that can be overlaid, nested, and positioned with ease.
 * Supports `rapid data exploration <Tutorials/Exploring_Data.html>`_ that naturally develops into a `fully reproducible workflow <Tutorials/Exporting.html>`_.
 * You can create complex animated or interactive visualizations with minimal code.
-* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <Tutorials/Transforming_Data.html>`_.
+* Rich semantics for `indexing and slicing of data in arbitrarily high-dimensional spaces <Tutorials/Sampling_Data.html>`_.
 * Every parameter of every object includes easy-to-access documentation.
 * All features `available in vanilla Python 2 or 3 <Tutorials/Options.html>`_, with minimal dependencies.
 * All examples on the website are tested automatically each night, using the latest version of the code.
@@ -25,7 +25,7 @@ ________
 **Analysis and data access features**
 
 * Allows you to annotate your data with dimensions, units, labels and data ranges.
-* Easily `slice and access <Tutorials/Transforming_Data.html>`_ regions of your data, no matter how high the dimensionality.
+* Easily `slice and access <Tutorials/Sampling_Data.html>`_ regions of your data, no matter how high the dimensionality.
 * Apply any suitable function to collapse your data or reduce dimensionality.
 * Helpful textual representation to inform you how every level of your data may be accessed.
 * Includes small library of common operations for any scientific or engineering data.


### PR DESCRIPTION

This PR addresses #1077. We opted to remove links to the transforming data page as it was incomplete and not in the notebook format. In addition the links to it were mostly mentioning slicing so the Sampling Data tutorial seems more appropriate anyway.

I don't think there is much to discuss and unless I get some feedback, I'll just trigger a docs build and merge.