### PR TITLE
Added support for GridImage deprecation in OptsSpec parser

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -393,7 +393,10 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         return self.sheet2matrixidx(*coord)
 
 
-GridImage = Image
+class GridImage(Image):
+    def __init__(self, *args, **kwargs):
+        self.warning('GridImage is now deprecated. Please use Image element instead.')
+        super(GridImage, self).__init__(*args, **kwargs)
 
 
 class RGB(Image):

--- a/holoviews/ipython/parser.py
+++ b/holoviews/ipython/parser.py
@@ -211,6 +211,8 @@ class OptsSpec(Parser):
                'show_xaxis':      'xaxis',
                'show_yaxis':      'yaxis'}
 
+    deprecations = [('GridImage', 'Image')]
+
     @classmethod
     def process_normalization(cls, parse_group):
         """
@@ -306,6 +308,17 @@ class OptsSpec(Parser):
 
         return merged
 
+    @classmethod
+    def apply_deprecations(cls, path):
+        "Convert any potentially deprecated paths and issue appropriate warnings"
+        split = path.split('.')
+        msg = 'Element {old} deprecated. Use {new} instead.'
+        for old, new in cls.deprecations:
+            if split[0] == old:
+                parsewarning.warning(msg.format(old=old, new=new))
+                return '.'.join([new] + split[1:])
+        return path
+
 
     @classmethod
     def parse(cls, line, ns={}):
@@ -345,7 +358,7 @@ class OptsSpec(Parser):
                 parse[pathspec] = cls._merge_options(parse.get(pathspec, {}), options)
 
         return {
-            path: {
+            cls.apply_deprecations(path): {
                 option_type: Options(**option_pairs)
                 for option_type, option_pairs in options.items()
             }


### PR DESCRIPTION

This PR addresses issue #1252 by converting 'GridImage' to 'Image' in the opts parser. Here is an example of what it does:

![image](https://cloud.githubusercontent.com/assets/890576/25029540/50220f8c-20b6-11e7-86b6-2f64ae12cfde.png)

