### PR TITLE
Deprecated max_branches output magic option

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -365,7 +365,6 @@ class Layout(AttrTree, Dimensioned):
     _deep_indexable = True
 
     def __init__(self, items=None, identifier=None, parent=None, **kwargs):
-        self.__dict__['_display'] = 'auto'
         self.__dict__['_max_cols'] = 4
         if items and all(isinstance(item, Dimensioned) for item in items):
             items = self._process_items(items)
@@ -474,7 +473,6 @@ class Layout(AttrTree, Dimensioned):
         # Standard relabel method except _max_cols and _display transferred
         relabelled = super(Layout, self).relabel(label=label, group=group, depth=depth)
         relabelled.__dict__['_max_cols'] = self.__dict__['_max_cols']
-        relabelled.__dict__['_display'] = self.__dict__['_display']
         return relabelled
 
     def clone(self, *args, **overrides):
@@ -483,7 +481,6 @@ class Layout(AttrTree, Dimensioned):
         display mode is also propagated.
         """
         clone = super(Layout, self).clone(*args, **overrides)
-        clone._display = self._display
         clone._max_cols = self._max_cols
         clone.id = self.id
         return clone
@@ -510,16 +507,12 @@ class Layout(AttrTree, Dimensioned):
 
     def display(self, option):
         "Sets the display policy of the Layout before returning self"
-        options = ['auto', 'all']
-        if option not in options:
-            raise Exception("Display option must be one of %s" %
-                            ','.join(repr(el) for el in options))
-        self._display = option
+        self.warning('Layout display option is deprecated and no longer needs to be used')
         return self
 
 
     def select(self, selection_specs=None, **selections):
-        return super(Layout, self).select(selection_specs, **selections).display(self._display)
+        return super(Layout, self).select(selection_specs, **selections)
 
 
     def grid_items(self):
@@ -557,7 +550,7 @@ class Layout(AttrTree, Dimensioned):
 
 
     def __add__(self, other):
-        return Layout.from_values([self, other]).display('all')
+        return Layout.from_values([self, other])
 
 
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -352,12 +352,7 @@ class Layout(AttrTree, Dimensioned):
     their row and column index in the layout.
 
     The maximum number of columns in such a layout may be controlled
-    with the cols method and the display policy is set with the
-    display method. A display policy of 'auto' may use the string repr
-    of the tree for large trees that would otherwise take a long time
-    to display wheras a policy of 'all' will always display all the
-    available leaves. The detailed settings for the 'auto' policy may
-    be set using the max_branches option of the %output magic.
+    with the cols method.
     """
 
     group = param.String(default='Layout', constant=True)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -198,14 +198,9 @@ def layout_display(layout, max_frames, max_branches):
     if not isinstance(layout, (Layout, NdLayout)): return None
 
     nframes = len(unique_dimkeys(layout)[1])
-    if isinstance(layout, Layout):
-        if layout._display == 'auto':
-            branches = len(set([path[0] for path in list(layout.data.keys())]))
-            if branches > max_branches:
-                return '<tt>'+ sanitize_HTML(layout) + '</tt>'
-            elif len(layout.data) * nframes > max_frames:
-                max_frame_warning(max_frames)
-                return '<tt>'+ sanitize_HTML(layout) + '</tt>'
+    if nframes > max_frames:
+        max_frame_warning(max_frames)
+        return '<tt>'+ sanitize_HTML(layout) + '</tt>'
 
     return render(layout)
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -129,8 +129,7 @@ def display_hook(fn):
 
         try:
             html = fn(element,
-                      max_frames=OutputMagic.options['max_frames'],
-                      max_branches = None)
+                      max_frames=OutputMagic.options['max_frames'])
 
             # Only want to add to the archive for one display hook...
             disabled_suffixes = ['png_display', 'svg_display']
@@ -162,7 +161,7 @@ def display_hook(fn):
 
 
 @display_hook
-def element_display(element, max_frames, max_branches):
+def element_display(element, max_frames):
     info = process_object(element)
     if info:
         IPython.display.display(IPython.display.HTML(info))
@@ -181,7 +180,7 @@ def element_display(element, max_frames, max_branches):
 
 
 @display_hook
-def map_display(vmap, max_frames, max_branches):
+def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
     if len(vmap) == 0 and (not isinstance(vmap, DynamicMap) or vmap.sampled):
         return sanitize_HTML(vmap)
@@ -193,7 +192,7 @@ def map_display(vmap, max_frames, max_branches):
 
 
 @display_hook
-def layout_display(layout, max_frames, max_branches):
+def layout_display(layout, max_frames):
     if isinstance(layout, AdjointLayout): layout = Layout.from_values(layout)
     if not isinstance(layout, (Layout, NdLayout)): return None
 
@@ -206,7 +205,7 @@ def layout_display(layout, max_frames, max_branches):
 
 
 @display_hook
-def grid_display(grid, max_frames, max_branches):
+def grid_display(grid, max_frames):
     if not isinstance(grid, GridSpace): return None
 
     nframes = len(unique_dimkeys(grid)[1])
@@ -252,7 +251,7 @@ def pprint_display(obj):
 
 
 @display_hook
-def element_png_display(element, max_frames, max_branches):
+def element_png_display(element, max_frames):
     """
     Used to render elements to PNG if requested in the display formats.
     """
@@ -277,7 +276,7 @@ def element_png_display(element, max_frames, max_branches):
 
 
 @display_hook
-def element_svg_display(element, max_frames, max_branches):
+def element_svg_display(element, max_frames):
     """
     Used to render elements to SVG if requested in the display formats.
     """

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -130,7 +130,7 @@ def display_hook(fn):
         try:
             html = fn(element,
                       max_frames=OutputMagic.options['max_frames'],
-                      max_branches = OutputMagic.options['max_branches'])
+                      max_branches = None)
 
             # Only want to add to the archive for one display hook...
             disabled_suffixes = ['png_display', 'svg_display']

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -219,7 +219,7 @@ class OutputMagic(OptionsMagic):
                'widgets'     : ['embed', 'live'],
                'fps'         : (0, float('inf')),
                'max_frames'  : (0, float('inf')),
-               'max_branches': (0, float('inf')),
+               'max_branches': {None},            # Deprecated
                'size'        : (0, float('inf')),
                'dpi'         : (1, float('inf')),
                'charwidth'   : (0, float('inf')),
@@ -236,7 +236,6 @@ class OutputMagic(OptionsMagic):
                             ('widgets'     , None),
                             ('fps'         , None),
                             ('max_frames'  , 500),
-                            ('max_branches', 2),
                             ('size'        , None),
                             ('dpi'         , None),
                             ('charwidth'   , 80),
@@ -246,7 +245,7 @@ class OutputMagic(OptionsMagic):
 
     # Defines the options the OutputMagic remembers. All other options
     # are held by the backend specific Renderer.
-    remembered = ['max_frames', 'max_branches', 'charwidth', 'info', 'filename']
+    remembered = ['max_frames', 'charwidth', 'info', 'filename']
 
     # Remaining backend specific options renderer options
     render_params = ['fig', 'holomap', 'size', 'fps', 'dpi', 'css', 'widget_mode', 'mode']
@@ -274,7 +273,7 @@ class OutputMagic(OptionsMagic):
             raise ValueError("Backend %r does not exist" % value)
 
     custom_exceptions = {'holomap':missing_dependency_exception,
-                         'backend': missing_backend_exception }
+                         'backend': missing_backend_exception}
 
     # Counter for nbagg figures
     nbagg_counter = 0
@@ -303,8 +302,6 @@ class OutputMagic(OptionsMagic):
                   % renderer.fps)
         frames=  ("max_frames   : The max number of frames rendered (default %r)"
                   % cls.defaults['max_frames'])
-        branches=("max_branches : The max number of Layout branches rendered (default %r)"
-                  % cls.defaults['max_branches'])
         size =   ("size         : The percentage size of displayed output (default %r)"
                   % renderer.size)
         dpi =    ("dpi          : The rendered dpi of the figure (default %r)"
@@ -317,7 +314,7 @@ class OutputMagic(OptionsMagic):
                   % cls.defaults['info'])
         css =   ("css     : Optional css style attributes to apply to the figure image tag")
 
-        descriptions = [backend, fig, holomap, widgets, fps, frames, branches, size, dpi, chars, fname, page, css]
+        descriptions = [backend, fig, holomap, widgets, fps, frames, size, dpi, chars, fname, page, css]
         return '\n'.join(intro + descriptions)
 
 
@@ -400,6 +397,10 @@ class OutputMagic(OptionsMagic):
         backend, mode = split if len(split)==2 else (split[0], 'default')
         if ':' not in backend_spec:
             backend_spec += ':default'
+
+        if 'max_branches' in items:
+            print('Warning: The max_branches option is now deprecated. Ignoring.')
+            del items['max_branches']
 
         # Get previous backend
         prev_backend = Store.current_backend


### PR DESCRIPTION

This PR addresses #1026 by deprecating the ``display`` method on Layout and the ``max_branches`` option of the output magic. All Layouts should now be displayed consistently.

The only potential improvement might be to use param.warning instead of a print statement. I'm not sure this is necessary though as the output magic isn't normal user API and isn't parameterized. In this case a simple print statement seems fine instead of using the global param logger which isn't ideal in any case.

