### PR TITLE
Handle empty subplots and overlay layers

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -594,6 +594,8 @@ class LabelledData(param.Parameterized):
         # Assumes composite objects are iterables
         if self._deep_indexable:
             for el in self:
+                if el is None:
+                    continue
                 accumulator += el.traverse(fn, specs, full_breadth)
                 if not full_breadth: break
         return accumulator

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -91,7 +91,7 @@ def unique_dimkeys(obj, default_dim='Frame'):
 
     with item_check(False):
         sorted_keys = NdMapping({key: None for key in unique_keys},
-                                kdims=all_dims_emptied).data.keys()
+                                kdims=all_dims).data.keys()
     return all_dims, list(sorted_keys)
 
 

--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -46,7 +46,7 @@ def unique_dimkeys(obj, default_dim='Frame'):
     Returns the list of dimensions followed by the list of unique
     keys.
     """
-    from .ndmapping import NdMapping
+    from .ndmapping import NdMapping, item_check
     from .spaces import HoloMap
     key_dims = obj.traverse(lambda x: (tuple(x.kdims),
                                        list(x.data.keys())), (HoloMap,))
@@ -89,8 +89,9 @@ def unique_dimkeys(obj, default_dim='Frame'):
             if not matches:
                 unique_keys.append(padded_key)
 
-    sorted_keys = NdMapping({key: None for key in unique_keys},
-                            kdims=all_dims).data.keys()
+    with item_check(False):
+        sorted_keys = NdMapping({key: None for key in unique_keys},
+                                kdims=all_dims_emptied).data.keys()
     return all_dims, list(sorted_keys)
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -779,7 +779,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if hasattr(glyph, 'visible'):
             glyph.visible = bool(element)
 
-        if not element or (not self.dynamic and self.static):
+        if element is None or (not self.dynamic and self.static):
             return
 
         if self.batched:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -170,7 +170,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     # The plot objects to be updated on each frame
     # Any entries should be existing keys in the handles
     # instance attribute.
-    _update_handles = ['source', 'glyph']
+    _update_handles = ['source', 'glyph', 'glyph_renderer']
     _categorical = False
 
     def __init__(self, element, plot=None, **params):
@@ -768,7 +768,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Updates an existing plot with data corresponding
         to the key.
         """
-        reused = isinstance(self.hmap, DynamicMap) and self.overlaid
+        reused = isinstance(self.hmap, DynamicMap) and (self.overlaid or self.batched)
         if not reused and element is None:
             element = self._get_frame(key)
         else:
@@ -776,10 +776,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.current_frame = element
 
         glyph = self.handles.get('glyph', None)
-        if hasattr(glyph, 'visible'):
-            glyph.visible = bool(element)
+        renderer = self.handles.get('glyph_renderer', None)
+        if hasattr(renderer, 'visible'):
+            renderer.visible = bool(element)
 
-        if element is None or (not self.dynamic and self.static):
+        if (self.batched and not element) or element is None or (not self.dynamic and self.static):
             return
 
         if self.batched:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -17,7 +17,8 @@ from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
 from ..util import get_dynamic_mode, attach_streams
 from .renderer import BokehRenderer
 from .util import (bokeh_version, layout_padding, pad_plots,
-                   filter_toolboxes, make_axis, update_shared_sources)
+                   filter_toolboxes, make_axis, update_shared_sources,
+                   empty_plot)
 
 if bokeh_version >= '0.12':
     from bokeh.layouts import gridplot
@@ -528,8 +529,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             obj = layouts[(r, c)]
             empty = isinstance(obj.main, Empty)
             if empty:
-                obj = AdjointLayout([])
-            elif obj.main and not obj.main.traverse(lambda x: x, [Element]):
+                continue
+            elif view is None or not view.traverse(lambda x: x, [Element]):
                 self.warning('%s is empty, skipping subplot.' % obj.main)
                 continue
             else:
@@ -663,6 +664,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                 if len(subplots) == 1 and c in insert_cols:
                     plots[r+offset].append(None)
                 passed_plots.append(subplots[0])
+            else:
+                plots[r+offset] += [empty_plot(0, 0)]
 
             if self.tabs:
                 if isinstance(self.layout, Layout):
@@ -674,8 +677,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
         # Replace None types with empty plots
         # to avoid bokeh bug
-        if adjoined:
-            plots = layout_padding(plots, self.renderer)
+        plots = layout_padding(plots, self.renderer)
 
         # Wrap in appropriate layout model
         if self.tabs:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -529,7 +529,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             empty = isinstance(obj.main, Empty)
             if empty:
                 obj = AdjointLayout([])
-            elif not obj.main.traverse(lambda x: x, [Element]):
+            elif obj.main and not obj.main.traverse(lambda x: x, [Element]):
                 self.warning('%s is empty, skipping subplot.' % obj.main)
                 continue
             else:

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -7,7 +7,7 @@ from bokeh.models import (ColumnDataSource, VBox, HBox, Column, Div)
 from bokeh.models.widgets import Panel, Tabs
 
 from ...core import (OrderedDict, CompositeOverlay, Store, Layout, GridMatrix,
-                     AdjointLayout, NdLayout, Empty, GridSpace, HoloMap)
+                     AdjointLayout, NdLayout, Empty, GridSpace, HoloMap, Element)
 from ...core import traversal
 from ...core.options import Compositor, SkipRendering
 from ...core.util import basestring, wrap_tuple, unique_iterator
@@ -529,6 +529,9 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             empty = isinstance(obj.main, Empty)
             if empty:
                 obj = AdjointLayout([])
+            elif not obj.main.traverse(lambda x: x, [Element]):
+                self.warning('%s is empty, skipping subplot.' % obj.main)
+                continue
             else:
                 layout_count += 1
             subplot_data = self._create_subplots(obj, positions,
@@ -560,7 +563,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         for pos in positions:
             # Pos will be one of 'main', 'top' or 'right' or None
             element = layout.get(pos, None)
-            if element is None:
+            if element is None or not element.traverse(lambda x: x, [Element]):
                 continue
 
             subplot_opts = dict(adjoined=main_plot)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -279,6 +279,22 @@ def replace_models(obj):
         return obj
 
 
+def references_json(references):
+    """
+    Generate json for supplied models. Modeled after bokeh's private
+    Document._references_json but ensures specific attributes are
+    always synced.
+    """
+    references_json = []
+    for r in references:
+        ref = r.ref
+        ref['attributes'] = r._to_json_like(include_defaults=False)
+        if ref['type'] == 'GlyphRenderer':
+            ref['attributes']['visible'] = r.visible
+        references_json.append(ref)
+    return references_json
+
+
 def to_references(doc):
     """
     Convert the document to a dictionary of references. Avoids
@@ -290,7 +306,7 @@ def to_references(doc):
         root_ids.append(r._id)
 
     references = {}
-    for obj in doc._references_json(doc._all_models.values()):
+    for obj in references_json(doc._all_models.values()):
         obj = replace_models(obj)
         references[obj['id']] = obj
     return references

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -139,16 +139,27 @@ def layout_padding(plots, renderer):
         expanded_plots.append([])
         for c, p in enumerate(row):
             if p is None:
-                x_range = Range1d(start=0, end=1)
-                y_range = Range1d(start=0, end=1)
-                p = Figure(plot_width=widths[c], plot_height=heights[r],
-                           x_range=x_range, y_range=y_range)
-                p.xaxis.visible = False
-                p.yaxis.visible = False
-                p.outline_line_alpha = 0
-                p.grid.grid_line_alpha = 0
+                p = empty_plot(widths[c], heights[r])
+            elif hasattr(p, 'plot_width') and p.plot_width == 0 and p.plot_height == 0:
+                p.plot_width = widths[c]
+                p.plot_height = heights[r]
             expanded_plots[r].append(p)
     return expanded_plots
+
+
+def empty_plot(width, height):
+    """
+    Creates an empty and invisible plot of the specified size.
+    """
+    x_range = Range1d(start=0, end=1)
+    y_range = Range1d(start=0, end=1)
+    p = Figure(plot_width=width, plot_height=height,
+               x_range=x_range, y_range=y_range)
+    p.xaxis.visible = False
+    p.yaxis.visible = False
+    p.outline_line_alpha = 0
+    p.grid.grid_line_alpha = 0
+    return p
 
 
 def font_size_to_pixels(size):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -11,7 +11,7 @@ from matplotlib import gridspec, animation
 import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
-                     Collator, GridMatrix, Layout)
+                     Collator, GridMatrix, Layout, ViewableElement)
 from ...core.options import Store, Compositor, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ...core import traversal
@@ -923,6 +923,9 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             empty = isinstance(obj.main, Empty)
             if empty:
                 obj = AdjointLayout([])
+            elif not obj.main.traverse(lambda x: x, [Element]):
+                self.warning('%s is empty, skipping subplot.' % obj.main)
+                continue
             elif self.transpose:
                 layout_count = (c*self.rows+(r+1))
             else:
@@ -1009,7 +1012,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             # Pos will be one of 'main', 'top' or 'right' or None
             view = layout.get(pos, None)
             ax = axes.get(pos, None)
-            if view is None:
+            if view is None or not view.traverse(lambda x: x, [Element]):
                 projections.append(None)
                 continue
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -923,7 +923,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             empty = isinstance(obj.main, Empty)
             if empty:
                 obj = AdjointLayout([])
-            elif not obj.main.traverse(lambda x: x, [Element]):
+            elif obj.main and not obj.main.traverse(lambda x: x, [Element]):
                 self.warning('%s is empty, skipping subplot.' % obj.main)
                 continue
             elif self.transpose:

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -923,7 +923,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             empty = isinstance(obj.main, Empty)
             if empty:
                 obj = AdjointLayout([])
-            elif obj.main and not obj.main.traverse(lambda x: x, [Element]):
+            elif view is None or not view.traverse(lambda x: x, [Element]):
                 self.warning('%s is empty, skipping subplot.' % obj.main)
                 continue
             elif self.transpose:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -880,6 +880,10 @@ class GenericOverlayPlot(GenericElementPlot):
 
             if issubclass(plottype, GenericOverlayPlot):
                 opts['show_legend'] = self.show_legend
+                if not any(len(frame) for frame in vmap):
+                    self.warning('%s is empty and will be skipped during plotting'
+                                 % vmap.last)
+                    continue
             elif self.batched and 'batched' in plottype._plot_methods:
                 opts['batched'] = self.batched
                 opts['overlaid'] = self.overlaid

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -259,20 +259,30 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))
         plot = mpl_renderer.get_plot(layout)
-        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
         for i, pos in enumerate(positions):
             adjoint = plot.subplots[pos]
             if 'main' in adjoint.subplots:
                 self.assertEqual(adjoint.subplots['main'].layout_num, i+1)
 
+    def test_layout_empty_subplots(self):
+        layout = Curve(range(10)) + NdOverlay() + HoloMap() + HoloMap({1: Image(np.random.rand(10,10))})
+        plot = mpl_renderer.get_plot(layout)
+        self.assertEqual(len(plot.subplots.values()), 2)
+
+    def test_overlay_empty_layers(self):
+        overlay = Curve(range(10)) * NdOverlay()
+        plot = mpl_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.subplots), 1)
+
     def test_layout_instantiate_subplots_transposed(self):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))
         plot = mpl_renderer.get_plot(layout(plot=dict(transpose=True)))
-        positions = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
+        positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
-        nums = [1, 5, 2, 6, 3, 7, 4, 8]
+        nums = [1, 5, 2, 3, 4]
         for pos, num in zip(positions, nums):
             adjoint = plot.subplots[pos]
             if 'main' in adjoint.subplots:
@@ -1103,6 +1113,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(sp4.state.xaxis[0].visible, False)
         self.assertEqual(sp4.state.yaxis[0].visible, False)
 
+    def test_layout_empty_subplots(self):
+        layout = Curve(range(10)) + NdOverlay() + HoloMap() + HoloMap({1: Image(np.random.rand(10,10))})
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertEqual(len(plot.subplots.values()), 2)
+
+    def test_overlay_empty_layers(self):
+        overlay = Curve(range(10)) * NdOverlay()
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(len(plot.subplots), 1)
+
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
                              for j in range(2,4)}) +
@@ -1153,20 +1173,20 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(len(row2.children), 2)
         fig, spacer = row2.children
         self.assertIsInstance(fig, Figure)
-        self.assertIsInstance(spacer, Spacer)
+        self.assertIsInstance(spacer, Figure)
 
     def test_layout_instantiate_subplots(self):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))
         plot = bokeh_renderer.get_plot(layout)
-        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        positions = [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
 
     def test_layout_instantiate_subplots_transposed(self):
         layout = (Curve(range(10)) + Curve(range(10)) + Image(np.random.rand(10,10)) +
                   Curve(range(10)) + Curve(range(10)))
         plot = bokeh_renderer.get_plot(layout(plot=dict(transpose=True)))
-        positions = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
+        positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
 
     def test_element_show_frame_disabled(self):


### PR DESCRIPTION
This PR adds some additional validation to the plotting code to check for empty objects, which are then skipped rather than causing errors somewhere downstream in the code.