### PR TITLE
Disabled batched plot optimization

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -124,7 +124,6 @@ class PointPlot(LegendPlot, ColorbarPlot):
                     data[sanitized].append([k]*nvals)
 
         data = {k: np.concatenate(v) for k, v in data.items()}
-        filter_batched_data(data, elmapping)
         return data, elmapping
 
 
@@ -278,7 +277,6 @@ class CurvePlot(ElementPlot):
                 if not any(v is None for v in vals)}
         mapping = {{'x': 'xs', 'y': 'ys'}.get(k, k): v
                    for k, v in elmapping.items()}
-        filter_batched_data(data, mapping)
         return data, mapping
 
 

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -57,7 +57,6 @@ class PathPlot(ElementPlot):
             for k, v in sdata.items():
                 data[k].extend(list(v))
 
-        filter_batched_data(data, elmapping)
         return data, elmapping
 
 


### PR DESCRIPTION
This optimization was a nice idea as it would avoid sending ColumnDataSource columns which all contain the same value and it might be possible to get it to work but it doesn't deal with empty elements well currently and I don't want to fiddle more before release.