### PR TITLE
Expose edgecolors for 3D surface plots

### DIFF
--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -167,7 +167,7 @@ class SurfacePlot(Plot3D):
 
     style_opts = ['antialiased', 'cmap', 'color', 'shade',
                   'linewidth', 'facecolors', 'rstride', 'cstride',
-                  'norm']
+                  'norm', 'edgecolors']
 
     def init_artists(self, ax, plot_data, plot_kwargs):
         if self.plot_type == "wireframe":


### PR DESCRIPTION
Because the default style in mpl 2.0 was changed from 'k' to 'w' I exposed the `edgecolors` style option to change it back if wanted.