### PR TITLE
Consistent event method on DynamicMap and Stream

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -684,8 +684,7 @@ class DynamicMap(HoloMap):
             applicable_kws = {k:v for k,v in kwargs.items()
                               if k in set(stream.contents.keys())}
             rkwargs = util.rename_stream_kwargs(stream, applicable_kws, reverse=True)
-            stream.update(**dict(rkwargs, trigger=False))
-
+            stream.update(**rkwargs)
 
         Stream.trigger(self.streams)
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -668,7 +668,7 @@ class DynamicMap(HoloMap):
                     raise StopIteration("Key value %s above upper bound %s"
                                         % (val, high))
 
-    def event(self, trigger=True, **kwargs):
+    def event(self, **kwargs):
         """
         This method allows any of the available stream parameters
         (renamed as appropriate) to be updated in an event.
@@ -686,8 +686,8 @@ class DynamicMap(HoloMap):
             rkwargs = util.rename_stream_kwargs(stream, applicable_kws, reverse=True)
             stream.update(**dict(rkwargs, trigger=False))
 
-        if trigger:
-            Stream.trigger(self.streams)
+
+        Stream.trigger(self.streams)
 
 
     def _style(self, retval):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -85,7 +85,7 @@ class MessageCallback(object):
             processed_msg = self._process_msg(filtered_msg)
             if not processed_msg:
                 continue
-            stream.update(trigger=False, **processed_msg)
+            stream.update(**processed_msg)
             stream._metadata = {h: {'id': hid, 'events': self.on_events}
                                 for h, hid in handle_ids.items()}
         Stream.trigger(self.streams)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -165,8 +165,8 @@ class Stream(param.Parameterized):
     def add_subscriber(self, subscriber):
         """
         Register a callable subscriber to this stream which will be
-        invoked either when update is called with trigger=True or when
-        this stream is passed to the trigger classmethod.
+        invoked either when event is called or when this stream is
+        passed to the trigger classmethod.
         """
         if not callable(subscriber):
             raise TypeError('Subscriber must be a callable.')
@@ -238,25 +238,22 @@ class Stream(param.Parameterized):
         """
         Update the stream parameters and trigger an event.
         """
-        self.update(trigger=True, **kwargs)
+        self.update(**kwargs)
+        self.trigger([self])
 
-    def update(self, trigger=False, **kwargs):
+    def update(self, **kwargs):
         """
         The update method updates the stream parameters (without any
         renaming applied) in response to some event. If the stream has a
         custom transform method, this is applied to transform the
         parameter values accordingly.
 
-        If trigger is enabled, the trigger classmethod is invoked on
-        this particular Stream instance.
+        To update and trigger, use the event method.
         """
         self._set_stream_parameters(**kwargs)
         transformed = self.transform()
         if transformed:
             self._set_stream_parameters(**transformed)
-        if trigger:
-            self.trigger([self])
-
 
     def __repr__(self):
         cls_name = self.__class__.__name__
@@ -493,7 +490,7 @@ class ParamValues(Stream):
         return remapped
 
 
-    def update(self, trigger=False, **kwargs):
+    def update(self, **kwargs):
         """
         The update method updates the parameters of the specified object.
 
@@ -506,10 +503,6 @@ class ParamValues(Stream):
                     setattr(self._obj, name, kwargs[name])
         else:
             self._obj.set_param(**kwargs)
-
-        if trigger:
-            self.trigger([self])
-
 
     def __repr__(self):
         cls_name = self.__class__.__name__

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -240,7 +240,7 @@ class Stream(param.Parameterized):
         """
         self.update(trigger=True, **kwargs)
 
-    def update(self, trigger=True, **kwargs):
+    def update(self, trigger=False, **kwargs):
         """
         The update method updates the stream parameters (without any
         renaming applied) in response to some event. If the stream has a
@@ -493,7 +493,7 @@ class ParamValues(Stream):
         return remapped
 
 
-    def update(self, trigger=True, **kwargs):
+    def update(self, trigger=False, **kwargs):
         """
         The update method updates the parameters of the specified object.
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -234,6 +234,11 @@ class Stream(param.Parameterized):
         with util.disable_constant(self) as constant:
             self.set_param(**kwargs)
 
+    def event(self, **kwargs):
+        """
+        Update the stream parameters and trigger an event.
+        """
+        self.update(trigger=True, **kwargs)
 
     def update(self, trigger=True, **kwargs):
         """

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -74,7 +74,7 @@ class Dynamic(param.ParameterizedFunction):
                 updates = {k: self.p.operation.p.get(k) for k, v in stream.contents.items()
                            if v is None and k in self.p.operation.p}
                 if updates:
-                    stream.update(trigger=False, **updates)
+                    stream.update(**updates)
             streams.append(stream)
         if isinstance(map_obj, DynamicMap):
             dim_streams = util.dimensioned_streams(map_obj)

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -370,12 +370,12 @@ class DynamicCallableMemoize(ComparisonTestCase):
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         for i in range(2):
-            x.update(x=1)
+            x.event(x=1)
 
         self.assertEqual(dmap[()], Curve([1]))
 
         for i in range(2):
-            x.update(x=2)
+            x.event(x=2)
 
         self.assertEqual(dmap[()], Curve([1, 2]))
 
@@ -395,11 +395,11 @@ class DynamicCallableMemoize(ComparisonTestCase):
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         for i in range(2):
-            x.update(x=1)
+            x.event(x=1)
         self.assertEqual(dmap[()], Curve([1, 1, 1]))
 
         for i in range(2):
-            x.update(x=2)
+            x.event(x=2)
         self.assertEqual(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
 
 
@@ -422,11 +422,11 @@ class DynamicStreamReset(ComparisonTestCase):
         x.add_subscriber(lambda **kwargs: dmap[()])
 
         for i in range(2):
-            x.update(x=1)
+            x.event(x=1)
         self.assertEqual(dmap[()], Curve([1, 1]))
 
         for i in range(2):
-            x.update(x=2)
+            x.event(x=2)
 
         self.assertEqual(dmap[()], Curve([1, 1, 2, 2]))
 
@@ -456,8 +456,8 @@ class DynamicStreamReset(ComparisonTestCase):
 
         # Update each stream and count when None default appears
         for i in range(2):
-            x.update(x=i)
-            y.update(y=i)
+            x.event(x=i)
+            y.event(y=i)
 
         self.assertEqual(xresets, 2)
         self.assertEqual(yresets, 2)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -141,7 +141,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         plot = mpl_renderer.get_plot(dmap)
         pre = mpl_renderer(plot, fmt='png')
         plot.state.set_dpi(72)
-        stream.update(x=1, y=1)
+        stream.event(x=1, y=1)
         post = mpl_renderer(plot, fmt='png')
         self.assertNotEqual(pre, post)
 
@@ -160,7 +160,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         mpl_renderer(plot)
         for i in range(20):
             plot.state.set_dpi(72)
-            stream.update(x=i)
+            stream.event(x=i)
         x, y = plot.handles['artist'].get_data()
         self.assertEqual(x, np.arange(10))
         self.assertEqual(y, np.arange(10, 20))
@@ -753,7 +753,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(dmap)
         bokeh_renderer(plot)
         for i in range(20):
-            stream.update(x=i)
+            stream.event(x=i)
         data = plot.handles['source'].data
         self.assertEqual(data['x'], np.arange(10))
         self.assertEqual(data['y'], np.arange(10, 20))
@@ -1437,7 +1437,7 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         plot = plotly_renderer.get_plot(dmap)
         plotly_renderer(plot)
         for i in range(20):
-            stream.update(x=i)
+            stream.event(x=i)
         state = plot.state
         self.assertEqual(state['data'][0]['x'], np.arange(10))
         self.assertEqual(state['data'][0]['y'], np.arange(10, 20))

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -101,7 +101,7 @@ class TestSubscribers(ComparisonTestCase):
         subscriber = TestSubscriber()
         position = PointerXY(subscribers=[subscriber])
         kwargs = dict(x=3, y=4)
-        position.update(trigger=False, **kwargs)
+        position.update(**kwargs)
         self.assertEqual(subscriber.kwargs, None)
 
 
@@ -120,8 +120,8 @@ class TestSubscribers(ComparisonTestCase):
         positionX = PointerX(subscribers=[subscriber])
         positionY = PointerY(subscribers=[subscriber])
 
-        positionX.update(trigger=False, x=5)
-        positionY.update(trigger=False, y=10)
+        positionX.update(x=5)
+        positionY.update(y=10)
 
         Stream.trigger([positionX, positionY])
         self.assertEqual(subscriber.kwargs, dict(x=5, y=10))
@@ -134,8 +134,8 @@ class TestSubscribers(ComparisonTestCase):
         positionX = PointerX(subscribers=[subscriber1, subscriber2])
         positionY = PointerY(subscribers=[subscriber1, subscriber2])
 
-        positionX.update(trigger=False, x=50)
-        positionY.update(trigger=False, y=100)
+        positionX.update(x=50)
+        positionY.update(y=100)
 
         Stream.trigger([positionX, positionY])
 

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -37,7 +37,7 @@ class TestPointerStreams(ComparisonTestCase):
 
     def test_positionXY_update_contents(self):
         position = PointerXY()
-        position.update(x=5, y=10)
+        position.event(x=5, y=10)
         self.assertEqual(position.contents, dict(x=5, y=10))
 
     def test_positionY_const_parameter(self):
@@ -77,13 +77,13 @@ class TestParamValuesStream(ComparisonTestCase):
         obj = self.inner()
         stream = ParamValues(obj)
         self.assertEqual(stream.contents, {'x':0, 'y':0})
-        stream.update(x=5, y=10)
+        stream.event(x=5, y=10)
         self.assertEqual(stream.contents, {'x':5, 'y':10})
 
     def test_class_value_update(self):
         stream = ParamValues(self.inner)
         self.assertEqual(stream.contents, {'x':0, 'y':0})
-        stream.update(x=5, y=10)
+        stream.event(x=5, y=10)
         self.assertEqual(stream.contents, {'x':5, 'y':10})
 
 
@@ -94,7 +94,7 @@ class TestSubscribers(ComparisonTestCase):
         subscriber = TestSubscriber()
         position = PointerXY(subscribers=[subscriber])
         kwargs = dict(x=3, y=4)
-        position.update(**kwargs)
+        position.event(**kwargs)
         self.assertEqual(subscriber.kwargs, kwargs)
 
     def test_subscriber_disabled(self):
@@ -110,7 +110,7 @@ class TestSubscribers(ComparisonTestCase):
         subscriber2 = TestSubscriber()
         position = PointerXY(subscribers=[subscriber1, subscriber2])
         kwargs = dict(x=3, y=4)
-        position.update(**kwargs)
+        position.event(**kwargs)
         self.assertEqual(subscriber1.kwargs, kwargs)
         self.assertEqual(subscriber2.kwargs, kwargs)
 
@@ -184,7 +184,7 @@ class TestParameterRenaming(ComparisonTestCase):
     def test_update_rename_valid(self):
         xy = PointerXY(x=0, y=4)
         renamed = xy.rename(x='xtest', y='ytest')
-        renamed.update(x=4, y=8)
+        renamed.event(x=4, y=8)
         self.assertEqual(renamed.contents, {'xtest':4, 'ytest':8})
 
     def test_update_rename_invalid(self):
@@ -192,7 +192,7 @@ class TestParameterRenaming(ComparisonTestCase):
         renamed = xy.rename(y='ytest')
         regexp = "ytest' is not a parameter of(.+?)"
         with self.assertRaisesRegexp(ValueError, regexp):
-            renamed.update(ytest=8)
+            renamed.event(ytest=8)
 
 
 class TestPlotSizeTransform(ComparisonTestCase):
@@ -203,7 +203,7 @@ class TestPlotSizeTransform(ComparisonTestCase):
 
     def test_plotsize_update_1(self):
         plotsize = PlotSize(scale=0.5)
-        plotsize.update(width=300, height=400)
+        plotsize.event(width=300, height=400)
         self.assertEqual(plotsize.contents, {'width':150, 'height':200, 'scale':0.5})
 
     def test_plotsize_initial_contents_2(self):
@@ -212,6 +212,6 @@ class TestPlotSizeTransform(ComparisonTestCase):
 
     def test_plotsize_update_2(self):
         plotsize = PlotSize(scale=2)
-        plotsize.update(width=600, height=100)
+        plotsize.event(width=600, height=100)
         self.assertEqual(plotsize.contents, {'width':1200, 'height':200, 'scale':2})
 


### PR DESCRIPTION

This PR just makes triggering events consistent between ``DynamicMap`` and ``Stream``: use the ``event`` method which always triggers.

Ideally the default of ``Stream.update`` would be ``trigger=False`` but that might have some backwards compatibility implications. Namely, anyone using ``stream.update`` as a callback would have to change it to ``stream.event`` to get the same behavior.