### PR TITLE
Fixed dynamic stream sources assignment in plotting code

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -150,7 +150,7 @@ class ElementOperation(Operation):
         elif dynamic:
             from ..util import Dynamic
             processed = Dynamic(element, streams=self.p.streams,
-                                link_inputs=self.p.link.inputs,
+                                link_inputs=self.p.link_inputs,
                                 operation=self, kwargs=params)
         elif isinstance(element, ViewableElement):
             processed = self._process(element)

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -104,8 +104,12 @@ class ElementOperation(Operation):
        component is Normalization.keys. """)
 
     link_inputs = param.Boolean(default=False, doc="""
-         Whether a plot created from the output of this operation
-         should be linked to the inputs of this operation.""")
+         If the operation is dynamic, whether or not linked streams
+         should be transferred from the operation inputs for backends
+         that support linked streams. For example if an operation is
+         applied to a DynamicMap with an RangeXY determines if the
+         output of the operation will update the stream on the input
+         with current axis ranges.""")
 
     streams = param.List(default=[], doc="""
         List of streams that are applied if dynamic=True, allowing

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -104,12 +104,14 @@ class ElementOperation(Operation):
        component is Normalization.keys. """)
 
     link_inputs = param.Boolean(default=False, doc="""
-         If the operation is dynamic, whether or not linked streams
-         should be transferred from the operation inputs for backends
-         that support linked streams. For example if an operation is
-         applied to a DynamicMap with an RangeXY determines if the
-         output of the operation will update the stream on the input
-         with current axis ranges.""")
+       If the operation is dynamic, whether or not linked streams
+       should be transferred from the operation inputs for backends
+       that support linked streams.
+
+       For example if an operation is applied to a DynamicMap with an
+       RangeXY, this switch determines whether the corresponding
+       visualization should update this stream with range changes
+       originating from the newly generated axes.""")
 
     streams = param.List(default=[], doc="""
         List of streams that are applied if dynamic=True, allowing

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -104,7 +104,8 @@ class ElementOperation(Operation):
        component is Normalization.keys. """)
 
     link_inputs = param.Boolean(default=False, doc="""
-       Whether to link to any stream sources on the inputs.""")
+         Whether a plot created from the output of this operation
+         should be linked to the inputs of this operation.""")
 
     streams = param.List(default=[], doc="""
         List of streams that are applied if dynamic=True, allowing

--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -103,6 +103,9 @@ class ElementOperation(Operation):
        first component is a Normalization.ranges list and the second
        component is Normalization.keys. """)
 
+    link_inputs = param.Boolean(default=False, doc="""
+       Whether to link to any stream sources on the inputs.""")
+
     streams = param.List(default=[], doc="""
         List of streams that are applied if dynamic=True, allowing
         for dynamic interaction with the plot.""")
@@ -139,8 +142,8 @@ class ElementOperation(Operation):
             processed = element.clone(grid_data)
         elif dynamic:
             from ..util import Dynamic
-            streams = getattr(self.p, 'streams', [])
-            processed = Dynamic(element, streams=streams,
+            processed = Dynamic(element, streams=self.p.streams,
+                                link_inputs=self.p.link.inputs,
                                 operation=self, kwargs=params)
         elif isinstance(element, ViewableElement):
             processed = self._process(element)

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -135,7 +135,15 @@ class Overlay(Layout, CompositeOverlay):
 
 
     def __mul__(self, other):
-        if not isinstance(other, ViewableElement):
+        if type(other).__name__ == 'DynamicMap':
+            from .spaces import OverlayCallable
+            def dynamic_mul(*args, **kwargs):
+                element = other[args]
+                return self * element
+            callback = OverlayCallable(dynamic_mul, inputs=[self, other])
+            return other.clone(shared_data=False, callback=callback,
+                               streams=[])
+        elif not isinstance(other, ViewableElement):
             raise NotImplementedError
         return Overlay.from_values([self, other])
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -29,7 +29,7 @@ class Overlayable(object):
                 element = other[args]
                 return self * element
             callback = Callable(dynamic_mul, inputs=[self, other])
-            callback._overlay = True
+            callback._is_overlay = True
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
@@ -142,7 +142,7 @@ class Overlay(Layout, CompositeOverlay):
                 element = other[args]
                 return self * element
             callback = Callable(dynamic_mul, inputs=[self, other])
-            callback._overlay = True
+            callback._is_overlay = True
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         elif not isinstance(other, ViewableElement):

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,11 +24,11 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .spaces import Callable
+            from .spaces import OverlayCallable
             def dynamic_mul(*args, **kwargs):
                 element = other[args]
                 return self * element
-            callback = Callable(dynamic_mul, inputs=[self, other])
+            callback = OverlayCallable(dynamic_mul, inputs=[self, other])
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
@@ -38,7 +38,6 @@ class Overlayable(object):
             return NotImplemented
 
         return Overlay.from_values([self, other])
-
 
 
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -24,11 +24,12 @@ class Overlayable(object):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .spaces import OverlayCallable
+            from .spaces import Callable
             def dynamic_mul(*args, **kwargs):
                 element = other[args]
                 return self * element
-            callback = OverlayCallable(dynamic_mul, inputs=[self, other])
+            callback = Callable(dynamic_mul, inputs=[self, other])
+            callback._overlay = True
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         if isinstance(other, UniformNdMapping) and not isinstance(other, CompositeOverlay):
@@ -136,11 +137,12 @@ class Overlay(Layout, CompositeOverlay):
 
     def __mul__(self, other):
         if type(other).__name__ == 'DynamicMap':
-            from .spaces import OverlayCallable
+            from .spaces import Callable
             def dynamic_mul(*args, **kwargs):
                 element = other[args]
                 return self * element
-            callback = OverlayCallable(dynamic_mul, inputs=[self, other])
+            callback = Callable(dynamic_mul, inputs=[self, other])
+            callback._overlay = True
             return other.clone(shared_data=False, callback=callback,
                                streams=[])
         elif not isinstance(other, ViewableElement):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -120,27 +120,11 @@ class HoloMap(UniformNdMapping, Overlayable):
             key_map = {d.name: k for d, k in zip(dimensions, key)}
             layers = []
             try:
-                if isinstance(self, DynamicMap):
-                    if self.kdims:
-                        self_el = self.select(**key_map)
-                    else:
-                        self_el = self[()]
-                    if self_el is not None:
-                        layers.append(self_el)
-                else:
-                    layers.append(self[key])
+                self_el = self.select(**key_map) if self.kdims else self[()]
             except KeyError:
                 pass
             try:
-                if isinstance(other, DynamicMap):
-                    if other.kdims:
-                        other_el = other.select(**key_map)
-                    else:
-                        other_el = other[()]
-                    if other_el is not None:
-                        layers.append(other_el)
-                else:
-                    layers.append(other[key])
+                other_el = other.select(**key_map) if other.kdims else other[()]
             except KeyError:
                 pass
             return Overlay(layers)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -139,7 +139,7 @@ class HoloMap(UniformNdMapping, Overlayable):
             except KeyError:
                 pass
             return Overlay(layers)
-        callback = Callable(dynamic_mul, inputs=[self, other])
+        callback = OverlayCallable(dynamic_mul, inputs=[self, other])
         if map_obj:
             return map_obj.clone(callback=callback, shared_data=False,
                                  kdims=dimensions, streams=[])
@@ -206,7 +206,7 @@ class HoloMap(UniformNdMapping, Overlayable):
                 def dynamic_mul(*args, **kwargs):
                     element = self[args]
                     return element * other
-                callback = Callable(dynamic_mul, inputs=[self, other])
+                callback = OverlayCallable(dynamic_mul, inputs=[self, other])
                 return self.clone(shared_data=False, callback=callback,
                                   streams=[])
             items = [(k, v * other) for (k, v) in self.data.items()]
@@ -493,6 +493,14 @@ class Callable(param.Parameterized):
         if hashed_key is not None:
             self._memoized = {hashed_key : ret}
         return ret
+
+
+
+class OverlayCallable(Callable):
+    """
+    A Callable subclass specifically meant to indicate that the Callable
+    represents an overlay operation between two objects.
+    """
 
 
 def get_nested_streams(dmap):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -118,24 +118,29 @@ class HoloMap(UniformNdMapping, Overlayable):
 
         def dynamic_mul(*key, **kwargs):
             layers = []
+            key_map = {d.name: k for d, k in zip(dimensions, key)}
             try:
-                if isinstance(self, DynamicMap):
-                    safe_key = () if not self.kdims else key
-                    _, self_el = util.get_dynamic_item(self, dimensions, safe_key)
+                if isinstance(self, HoloMap):
+                    if self.kdims:
+                        self_el = self.select(**key_map)
+                    else:
+                        self_el = self[()]
                     if self_el is not None:
                         layers.append(self_el)
                 else:
-                    layers.append(self[key])
+                    layers.append(self)
             except KeyError:
                 pass
             try:
-                if isinstance(other, DynamicMap):
-                    safe_key = () if not other.kdims else key
-                    _, other_el = util.get_dynamic_item(other, dimensions, safe_key)
+                if isinstance(other, HoloMap):
+                    if other.kdims:
+                        other_el = other.select(**key_map)
+                    else:
+                        other_el = other[()]
                     if other_el is not None:
                         layers.append(other_el)
                 else:
-                    layers.append(other[key])
+                    layers.append(other)
             except KeyError:
                 pass
             return Overlay(layers)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1113,7 +1113,7 @@ class DynamicMap(HoloMap):
                             adjoin=False, **kwargs)
 
         from ..util import Dynamic
-        hist = Dynamic(self, operation=dynamic_hist)
+        hist = Dynamic(self, link_inputs=False, operation=dynamic_hist)
         if adjoin:
             return self << hist
         else:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -420,7 +420,10 @@ class Callable(param.Parameterized):
     when composite objects such as Layouts are returned from the
     callback. This is required for building interactive, linked
     visualizations (for the backends that support them) when returning
-    Layouts, NdLayouts or GridSpace objects.
+    Layouts, NdLayouts or GridSpace objects. When chaining multiple
+    DynamicMaps into a pipeline the link_inputs parameter declares
+    whether a plot created from the Callable owner is linked to objects
+    referenced in the inputs.
 
     The mapping should map from an appropriate key to a list of
     streams associated with the selected object. The appropriate key
@@ -437,7 +440,8 @@ class Callable(param.Parameterized):
          to allow deep access to streams in chained Callables.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         Whether the inputs on the Callable should be linked.""")
+         Whether a plot created from this Callable should be linked
+         to the declared inputs.""")
 
     memoize = param.Boolean(default=True, doc="""
          Whether the return value of the callable should be memoized

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -121,10 +121,12 @@ class HoloMap(UniformNdMapping, Overlayable):
             layers = []
             try:
                 self_el = self.select(**key_map) if self.kdims else self[()]
+                layers.append(self_el)
             except KeyError:
                 pass
             try:
                 other_el = other.select(**key_map) if other.kdims else other[()]
+                layers.append(other_el)
             except KeyError:
                 pass
             return Overlay(layers)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -406,7 +406,7 @@ class Callable(param.Parameterized):
     visualizations (for the backends that support them) when returning
     Layouts, NdLayouts or GridSpace objects. When chaining multiple
     DynamicMaps into a pipeline, the link_inputs parameter declares
-    whether the visualization generated from this Callable will
+    whether the visualization generated using this Callable will
     inherit the linked streams. This parameter is used as a hint by
     the applicable backend.
 
@@ -426,13 +426,13 @@ class Callable(param.Parameterized):
 
     link_inputs = param.Boolean(default=True, doc="""
          If the Callable wraps around other DynamicMaps in its inputs,
-         determines if linked streams attached to the inputs areb
+         determines whether linked streams attached to the inputs are
          transferred to the objects returned by the Callable.
 
-         For example if the Callable wraps a DynamicMap with an
-         RangeXY stream determines if the output of the Callable will
-         update the stream on the input with current axis ranges for
-         backends that support linked streams.""")
+         For example the Callable wraps a DynamicMap with an RangeXY
+         stream, this switch determines whether the corresponding
+         visualization should update this stream with range changes
+         originating from the newly generated axes.""")
 
     memoize = param.Boolean(default=True, doc="""
          Whether the return value of the callable should be memoized

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -264,6 +264,9 @@ class shade(ElementOperation):
         and any valid transfer function that accepts data, mask, nbins
         arguments.""")
 
+    link_inputs = param.Boolean(default=True, doc="""
+       Whether to link to any stream sources on the inputs.""")
+
     @classmethod
     def concatenate(cls, overlay):
         """
@@ -394,6 +397,9 @@ class dynspread(ElementOperation):
         of adjacent non-empty pixels reaches this threshold.
         Higher values give more spreading, up to the max_px
         allowed.""")
+
+    link_inputs = param.Boolean(default=True, doc="""
+       Whether to link to any stream sources on the inputs.""")
 
     @classmethod
     def uint8_to_uint32(cls, img):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -265,8 +265,9 @@ class shade(ElementOperation):
         arguments.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         Whether a plot created from the output of this operation
-         should be linked to the inputs of this operation.""")
+         By default, the link_inputs parameter is set to True so that
+         when applying shade, backends that support linked streams
+         update RangeXY streams on the inputs of the shade operation.""")
 
     @classmethod
     def concatenate(cls, overlay):
@@ -400,8 +401,9 @@ class dynspread(ElementOperation):
         allowed.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         Whether a plot created from the output of this operation
-         should be linked to the inputs of this operation.""")
+         By default, the link_inputs parameter is set to True so that
+         when applying dynspread, backends that support linked streams
+         update RangeXY streams on the inputs of the dynspread operation.""")
 
     @classmethod
     def uint8_to_uint32(cls, img):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -265,7 +265,8 @@ class shade(ElementOperation):
         arguments.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-       Whether to link to any stream sources on the inputs.""")
+         Whether a plot created from the output of this operation
+         should be linked to the inputs of this operation.""")
 
     @classmethod
     def concatenate(cls, overlay):
@@ -399,7 +400,8 @@ class dynspread(ElementOperation):
         allowed.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-       Whether to link to any stream sources on the inputs.""")
+         Whether a plot created from the output of this operation
+         should be linked to the inputs of this operation.""")
 
     @classmethod
     def uint8_to_uint32(cls, img):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -500,7 +500,7 @@ class Callback(CustomJSCallback, ServerCallback):
             if cb_hash in self._callbacks:
                 # Merge callbacks if another callback has already been attached
                 cb = self._callbacks[cb_hash]
-                cb.streams += self.streams
+                cb.streams = list(set(cb.streams+self.streams))
                 for k, v in self.handle_ids.items():
                     cb.handle_ids[k].update(v)
                 continue

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -191,8 +191,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         the plotted object as a source.
         """
         if not self.static or isinstance(self.hmap, DynamicMap):
-            sources = [(i, o) for i, o in get_sources(self.hmap)
-                       if i in [None, self.zorder]]
+            sources = [(i, o) for i, inputs in get_sources(self.hmap).items()
+                       for o in inputs if i in [None, self.zorder]]
         else:
             sources = [(self.zorder, self.hmap.last)]
         cb_classes = set()

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -196,6 +196,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             zorders = list(range(self.zorder, self.zorder+len(self.hmap.last)))
         else:
             zorders = [self.zorder]
+
+        if isinstance(self, OverlayPlot) and not self.batched:
+            sources = []
         if not self.static or isinstance(self.hmap, DynamicMap):
             sources = [(i, o) for i, inputs in self.stream_sources.items()
                        for o in inputs if i in zorders]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -23,11 +23,12 @@ from bokeh.plotting.helpers import _known_tools as known_tools
 from ...core import (Store, HoloMap, Overlay, DynamicMap,
                      CompositeOverlay, Element, Dimension)
 from ...core.options import abbreviated_exception, SkipRendering
+from ...core.spaces import get_sources
 from ...core import util
 from ...element import RGB
 from ...streams import Stream, RangeXY, RangeX, RangeY
 from ..plot import GenericElementPlot, GenericOverlayPlot
-from ..util import dynamic_update, get_sources, attach_streams
+from ..util import dynamic_update, attach_streams
 from .plot import BokehPlot, TOOLS
 from .util import (mpl_to_bokeh, convert_datetime, update_plot, get_tab_title,
                    bokeh_version, mplcmap_to_palette, py2js_tickformatter,

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -17,11 +17,12 @@ from ..core.overlay import Overlay, CompositeOverlay
 from ..core.layout import Empty, NdLayout, Layout
 from ..core.options import Store, Compositor, SkipRendering
 from ..core.overlay import NdOverlay
-from ..core.spaces import HoloMap, DynamicMap, get_stream_sources
+from ..core.spaces import HoloMap, DynamicMap
 from ..core.util import stream_parameters
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
-                   attach_streams, traverse_setter, get_nested_streams)
+                   attach_streams, traverse_setter, get_nested_streams,
+                   linked_zorders)
 
 
 class Plot(param.Parameterized):
@@ -570,7 +571,7 @@ class GenericElementPlot(DimensionedPlot):
         if overlaid:
             self.stream_sources = stream_sources
         else:
-            self.stream_sources = get_stream_sources(self.hmap)
+            self.stream_sources = linked_zorders(self.hmap)
 
         plot_element = self.hmap.last
         if self.batched and not isinstance(self, GenericOverlayPlot):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -22,7 +22,7 @@ from ..core.util import stream_parameters
 from ..element import Table
 from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
                    attach_streams, traverse_setter, get_nested_streams,
-                   linked_zorders)
+                   compute_overlayable_zorders)
 
 
 class Plot(param.Parameterized):
@@ -571,7 +571,7 @@ class GenericElementPlot(DimensionedPlot):
         if overlaid:
             self.stream_sources = stream_sources
         else:
-            self.stream_sources = linked_zorders(self.hmap)
+            self.stream_sources = compute_overlayable_zorders(self.hmap)
 
         plot_element = self.hmap.last
         if self.batched and not isinstance(self, GenericOverlayPlot):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -132,7 +132,9 @@ def compute_overlayable_zorders(obj, path=[]):
             # Skips branches of graph that collapse Overlay layers
             # to avoid adding layers that have been reduced or removed
             continue
-        elif depth is not None and depth < overlay_depth(inp):
+
+        input_depth = overlay_depth(inp)
+        if depth is not None and input_depth is not None and depth < input_depth:
             # Skips branch of graph where the number of elements in an
             # overlay has been reduced
             continue

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -29,14 +29,14 @@ class Dynamic(param.ParameterizedFunction):
         Keyword arguments passed to the function.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         If Dynamic is applied to another DynamicMap, determines if
+         If Dynamic is applied to another DynamicMap, determines whether
          linked streams attached to its Callable inputs are
          transferred to the output of the utility.
 
          For example if the Dynamic utility is applied to a DynamicMap
-         with an RangeXY stream determines if the output of the
-         utility will update the stream on the input with current axis
-         ranges for backends that support linked streams.""")
+         with an RangeXY, this switch determines whether the
+         corresponding visualization should update this stream with
+         range changes originating from the newly generated axes.""")
 
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -28,6 +28,9 @@ class Dynamic(param.ParameterizedFunction):
     kwargs = param.Dict(default={}, doc="""
         Keyword arguments passed to the function.""")
 
+    link_inputs = param.Boolean(default=True, doc="""
+       Whether to link to any stream sources on the inputs.""")
+
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")
 
@@ -85,9 +88,11 @@ class Dynamic(param.ParameterizedFunction):
                 return self._process(el, key)
         if isinstance(self.p.operation, ElementOperation):
             return OperationCallable(dynamic_operation, inputs=[map_obj],
+                                     link_inputs=self.p.link_inputs,
                                      operation=self.p.operation)
         else:
-            return Callable(dynamic_operation, inputs=[map_obj])
+            return Callable(dynamic_operation, inputs=[map_obj],
+                            link_inputs=self.p.link_inputs)
 
 
     def _make_dynamic(self, hmap, dynamic_fn):

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -29,7 +29,8 @@ class Dynamic(param.ParameterizedFunction):
         Keyword arguments passed to the function.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-       Whether to link to any stream sources on the inputs.""")
+         Whether a plot created from the output of this utility should
+         be linked to the inputs passed to this utility.""")
 
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -29,8 +29,14 @@ class Dynamic(param.ParameterizedFunction):
         Keyword arguments passed to the function.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         Whether a plot created from the output of this utility should
-         be linked to the inputs passed to this utility.""")
+         If Dynamic is applied to another DynamicMap, determines if
+         linked streams attached to its Callable inputs are
+         transferred to the output of the utility.
+
+         For example if the Dynamic utility is applied to a DynamicMap
+         with an RangeXY stream determines if the output of the
+         utility will update the stream on the input with current axis
+         ranges for backends that support linked streams.""")
 
     shared_data = param.Boolean(default=False, doc="""
         Whether the cloned DynamicMap will share the same cache.""")
@@ -85,8 +91,7 @@ class Dynamic(param.ParameterizedFunction):
             def dynamic_operation(*key, **kwargs):
                 self.p.kwargs.update(kwargs)
                 safe_key = () if not map_obj.kdims else key
-                el = map_obj[key]
-                return self._process(el, key)
+                return self._process(map_obj[key], key)
         if isinstance(self.p.operation, ElementOperation):
             return OperationCallable(dynamic_operation, inputs=[map_obj],
                                      link_inputs=self.p.link_inputs,

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -80,7 +80,8 @@ class Dynamic(param.ParameterizedFunction):
         else:
             def dynamic_operation(*key, **kwargs):
                 self.p.kwargs.update(kwargs)
-                _, el = util.get_dynamic_item(map_obj, map_obj.kdims, key)
+                safe_key = () if not map_obj.kdims else key
+                el = map_obj[key]
                 return self._process(el, key)
         if isinstance(self.p.operation, ElementOperation):
             return OperationCallable(dynamic_operation, inputs=[map_obj],

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -1,13 +1,143 @@
 from unittest import SkipTest
 
+from holoviews.core.spaces import DynamicMap, get_sources
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.element import Curve, Area
+
 
 try:
     from holoviews.plotting.bokeh import util
     bokeh_renderer = Store.renderers['bokeh']
 except:
     bokeh_renderer = None
+
+
+class TestPlotUtils(ComparisonTestCase):
+
+    def test_dynamic_get_sources_two_mixed_layers(self):
+        area = Area(range(10))
+        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        combined = area*dmap
+        combined[()]
+        sources = get_sources(combined)
+        self.assertEqual(sources[0], [area])
+        self.assertEqual(sources[1], [dmap])
+
+    def test_dynamic_get_sources_two_dynamic_layers(self):
+        area = DynamicMap(lambda: Area(range(10)), kdims=[])
+        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        combined = area*dmap
+        combined[()]
+        sources = get_sources(combined)
+        self.assertEqual(sources[0], [area])
+        self.assertEqual(sources[1], [dmap])
+
+    def test_dynamic_get_sources_two_deep_dynamic_layers(self):
+        area = DynamicMap(lambda: Area(range(10)), kdims=[])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area_redim = area.redim(x='x2')
+        curve_redim = curve.redim(x='x2')
+        combined = area_redim*curve_redim
+        combined[()]
+        sources = get_sources(combined)
+        self.assertIn(area_redim, sources[0])
+        self.assertIn(area, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+        self.assertIn(curve_redim, sources[1])
+        self.assertIn(curve, sources[1])
+        self.assertNotIn(area_redim, sources[1])
+        self.assertNotIn(area, sources[1])
+
+    def test_dynamic_get_sources_three_deep_dynamic_layers(self):
+        area = DynamicMap(lambda: Area(range(10)), kdims=[])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area_redim = area.redim(x='x2')
+        curve_redim = curve.redim(x='x2')
+        curve2_redim = curve2.redim(x='x3')
+        combined = area_redim*curve_redim
+        combined1 = (combined*curve2_redim)
+        combined1[()]
+        sources = get_sources(combined1)
+        self.assertIn(area_redim, sources[0])
+        self.assertIn(area, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+        self.assertNotIn(curve2_redim, sources[0])
+        self.assertNotIn(curve2, sources[0])
+
+        self.assertIn(curve_redim, sources[1])
+        self.assertIn(curve, sources[1])
+        self.assertNotIn(area_redim, sources[1])
+        self.assertNotIn(area, sources[1])
+        self.assertNotIn(curve2_redim, sources[1])
+        self.assertNotIn(curve2, sources[1])
+
+        self.assertIn(curve2_redim, sources[2])
+        self.assertIn(curve2, sources[2])
+        self.assertNotIn(area_redim, sources[2])
+        self.assertNotIn(area, sources[2])
+        self.assertNotIn(curve_redim, sources[2])
+        self.assertNotIn(curve, sources[2])
+
+    def test_dynamic_get_sources_three_deep_dynamic_layers_cloned(self):
+        area = DynamicMap(lambda: Area(range(10)), kdims=[])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area_redim = area.redim(x='x2')
+        curve_redim = curve.redim(x='x2')
+        curve2_redim = curve2.redim(x='x3')
+        combined = area_redim*curve_redim
+        combined1 = (combined*curve2_redim).redim(y='y2')
+        combined1[()]
+        sources = get_sources(combined1)
+        self.assertIn(area_redim, sources[0])
+        self.assertIn(area, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+        self.assertNotIn(curve2_redim, sources[0])
+        self.assertNotIn(curve2, sources[0])
+
+        self.assertIn(curve_redim, sources[1])
+        self.assertIn(curve, sources[1])
+        self.assertNotIn(area_redim, sources[1])
+        self.assertNotIn(area, sources[1])
+        self.assertNotIn(curve2_redim, sources[1])
+        self.assertNotIn(curve2, sources[1])
+
+        self.assertIn(curve2_redim, sources[2])
+        self.assertIn(curve2, sources[2])
+        self.assertNotIn(area_redim, sources[2])
+        self.assertNotIn(area, sources[2])
+        self.assertNotIn(curve_redim, sources[2])
+        self.assertNotIn(curve, sources[2])
+
+    def test_dynamic_get_sources_mixed_dynamic_and_non_dynamic_overlays(self):
+        area1 = Area(range(10))
+        area2 = Area(range(10))
+        overlay = area1 * area2
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve_redim = curve.redim(x='x2')
+        combined = overlay*curve_redim
+        combined[()]
+        sources = get_sources(combined)
+
+        self.assertIn(area1, sources[0])
+        self.assertIn(overlay, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+
+        self.assertIn(area2, sources[1])
+        self.assertIn(overlay, sources[1])
+        self.assertNotIn(curve_redim, sources[1])
+        self.assertNotIn(curve, sources[1])
+
+        self.assertIn(curve_redim, sources[2])
+        self.assertIn(curve, sources[2])
+        self.assertNotIn(overlay, sources[2])
+
 
 
 class TestBokehUtils(ComparisonTestCase):

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -5,7 +5,7 @@ from holoviews.core.spaces import DynamicMap
 from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Curve, Area
-from holoviews.plotting.util import linked_zorders
+from holoviews.plotting.util import compute_overlayable_zorders
 
 try:
     from holoviews.plotting.bokeh import util
@@ -16,41 +16,41 @@ except:
 
 class TestPlotUtils(ComparisonTestCase):
 
-    def test_dynamic_linked_zorders_two_mixed_layers(self):
+    def test_dynamic_compute_overlayable_zorders_two_mixed_layers(self):
         area = Area(range(10))
         dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
         combined = area*dmap
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
         self.assertEqual(sources[0], [area])
         self.assertEqual(sources[1], [dmap])
 
-    def test_dynamic_linked_zorders_two_mixed_layers_reverse(self):
+    def test_dynamic_compute_overlayable_zorders_two_mixed_layers_reverse(self):
         area = Area(range(10))
         dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
         combined = dmap*area
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
         self.assertEqual(sources[0], [dmap])
         self.assertEqual(sources[1], [area])
 
-    def test_dynamic_linked_zorders_two_dynamic_layers(self):
+    def test_dynamic_compute_overlayable_zorders_two_dynamic_layers(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
         combined = area*dmap
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
         self.assertEqual(sources[0], [area])
         self.assertEqual(sources[1], [dmap])
 
-    def test_dynamic_linked_zorders_two_deep_dynamic_layers(self):
+    def test_dynamic_compute_overlayable_zorders_two_deep_dynamic_layers(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         area_redim = area.redim(x='x2')
         curve_redim = curve.redim(x='x2')
         combined = area_redim*curve_redim
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
         self.assertIn(area_redim, sources[0])
         self.assertIn(area, sources[0])
         self.assertNotIn(curve_redim, sources[0])
@@ -60,7 +60,7 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(area_redim, sources[1])
         self.assertNotIn(area, sources[1])
 
-    def test_dynamic_linked_zorders_three_deep_dynamic_layers(self):
+    def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
@@ -70,7 +70,7 @@ class TestPlotUtils(ComparisonTestCase):
         combined = area_redim*curve_redim
         combined1 = (combined*curve2_redim)
         combined1[()]
-        sources = linked_zorders(combined1)
+        sources = compute_overlayable_zorders(combined1)
         self.assertIn(area_redim, sources[0])
         self.assertIn(area, sources[0])
         self.assertNotIn(curve_redim, sources[0])
@@ -92,7 +92,7 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
 
-    def test_dynamic_linked_zorders_three_deep_dynamic_layers_cloned(self):
+    def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_cloned(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
@@ -102,7 +102,7 @@ class TestPlotUtils(ComparisonTestCase):
         combined = area_redim*curve_redim
         combined1 = (combined*curve2_redim).redim(y='y2')
         combined1[()]
-        sources = linked_zorders(combined1)
+        sources = compute_overlayable_zorders(combined1)
 
         self.assertIn(area_redim, sources[0])
         self.assertIn(area, sources[0])
@@ -125,7 +125,7 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
 
-    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_overlays_reverse(self):
+    def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_overlays_reverse(self):
         area1 = Area(range(10))
         area2 = Area(range(10))
         overlay = area1 * area2
@@ -133,7 +133,7 @@ class TestPlotUtils(ComparisonTestCase):
         curve_redim = curve.redim(x='x2')
         combined = curve_redim*overlay
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
 
         self.assertIn(curve_redim, sources[0])
         self.assertIn(curve, sources[0])
@@ -149,13 +149,13 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
 
-    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_ndoverlays(self):
+    def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_ndoverlays(self):
         ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
 
         self.assertIn(ndoverlay[0], sources[0])
         self.assertIn(ndoverlay, sources[0])
@@ -171,13 +171,13 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertIn(curve, sources[2])
         self.assertNotIn(ndoverlay, sources[2])
 
-    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_ndoverlays_reverse(self):
+    def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_non_dynamic_ndoverlays_reverse(self):
         ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = curve_redim*ndoverlay
         combined[()]
-        sources = linked_zorders(combined)
+        sources = compute_overlayable_zorders(combined)
 
         self.assertIn(curve_redim, sources[0])
         self.assertIn(curve, sources[0])
@@ -193,7 +193,7 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
 
-    def test_dynamic_linked_zorders_three_deep_dynamic_layers_reduced(self):
+    def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_reduced(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
@@ -203,7 +203,7 @@ class TestPlotUtils(ComparisonTestCase):
         combined = (area_redim*curve_redim).map(lambda x: x.get(0), Overlay)
         combined1 = combined*curve2_redim
         combined1[()]
-        sources = linked_zorders(combined1)
+        sources = compute_overlayable_zorders(combined1)
 
         self.assertNotIn(curve_redim, sources[0])
         self.assertNotIn(curve, sources[0])
@@ -216,6 +216,42 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(area, sources[1])
         self.assertNotIn(curve_redim, sources[1])
         self.assertNotIn(curve, sources[1])
+
+
+    def test_dynamic_compute_overlayable_zorders_three_deep_dynamic_layers_reduced_layers_by_one(self):
+        area = DynamicMap(lambda: Area(range(10)), kdims=[])
+        area2 = DynamicMap(lambda: Area(range(10)), kdims=[])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve2 = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        area_redim = area.redim(x='x2')
+        curve_redim = curve.redim(x='x2')
+        curve2_redim = curve2.redim(x='x3')
+        combined = (area_redim*curve_redim*area2).map(lambda x: x.clone(x.items()[:2]), Overlay)
+        combined1 = combined*curve2_redim
+        combined1[()]
+        sources = compute_overlayable_zorders(combined1)
+
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+        self.assertNotIn(curve2_redim, sources[0])
+        self.assertNotIn(curve2, sources[0])
+        self.assertNotIn(area, sources[0])
+        self.assertNotIn(area_redim, sources[0])
+        self.assertNotIn(area2, sources[0])
+
+        self.assertNotIn(area_redim, sources[1])
+        self.assertNotIn(area, sources[1])
+        self.assertNotIn(curve2_redim, sources[1])
+        self.assertNotIn(curve2, sources[1])
+        self.assertNotIn(area2, sources[0])
+
+        self.assertIn(curve2_redim, sources[2])
+        self.assertIn(curve2, sources[2])
+        self.assertNotIn(area_redim, sources[2])
+        self.assertNotIn(area, sources[2])
+        self.assertNotIn(area2, sources[0])
+        self.assertNotIn(curve_redim, sources[2])
+        self.assertNotIn(curve, sources[2])
 
 
 class TestBokehUtils(ComparisonTestCase):

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -25,6 +25,15 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertEqual(sources[0], [area])
         self.assertEqual(sources[1], [dmap])
 
+    def test_dynamic_linked_zorders_two_mixed_layers_reverse(self):
+        area = Area(range(10))
+        dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        combined = dmap*area
+        combined[()]
+        sources = linked_zorders(combined)
+        self.assertEqual(sources[0], [dmap])
+        self.assertEqual(sources[1], [area])
+
     def test_dynamic_linked_zorders_two_dynamic_layers(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])
         dmap = DynamicMap(lambda: Curve(range(10)), kdims=[])
@@ -116,29 +125,29 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
 
-    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_overlays(self):
+    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_overlays_reverse(self):
         area1 = Area(range(10))
         area2 = Area(range(10))
         overlay = area1 * area2
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
-        combined = overlay*curve_redim
+        combined = curve_redim*overlay
         combined[()]
         sources = linked_zorders(combined)
 
-        self.assertIn(area1, sources[0])
-        self.assertIn(overlay, sources[0])
-        self.assertNotIn(curve_redim, sources[0])
-        self.assertNotIn(curve, sources[0])
+        self.assertIn(curve_redim, sources[0])
+        self.assertIn(curve, sources[0])
+        self.assertNotIn(overlay, sources[0])
 
-        self.assertIn(area2, sources[1])
+        self.assertIn(area1, sources[1])
         self.assertIn(overlay, sources[1])
         self.assertNotIn(curve_redim, sources[1])
         self.assertNotIn(curve, sources[1])
 
-        self.assertIn(curve_redim, sources[2])
-        self.assertIn(curve, sources[2])
-        self.assertNotIn(overlay, sources[2])
+        self.assertIn(area2, sources[2])
+        self.assertIn(overlay, sources[2])
+        self.assertNotIn(curve_redim, sources[2])
+        self.assertNotIn(curve, sources[2])
 
     def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_ndoverlays(self):
         ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
@@ -161,6 +170,28 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertIn(curve_redim, sources[2])
         self.assertIn(curve, sources[2])
         self.assertNotIn(ndoverlay, sources[2])
+
+    def test_dynamic_linked_zorders_mixed_dynamic_and_non_dynamic_ndoverlays_reverse(self):
+        ndoverlay = NdOverlay({i: Area(range(10+i)) for i in range(2)})
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve_redim = curve.redim(x='x2')
+        combined = curve_redim*ndoverlay
+        combined[()]
+        sources = linked_zorders(combined)
+
+        self.assertIn(curve_redim, sources[0])
+        self.assertIn(curve, sources[0])
+        self.assertNotIn(ndoverlay, sources[0])
+
+        self.assertIn(ndoverlay[0], sources[1])
+        self.assertIn(ndoverlay, sources[1])
+        self.assertNotIn(curve_redim, sources[1])
+        self.assertNotIn(curve, sources[1])
+
+        self.assertIn(ndoverlay[1], sources[2])
+        self.assertIn(ndoverlay, sources[2])
+        self.assertNotIn(curve_redim, sources[2])
+        self.assertNotIn(curve, sources[2])
 
     def test_dynamic_linked_zorders_three_deep_dynamic_layers_reduced(self):
         area = DynamicMap(lambda: Area(range(10)), kdims=[])


### PR DESCRIPTION
Previously the ``get_sources`` function was very wrong in the way it reconstructed the individual layers of an Overlay from a DynamicMap. This resulted in issues in correctly detecting stream sources while plotting. This PR readds the OverlayCallable class which lets an improved ``get_sources`` function correctly infer stream sources.

Will add a lot of unit tests for the ``get_sources`` function before merging.