### PR TITLE
Avoid side-effects in datashader operation

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -128,8 +128,8 @@ class aggregate(ElementOperation):
         xarray Dataset that can be aggregated.
         """
         paths = []
-        kdims = obj.kdims
-        vdims = obj.vdims
+        kdims = list(obj.kdims)
+        vdims = list(obj.vdims)
         dims = obj.dimensions(label=True)[:2]
         if isinstance(obj, Path):
             glyph = 'line'


### PR DESCRIPTION
The kdims and vdims declared here are modified later messing up modifying the kdims and vdims on the original object.