### PR TITLE
Added support for batching plot updates

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -14,7 +14,7 @@ from ...core.util import basestring, wrap_tuple, unique_iterator
 from ...element import Histogram
 from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
                     GenericElementPlot)
-from ..util import get_dynamic_mode
+from ..util import get_dynamic_mode, attach_streams
 from .renderer import BokehRenderer
 from .util import (bokeh_version, layout_padding, pad_plots,
                    filter_toolboxes, make_axis, update_shared_sources)
@@ -292,10 +292,11 @@ class GridPlot(CompositePlot, GenericCompositePlot):
                                        ranges=ranges, keys=keys, **params)
         self.cols, self.rows = layout.shape
         self.subplots, self.layout = self._create_subplots(layout, ranges)
-        top_level = keys is None
-        if top_level:
+        if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
+            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+                          [GenericElementPlot])
 
 
     def _create_subplots(self, layout, ranges):
@@ -485,11 +486,11 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
     def __init__(self, layout, keys=None, **params):
         super(LayoutPlot, self).__init__(layout, keys=keys, **params)
         self.layout, self.subplots, self.paths = self._init_layout(layout)
-        top_level = keys is None
-        if top_level:
+        if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-
+            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+                          [GenericElementPlot])
 
     def _init_layout(self, layout):
         # Situate all the Layouts in the grid and compute the gridspec

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -148,8 +148,9 @@ class BokehRenderer(Renderer):
         Returns a json diff required to update an existing plot with
         the latest plot data.
         """
-        plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles)
+        plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles, [lambda x: x._updated])
                        for h in handles]
+        plot.traverse(lambda x: setattr(x, '_updated', False))
         patch = compute_static_patch(plot.document, plotobjects)
         processed = self._apply_post_render_hooks(patch, plot, 'json')
         return serialize_json(processed) if serialize else processed

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -294,7 +294,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         self.zorder = 0
         self.layout_num = layout_num
         self.overlaid = False
-        self.hmap = {}
+        self.hmap = layout
         if layout.ndims > 1:
             xkeys, ykeys = zip(*layout.data.keys())
         else:

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -408,14 +408,14 @@ def dim_axis_label(dimensions, separator=', '):
     return separator.join([d.pprint_label for d in dimensions])
 
 
-def attach_streams(plot, obj):
+def attach_streams(plot, obj, precedence=0):
     """
     Attaches plot refresh to all streams on the object.
     """
     def append_refresh(dmap):
         for stream in get_nested_streams(dmap):
             if plot.refresh not in stream._subscribers:
-                stream.add_subscriber(plot.refresh)
+                stream.add_subscriber(plot.refresh, precedence)
     return obj.traverse(append_refresh, [DynamicMap])
 
 


### PR DESCRIPTION
Adds precedences to Stream subscribers, which allow updates to individual subplots to be batched. Each subplot now adds itself as a subscriber along with the top-level plot. When a subplot is updated it marks itself with an ``_update`` flag so that the top-level plot can then dispatch the necessary updates once the subplot updates have completed.

* [x] Ensure GridPlot/LayoutPlot titles are updated
* [x] Ensure that batched OverlayPlots aren't getting updated multiple times.