### PR TITLE
Restored logo parameter and removed banner text

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -117,8 +117,7 @@ class notebook_extension(param.ParameterizedFunction):
 
     css = param.String(default='', doc="Optional CSS rule set to apply to the notebook.")
 
-    banner = param.Boolean(default=True, doc="""
-        Toggles display of HoloViews logo and loading message.""")
+    logo = param.Boolean(default=True, doc="Toggles display of HoloViews logo")
 
     inline = param.Boolean(default=True, doc="""Whether to inline JS and CSS resources,
         if disabled resources are loaded from CDN if one is available.""")
@@ -229,8 +228,7 @@ class notebook_extension(param.ParameterizedFunction):
         loaded = ', '.join(js_names[r] if r in js_names else r.capitalize()+'JS'
                            for r in resources)
 
-        message = '' if not p.banner else '%s successfully loaded in this cell.' % loaded
-        load_hvjs(logo=p.banner, JS=('holoviews' in resources), message = message)
+        load_hvjs(logo=p.logo, JS=('holoviews' in resources), message='')
 
 
 


### PR DESCRIPTION

This PR reverts the changes of PR #1231 after the discussion in issue #1186.

The logo switch has now been restored and the banner message disable. In HoloViews 2.0 we would like a logo per backend (or better, combine logos somehow?)

Here is the new behavior:

![image](https://cloud.githubusercontent.com/assets/890576/25029304/ef8af53c-20b3-11e7-86cc-9876e7c54df3.png)
