### PR TITLE
Ensure Plots correctly cache lookups in DynamicMaps

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1292,22 +1292,29 @@ def arglexsort(arrays):
     return recarray.argsort()
 
 
-def get_dynamic_item(map_obj, dimensions, key):
+def get_dynamic_item(map_obj, dimensions, key, cached=False):
     """
     Looks up an item in a DynamicMap given a list of dimensions
     and a corresponding key. The dimensions must be a subset
-    of the map_obj key dimensions.
+    of the map_obj key dimensions. The cached option simply
+    returns the last item in the DynamicMap cache ignoring the
+    key (this option should only be used by plotting initialization
+    where the precise key does not matter).
     """
     dmaps = map_obj.traverse(lambda x: x, ['DynamicMap'])
     dmap = dmaps[0] if dmaps else map_obj
     if key == () and (not dimensions or not dmap.kdims):
-        map_obj.traverse(lambda x: x[()], ['DynamicMap'])
+        if not cached:
+            map_obj.traverse(lambda x: x[()], ['DynamicMap'])
         return key, map_obj.map(lambda x: x.last, ['DynamicMap'])
     elif isinstance(key, tuple):
         dims = {d.name: k for d, k in zip(dimensions, key)
                 if d in map_obj.kdims}
         key = tuple(dims.get(d.name) for d in map_obj.kdims)
-        el = map_obj.select(['DynamicMap', 'HoloMap'], **dims)
+        if cached:
+            el = map_obj.map(lambda x: x.last, ['DynamicMap', 'HoloMap'])
+        else:
+            el = map_obj.select(['DynamicMap', 'HoloMap'], **dims)
     else:
         el = None
     return key, el

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1292,34 +1292,6 @@ def arglexsort(arrays):
     return recarray.argsort()
 
 
-def get_dynamic_item(map_obj, dimensions, key, cached=False):
-    """
-    Looks up an item in a DynamicMap given a list of dimensions
-    and a corresponding key. The dimensions must be a subset
-    of the map_obj key dimensions. The cached option simply
-    returns the last item in the DynamicMap cache ignoring the
-    key (this option should only be used by plotting initialization
-    where the precise key does not matter).
-    """
-    dmaps = map_obj.traverse(lambda x: x, ['DynamicMap'])
-    dmap = dmaps[0] if dmaps else map_obj
-    if key == () and (not dimensions or not dmap.kdims):
-        if not cached:
-            map_obj.traverse(lambda x: x[()], ['DynamicMap'])
-        return key, map_obj.map(lambda x: x.last, ['DynamicMap'])
-    elif isinstance(key, tuple):
-        dims = {d.name: k for d, k in zip(dimensions, key)
-                if d in map_obj.kdims}
-        key = tuple(dims.get(d.name) for d in map_obj.kdims)
-        if cached:
-            el = map_obj.map(lambda x: x.last, ['DynamicMap', 'HoloMap'])
-        else:
-            el = map_obj.select(['DynamicMap', 'HoloMap'], **dims)
-    else:
-        el = None
-    return key, el
-
-
 def dimensioned_streams(dmap):
     """
     Given a DynamicMap return all streams that have any dimensioned

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -175,6 +175,24 @@ def initialize_dynamic(obj):
             dmap[dmap._initial_key()]
 
 
+def get_plot_frame(map_obj, key_map, cached=False):
+    """
+    Returns an item in a HoloMap or DynamicMap given a mapping key
+    dimensons and their values.
+    """
+    if map_obj.kdims and len(map_obj.kdims) == 1 and map_obj.kdims[0] == 'Frame':
+        # Special handling for static plots
+        return map_obj.last
+    key = tuple(key_map[kd.name] for kd in map_obj.kdims)
+    if key in map_obj.data and cached:
+        return map_obj.data[key]
+    else:
+        try:
+            return map_obj[key]
+        except KeyError:
+            return None
+
+
 def undisplayable_info(obj, html=False):
     "Generate helpful message regarding an undisplayable object"
 

--- a/tests/testtraversal.py
+++ b/tests/testtraversal.py
@@ -1,0 +1,46 @@
+from holoviews import HoloMap, DynamicMap, Curve
+from holoviews.core.traversal import unique_dimkeys
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class TestUniqueDimKeys(ComparisonTestCase):
+
+    def test_unique_keys_complete_overlap(self):
+        hmap1 = HoloMap({i: Curve(range(10)) for i in range(5)})
+        hmap2 = HoloMap({i: Curve(range(10)) for i in range(3, 10)})
+        dims, keys = unique_dimkeys(hmap1+hmap2)
+        self.assertEqual(hmap1.kdims, dims)
+        self.assertEqual(keys, [(i,) for i in range(10)])
+
+    def test_unique_keys_partial_overlap(self):
+        hmap1 = HoloMap({(i, j): Curve(range(10)) for i in range(5) for j in range(3)}, kdims=['A', 'B'])
+        hmap2 = HoloMap({i: Curve(range(10)) for i in range(5)}, kdims=['A'])
+        dims, keys = unique_dimkeys(hmap1+hmap2)
+        self.assertEqual(hmap1.kdims, dims)
+        self.assertEqual(keys, [(i, j) for i in range(5) for j in list(range(3))])
+
+    def test_unique_keys_no_overlap_exception(self):
+        hmap1 = HoloMap({i: Curve(range(10)) for i in range(5)}, kdims=['A'])
+        hmap2 = HoloMap({i: Curve(range(10)) for i in range(3, 10)})
+        exception = ('When combining HoloMaps into a composite plot '
+                     'their dimensions must be subsets of each other.')
+        with self.assertRaisesRegexp(Exception, exception):
+            dims, keys = unique_dimkeys(hmap1+hmap2)
+
+    def test_unique_keys_no_overlap_dynamicmap_uninitialized(self):
+        dmap1 = DynamicMap(lambda A: Curve(range(10)), kdims=['A'])
+        dmap2 = DynamicMap(lambda B: Curve(range(10)), kdims=['B'])
+        dims, keys = unique_dimkeys(dmap1+dmap2)
+        self.assertEqual(dims, dmap1.kdims+dmap2.kdims)
+        self.assertEqual(keys, [])
+
+    def test_unique_keys_no_overlap_dynamicmap_initialized(self):
+        dmap1 = DynamicMap(lambda A: Curve(range(10)), kdims=['A'])
+        dmap2 = DynamicMap(lambda B: Curve(range(10)), kdims=['B'])
+        dmap1[0]
+        dmap2[1]
+        dims, keys = unique_dimkeys(dmap1+dmap2)
+        self.assertEqual(dims, dmap1.kdims+dmap2.kdims)
+        self.assertEqual(keys, [(0, 1)])
+
+


### PR DESCRIPTION
Ensures the plots respect the _force option telling them not to request a new frame on the DynamicMap, both during initialization and for subsequent updates. Relies on the fact that the initialization pass of creating Plots does not care which exact Element is being plotted, since it is subsequently updated again anyway.