### PR TITLE
Wait for DOM to be ready to initialize widgets

### DIFF
--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -24,6 +24,7 @@
         </div>
       </div>
 	  <script>
+	    function init_slider() {
         // Slider JS Block START
         function loadcssfile(filename){
             var fileref=document.createElement("link")
@@ -95,7 +96,7 @@
 				text.css('font-size', size);
 			}
             var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
-            slider.slider({
+			slider.slider({
                 animate: "fast",
                 min: min,
                 max: max,
@@ -162,6 +163,8 @@
 			textInput.val(labels[0]);
 			adjustFontSize(textInput);
         });
+		}
+        $(document).ready(init_slider)
         // Slider JS Block END
         </script>
         {% elif widget_data['type']=='dropdown' %}
@@ -173,6 +176,7 @@
         <script>
         var vals = {{ widget_data['vals'] }};
         var labels = {{ widget_data['labels'] }};
+        function init_dropdown() {
         var widget = $("#_anim_widget{{ id }}_{{ widget_data['dim'] }}");
         widget.data('values', vals)
         for (var i=0; i<vals.length; i++){
@@ -204,6 +208,8 @@
             }
 
         });
+        }
+        $(document).ready(init_dropdown)
         </script>
         {% endif %}
         {% endfor %}


### PR DESCRIPTION
Potentially fixes issues when embedding HoloMaps into a website.

Seems to be fixing previous issues, this example wasn't working before and you can now clearly tell how it waits until the document is loaded until creating the widgets: http://assets.holoviews.org/topocm/w4_haldane/haldane_model.html