### PR TITLE
Do not change mpl interactive mode in notebook

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -152,6 +152,7 @@ class notebook_extension(param.ParameterizedFunction):
             if p in self._backends:
                 imports.append((p, self._backends[p]))
         if not imports:
+            args = ['matplotlib']
             imports = [('matplotlib', 'mpl')]
 
         args = list(args)

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -221,6 +221,7 @@ class notebook_extension(param.ParameterizedFunction):
         resources = list(resources)
         if len(resources) == 0: return
 
+        Renderer.load_nb()
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -138,7 +138,7 @@ class MPLPlot(DimensionedPlot):
         if self.renderer.interactive:
             plt.ion()
             self._close_figures = False
-        else:
+        elif not self.renderer._notebook:
             plt.ioff()
 
         with mpl.rc_context(rc=self.fig_rcparams):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -138,7 +138,7 @@ class MPLPlot(DimensionedPlot):
         if self.renderer.interactive:
             plt.ion()
             self._close_figures = False
-        elif not self.renderer._notebook:
+        elif not self.renderer.notebook_context:
             plt.ioff()
 
         with mpl.rc_context(rc=self.fig_rcparams):

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -93,9 +93,6 @@ class MPLRenderer(Renderer):
              'nbagg':   (NbAggJupyterComm, None),
              'mpld3':   (JupyterComm, mpld3_msg_handler)}
 
-    # Whether in a notebook context
-    _notebook = False
-
     def __call__(self, obj, fmt='auto'):
         """
         Render the supplied HoloViews component or MPLPlot instance
@@ -321,4 +318,3 @@ class MPLRenderer(Renderer):
         """
         import matplotlib.pyplot as plt
         plt.switch_backend('agg')
-        cls._notebook = True

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -93,6 +93,9 @@ class MPLRenderer(Renderer):
              'nbagg':   (NbAggJupyterComm, None),
              'mpld3':   (JupyterComm, mpld3_msg_handler)}
 
+    # Whether in a notebook context
+    _notebook = False
+
     def __call__(self, obj, fmt='auto'):
         """
         Render the supplied HoloViews component or MPLPlot instance
@@ -318,3 +321,4 @@ class MPLRenderer(Renderer):
         """
         import matplotlib.pyplot as plt
         plt.switch_backend('agg')
+        cls._notebook = True

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -150,6 +150,9 @@ class Renderer(Exporter):
     # Any additional JS and CSS dependencies required by a specific backend
     backend_dependencies = {}
 
+    # Whether in a notebook context, set when running Renderer.load_nb
+    notebook_context = False
+
     def __init__(self, **params):
         self.last_plot = None
         super(Renderer, self).__init__(**params)
@@ -516,3 +519,6 @@ class Renderer(Exporter):
         Loads any resources required for display of plots
         in the Jupyter notebook
         """
+        with param.logging_level('ERROR'):
+            cls.notebook_context = True
+


### PR DESCRIPTION
When I implemented support for using the matplotlib backend outside a notebook context I added some code which fiddles with the interactive mode of pyplot, which interacts badly with the inline mode in the notebook. This PR ensures that when the notebook_extension loads the matplotlib backend a flag is set that ensures interactive mode is not disabled.

Fixes #1314 