### PR TITLE
Allowed styling bokeh hover glyphs

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -38,7 +38,7 @@ if bokeh_version >= '0.12':
 else:
     FuncTickFormatter = None
 
-property_prefixes = ['selection', 'nonselection', 'muted']
+property_prefixes = ['selection', 'nonselection', 'muted', 'hover']
 
 # Define shared style properties for bokeh plots
 line_properties = ['line_color', 'line_alpha', 'color', 'alpha', 'line_width',
@@ -628,7 +628,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         allowed_properties = glyph.properties()
         properties = mpl_to_bokeh(properties)
         merged = dict(properties, **mapping)
-        for glyph_type in ('', 'selection_', 'nonselection_'):
+        for glyph_type in ('', 'selection_', 'nonselection_', 'hover_', 'muted_'):
             if renderer:
                 glyph = getattr(renderer, glyph_type+'glyph', None)
             if not glyph or (not renderer and glyph_type):


### PR DESCRIPTION
I introduced all the machinery for this in https://github.com/ioam/holoviews/pull/1220 but forgot to enable it for hover glyphs. Here's an example of applying styling to the glyph for a QuadMesh Element:

![hover](https://cloud.githubusercontent.com/assets/1550771/24977658/add949a2-1fc5-11e7-8c25-496750e7f8ac.gif)
