### PR TITLE
Avoid overriding %matplotlib inline in notebook

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -40,7 +40,7 @@ def set_style(key):
         raise KeyError('%r not in available styles.')
     else:
         path = os.path.join(os.path.dirname(__file__), styles[key])
-        new_style = rc_params_from_file(path)
+        new_style = rc_params_from_file(path, use_default_template=False)
         styles['backup'] = dict(plt.rcParams)
 
         plt.rcParams.update(new_style)

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -317,4 +317,6 @@ class MPLRenderer(Renderer):
         Initialize matplotlib backend
         """
         import matplotlib.pyplot as plt
-        plt.switch_backend('agg')
+        backend = plt.get_backend()
+        if backend not in ['agg', 'module://ipykernel.pylab.backend_inline']:
+            plt.switch_backend('agg')


### PR DESCRIPTION
We were previously overriding the default backend because the all defaults were loaded from the rc file. The notebook_extension now also doesn't override the currently set backend if it is already valid for the notebook.