### PR TITLE
Ensure batched plots respect parameters set on (Nd)Overlay

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -850,6 +850,9 @@ class GenericOverlayPlot(GenericElementPlot):
             (not self.show_legend or len(ordering) > self.legend_limit)):
             self.batched = True
             keys, vmaps = [()], [self.hmap]
+            param_vals = dict(self.get_param_values())
+            propagate = {opt: param_vals[opt] for opt in self._propagate_options
+                         if opt in param_vals}
         else:
             self.batched = False
             keys, vmaps = self.hmap.split_overlays()
@@ -899,6 +902,7 @@ class GenericOverlayPlot(GenericElementPlot):
             elif self.batched and 'batched' in plottype._plot_methods:
                 opts['batched'] = self.batched
                 opts['overlaid'] = self.overlaid
+                opts.update(propagate)
             if len(ordering) > self.legend_limit:
                 opts['show_legend'] = False
             style = self.lookup_options(vmap.last, 'style').max_cycles(group_length)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -21,6 +21,7 @@ from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                BoxWhisker)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import PositionXY, PositionX
+from holoviews.operation import gridmatrix
 from holoviews.plotting import comms
 from holoviews.plotting.util import rgb2hex
 
@@ -1081,6 +1082,25 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                          {'value': '18pt'})
         self.assertEqual(plot.handles['yaxis'].major_label_text_font_size,
                          {'value': '14pt'})
+
+    def test_gridmatrix_overlaid_batched(self):
+        ds = Dataset((['A']*5+['B']*5, np.random.rand(10), np.random.rand(10)),
+                     kdims=['a', 'b', 'c'])
+        gmatrix = gridmatrix(ds.groupby('a', container_type=NdOverlay))
+        plot = bokeh_renderer.get_plot(gmatrix)
+
+        sp1 = plot.subplots[('b', 'c')]
+        self.assertEqual(sp1.state.xaxis[0].visible, False)
+        self.assertEqual(sp1.state.yaxis[0].visible, True)
+        sp2 = plot.subplots[('b', 'b')]
+        self.assertEqual(sp2.state.xaxis[0].visible, True)
+        self.assertEqual(sp2.state.yaxis[0].visible, True)
+        sp3 = plot.subplots[('c', 'b')]
+        self.assertEqual(sp3.state.xaxis[0].visible, True)
+        self.assertEqual(sp3.state.yaxis[0].visible, False)
+        sp4 = plot.subplots[('c', 'c')]
+        self.assertEqual(sp4.state.xaxis[0].visible, False)
+        self.assertEqual(sp4.state.yaxis[0].visible, False)
 
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)


### PR DESCRIPTION
In batched mode the OverlayPlot exists only as an intermediate layer and is not responsible for creating the axes or the actual plot object. This means this is all delegated to the batched ElementPlot, but this also means that any options set on the OverlayPlot are ignored, which is inconsistent and confusing. Since the options this applies to already propagate upwards from ElementPlots to the OverlayPlot we can use the same mechanism to pass those options back down to the batched ElementPlot, ensuring that they are respected.

This is particularly import for things like grids where options should propagate downwards from the gridplot to all the subplots, e.g. here's an example from a GridMatrix plot with batched subplots

**Before:**

![screen shot 2017-04-18 at 5 03 48 pm](https://cloud.githubusercontent.com/assets/1550771/25140700/1a36c7a4-2459-11e7-8696-c61da16936b1.png)

**After**:

![screen shot 2017-04-18 at 5 02 59 pm](https://cloud.githubusercontent.com/assets/1550771/25140713/21126132-2459-11e7-943e-bdafc230fbf4.png)
