### PR TITLE
Fixed py3 bug on Renderer.export_widgets

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -354,7 +354,7 @@ class Renderer(Exporter):
             filename.write(encoded)
             filename.seek(0)
         else:
-            with open(filename, 'w') as f:
+            with open(filename, 'wb') as f:
                 f.write(encoded)
 
 


### PR DESCRIPTION
Renderer.export_widgets wasn't correctly declaring it was writing bytes.

Fixes https://github.com/ioam/holoviews/issues/1234