### PR TITLE
Handle additional linked stream condition

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -9,7 +9,7 @@ from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
 from ..core.spaces import get_nested_streams, Callable
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
                          get_overlay_spec, unique_iterator, unique_iterator)
-
+from ..streams import LinkedStream
 
 def displayable(obj):
     """
@@ -150,9 +150,12 @@ def compute_overlayable_zorders(obj, path=[]):
     # If object branches but does not declare inputs (e.g. user defined
     # DynamicMaps returning (Nd)Overlay) add the items on the DynamicMap.last
     found = any(isinstance(p, DynamicMap) and p.callback._is_overlay for p in path)
-    if found and isoverlay and not isdynoverlay:
+    linked =  any(isinstance(s, LinkedStream) and s.linked for s in obj.streams)
+    if (found or linked) and isoverlay and not isdynoverlay:
         offset = max(zorder_map.keys())
         for z, o in enumerate(obj.last):
+            if isoverlay and linked:
+                zorder_map[offset+z].append(obj)
             if o not in zorder_map[offset+z]:
                 zorder_map[offset+z].append(o)
     return zorder_map

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -6,6 +6,7 @@ from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Curve, Area
 from holoviews.plotting.util import compute_overlayable_zorders
+from holoviews.streams import PositionX
 
 try:
     from holoviews.plotting.bokeh import util
@@ -163,6 +164,49 @@ class TestPlotUtils(ComparisonTestCase):
         self.assertNotIn(curve, sources[0])
 
         self.assertIn(ndoverlay[1], sources[1])
+        self.assertIn(ndoverlay, sources[1])
+        self.assertNotIn(curve_redim, sources[1])
+        self.assertNotIn(curve, sources[1])
+
+        self.assertIn(curve_redim, sources[2])
+        self.assertIn(curve, sources[2])
+        self.assertNotIn(ndoverlay, sources[2])
+
+
+    def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams(self):
+        ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
+                               kdims=[], streams=[PositionX()])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve_redim = curve.redim(x='x2')
+        combined = ndoverlay*curve_redim
+        combined[()]
+        sources = compute_overlayable_zorders(combined)
+
+        self.assertIn(ndoverlay, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+
+        self.assertIn(ndoverlay, sources[1])
+        self.assertNotIn(curve_redim, sources[1])
+        self.assertNotIn(curve, sources[1])
+
+        self.assertIn(curve_redim, sources[2])
+        self.assertIn(curve, sources[2])
+        self.assertNotIn(ndoverlay, sources[2])
+
+    def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams_cloned(self):
+        ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
+                               kdims=[], streams=[PositionX()])
+        curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
+        curve_redim = curve.redim(x='x2')
+        combined = ndoverlay*curve_redim
+        combined[()]
+        sources = compute_overlayable_zorders(combined.clone())
+
+        self.assertIn(ndoverlay, sources[0])
+        self.assertNotIn(curve_redim, sources[0])
+        self.assertNotIn(curve, sources[0])
+
         self.assertIn(ndoverlay, sources[1])
         self.assertNotIn(curve_redim, sources[1])
         self.assertNotIn(curve, sources[1])


### PR DESCRIPTION
Followup for #1297 to handle one more condition where a DynamicMap which returns an (Nd)Overlay itself has linked streams.