### PR TITLE
Restore generator and argument-free callable support

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1213,6 +1213,13 @@ class DynamicMap(HoloMap):
         raise NotImplementedError('Cannot add dimensions to a DynamicMap, '
                                   'cast to a HoloMap first.')
 
+    def next(self):
+        if self.callback.noargs:
+            return self[()]
+        else:
+            raise Exception('The next method can only be used for DynamicMaps using'
+                            'generators (or callables without arguments)')
+
     # For Python 2 and 3 compatibility
     __next__ = next
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -779,8 +779,9 @@ class DynamicMap(HoloMap):
         # Ensure the clone references this object to ensure
         # stream sources are inherited
         if clone.callback is self.callback:
-            clone.callback = clone.callback.clone(inputs=[self],
-                                                  link_inputs=True)
+            with util.disable_constant(clone):
+                clone.callback = clone.callback.clone(inputs=[self],
+                                                      link_inputs=True)
         return clone
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -582,7 +582,7 @@ class DynamicMap(HoloMap):
         The key dimensions of a DynamicMap map to the arguments of the
         callback. This mapping can be by position or by name.""")
 
-    callback = param.ClassSelector(class_=Callable, doc="""
+    callback = param.ClassSelector(class_=Callable, constant=True, doc="""
         The callable used to generate the elements. The arguments to the
         callable includes any number of declared key dimensions as well
         as any number of stream parameters defined on the input streams.
@@ -590,7 +590,7 @@ class DynamicMap(HoloMap):
         If the callable is an instance of Callable it will be used
         directly, otherwise it will be automatically wrapped in one.""")
 
-    streams = param.List(default=[], doc="""
+    streams = param.List(default=[], constant=True, doc="""
        List of Stream instances to associate with the DynamicMap. The
        set of parameter values across these streams will be supplied as
        keyword arguments to the callback when the events are received,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -620,15 +620,14 @@ class DynamicMap(HoloMap):
                    'are not Stream instances: {objs}')
             raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
 
-        if isinstance(self.callback, Generator):
+
+        noargs = ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        if self.callback.argspec == noargs:
+            prefix = 'DynamicMaps using generators (or callables without arguments)'
             if self.kdims:
-                raise Exception('DynamicMaps using generators can only be declared '
-                                'without key dimensions')
+                raise Exception(prefix + ' must be declared without key dimensions')
             if not (len(self.streams) == 1 and isinstance(self.streams[0], Next)):
-                raise Exception('DynamicMaps using Generators must be declared '
-                                'with a single Next() stream')
-            if util.stream_parameters(self.streams):
-                raise Exception('Generators can only be used with empty streams')
+                raise Exception(prefix +' must be declared using streams=[Next()]')
 
         self._posarg_keys = util.validate_dynamic_argspec(self.callback.argspec,
                                                           self.kdims,

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -523,8 +523,9 @@ class Generator(Callable):
     arguments and never memoize.
     """
 
-    callable = param.Parameter(default=None, constant=True, doc="""
-         The generator function being wrapped.""")
+    callable = param.ClassSelector(default=None, class_ = types.GeneratorType,
+                                   constant=True, doc="""
+         The generator that is wrapped by this Generator.""")
 
     @property
     def argspec(self):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -15,7 +15,7 @@ from .layout import Layout, AdjointLayout, NdLayout
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream
+from ..streams import Stream, Next
 
 class HoloMap(UniformNdMapping, Overlayable):
     """
@@ -622,9 +622,11 @@ class DynamicMap(HoloMap):
 
         if isinstance(self.callback, Generator):
             if self.kdims:
-                raise Exception('Generators can only be used without key dimensions')
-            if self.streams == []:
-                self.warning('Empty streams required to trigger generator')
+                raise Exception('DynamicMaps using generators can only be declared '
+                                'without key dimensions')
+            if not (len(self.streams) == 1 and isinstance(self.streams[0], Next)):
+                raise Exception('DynamicMaps using Generators must be declared '
+                                'with a single Next() stream')
             if util.stream_parameters(self.streams):
                 raise Exception('Generators can only be used with empty streams')
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -465,6 +465,12 @@ class Callable(param.Parameterized):
     def argspec(self):
         return util.argspec(self.callable)
 
+    @property
+    def noargs(self):
+        "Returns True if the callable takes no arguments"
+        noargs = ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        return self.argspec == noargs
+
 
     def clone(self, callable=None, **overrides):
         """
@@ -621,8 +627,7 @@ class DynamicMap(HoloMap):
             raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
 
 
-        noargs = ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
-        if self.callback.argspec == noargs:
+        if self.callback.noargs:
             prefix = 'DynamicMaps using generators (or callables without arguments)'
             if self.kdims:
                 raise Exception(prefix + ' must be declared without key dimensions')

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -29,8 +29,6 @@ def _rc_context(rcparams):
     plt.rcParams.update(rcparams)
     try:
         yield
-    except:
-        pass
     finally:
         plt.rcParams = old_rcparams
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -269,6 +269,14 @@ class Stream(param.Parameterized):
         return repr(self)
 
 
+class Next(Stream):
+    """
+    Example of an empty stream that can be used to trigger generators or
+    callbacks that take no arguments.
+    """
+    pass
+
+
 class Counter(Stream):
     """
     Simple stream that automatically increments an integer counter

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -271,8 +271,8 @@ class Stream(param.Parameterized):
 
 class Next(Stream):
     """
-    Example of an empty stream that can be used to trigger generators or
-    callbacks that take no arguments.
+    Next is a special stream used to trigger generators. It may also be
+    used to trigger DynamicMaps using callables with no arguments.
     """
     pass
 


### PR DESCRIPTION
This PR is clearly docs related: instead of apologizing for dropping support for generators, I thought we might as well support them again. ;-p

Essentially, I realized that you could have stream objects without stream parameters, allowing support for callbacks accepting no arguments:

![image](https://cloud.githubusercontent.com/assets/890576/25178756/1b3a4788-24ff-11e7-96cb-90e538542d23.png)

And generators:

![image](https://cloud.githubusercontent.com/assets/890576/25178728/f08609be-24fe-11e7-8674-673b552cd97c.png)

Very little code needed to be changed so I think this is a decent prototype of how generators can be supported with our new simplified DynamicMaps.