### PR TITLE
Added custom rcParam context manager

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -424,6 +424,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             tick.set_rotation(rotation)
 
 
+    @mpl_rc_context
     def update_frame(self, key, ranges=None, element=None):
         """
         Set the plot(s) to the given frame number.  Operates by
@@ -838,6 +839,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                                    title=self._format_title(key))
 
 
+    @mpl_rc_context
     def update_frame(self, key, ranges=None, element=None):
         axis = self.handles['axis']
         if element is None:

--- a/holoviews/plotting/mpl/pandas.py
+++ b/holoviews/plotting/mpl/pandas.py
@@ -8,6 +8,7 @@ import param
 from ...core.options import Store
 from ...interface.pandas import DFrame, DataFrameView, pd
 from .element import ElementPlot
+from .plot import mpl_rc_context
 
 
 class DFrameViewPlot(ElementPlot):
@@ -65,7 +66,7 @@ class DFrameViewPlot(ElementPlot):
         if self.hmap.last.plot_type and 'plot_type' not in params:
             self.plot_type = self.hmap.last.plot_type
 
-
+    @mpl_rc_context
     def initialize_plot(self, ranges=None):
         element = self.hmap.last
         self._validate(element)

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 from itertools import chain
+from contextlib import contextmanager
 
 import numpy as np
 import matplotlib as mpl
@@ -19,12 +20,27 @@ from ..util import get_dynamic_mode, initialize_sampled
 from .util import compute_ratios, fix_aspect
 
 
+@contextmanager
+def rc_context(rcparams):
+    """
+    Context manager that temporarily overrides the pyplot rcParams.
+    """
+    old_rcparams = plt.rcParams.copy()
+    plt.rcParams.update(rcparams)
+    try:
+        yield
+    except:
+        pass
+    finally:
+        plt.rcParams = old_rcparams
+
 def mpl_rc_context(f):
     """
-    Applies matplotlib rc params while when method is called.
+    Decorator for MPLPlot methods applying the matplotlib rc params
+    in the plots fig_rcparams while when method is called.
     """
     def wrapper(self, *args, **kwargs):
-        with mpl.rc_context(rc=self.fig_rcparams):
+        with rc_context(self.fig_rcparams):
             return f(self, *args, **kwargs)
     return wrapper
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -21,7 +21,7 @@ from .util import compute_ratios, fix_aspect
 
 
 @contextmanager
-def rc_context(rcparams):
+def _rc_context(rcparams):
     """
     Context manager that temporarily overrides the pyplot rcParams.
     """
@@ -40,7 +40,7 @@ def mpl_rc_context(f):
     in the plots fig_rcparams while when method is called.
     """
     def wrapper(self, *args, **kwargs):
-        with rc_context(self.fig_rcparams):
+        with _rc_context(self.fig_rcparams):
             return f(self, *args, **kwargs)
     return wrapper
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -365,7 +365,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         kwargs = self._get_axis_kwargs()
         return self._finalize_axis(key, ranges=ranges, **kwargs)
 
-
+    @mpl_rc_context
     def update_frame(self, key, ranges=None):
         grid = self._get_frame(key)
         ranges = self.compute_ranges(self.layout, key, ranges)


### PR DESCRIPTION
For some reason the context manager to set rcParams provided by matplotlib is not working correctly, I've implemented a tiny one of our own here which fixes the bug mentioned in https://github.com/ioam/holoviews/issues/1299.