### PR TITLE
Disable caching of renderer parameters on OutputMagic 

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -206,6 +206,11 @@ class notebook_extension(param.ParameterizedFunction):
         if css:
             display(HTML(css))
 
+        for r in [r for r in resources if r != 'holoviews']:
+            Store.renderers[r].load_nb(inline=p.inline)
+        if selected_backend is not None:
+            Store.current_backend = selected_backend
+
         resources = list(resources)
         if len(resources) == 0: return
 
@@ -217,9 +222,6 @@ class notebook_extension(param.ParameterizedFunction):
         message = '' if not p.banner else '%s successfully loaded in this cell.' % loaded
         load_hvjs(logo=p.banner, JS=('holoviews' in resources), message = message)
 
-        for r in [r for r in resources if r != 'holoviews']:
-            Store.renderers[r].load_nb(inline=p.inline)
-        Store.current_backend = selected_backend
 
 
     def _get_resources(self, args, params):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -146,15 +146,22 @@ class notebook_extension(param.ParameterizedFunction):
                  'plotly': 'plotly'}
 
     def __call__(self, *args, **params):
-        imports = [(name, b) for name, b in self._backends.items()
-                   if name in args or params.get(name, False)]
-        if not imports or 'matplotlib' not in Store.renderers:
-            imports = imports + [('matplotlib', 'mpl')]
+        # Get requested backends
+        imports = [(arg, self._backends[arg]) for arg in args
+                   if arg in self._backends]
+        for p, val in sorted(params.items()):
+            if p in self._backends:
+                imports.append((p, self._backends[p]))
+        if not imports:
+            imports = [('matplotlib', 'mpl')]
 
         args = list(args)
+        selected_backend = None
         for backend, imp in imports:
             try:
                 __import__('holoviews.plotting.%s' % imp)
+                if selected_backend is None:
+                    selected_backend = backend
             except ImportError:
                 if backend in args:
                     args.pop(args.index(backend))
@@ -187,7 +194,7 @@ class notebook_extension(param.ParameterizedFunction):
             ip = get_ipython() if ip is None else ip # noqa (get_ipython)
             param_ext.load_ipython_extension(ip, verbose=False)
             load_magics(ip)
-            OutputMagic.initialize(list( self._backends.keys()))
+            OutputMagic.initialize([backend for backend, _ in imports])
             set_display_hooks(ip)
             notebook_extension._loaded = True
 
@@ -209,11 +216,10 @@ class notebook_extension(param.ParameterizedFunction):
 
         message = '' if not p.banner else '%s successfully loaded in this cell.' % loaded
         load_hvjs(logo=p.banner, JS=('holoviews' in resources), message = message)
+
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
-
-        if resources[-1] != 'holoviews':
-            get_ipython().magic(u"output backend=%r" % resources[-1]) # noqa (get_ipython))
+        Store.current_backend = selected_backend
 
 
     def _get_resources(self, args, params):

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -244,8 +244,8 @@ class OutputMagic(OptionsMagic):
                             ('info'        , False),
                             ('css'         , None)])
 
-    # Defines the options the OutputMagic remembers the remainder
-    # is simply state on the backend specific Renderer
+    # Defines the options the OutputMagic remembers. All other options
+    # are held by the backend specific Renderer.
     remembered = ['max_frames', 'max_branches', 'charwidth', 'info', 'filename']
 
     # Remaining backend specific options renderer options

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -346,6 +346,9 @@ class OutputMagic(OptionsMagic):
 
         restore_copy = OrderedDict(OutputMagic.options.items())
         prev_backend = Store.current_backend
+        renderer = Store.renderers[prev_backend]
+        render_params = [(k, v) for k, v in renderer.get_param_values()
+                         if k in self.render_params]
         try:
             options = OrderedDict([(k, v) for k, v in OutputMagic.options.items()
                                    if k in self.remembered])
@@ -355,7 +358,7 @@ class OutputMagic(OptionsMagic):
             OutputMagic.options = new_options
         except Exception as e:
             OutputMagic.options = restore_copy
-            self._set_render_options(restore_copy, prev_backend)
+            self._set_render_options(dict(render_params, **restore_copy), prev_backend)
             print('Error: %s' % str(e))
             print("For help with the %output magic, call %output?\n")
             return
@@ -363,7 +366,7 @@ class OutputMagic(OptionsMagic):
         if cell is not None:
             self.shell.run_cell(cell, store_history=STORE_HISTORY)
             OutputMagic.options = restore_copy
-            self._set_render_options(restore_copy, prev_backend)
+            self._set_render_options(dict(render_params, **restore_copy), prev_backend)
 
 
     @classmethod

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -43,6 +43,9 @@ class MPLRenderer(Renderer):
 
     backend = param.String('matplotlib', doc="The backend name.")
 
+    dpi=param.Integer(72, doc="""
+        The render resolution in dpi (dots per inch)""")
+
     fig = param.ObjectSelector(default='auto',
                                objects=['png', 'svg', 'pdf', 'html', None, 'auto'], doc="""
         Output render format for static figures. If None, no figure

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -84,7 +84,7 @@ class Renderer(Exporter):
         The full, lowercase name of the rendering backend or third
         part plotting package used e.g 'matplotlib' or 'cairo'.""")
 
-    dpi=param.Integer(72, doc="""
+    dpi=param.Integer(None, doc="""
         The render resolution in dpi (dots per inch)""")
 
     fig = param.ObjectSelector(default='auto', objects=['auto'], doc="""

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -387,7 +387,7 @@ class Renderer(Exporter):
             backends = [cls.backend] if cls.backend else []
 
         # Get all the widgets and find the set of required js widget files
-        widgets = [wdgt for r in Renderer.__subclasses__()
+        widgets = [wdgt for r in [Renderer]+Renderer.__subclasses__()
                    for wdgt in r.widgets.values()]
         css = list({wdgt.css for wdgt in widgets})
         basejs = list({wdgt.basejs for wdgt in widgets})

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -84,7 +84,7 @@ class Renderer(Exporter):
         The full, lowercase name of the rendering backend or third
         part plotting package used e.g 'matplotlib' or 'cairo'.""")
 
-    dpi=param.Integer(None, allow_None=True, doc="""
+    dpi=param.Integer(72, doc="""
         The render resolution in dpi (dots per inch)""")
 
     fig = param.ObjectSelector(default='auto', objects=['auto'], doc="""

--- a/tests/testmagics.py
+++ b/tests/testmagics.py
@@ -95,7 +95,6 @@ class TestOptsMagic(ExtensionTestCase):
 class TestOutputMagic(ExtensionTestCase):
 
     def tearDown(self):
-        ipython.OutputMagic.options = ipython.OutputMagic.defaults
         super(TestOutputMagic, self).tearDown()
 
     def test_output_svg(self):
@@ -126,7 +125,7 @@ class TestOutputMagic(ExtensionTestCase):
 
     def test_output_invalid_size(self):
         self.line_magic('output', "size=-50")
-        self.assertEqual(ipython.OutputMagic.options.get('size', None), 100)
+        self.assertEqual(ipython.OutputMagic.options.get('size', None), None)
 
 
 class TestCompositorMagic(ExtensionTestCase):


### PR DESCRIPTION
Additionally ensures that the order of backends supplied to the notebook_extension is respected. Fixes https://github.com/ioam/holoviews/issues/947.