### PR TITLE
Link inputs fixes

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -739,7 +739,8 @@ class DynamicMap(HoloMap):
         # Ensure the clone references this object to ensure
         # stream sources are inherited
         if clone.callback is self.callback:
-            clone.callback = clone.callback.clone(inputs=[self])
+            clone.callback = clone.callback.clone(inputs=[self],
+                                                  link_inputs=True)
         return clone
 
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -558,6 +558,11 @@ class decimate(ElementOperation):
     dynamic = param.Boolean(default=True, doc="""
        Enables dynamic processing by default.""")
 
+    link_inputs = param.Boolean(default=True, doc="""
+         By default, the link_inputs parameter is set to True so that
+         when applying shade, backends that support linked streams
+         update RangeXY streams on the inputs of the shade operation.""")
+
     max_samples = param.Integer(default=5000, doc="""
         Maximum number of samples to display at the same time.""")
 
@@ -580,7 +585,7 @@ class decimate(ElementOperation):
         if not isinstance(element, Dataset):
             raise ValueError("Cannot downsample non-Dataset types.")
         if element.interface not in column_interfaces:
-            element = element.current_frame.clone(datatype=['dataframe', 'dictionary'])
+            element = element.clone(tuple(element.columns().values()))
 
         xstart, xend = self.p.x_range if self.p.x_range else element.range(0)
         ystart, yend = self.p.y_range if self.p.y_range else element.range(1)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -199,7 +199,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         if isinstance(self, OverlayPlot) and not self.batched:
             sources = []
-        if not self.static or isinstance(self.hmap, DynamicMap):
+        elif not self.static or isinstance(self.hmap, DynamicMap):
             sources = [(i, o) for i, inputs in self.stream_sources.items()
                        for o in inputs if i in zorders]
         else:

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -267,6 +267,12 @@ class DynamicTestOperation(ComparisonTestCase):
         dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
+    def test_dynamic_operation_link_inputs_not_transferred_on_clone(self):
+        fn = lambda i: Image(sine_array(0,i))
+        dmap=DynamicMap(fn, kdims=['i'])
+        dmap_with_fn = Dynamic(dmap, link_inputs=False, operation=lambda x: x.clone(x.data*2))
+        self.assertTrue(dmap_with_fn.clone().callback.link_inputs)
+
     def test_dynamic_operation_on_element(self):
         img = Image(sine_array(0,5))
         posxy = PointerXY(x=2, y=1)


### PR DESCRIPTION
The main issue fixed here is that linked_inputs was being inherited when making a clone, when a clone should always link_inputs. I've also ensured that the decimate operation links inputs and fixed a small bug while hooking up the stream sources.

Fixes: https://github.com/ioam/holoviews/issues/1325