### PR TITLE
Do not attach stream subscribers to batched ElementPlot

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -602,7 +602,8 @@ class GenericElementPlot(DimensionedPlot):
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
 
-        if not self.overlaid:
+        # Attach streams if not overlaid and not a batched ElementPlot
+        if not (self.overlaid or (self.batched and not isinstance(self, GenericOverlayPlot))):
             attach_streams(self, self.hmap)
 
         # Update plot and style options for batched plots

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -349,6 +349,17 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         extents = plot.get_extents(overlay, {})
         self.assertEqual(extents, (0, 0, 9, 1))
 
+    def test_batched_curve_subscribers_correctly_attached(self):
+        posx = PositionX()
+        opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
+                'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
+        overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
+                                                  for i in range(2)})(opts), kdims=[],
+                             streams=[posx])
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertIn(plot.refresh, posx.subscribers)
+        self.assertNotIn(list(plot.subplots.values())[0].refresh, posx.subscribers)
+
     def test_batched_points_size_and_color(self):
         opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
                 'Points': dict(style=dict(size=Cycle(values=[1, 2])))}


### PR DESCRIPTION
Batched plots create both an OverlayPlot and an ElementPlot instance which currently both attach themselves as stream subscribers, however the correct thing to do is for only the OverlayPlot to attach itself so that the batched plot is updated correctly.