### PR TITLE
Silenced expected warning from the rolling_outlier_std operation

### DIFF
--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -109,7 +109,8 @@ class rolling_outlier_std(ElementOperation):
         std = pd.Series(residual).rolling(window, center=True).std()
 
         # Get indices of outliers
-        outliers = (np.abs(residual) > std * sigma).values
+        with np.errstate(invalid='ignore'):
+            outliers = (np.abs(residual) > std * sigma).values
         return element[outliers].clone(new_type=Scatter)
 
     def _process(self, element, key=None):


### PR DESCRIPTION
The `rolling_outlier_std` operation first computes a rolling window, using a calculation that leaves NaN values at the beginning and end of the series (depending on the size of the window).  `np.abs()` was raising a warning ``invalid value encountered in absolute``, but this warning is just distracting because invalid values are expected in this case, so this PR ensures that the warning is silenced.