### PR TITLE
Allow casting Image to QuadMesh

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -569,8 +569,13 @@ class QuadMesh(Raster):
 
 
     def _process_data(self, data):
-        data = tuple(np.array(el) for el in data)
-        x, y, zarray = data
+        if isinstance(data, Image):
+            x = data.dimension_values(0, expanded=False)
+            y = data.dimension_values(1, expanded=False)
+            zarray = data.dimension_values(2, flat=False)
+        else:
+            data = tuple(np.array(el) for el in data)
+            x, y, zarray = data
         ys, xs = zarray.shape
         if x.ndim == 1 and len(x) == xs:
             x = compute_edges(x)


### PR DESCRIPTION
This reapplies https://github.com/ioam/holoviews/pull/1223 as it seems to have gotten lost when rebasing the image interface.