### PR TITLE
Improve DynamicMap usability and deprecate sampled mode

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -676,16 +676,14 @@ class DynamicMap(HoloMap):
             msg = 'Key(s) {invalid} do not correspond to stream parameters'
             raise KeyError(msg.format(invalid = ', '.join('%r' % i for i in invalid)))
 
-        updated_streams = []
         for stream in self.streams:
             applicable_kws = {k:v for k,v in kwargs.items()
                               if k in set(stream.contents.keys())}
             rkwargs = util.rename_stream_kwargs(stream, applicable_kws, reverse=True)
             stream.update(**dict(rkwargs, trigger=False))
-            updated_streams.append(stream)
 
-        if updated_streams and trigger:
-            updated_streams[0].trigger(updated_streams)
+        if trigger:
+            Stream.trigger(self.streams)
 
 
     def _style(self, retval):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -671,8 +671,10 @@ class DynamicMap(HoloMap):
         """
         if self.streams == []: return
         stream_params = set(util.stream_parameters(self.streams))
-        for k in stream_params - set(kwargs.keys()):
-            raise KeyError('Key %r does not correspond to any stream parameter')
+        invalid = [k for k in kwargs.keys() if k not in stream_params]
+        if invalid:
+            msg = 'Key(s) {invalid} do not correspond to stream parameters'
+            raise KeyError(msg.format(invalid = ', '.join('%r' % i for i in invalid)))
 
         updated_streams = []
         for stream in self.streams:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -620,8 +620,11 @@ class DynamicMap(HoloMap):
         """
         key = []
         undefined = []
+        stream_params = set(util.stream_parameters(self.streams))
         for kdim in self.kdims:
-            if kdim.values:
+            if str(kdim) in stream_params:
+                key.append(None)
+            elif kdim.values:
                 key.append(kdim.values[0])
             elif kdim.range[0] is not None:
                 key.append(kdim.range[0])

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -595,16 +595,19 @@ class DynamicMap(HoloMap):
         self.redim = redim(self, mode='dynamic')
 
     @property
-    def sampled(self):
+    def unbounded(self):
         """
-        Whether the DynamicMap cannot generate an initial key and has to be sampled.
-        This read-only property replaces the deprecated sampled parameter.
+        Returns a list of key dimensions that are unbounded. If any key
+        dimensions are unbounded, the DynamicMap as a whole is also
+        unbounded.
         """
-        try:
-            self._initial_key()
-        except KeyError:
-            return True
-        return False
+        unbounded_dims = []
+        for kdim in self.kdims:
+            if kdim.values:
+                continue
+            if None in kdim.range:
+                unbounded_dims.append(str(kdim))
+        return unbounded_dims
 
     def _initial_key(self):
         """

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -605,7 +605,7 @@ class DynamicMap(HoloMap):
         for kdim in self.kdims:
             if kdim.values:
                 key.append(kdim.values[0])
-            elif kdim.range:
+            elif kdim.range[0] is not None:
                 key.append(kdim.range[0])
             else:
                 undefined.append(kdim)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -574,13 +574,6 @@ class DynamicMap(HoloMap):
        cache where the least recently used item is overwritten once
        the cache is full.""")
 
-    sampled = param.Boolean(default=False, doc="""
-       Allows defining a DynamicMap without defining the dimension
-       bounds or values. The DynamicMap may then be explicitly sampled
-       via getitem or the sampling is determined during plotting by a
-       HoloMap with fixed sampling.
-       """)
-
     def __init__(self, callback, initial_items=None, **params):
         if not isinstance(callback, Callable):
             callback = Callable(callback)
@@ -594,6 +587,18 @@ class DynamicMap(HoloMap):
             if stream.source is None:
                 stream.source = self
         self.redim = redim(self, mode='dynamic')
+
+    @property
+    def sampled(self):
+        """
+        Whether the DynamicMap cannot generate an initial key and has to be sampled.
+        This read-only property replaces the deprecated sampled parameter.
+        """
+        try:
+            self._initial_key()
+        except KeyError:
+            return True
+        return False
 
     def _initial_key(self):
         """

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -669,6 +669,7 @@ class DynamicMap(HoloMap):
         This method allows any of the available stream parameters
         (renamed as appropriate) to be updated in an event.
         """
+        if self.streams == []: return
         stream_params = set(util.stream_parameters(self.streams))
         for k in stream_params - set(kwargs.keys()):
             raise KeyError('Key %r does not correspond to any stream parameter')

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -610,7 +610,7 @@ class DynamicMap(HoloMap):
             else:
                 undefined.append(kdim)
         if undefined:
-            msg = ('Dimensions {undefined_dims} do not specify range or values needed '
+            msg = ('Dimension(s) {undefined_dims} do not specify range or values needed '
                    'to generate initial key')
             undefined_dims = ', '.join(['%r' % str(dim) for dim in undefined])
             raise KeyError(msg.format(undefined_dims=undefined_dims))

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -610,8 +610,11 @@ class DynamicMap(HoloMap):
             else:
                 undefined.append(kdim)
         if undefined:
-            raise KeyError('dimensions do not specify a range or values, '
-                           'cannot supply initial key' % ', '.join(undefined))
+            msg = ('Dimensions {undefined_dims} do not specify range or values needed '
+                   'to generate initial key')
+            undefined_dims = ', '.join(['%r' % str(dim) for dim in undefined])
+            raise KeyError(msg.format(undefined_dims=undefined_dims))
+
         return tuple(key)
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -14,6 +14,7 @@ from .layout import Layout, AdjointLayout, NdLayout
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
+from ..streams import Stream
 
 class HoloMap(UniformNdMapping, Overlayable):
     """
@@ -584,6 +585,11 @@ class DynamicMap(HoloMap):
             del params['sampled']
 
         super(DynamicMap, self).__init__(initial_items, callback=callback, **params)
+        invalid = [s for s in self.streams if not isinstance(s, Stream)]
+        if invalid:
+            msg = ('The supplied streams list contains objects that '
+                   'are not Stream instances: {objs}')
+            raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
 
         self._posarg_keys = util.validate_dynamic_argspec(self.callback.argspec,
                                                           self.kdims,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -597,12 +597,14 @@ class DynamicMap(HoloMap):
     @property
     def unbounded(self):
         """
-        Returns a list of key dimensions that are unbounded. If any key
-        dimensions are unbounded, the DynamicMap as a whole is also
-        unbounded.
+        Returns a list of key dimensions that are unbounded, excluding
+        stream parameters. If any of theses key dimensions are
+        unbounded, the DynamicMap as a whole is also unbounded.
         """
         unbounded_dims = []
-        for kdim in self.kdims:
+        # Dimensioned streams do not need to be bounded
+        kdims = sorted(set(self.kdims) - set(util.stream_parameters(self.streams)))
+        for kdim in kdims:
             if kdim.values:
                 continue
             if None in kdim.range:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -603,8 +603,10 @@ class DynamicMap(HoloMap):
         """
         unbounded_dims = []
         # Dimensioned streams do not need to be bounded
-        kdims = sorted(set(self.kdims) - set(util.stream_parameters(self.streams)))
-        for kdim in kdims:
+        stream_params = set(util.stream_parameters(self.streams))
+        for kdim in self.kdims:
+            if str(kdim) in stream_params:
+                continue
             if kdim.values:
                 continue
             if None in kdim.range:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -577,6 +577,12 @@ class DynamicMap(HoloMap):
     def __init__(self, callback, initial_items=None, **params):
         if not isinstance(callback, Callable):
             callback = Callable(callback)
+
+        if 'sampled' in params:
+            self.warning('DynamicMap sampled parameter is deprecated '
+                         'and no longer neededs to be specified.')
+            del params['sampled']
+
         super(DynamicMap, self).__init__(initial_items, callback=callback, **params)
 
         self._posarg_keys = util.validate_dynamic_argspec(self.callback.argspec,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -556,6 +556,10 @@ class DynamicMap(HoloMap):
     # Declare that callback is a positional parameter (used in clone)
     __pos_params = ['callback']
 
+    kdims = param.List(default=[], constant=True, doc="""
+        The key dimensions of a DynamicMap map to the arguments of the
+        callback. This mapping can be by position or by name.""")
+
     callback = param.ClassSelector(class_=Callable, doc="""
         The callable used to generate the elements. The arguments to the
         callable includes any number of declared key dimensions as well

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -169,6 +169,10 @@ def validate_dynamic_argspec(argspec, kdims, streams):
             raise KeyError('Callable missing keywords to accept %s stream parameters'
                            % ', '.join(unassigned_streams))
 
+
+    if len(posargs) > len(kdims) + len(stream_params):
+        raise KeyError('Callable accepts more positional arguments than '
+                       'there are kdims and stream parameters')
     if kdims == []:                  # Can be no posargs, stream kwargs already validated
         return []
     if set(kdims) == set(posargs):   # Posargs match exactly, can all be passed as kwargs

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -179,7 +179,7 @@ def element_display(element, max_frames):
 @display_hook
 def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
-    if len(vmap) == 0 and (not isinstance(vmap, DynamicMap) or vmap.sampled):
+    if len(vmap) == 0 and (not isinstance(vmap, DynamicMap) or vmap.unbounded):
         return None
     elif len(vmap) > max_frames:
         max_frame_warning(max_frames)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -181,7 +181,8 @@ def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
     if len(vmap) == 0 and isinstance(vmap, DynamicMap) and vmap.unbounded:
         dims = ', '.join('%r' % dim for dim in  vmap.unbounded)
-        msg = ('DynamicMap cannot be displayed as {dims} dimension(s) are unbounded. '
+        msg = ('DynamicMap cannot be displayed without explicit indexing '
+               'as {dims} dimension(s) are unbounded. '
                '\nSet dimensions bounds with the DynamicMap redim.range '
                'or redim.values methods.')
         sys.stderr.write(msg.format(dims=dims))

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -140,7 +140,7 @@ def display_hook(fn):
             return html
         except SkipRendering as e:
             if e.warn:
-                sys.stderr.write("Rendering process skipped: %s" % str(e))
+                sys.stderr.write(str(e))
             return None
         except AbbreviatedException as e:
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -179,8 +179,14 @@ def element_display(element, max_frames):
 @display_hook
 def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
-    if len(vmap) == 0 and (not isinstance(vmap, DynamicMap) or vmap.unbounded):
+    if len(vmap) == 0 and isinstance(vmap, DynamicMap) and vmap.unbounded:
+        dims = ', '.join('%r' % dim for dim in  vmap.unbounded)
+        msg = ('DynamicMap cannot be displayed as {dims} dimension(s) are unbounded. '
+               '\nSet dimensions bounds with the DynamicMap redim.range '
+               'or redim.values methods.')
+        sys.stderr.write(msg.format(dims=dims))
         return None
+
     elif len(vmap) > max_frames:
         max_frame_warning(max_frames)
         return None

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -8,6 +8,7 @@ from ...core import OrderedDict
 from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         RangeY, PointerX, PointerY, Bounds, Tap,
                         DoubleTap, MouseEnter, MouseLeave, PlotSize)
+from ...streams import PositionX, PositionY, PositionXY # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS
 from .util import bokeh_version
 
@@ -689,3 +690,8 @@ callbacks[RangeY]      = RangeYCallback
 callbacks[Bounds]      = BoundsCallback
 callbacks[Selection1D] = Selection1DCallback
 callbacks[PlotSize]    = PlotSizeCallback
+
+# Aliases for deprecated streams
+callbacks[PositionXY]  = PointerXYCallback
+callbacks[PositionX]   = PointerXCallback
+callbacks[PositionY]   = PointerYCallback

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -5,8 +5,8 @@ import numpy as np
 from bokeh.models import CustomJS
 
 from ...core import OrderedDict
-from ...streams import (Stream, PositionXY, RangeXY, Selection1D, RangeX,
-                        RangeY, PositionX, PositionY, Bounds, Tap,
+from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
+                        RangeY, PointerX, PointerY, Bounds, Tap,
                         DoubleTap, MouseEnter, MouseLeave, PlotSize)
 from ..comms import JupyterCommJS
 from .util import bokeh_version
@@ -515,7 +515,7 @@ class Callback(CustomJSCallback, ServerCallback):
 
 
 
-class PositionXYCallback(Callback):
+class PointerXYCallback(Callback):
     """
     Returns the mouse x/y-position on mousemove event.
     """
@@ -525,7 +525,7 @@ class PositionXYCallback(Callback):
     on_events = ['mousemove']
 
 
-class PositionXCallback(PositionXYCallback):
+class PointerXCallback(PointerXYCallback):
     """
     Returns the mouse x-position on mousemove event.
     """
@@ -533,7 +533,7 @@ class PositionXCallback(PositionXYCallback):
     attributes = {'x': 'cb_obj.x'}
 
 
-class PositionYCallback(PositionXYCallback):
+class PointerYCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on mousemove event.
     """
@@ -541,7 +541,7 @@ class PositionYCallback(PositionXYCallback):
     attributes = {'y': 'cb_obj.y'}
 
 
-class TapCallback(PositionXYCallback):
+class TapCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on tap event.
     """
@@ -549,7 +549,7 @@ class TapCallback(PositionXYCallback):
     on_events = ['tap']
 
 
-class DoubleTapCallback(PositionXYCallback):
+class DoubleTapCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on doubletap event.
     """
@@ -557,7 +557,7 @@ class DoubleTapCallback(PositionXYCallback):
     on_events = ['doubletap']
 
 
-class MouseEnterCallback(PositionXYCallback):
+class MouseEnterCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on mouseenter event, i.e. when
     mouse enters the plot canvas.
@@ -566,7 +566,7 @@ class MouseEnterCallback(PositionXYCallback):
     on_events = ['mouseenter']
 
 
-class MouseLeaveCallback(PositionXYCallback):
+class MouseLeaveCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on mouseleave event, i.e. when
     mouse leaves the plot canvas.
@@ -676,9 +676,9 @@ class Selection1DCallback(Callback):
 
 callbacks = Stream._callbacks['bokeh']
 
-callbacks[PositionXY]  = PositionXYCallback
-callbacks[PositionX]   = PositionXCallback
-callbacks[PositionY]   = PositionYCallback
+callbacks[PointerXY]  = PointerXYCallback
+callbacks[PointerX]   = PointerXCallback
+callbacks[PointerY]   = PointerYCallback
 callbacks[Tap]         = TapCallback
 callbacks[DoubleTap]   = DoubleTapCallback
 callbacks[MouseEnter]  = MouseEnterCallback

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -14,7 +14,7 @@ from ...core.util import basestring, wrap_tuple, unique_iterator
 from ...element import Histogram
 from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
                     GenericElementPlot)
-from ..util import get_dynamic_mode, initialize_sampled
+from ..util import get_dynamic_mode
 from .renderer import BokehRenderer
 from .util import (bokeh_version, layout_padding, pad_plots,
                    filter_toolboxes, make_axis, update_shared_sources)

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -16,7 +16,7 @@ from ...core.options import Store, Compositor, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
 from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
-from ..util import get_dynamic_mode, initialize_sampled
+from ..util import get_dynamic_mode
 from .util import compute_ratios, fix_aspect
 
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -20,7 +20,7 @@ from ..core.overlay import NdOverlay
 from ..core.spaces import HoloMap, DynamicMap
 from ..core.util import stream_parameters
 from ..element import Table
-from .util import (get_dynamic_mode, initialize_sampled, dim_axis_label,
+from .util import (get_dynamic_mode, initialize_unbounded, dim_axis_label,
                    attach_streams, traverse_setter, get_nested_streams,
                    compute_overlayable_zorders)
 
@@ -590,7 +590,7 @@ class GenericElementPlot(DimensionedPlot):
                                                defaults=False)
             plot_opts.update(**{k: v[0] for k, v in inherited.items()})
 
-        dynamic = isinstance(element, DynamicMap) and not element.sampled
+        dynamic = isinstance(element, DynamicMap) and not element.unbounded
         super(GenericElementPlot, self).__init__(keys=keys, dimensions=dimensions,
                                                  dynamic=dynamic,
                                                  **dict(params, **plot_opts))
@@ -966,9 +966,9 @@ class GenericCompositePlot(DimensionedPlot):
         if top_level:
             dimensions, keys = traversal.unique_dimkeys(layout)
 
-        dynamic, sampled = get_dynamic_mode(layout)
-        if sampled:
-            initialize_sampled(layout, dimensions, keys[0])
+        dynamic, unbounded = get_dynamic_mode(layout)
+        if unbounded:
+            initialize_unbounded(layout, dimensions, keys[0])
         self.layout = layout
         super(GenericCompositePlot, self).__init__(keys=keys,
                                                    dynamic=dynamic,

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -7,6 +7,7 @@ import param
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     Overlay, GridSpace, NdLayout, Store, Dataset)
 from ..core.spaces import get_nested_streams, Callable
+from ..core.options import SkipRendering
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
                          get_overlay_spec, unique_iterator, unique_iterator)
 from ..streams import LinkedStream
@@ -171,7 +172,12 @@ def initialize_dynamic(obj):
             # Skip initialization until plotting code
             continue
         if not len(dmap):
-            dmap[dmap._initial_key()]
+            try:
+                dmap[dmap._initial_key()]
+            except KeyError as e:
+                suffix_msg = (' required for display.\n'
+                              'Try using DynamicMap redim.range or redim.values methods.')
+                raise SkipRendering(str(e)[1:-1] + suffix_msg, warn=True)
 
 
 def undisplayable_info(obj, html=False):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -267,6 +267,18 @@ class Stream(param.Parameterized):
         return repr(self)
 
 
+class Counter(Stream):
+    """
+    Simple stream that automatically increments an integer counter
+    parameter every time it is updated.
+    """
+
+    counter = param.Integer(default=0, bounds=(0,None))
+
+    def transform(self):
+        return {'counter': self.counter + 1}
+
+
 class LinkedStream(Stream):
     """
     A LinkedStream indicates is automatically linked to plot interactions

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -273,7 +273,7 @@ class Counter(Stream):
     parameter every time it is updated.
     """
 
-    counter = param.Integer(default=0, bounds=(0,None))
+    counter = param.Integer(default=0, constant=True, bounds=(0,None))
 
     def transform(self):
         return {'counter': self.counter + 1}

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -476,3 +476,19 @@ class ParamValues(Stream):
 
     def __str__(self):
         return repr(self)
+
+
+class PositionX(PointerX):
+    def __init__(self, **params):
+        self.warning('PositionX stream deprecated: use PointerX instead')
+        super(PositionX, self).__init__(**params)
+
+class PositionY(PointerY):
+    def __init__(self, **params):
+        self.warning('PositionY stream deprecated: use PointerY instead')
+        super(PositionY, self).__init__(**params)
+
+class PositionXY(PointerXY):
+    def __init__(self, **params):
+        self.warning('PositionXY stream deprecated: use PointerXY instead')
+        super(PositionXY, self).__init__(**params)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -322,10 +322,12 @@ class LinkedStream(Stream):
 
 class PointerX(LinkedStream):
     """
-    A pointer position along the x-axis in data coordinates.
+    A pointer position along the x-axis in data coordinates which may be
+    a numeric or categorical dimension.
 
     With the appropriate plotting backend, this corresponds to the
-    position of the mouse/trackpad cursor.
+    position of the mouse/trackpad cursor. If the pointer is outside the
+    plot bounds, the position is set to None.
     """
 
     x = param.ClassSelector(class_=(Number, util.basestring), default=None,
@@ -335,11 +337,14 @@ class PointerX(LinkedStream):
 
 class PointerY(LinkedStream):
     """
-    A pointer position along the y-axis in data coordinates.
+    A pointer position along the y-axis in data coordinates which may be
+    a numeric or categorical dimension.
 
     With the appropriate plotting backend, this corresponds to the
-    position of the mouse/trackpad cursor.
+    position of the mouse/trackpad pointer. If the pointer is outside
+    the plot bounds, the position is set to None.
     """
+
 
     y = param.ClassSelector(class_=(Number, util.basestring), default=None,
                             constant=True, doc="""
@@ -348,10 +353,12 @@ class PointerY(LinkedStream):
 
 class PointerXY(LinkedStream):
     """
-    A pointer position along the x- and y-axes in data coordinates.
+    A pointer position along the x- and y-axes in data coordinates which
+    may numeric or categorical dimensions.
 
     With the appropriate plotting backend, this corresponds to the
-    position of the mouse/trackpad cursor.
+    position of the mouse/trackpad pointer. If the pointer is outside
+    the plot bounds, the position values are set to None.
     """
 
     x = param.ClassSelector(class_=(Number, util.basestring), default=None,

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -290,69 +290,69 @@ class LinkedStream(Stream):
         super(LinkedStream, self).__init__(linked=linked, **params)
 
 
-class PositionX(LinkedStream):
+class PointerX(LinkedStream):
     """
-    A position along the x-axis in data coordinates.
+    A pointer position along the x-axis in data coordinates.
 
-    With the appropriate plotting backend, this may correspond to the
+    With the appropriate plotting backend, this corresponds to the
     position of the mouse/trackpad cursor.
     """
 
     x = param.ClassSelector(class_=(Number, util.basestring), default=None,
                             constant=True, doc="""
-           Position along the x-axis in data coordinates""")
+           Pointer position along the x-axis in data coordinates""")
 
 
-class PositionY(LinkedStream):
+class PointerY(LinkedStream):
     """
-    A position along the y-axis in data coordinates.
+    A pointer position along the y-axis in data coordinates.
 
-    With the appropriate plotting backend, this may correspond to the
+    With the appropriate plotting backend, this corresponds to the
     position of the mouse/trackpad cursor.
     """
 
     y = param.ClassSelector(class_=(Number, util.basestring), default=None,
                             constant=True, doc="""
-           Position along the y-axis in data coordinates""")
+           Pointer position along the y-axis in data coordinates""")
 
 
-class PositionXY(LinkedStream):
+class PointerXY(LinkedStream):
     """
-    A position along the x- and y-axes in data coordinates.
+    A pointer position along the x- and y-axes in data coordinates.
 
-    With the appropriate plotting backend, this may correspond to the
+    With the appropriate plotting backend, this corresponds to the
     position of the mouse/trackpad cursor.
     """
 
     x = param.ClassSelector(class_=(Number, util.basestring), default=None,
                             constant=True, doc="""
-           Position along the x-axis in data coordinates""")
+           Pointer position along the x-axis in data coordinates""")
 
     y = param.ClassSelector(class_=(Number, util.basestring), default=None,
                             constant=True, doc="""
-           Position along the y-axis in data coordinates""")
+           Pointer position along the y-axis in data coordinates""")
 
 
-class Tap(PositionXY):
+class Tap(PointerXY):
     """
     The x/y-position of a tap or click in data coordinates.
     """
 
 
-class DoubleTap(PositionXY):
+class DoubleTap(PointerXY):
     """
     The x/y-position of a double-tap or -click in data coordinates.
     """
 
 
-class MouseEnter(PositionXY):
+class MouseEnter(PointerXY):
     """
     The x/y-position where the mouse/cursor entered the plot area
     in data coordinates.
     """
 
 
-class MouseLeave(PositionXY):
+class MouseLeave(PointerXY):
     """
     The x/y-position where the mouse/cursor entered the plot area
     in data coordinates.

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -279,6 +279,36 @@ class Counter(Stream):
         return {'counter': self.counter + 1}
 
 
+class X(Stream):
+    """
+    Simple numeric stream representing a position along the x-axis.
+    """
+
+    x = param.Number(default=0, constant=True, doc="""
+       Numeric position along the x-axis.""")
+
+
+class Y(Stream):
+    """
+    Simple numeric stream representing a position along the y-axis.
+    """
+
+    y = param.Number(default=0, constant=True, doc="""
+       Numeric position along the y-axis.""")
+
+
+class XY(Stream):
+    """
+    Simple numeric stream representing a position along the x- and y-axes.
+    """
+
+    x = param.Number(default=0, constant=True, doc="""
+       Numeric position along the x-axis.""")
+
+    y = param.Number(default=0, constant=True, doc="""
+       Numeric position along the y-axis.""")
+
+
 class LinkedStream(Stream):
     """
     A LinkedStream indicates is automatically linked to plot interactions

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -147,7 +147,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(A,B):
             return Scatter([(A,2)], label=A)
 
-        regexp="Callable accepts more positional arguments (.+?) than there are key dimensions (.+?)"
+        regexp="Callable accepts more positional arguments than there are kdims and stream parameters"
         with self.assertRaisesRegexp(KeyError, regexp):
             dmap = DynamicMap(fn, kdims=['A'])
 

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -140,7 +140,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(A,B):
             return Scatter([(A,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['A','B'], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A','B'])
         self.assertEqual(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_kdims_only_invalid(self):
@@ -149,7 +149,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
 
         regexp="Callable accepts more positional arguments (.+?) than there are key dimensions (.+?)"
         with self.assertRaisesRegexp(KeyError, regexp):
-            dmap = DynamicMap(fn, kdims=['A'], sampled=True)
+            dmap = DynamicMap(fn, kdims=['A'])
 
 
     def test_dynamic_kdims_args_only(self):
@@ -157,7 +157,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             (A,B) = args
             return Scatter([(A,2)], label=A)
 
-        dmap = DynamicMap(fn, kdims=['A','B'], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A','B'])
         self.assertEqual(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
 
 
@@ -166,7 +166,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label='default')
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=[], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=[], streams=[xy])
         self.assertEqual(dmap[:], Scatter([(1, 2)], label='default'))
 
 
@@ -175,7 +175,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(kwargs['x'],kwargs['y'])], label='default')
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=[], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=[], streams=[xy])
         self.assertEqual(dmap[:], Scatter([(1, 2)], label='default'))
 
 
@@ -186,7 +186,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label=A)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_kdims_and_streams_invalid(self):
@@ -198,7 +198,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         xy = streams.PositionXY(x=1, y=2)
         regexp = "Callback signature over (.+?) does not accommodate required kdims"
         with self.assertRaisesRegexp(KeyError, regexp):
-            DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+            DynamicMap(fn, kdims=['A'], streams=[xy])
 
     def test_dynamic_split_mismatched_kdims(self):
         # Corresponds to the old style of kdims as posargs and streams
@@ -207,7 +207,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label=B)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_mismatched_kdims_invalid(self):
@@ -222,7 +222,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         regexp = ("Unmatched positional kdim arguments only allowed "
                   "at the start of the signature")
         with self.assertRaisesRegexp(KeyError, regexp):
-            DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+            DynamicMap(fn, kdims=['A'], streams=[xy])
 
     def test_dynamic_split_args_and_kwargs(self):
         # Corresponds to the old style of kdims as posargs and streams
@@ -231,7 +231,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(kwargs['x'],kwargs['y'])], label=args[0])
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
 
@@ -240,7 +240,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label=A)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
 
@@ -249,7 +249,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x,y)], label=A)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
 
@@ -258,7 +258,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
             return Scatter([(x, y)], label=A)
 
         xy = streams.PositionXY(x=1, y=2)
-        dmap = DynamicMap(fn, kdims=['A'], streams=[xy], sampled=True)
+        dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
 

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -165,7 +165,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(x=1, y=2):
             return Scatter([(x,y)], label='default')
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
         self.assertEqual(dmap[:], Scatter([(1, 2)], label='default'))
 
@@ -174,7 +174,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(**kwargs):
             return Scatter([(kwargs['x'],kwargs['y'])], label='default')
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
         self.assertEqual(dmap[:], Scatter([(1, 2)], label='default'))
 
@@ -185,40 +185,40 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(A, x=1, y=2):
             return Scatter([(x,y)], label=A)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_kdims_and_streams_invalid(self):
         # Corresponds to the old style of kdims as posargs and streams
-        # as kwargs. Positional arg names don't have to match
+        # as kwargs. Pointeral arg names don't have to match
         def fn(x=1, y=2, B='default'):
             return Scatter([(x,y)], label=B)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         regexp = "Callback signature over (.+?) does not accommodate required kdims"
         with self.assertRaisesRegexp(KeyError, regexp):
             DynamicMap(fn, kdims=['A'], streams=[xy])
 
     def test_dynamic_split_mismatched_kdims(self):
         # Corresponds to the old style of kdims as posargs and streams
-        # as kwargs. Positional arg names don't have to match
+        # as kwargs. Pointeral arg names don't have to match
         def fn(B, x=1, y=2):
             return Scatter([(x,y)], label=B)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
     def test_dynamic_split_mismatched_kdims_invalid(self):
         # Corresponds to the old style of kdims as posargs and streams
-        # as kwargs. Positional arg names don't have to match and the
+        # as kwargs. Pointeral arg names don't have to match and the
         # stream parameters can be passed by position but *only* if they
         # come first
         def fn(x, y, B):
             return Scatter([(x,y)], label=B)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         regexp = ("Unmatched positional kdim arguments only allowed "
                   "at the start of the signature")
         with self.assertRaisesRegexp(KeyError, regexp):
@@ -230,7 +230,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(*args, **kwargs):
             return Scatter([(kwargs['x'],kwargs['y'])], label=args[0])
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
@@ -239,7 +239,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(A='default', x=1, y=2):
             return Scatter([(x,y)], label=A)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
@@ -248,7 +248,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(A='default', x=1, y=2, **kws):
             return Scatter([(x,y)], label=A)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 
@@ -257,7 +257,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         def fn(x, A, y):
             return Scatter([(x, y)], label=A)
 
-        xy = streams.PositionXY(x=1, y=2)
+        xy = streams.PointerXY(x=1, y=2)
         dmap = DynamicMap(fn, kdims=['A'], streams=[xy])
         self.assertEqual(dmap['Test'], Scatter([(1, 2)], label='Test'))
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -203,11 +203,11 @@ class DynamicTestSampledBounded(ComparisonTestCase):
 
     def test_sampled_bounded_init(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
 
     def test_sampled_bounded_resample(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
 
 
@@ -215,14 +215,14 @@ class DynamicTestOperation(ComparisonTestCase):
 
     def test_dynamic_operation(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
 
     def test_dynamic_operation_with_kwargs(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         def fn(x, multiplier=2):
             return x.clone(x.data*multiplier)
         dmap_with_fn = Dynamic(dmap, operation=fn, kwargs=dict(multiplier=3))
@@ -234,30 +234,30 @@ class DynamicTestOverlay(ComparisonTestCase):
 
     def test_dynamic_element_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         dynamic_overlay = dmap * Image(sine_array(0,10))
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_element_underlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         dynamic_overlay = Image(sine_array(0,10)) * dmap
         overlaid = Image(sine_array(0,10)) * Image(sine_array(0,5))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_dynamicmap_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn, sampled=True)
+        dmap=DynamicMap(fn)
         fn2 = lambda i: Image(sine_array(0,i*2))
-        dmap2=DynamicMap(fn2, sampled=True)
+        dmap2=DynamicMap(fn2)
         dynamic_overlay = dmap * dmap2
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_holomap_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn, sampled=True)
+        dmap = DynamicMap(fn)
         hmap = HoloMap({i: Image(sine_array(0,i*2)) for i in range(10)})
         dynamic_overlay = dmap * hmap
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -16,6 +16,7 @@ def sine_array(phase, freq):
     return np.sin(phase + (freq*x**2+freq*y**2))
 
 
+
 class DynamicMethods(ComparisonTestCase):
 
     def test_deep_relabel_label(self):
@@ -143,16 +144,26 @@ class DynamicMethods(ComparisonTestCase):
             reindexed = dmap.reindex(['x'])
 
 
-class DynamicTestCallableBounded(ComparisonTestCase):
+class DynamicMapBounded(ComparisonTestCase):
 
     def test_callable_bounded_init(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
 
-    def test_generator_bounded_clone(self):
+    def test_callable_bounded_clone(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
         self.assertEqual(dmap, dmap.clone())
+
+    def test_sampled_bounded_init(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn)
+
+    def test_sampled_bounded_resample(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn)
+        self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
+
 
 
 class DynamicTransferStreams(ComparisonTestCase):
@@ -196,19 +207,7 @@ class DynamicTransferStreams(ComparisonTestCase):
                      "PositionX\(x=0\) clash on the following parameters: \['x'\]")
         with self.assertRaisesRegexp(Exception, exception):
             hist = Dynamic(self.dmap, streams=[PositionX])
-        
 
-
-class DynamicTestSampledBounded(ComparisonTestCase):
-
-    def test_sampled_bounded_init(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
-
-    def test_sampled_bounded_resample(self):
-        fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
-        self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
 
 
 class DynamicTestOperation(ComparisonTestCase):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -302,7 +302,7 @@ class DynamicTestOverlay(ComparisonTestCase):
         xy = PositionXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
 
-        regexp = '(.+?)does not correspond to any stream parameter'
+        regexp = '(.+?)do not correspond to stream parameters'
         with self.assertRaisesRegexp(KeyError, regexp):
             dmap.event(x=1, y=2)
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -183,26 +183,29 @@ class DynamicMapMethods(ComparisonTestCase):
             reindexed = dmap.reindex(['x'])
 
 
-class DynamicMapBounded(ComparisonTestCase):
+class DynamicMapUnboundedProperty(ComparisonTestCase):
 
     def test_callable_bounded_init(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
+        self.assertEqual(dmap.unbounded, [])
 
     def test_callable_bounded_clone(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=[Dimension('dim', range=(0,10))])
         self.assertEqual(dmap, dmap.clone())
+        self.assertEqual(dmap.unbounded, [])
 
-    def test_sampled_bounded_init(self):
+    def test_sampled_unbounded_init(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
+        self.assertEqual(dmap.unbounded, ['i'])
 
     def test_sampled_bounded_resample(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=['i'])
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
-
+        self.assertEqual(dmap.unbounded, ['i'])
 
 
 class DynamicTransferStreams(ComparisonTestCase):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -4,7 +4,7 @@ import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
 from holoviews.element import Image, Scatter, Curve, Text, Points
-from holoviews.streams import PointerXY, PointerX, PointerY
+from holoviews.streams import XY, PointerXY, PointerX, PointerY
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -201,12 +201,19 @@ class DynamicMapUnboundedProperty(ComparisonTestCase):
         dmap=DynamicMap(fn, kdims=['i'])
         self.assertEqual(dmap.unbounded, ['i'])
 
-    def test_sampled_bounded_resample(self):
+    def test_sampled_unbounded_resample(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=['i'])
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
         self.assertEqual(dmap.unbounded, ['i'])
 
+    def test_mixed_kdim_streams_unbounded(self):
+        dmap=DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
+        self.assertEqual(dmap.unbounded, ['z'])
+
+    def test_mixed_kdim_streams_bounded_redim(self):
+        dmap=DynamicMap(lambda x,y,z: x+y, kdims=['z'], streams=[XY()])
+        self.assertEqual(dmap.redim.range(z=(-0.5,0.5)).unbounded, [])
 
 class DynamicTransferStreams(ComparisonTestCase):
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -17,46 +17,46 @@ def sine_array(phase, freq):
 
 
 
-class DynamicMethods(ComparisonTestCase):
+class DynamicMapMethods(ComparisonTestCase):
 
     def test_deep_relabel_label(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).relabel(label='Test')
+        dmap = DynamicMap(fn, kdims=['i']).relabel(label='Test')
         self.assertEqual(dmap[0].label, 'Test')
 
     def test_deep_relabel_group(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).relabel(group='Test')
+        dmap = DynamicMap(fn, kdims=['i']).relabel(group='Test')
         self.assertEqual(dmap[0].group, 'Test')
 
     def test_redim_dimension_name(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim(Default='New')
+        dmap = DynamicMap(fn, kdims=['i']).redim(i='New')
         self.assertEqual(dmap.kdims[0].name, 'New')
 
     def test_redim_dimension_range_aux(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim.range(Default=(0,1))
+        dmap = DynamicMap(fn, kdims=['i']).redim.range(i=(0,1))
         self.assertEqual(dmap.kdims[0].range, (0,1))
 
     def test_redim_dimension_unit_aux(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim.unit(Default='m/s')
+        dmap = DynamicMap(fn, kdims=['i']).redim.unit(i='m/s')
         self.assertEqual(dmap.kdims[0].unit, 'm/s')
 
     def test_redim_dimension_type_aux(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim.type(Default=int)
+        dmap = DynamicMap(fn, kdims=['i']).redim.type(i=int)
         self.assertEqual(dmap.kdims[0].type, int)
 
     def test_deep_redim_dimension_name(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim(x='X')
+        dmap = DynamicMap(fn, kdims=['i']).redim(x='X')
         self.assertEqual(dmap[0].kdims[0].name, 'X')
 
     def test_deep_redim_dimension_name_with_spec(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn).redim(Image, x='X')
+        dmap = DynamicMap(fn, kdims=['i']).redim(Image, x='X')
         self.assertEqual(dmap[0].kdims[0].name, 'X')
 
     def test_deep_getitem_bounded_kdims(self):
@@ -161,7 +161,7 @@ class DynamicMapBounded(ComparisonTestCase):
 
     def test_sampled_bounded_resample(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         self.assertEqual(dmap[{0, 1, 2}].keys(), [0, 1, 2])
 
 
@@ -214,14 +214,14 @@ class DynamicTestOperation(ComparisonTestCase):
 
     def test_dynamic_operation(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
 
     def test_dynamic_operation_with_kwargs(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         def fn(x, multiplier=2):
             return x.clone(x.data*multiplier)
         dmap_with_fn = Dynamic(dmap, operation=fn, kwargs=dict(multiplier=3))
@@ -233,31 +233,31 @@ class DynamicTestOverlay(ComparisonTestCase):
 
     def test_dynamic_element_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         dynamic_overlay = dmap * Image(sine_array(0,10))
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_element_underlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         dynamic_overlay = Image(sine_array(0,10)) * dmap
         overlaid = Image(sine_array(0,10)) * Image(sine_array(0,5))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_dynamicmap_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap=DynamicMap(fn)
+        dmap=DynamicMap(fn, kdims=['i'])
         fn2 = lambda i: Image(sine_array(0,i*2))
-        dmap2=DynamicMap(fn2)
+        dmap2=DynamicMap(fn2, kdims=['i'])
         dynamic_overlay = dmap * dmap2
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
         self.assertEqual(dynamic_overlay[5], overlaid)
 
     def test_dynamic_holomap_overlay(self):
         fn = lambda i: Image(sine_array(0,i))
-        dmap = DynamicMap(fn)
-        hmap = HoloMap({i: Image(sine_array(0,i*2)) for i in range(10)})
+        dmap = DynamicMap(fn, kdims=['i'])
+        hmap = HoloMap({i: Image(sine_array(0,i*2)) for i in range(10)}, kdims=['i'])
         dynamic_overlay = dmap * hmap
         overlaid = Image(sine_array(0,5)) * Image(sine_array(0,10))
         self.assertEqual(dynamic_overlay[5], overlaid)

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -4,7 +4,7 @@ import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
 from holoviews.element import Image, Scatter, Curve, Text, Points
-from holoviews.streams import PositionXY, PositionX, PositionY
+from holoviews.streams import PointerXY, PointerX, PointerY
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -169,8 +169,8 @@ class DynamicMapBounded(ComparisonTestCase):
 class DynamicTransferStreams(ComparisonTestCase):
 
     def setUp(self):
-        self.dimstream = PositionX(x=0)
-        self.stream = PositionY(y=0)
+        self.dimstream = PointerX(x=0)
+        self.stream = PointerY(y=0)
         self.dmap = DynamicMap(lambda x, y, z: Curve([x, y, z]),
                                kdims=['x', 'z'], streams=[self.stream, self.dimstream])
 
@@ -203,10 +203,10 @@ class DynamicTransferStreams(ComparisonTestCase):
         self.assertEqual(hist.streams, self.dmap.streams[1:])
 
     def test_dynamic_util_inherits_dim_streams_clash(self):
-        exception = ("The supplied stream objects PositionX\(x=None\) and "
-                     "PositionX\(x=0\) clash on the following parameters: \['x'\]")
+        exception = ("The supplied stream objects PointerX\(x=None\) and "
+                     "PointerX\(x=0\) clash on the following parameters: \['x'\]")
         with self.assertRaisesRegexp(Exception, exception):
-            hist = Dynamic(self.dmap, streams=[PositionX])
+            hist = Dynamic(self.dmap, streams=[PointerX])
 
 
 
@@ -266,13 +266,13 @@ class DynamicTestOverlay(ComparisonTestCase):
         """Tests that Callable memoizes unchanged callbacks"""
         def fn(x, y):
             return Scatter([(x, y)])
-        dmap = DynamicMap(fn, kdims=[], streams=[PositionXY()])
+        dmap = DynamicMap(fn, kdims=[], streams=[PointerXY()])
 
         counter = [0]
         def fn2(x, y):
             counter[0] += 1
             return Image(np.random.rand(10, 10))
-        dmap2 = DynamicMap(fn2, kdims=[], streams=[PositionXY()])
+        dmap2 = DynamicMap(fn2, kdims=[], streams=[PointerXY()])
 
         overlaid = dmap * dmap2
         overlay = overlaid[()]
@@ -290,7 +290,7 @@ class DynamicTestOverlay(ComparisonTestCase):
         def fn(x1, y1):
             return Scatter([(x1, y1)])
 
-        xy = PositionXY(rename={'x':'x1','y':'y1'})
+        xy = PointerXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
         dmap.event(x1=1, y1=2)
 
@@ -298,7 +298,7 @@ class DynamicTestOverlay(ComparisonTestCase):
         def fn(x1, y1):
             return Scatter([(x1, y1)])
 
-        xy = PositionXY(rename={'x':'x1','y':'y1'})
+        xy = PointerXY(rename={'x':'x1','y':'y1'})
         dmap = DynamicMap(fn, kdims=[], streams=[xy])
 
         regexp = '(.+?)do not correspond to stream parameters'
@@ -314,7 +314,7 @@ class DynamicCallableMemoize(ComparisonTestCase):
             history.append(x)
             return Curve(list(history))
 
-        x = PositionX()
+        x = PointerX()
         dmap = DynamicMap(history_callback, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
@@ -338,7 +338,7 @@ class DynamicCallableMemoize(ComparisonTestCase):
             history.append(x)
             return Curve(list(history))
 
-        x = PositionX()
+        x = PointerX()
         callable_obj = Callable(history_callback, memoize=False)
         dmap = DynamicMap(callable_obj, kdims=[], streams=[x])
 
@@ -366,7 +366,7 @@ class DynamicStreamReset(ComparisonTestCase):
                 history.append(x)
             return Curve(list(history))
 
-        x = PositionX(transient=True)
+        x = PointerX(transient=True)
         dmap = DynamicMap(history_callback, kdims=[], streams=[x])
 
         # Add stream subscriber mocking plot
@@ -397,8 +397,8 @@ class DynamicStreamReset(ComparisonTestCase):
 
             return Curve(list(history))
 
-        x = PositionX(transient=True)
-        y = PositionY(transient=True)
+        x = PointerX(transient=True)
+        y = PointerY(transient=True)
         dmap = DynamicMap(history_callback, kdims=[], streams=[x, y])
 
         # Add stream subscriber mocking plot
@@ -427,7 +427,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_layout_raise_no_remapping_error(self):
         def callback(x, y):
             return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback)
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         with self.assertRaisesRegexp(ValueError, 'The following streams are set to be automatically linked'):
@@ -436,7 +436,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_layout_raise_ambiguous_remapping_error(self):
         def callback(x, y):
             return Image(np.array([[0, 1], [2, 3]])) + Image(np.array([[0, 1], [2, 3]]))
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={'Image': [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         with self.assertRaisesRegexp(ValueError, 'The stream_mapping supplied on the Callable is ambiguous'):
@@ -445,7 +445,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_layout_with_integer_stream_mapping(self):
         def callback(x, y):
             return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={0: [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
@@ -455,7 +455,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_layout_with_spec_stream_mapping(self):
         def callback(x, y):
             return Image(np.array([[0, 1], [2, 3]])) + Text(0, 0, 'Test')
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={'Image': [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
@@ -473,7 +473,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_ndlayout_with_integer_stream_mapping(self):
         def callback(x, y):
             return NdLayout({i: Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={0: [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
@@ -483,7 +483,7 @@ class DynamicCollate(ComparisonTestCase):
     def test_dynamic_collate_ndlayout_with_key_stream_mapping(self):
         def callback(x, y):
             return NdLayout({i: Image(np.array([[i, 1], [2, 3]])) for i in range(1, 3)})
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={(1,): [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         layout = dmap.collate()
@@ -504,7 +504,7 @@ class DynamicCollate(ComparisonTestCase):
         def callback():
             return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))
                               for i in range(1, 3) for j in range(1, 3)})
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={1: [stream]})
         dmap = DynamicMap(cb_callable, kdims=[])
         grid = dmap.collate()
@@ -516,7 +516,7 @@ class DynamicCollate(ComparisonTestCase):
         def callback():
             return GridSpace({(i, j): Image(np.array([[i, j], [2, 3]]))
                               for i in range(1, 3) for j in range(1, 3)})
-        stream = PositionXY()
+        stream = PointerXY()
         cb_callable = Callable(callback, stream_mapping={(1, 2): [stream]})
         dmap = DynamicMap(cb_callable, kdims=[])
         grid = dmap.collate()

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -19,11 +19,14 @@ def sine_array(phase, freq):
 
 class DynamicMapConstructor(ComparisonTestCase):
 
-    def test_simple_constructor(self):
-        DynamicMap(lambda x: x)
-
     def test_simple_constructor_kdims(self):
         DynamicMap(lambda x: x, kdims=['test'])
+
+    def test_simple_constructor_invalid_no_kdims(self):
+        regexp = ('Callable accepts more positional arguments than there are '
+                  'kdims and stream parameters')
+        with self.assertRaisesRegexp(KeyError, regexp):
+            DynamicMap(lambda x: x)
 
     def test_simple_constructor_invalid(self):
         regexp = ("Callback signature over \['x'\] does not accommodate "

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -17,6 +17,42 @@ def sine_array(phase, freq):
 
 
 
+class DynamicMapConstructor(ComparisonTestCase):
+
+    def test_simple_constructor(self):
+        DynamicMap(lambda x: x)
+
+    def test_simple_constructor_kdims(self):
+        DynamicMap(lambda x: x, kdims=['test'])
+
+    def test_simple_constructor_invalid(self):
+        regexp = ("Callback signature over \['x'\] does not accommodate "
+                  "required kdims \['x', 'y'\]")
+        with self.assertRaisesRegexp(KeyError, regexp):
+            DynamicMap(lambda x: x, kdims=['x','y'])
+
+    def test_simple_constructor_streams(self):
+        DynamicMap(lambda x: x, streams=[PointerX()])
+
+    def test_simple_constructor_streams_invalid_uninstantiated(self):
+        regexp = ("The supplied streams list contains objects "
+                  "that are not Stream instances:(.+?)")
+        with self.assertRaisesRegexp(TypeError, regexp):
+            DynamicMap(lambda x: x, streams=[PointerX])
+
+    def test_simple_constructor_streams_invalid_type(self):
+        regexp = ("The supplied streams list contains objects "
+                  "that are not Stream instances:(.+?)")
+        with self.assertRaisesRegexp(TypeError, regexp):
+            DynamicMap(lambda x: x, streams=[3])
+
+    def test_simple_constructor_streams_invalid_mismatch(self):
+        regexp = 'Callable missing keywords to accept y stream parameters'
+        with self.assertRaisesRegexp(KeyError, regexp):
+            DynamicMap(lambda x: x, streams=[PointerXY()])
+
+
+
 class DynamicMapMethods(ComparisonTestCase):
 
     def test_deep_relabel_label(self):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -20,7 +20,7 @@ from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                Scatter3D, Path, Polygons, Bars, Text,
                                BoxWhisker)
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.streams import PositionXY, PositionX
+from holoviews.streams import PointerXY, PointerX
 from holoviews.operation import gridmatrix
 from holoviews.plotting import comms
 from holoviews.plotting.util import rgb2hex
@@ -135,7 +135,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         mpl_renderer.get_widget(dmap1 + dmap2, 'selection')
 
     def test_dynamic_streams_refresh(self):
-        stream = PositionXY(x=0, y=0)
+        stream = PointerXY(x=0, y=0)
         dmap = DynamicMap(lambda x, y: Points([(x, y)]),
                              kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
@@ -154,7 +154,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX(x=0)
+        stream = PointerX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = mpl_renderer.get_plot(dmap)
         mpl_renderer(plot)
@@ -351,7 +351,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(extents, (0, 0, 9, 1))
 
     def test_batched_curve_subscribers_correctly_attached(self):
-        posx = PositionX()
+        posx = PointerX()
         opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),
                 'Curve': dict(style=dict(line_color=Cycle(values=['red', 'blue'])))}
         overlay = DynamicMap(lambda x: NdOverlay({i: Curve([(i, j) for j in range(2)])
@@ -719,7 +719,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
     def test_stream_callback(self):
         if bokeh_version < str('0.12.5'):
             raise SkipTest("Bokeh >= 0.12.5 required to test streams")
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
+        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
         plot.callbacks[0].on_msg({"x": 10, "y": -10})
@@ -731,7 +731,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         if bokeh_version < str('0.12.5'):
             raise SkipTest("Bokeh >= 0.12.5 required to test streams")
 
-        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PositionXY()])
+        dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
         model = plot.state
@@ -748,7 +748,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX(x=0)
+        stream = PointerX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
@@ -1432,7 +1432,7 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
             return Curve(list(history))
-        stream = PositionX(x=0)
+        stream = PointerX(x=0)
         dmap = DynamicMap(history_callback, kdims=[], streams=[stream])
         plot = plotly_renderer.get_plot(dmap)
         plotly_renderer(plot)

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -6,7 +6,7 @@ from holoviews.core.options import Store
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Curve, Area
 from holoviews.plotting.util import compute_overlayable_zorders
-from holoviews.streams import PositionX
+from holoviews.streams import PointerX
 
 try:
     from holoviews.plotting.bokeh import util
@@ -175,7 +175,7 @@ class TestPlotUtils(ComparisonTestCase):
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams(self):
         ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
-                               kdims=[], streams=[PositionX()])
+                               kdims=[], streams=[PointerX()])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim
@@ -196,7 +196,7 @@ class TestPlotUtils(ComparisonTestCase):
 
     def test_dynamic_compute_overlayable_zorders_mixed_dynamic_and_dynamic_ndoverlay_with_streams_cloned(self):
         ndoverlay = DynamicMap(lambda x: NdOverlay({i: Area(range(10+i)) for i in range(2)}),
-                               kdims=[], streams=[PositionX()])
+                               kdims=[], streams=[PointerX()])
         curve = DynamicMap(lambda: Curve(range(10)), kdims=[])
         curve_redim = curve.redim(x='x2')
         combined = ndoverlay*curve_redim

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -26,22 +26,22 @@ class TestSubscriber(object):
         self.kwargs = kwargs
 
 
-class TestPositionStreams(ComparisonTestCase):
+class TestPointerStreams(ComparisonTestCase):
 
     def test_positionX_init(self):
-        PositionX()
+        PointerX()
 
     def test_positionXY_init_contents(self):
-        position = PositionXY(x=1, y=3)
+        position = PointerXY(x=1, y=3)
         self.assertEqual(position.contents, dict(x=1, y=3))
 
     def test_positionXY_update_contents(self):
-        position = PositionXY()
+        position = PointerXY()
         position.update(x=5, y=10)
         self.assertEqual(position.contents, dict(x=5, y=10))
 
     def test_positionY_const_parameter(self):
-        position = PositionY()
+        position = PointerY()
         try:
             position.y = 5
             raise Exception('No constant parameter exception')
@@ -92,14 +92,14 @@ class TestSubscribers(ComparisonTestCase):
 
     def test_exception_subscriber(self):
         subscriber = TestSubscriber()
-        position = PositionXY(subscribers=[subscriber])
+        position = PointerXY(subscribers=[subscriber])
         kwargs = dict(x=3, y=4)
         position.update(**kwargs)
         self.assertEqual(subscriber.kwargs, kwargs)
 
     def test_subscriber_disabled(self):
         subscriber = TestSubscriber()
-        position = PositionXY(subscribers=[subscriber])
+        position = PointerXY(subscribers=[subscriber])
         kwargs = dict(x=3, y=4)
         position.update(trigger=False, **kwargs)
         self.assertEqual(subscriber.kwargs, None)
@@ -108,7 +108,7 @@ class TestSubscribers(ComparisonTestCase):
     def test_subscribers(self):
         subscriber1 = TestSubscriber()
         subscriber2 = TestSubscriber()
-        position = PositionXY(subscribers=[subscriber1, subscriber2])
+        position = PointerXY(subscribers=[subscriber1, subscriber2])
         kwargs = dict(x=3, y=4)
         position.update(**kwargs)
         self.assertEqual(subscriber1.kwargs, kwargs)
@@ -117,8 +117,8 @@ class TestSubscribers(ComparisonTestCase):
     def test_batch_subscriber(self):
         subscriber = TestSubscriber()
 
-        positionX = PositionX(subscribers=[subscriber])
-        positionY = PositionY(subscribers=[subscriber])
+        positionX = PointerX(subscribers=[subscriber])
+        positionY = PointerY(subscribers=[subscriber])
 
         positionX.update(trigger=False, x=5)
         positionY.update(trigger=False, y=10)
@@ -131,8 +131,8 @@ class TestSubscribers(ComparisonTestCase):
         subscriber1 = TestSubscriber()
         subscriber2 = TestSubscriber()
 
-        positionX = PositionX(subscribers=[subscriber1, subscriber2])
-        positionY = PositionY(subscribers=[subscriber1, subscriber2])
+        positionX = PointerX(subscribers=[subscriber1, subscriber2])
+        positionY = PointerY(subscribers=[subscriber1, subscriber2])
 
         positionX.update(trigger=False, x=50)
         positionY.update(trigger=False, y=100)
@@ -149,46 +149,46 @@ class TestSubscribers(ComparisonTestCase):
 class TestParameterRenaming(ComparisonTestCase):
 
     def test_simple_rename_constructor(self):
-        xy = PositionXY(rename={'x':'xtest', 'y':'ytest'}, x=0, y=4)
+        xy = PointerXY(rename={'x':'xtest', 'y':'ytest'}, x=0, y=4)
         self.assertEqual(xy.contents, {'xtest':0, 'ytest':4})
 
     def test_invalid_rename_constructor(self):
         regexp = '(.+?)is not a stream parameter'
         with self.assertRaisesRegexp(KeyError, regexp):
-            PositionXY(rename={'x':'xtest', 'z':'ytest'}, x=0, y=4)
+            PointerXY(rename={'x':'xtest', 'z':'ytest'}, x=0, y=4)
             self.assertEqual(str(cm).endswith(), True)
 
     def test_clashing_rename_constructor(self):
         regexp = '(.+?)parameter of the same name'
         with self.assertRaisesRegexp(KeyError, regexp):
-            PositionXY(rename={'x':'xtest', 'y':'x'}, x=0, y=4)
+            PointerXY(rename={'x':'xtest', 'y':'x'}, x=0, y=4)
 
     def test_simple_rename_method(self):
-        xy = PositionXY(x=0, y=4)
+        xy = PointerXY(x=0, y=4)
         renamed = xy.rename(x='xtest', y='ytest')
         self.assertEqual(renamed.contents, {'xtest':0, 'ytest':4})
 
     def test_invalid_rename_method(self):
-        xy = PositionXY(x=0, y=4)
+        xy = PointerXY(x=0, y=4)
         regexp = '(.+?)is not a stream parameter'
         with self.assertRaisesRegexp(KeyError, regexp):
             renamed = xy.rename(x='xtest', z='ytest')
 
 
     def test_clashing_rename_method(self):
-        xy = PositionXY(x=0, y=4)
+        xy = PointerXY(x=0, y=4)
         regexp = '(.+?)parameter of the same name'
         with self.assertRaisesRegexp(KeyError, regexp):
             renamed = xy.rename(x='xtest', y='x')
 
     def test_update_rename_valid(self):
-        xy = PositionXY(x=0, y=4)
+        xy = PointerXY(x=0, y=4)
         renamed = xy.rename(x='xtest', y='ytest')
         renamed.update(x=4, y=8)
         self.assertEqual(renamed.contents, {'xtest':4, 'ytest':8})
 
     def test_update_rename_invalid(self):
-        xy = PositionXY(x=0, y=4)
+        xy = PointerXY(x=0, y=4)
         renamed = xy.rename(y='ytest')
         regexp = "ytest' is not a parameter of(.+?)"
         with self.assertRaisesRegexp(ValueError, regexp):

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -19,7 +19,7 @@ from holoviews.core.util import (
     deephash, merge_dimensions, get_path, make_path_unique
 )
 from holoviews import Dimension, Element
-from holoviews.streams import PositionXY
+from holoviews.streams import PointerXY
 from holoviews.element.comparison import ComparisonTestCase
 
 py_version = sys.version_info.major
@@ -442,13 +442,13 @@ class TestWrapTupleStreams(unittest.TestCase):
     def test_no_streams_one_stream_substitution(self):
         result = wrap_tuple_streams((None,3),
                                     [Dimension('x'), Dimension('y')],
-                                    [PositionXY(x=-5,y=10)])
+                                    [PointerXY(x=-5,y=10)])
         self.assertEqual(result, (-5,3))
 
     def test_no_streams_two_stream_substitution(self):
         result = wrap_tuple_streams((None,None),
                                     [Dimension('x'), Dimension('y')],
-                                    [PositionXY(x=0,y=5)])
+                                    [PointerXY(x=0,y=5)])
         self.assertEqual(result, (0,5))
 
 


### PR DESCRIPTION
After PRs #1238, #1260 and #1302, DynamicMaps are much more user friendly. After #1302 we realized we could also deprecate sampled mode, finishing off the job of #1238.

In particular you can now create a DynamicMap using this syntax:

```python
hv.DynamicMap(lambda x: hv.Curve([x*1,x*2,x*3]), kdims=['x']).redim.range(x=(0,1))
```

But if you forget to set the ranges, an exception is currently raised. Instead, what should happen is that the repr of the ``DynamicMap`` should be shown with a warning, suggesting the use of ``redim.range``. 

This would make a basic, valid DynamicMap declaration completely analogous to that needed to declare a HoloMap: instead of ``HoloMap(data, kdims=['x'])`` you'll be able to do ``DynamicMap(callable, kdims=['x'])``. This object won't display itself (unless you follow the ``redim.range`` advice in the warning but you can visualize it by indexing (i.e sampling) it.

In addition to being more user friendly, this should make sample mode unnecessary and actually simplify the implementation. I would also like to add all extra validation to DynamicMap declarations that I can think of to make our exceptions more user friendly.

## Tasks

- [x] Fix bug in ``_initial_key``
- [x] Improve exception message when an ``_initial_key`` cannot be generated  (dimension ranges lacking)
- [x] Raise a SkipRendering exception to show the DynamicMap repr and a suitable warning.
- [x] Remove sample mode
- [x] Add extra validation, perhaps in ``redim``.
- [x] Add unit tests
