### PR TITLE
Small fix for Polygons/Contours colormapping

### DIFF
--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -53,7 +53,7 @@ class PathPlot(ElementPlot):
             style = styles[zorder]
             sdata, smapping = expand_batched_style(style, self._batched_style_opts,
                                                    elmapping, nvals)
-            elmapping.update(smapping)
+            elmapping.update({k: v for k, v in smapping.items() if k not in elmapping})
             for k, v in sdata.items():
                 data[k].extend(list(v))
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -583,6 +583,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(cmapper.low, 0)
         self.assertEqual(cmapper.high, 4)
         source = plot.handles['source']
+        self.assertEqual(plot.handles['glyph'].fill_color['transform'], cmapper)
         self.assertEqual(source.data['Value'], list(range(5)))
 
     def test_polygons_colored_batched_unsanitized(self):


### PR DESCRIPTION
Small bug when colormapping a Polygons/Contours object. The unit test already checked the colormapper was created but didn't check it was actually used.