### PR TITLE
Added pivot option to bokeh VectorField plot

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -153,7 +153,7 @@ class VectorFieldPlot(ColorbarPlot):
        Whether the lengths will be rescaled to take into account the
        smallest non-zero distance between two vectors.""")
 
-    style_opts = line_properties
+    style_opts = line_properties + ['scale']
     _plot_methods = dict(single='segment')
 
     def _get_lengths(self, element, ranges):
@@ -168,17 +168,26 @@ class VectorFieldPlot(ColorbarPlot):
             if self.rescale_lengths:
                 magnitudes *= base_dist
         else:
-            magnitudes = np.ones(len(element))*base_dist
+            magnitudes = np.ones(len(element))
+            if self.rescale_lengths:
+                magnitudes *= base_dist
+
         return magnitudes
+
+    def _glyph_properties(self, *args):
+        properties = super(VectorFieldPlot, self)._glyph_properties(*args)
+        properties.pop('scale', None)
+        return properties
 
 
     def get_data(self, element, ranges=None, empty=False):
         style = self.style[self.cyclic_index]
+        input_scale = style.pop('scale', 1.0)
 
         # Get x, y, angle, magnitude and color data
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         rads = element.dimension_values(2)
-        lens = self._get_lengths(element, ranges)
+        lens = self._get_lengths(element, ranges)/input_scale
         cdim = element.get_dimension(self.color_index)
         cdata, cmapping = self._get_color_data(element, ranges, style,
                                                name='line_color')

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -144,6 +144,11 @@ class VectorFieldPlot(ColorbarPlot):
        it will be assumed that the lengths have already been correctly
        normalized.""")
 
+    pivot = param.ObjectSelector(default='mid', objects=['mid', 'tip', 'tail'],
+                                 doc="""
+       The point around which the arrows should pivot valid options
+       include 'mid', 'tip' and 'tail'.""")
+
     rescale_lengths = param.Boolean(default=True, doc="""
        Whether the lengths will be rescaled to take into account the
        smallest non-zero distance between two vectors.""")
@@ -181,10 +186,21 @@ class VectorFieldPlot(ColorbarPlot):
         # Compute segments and arrowheads
         xs = element.dimension_values(xidx)
         ys = element.dimension_values(yidx)
+
+        # Compute offset depending on pivot option
         xoffsets = np.cos(rads)*lens/2.
         yoffsets = np.sin(rads)*lens/2.
-        x0s, x1s = (xs + xoffsets, xs - xoffsets)
-        y0s, y1s = (ys + yoffsets, ys - yoffsets)
+        if self.pivot == 'mid':
+            nxoff, pxoff = xoffsets, xoffsets
+            nyoff, pyoff = yoffsets, yoffsets
+        elif self.pivot == 'tip':
+            nxoff, pxoff = 0, xoffsets*2
+            nyoff, pyoff = 0, yoffsets*2
+        elif self.pivot == 'tail':
+            nxoff, pxoff = xoffsets*2, 0
+            nyoff, pyoff = yoffsets*2, 0
+        x0s, x1s = (xs + nxoff, xs - pxoff)
+        y0s, y1s = (ys + nyoff, ys - pyoff)
 
         if self.arrow_heads:
             arrow_len = (lens/4.)


### PR DESCRIPTION
I was just going through my example and came across [this demo](http://matplotlib.org/examples/pylab_examples/quiver_demo.html) for quivers I had already adapted for the matplotlib backend. The third plot shows how to change the pivot point of the quivers, and since this is a trivial option to support I thought it would be a shame if bokeh didn't. Here is an example:

<img width="508" alt="screen shot 2017-04-18 at 12 21 26 pm" src="https://cloud.githubusercontent.com/assets/1550771/25128412/942c2428-2431-11e7-945f-0ff61a246751.png">

Compared to the matplotlib version:

![image](https://cloud.githubusercontent.com/assets/1550771/25128461/c2c146a6-2431-11e7-958b-a199de57ca31.png)

