### PR TITLE
Ensure streams are transferred when applying Dynamic

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -125,9 +125,10 @@ class redim(object):
             return redimmed
 
         from ..util import Dynamic
-        def dynamic_redim(obj):
+        def dynamic_redim(obj, **dynkwargs):
             return obj.redim(specs, **dimensions)
-        return Dynamic(redimmed, shared_data=True, operation=dynamic_redim)
+        return Dynamic(redimmed, shared_data=True, streams=parent.streams,
+                       operation=dynamic_redim)
 
 
     def _redim(self, name, specs, **dims):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -119,7 +119,7 @@ class HoloMap(UniformNdMapping, Overlayable):
         if isinstance(self, DynamicMap) and isinstance(other, DynamicMap):
             self_streams = util.dimensioned_streams(self)
             other_streams = util.dimensioned_streams(other)
-            streams = self_streams+other_streams
+            streams = list(util.unique_iterator(self_streams+other_streams))
         else:
             streams = map_obj.streams
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -117,8 +117,8 @@ class HoloMap(UniformNdMapping, Overlayable):
         # Combine streams
         map_obj = self if isinstance(self, DynamicMap) else other
         if isinstance(self, DynamicMap) and isinstance(other, DynamicMap):
-            self_streams = util.dimensioned_streams(self.streams)
-            other_streams = util.dimensioned_streams(other.streams)
+            self_streams = util.dimensioned_streams(self)
+            other_streams = util.dimensioned_streams(other)
             streams = self_streams+other_streams
         else:
             streams = map_obj.streams

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1082,9 +1082,9 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
         clash_streams = [s for s in streams for c in clashes if c in s.contents]
         if clashes:
             clashing = ', '.join([repr(c) for c in clash_streams[:-1]])
-            raise KeyError('The supplied stream objects %s and %s '
-                           'clash on the following parameters: %r'
-                           % (clashing, str(clash_streams[-1]), clashes))
+            raise Exception('The supplied stream objects %s and %s '
+                            'clash on the following parameters: %r'
+                            % (clashing, clash_streams[-1], clashes))
     return [name for name in names if name not in exclude]
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1305,6 +1305,19 @@ def get_dynamic_item(map_obj, dimensions, key):
     return key, el
 
 
+def dimensioned_streams(dmap):
+    """
+    Given a DynamicMap return all streams that have any dimensioned
+    parameters i.e parameters also listed in the key dimensions.
+    """
+    dimensioned = []
+    for stream in dmap.streams:
+        stream_params = stream_parameters([stream])
+        if set([str(k) for k in dmap.kdims]) & set(stream_params):
+            dimensioned.append(stream)
+    return dimensioned
+
+
 def expand_grid_coords(dataset, dim):
     """
     Expand the coordinates along a dimension of the gridded

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1078,9 +1078,13 @@ def stream_parameters(streams, no_duplicates=True, exclude=['name']):
     names = [name for group in param_groups for name in group]
 
     if no_duplicates:
-        clashes = set([n for n in names if names.count(n) > 1])
+        clashes = sorted(set([n for n in names if names.count(n) > 1]))
+        clash_streams = [s for s in streams for c in clashes if c in s.contents]
         if clashes:
-            raise KeyError('Parameter name clashes for keys: %r' % clashes)
+            clashing = ', '.join([repr(c) for c in clash_streams[:-1]])
+            raise KeyError('The supplied stream objects %s and %s '
+                           'clash on the following parameters: %r'
+                           % (clashing, str(clash_streams[-1]), clashes))
     return [name for name in names if name not in exclude]
 
 

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -64,7 +64,7 @@ class Dynamic(param.ParameterizedFunction):
         of supplied stream classes and instances are processed and
         added to the list.
         """
-        streams = util.dimensioned_streams(map_obj) if isinstance(map_obj, DynamicMap) else []
+        streams = []
         for stream in self.p.streams:
             if inspect.isclass(stream) and issubclass(stream, Stream):
                 stream = stream()
@@ -75,8 +75,10 @@ class Dynamic(param.ParameterizedFunction):
                            if v is None and k in self.p.operation.p}
                 if updates:
                     stream.update(trigger=False, **updates)
-            if stream not in streams:
-                streams.append(stream)
+            streams.append(stream)
+        if isinstance(map_obj, DynamicMap):
+            dim_streams = util.dimensioned_streams(map_obj)
+            streams = list(util.unique_iterator(streams + dim_streams))
         return streams
 
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -155,6 +155,49 @@ class DynamicTestCallableBounded(ComparisonTestCase):
         self.assertEqual(dmap, dmap.clone())
 
 
+class DynamicTransferStreams(ComparisonTestCase):
+
+    def setUp(self):
+        self.dimstream = PositionX(x=0)
+        self.stream = PositionY(y=0)
+        self.dmap = DynamicMap(lambda x, y, z: Curve([x, y, z]),
+                               kdims=['x', 'z'], streams=[self.stream, self.dimstream])
+
+    def test_dynamic_redim_inherits_streams(self):
+        redimmed = self.dmap.redim.range(z=(0, 5))
+        self.assertEqual(redimmed.streams, self.dmap.streams)
+
+    def test_dynamic_relabel_inherits_streams(self):
+        relabelled = self.dmap.relabel(label='Test')
+        self.assertEqual(relabelled.streams, self.dmap.streams)
+
+    def test_dynamic_map_inherits_streams(self):
+        mapped = self.dmap.map(lambda x: x, Curve)
+        self.assertEqual(mapped.streams, self.dmap.streams)
+
+    def test_dynamic_select_inherits_streams(self):
+        selected = self.dmap.select(Curve, x=(0, 5))
+        self.assertEqual(selected.streams, self.dmap.streams)
+
+    def test_dynamic_hist_inherits_streams(self):
+        hist = self.dmap.hist(adjoin=False)
+        self.assertEqual(hist.streams, self.dmap.streams)
+
+    def test_dynamic_mul_inherits_dim_streams(self):
+        hist = self.dmap * self.dmap
+        self.assertEqual(hist.streams, self.dmap.streams[1:])
+
+    def test_dynamic_util_inherits_dim_streams(self):
+        hist = Dynamic(self.dmap)
+        self.assertEqual(hist.streams, self.dmap.streams[1:])
+
+    def test_dynamic_util_inherits_dim_streams_clash(self):
+        exception = ("The supplied stream objects PositionX\(x=None\) and "
+                     "PositionX\(x=0\) clash on the following parameters: \['x'\]")
+        with self.assertRaisesRegexp(Exception, exception):
+            hist = Dynamic(self.dmap, streams=[PositionX])
+        
+
 
 class DynamicTestSampledBounded(ComparisonTestCase):
 


### PR DESCRIPTION
Currently the Dynamic utility does not inherit the streams of the DynamicMap it is wrapping. Since it is used for internal operations like redim, map, select, etc. this is confusing because streams you specified just disappear. This PR ensures that internal operations always inherit **ALL** the streams, while Dynamic also ensures that dimensioned streams (i.e. streams that have contents which correspond to a Dynamic key dimension) are always inherited. This will also have the added bonus that validation will ensure that you you don't accidentally override a dimensioned stream.

* [x] Ensure internal operations/methods transfer all streams
* [x] Ensure that Dynamic always transfers dimensioned streams
* [x] Improve exception message when overriding dimensioned stream.