### PR TITLE
Fixed JS logic to check for comm_manager

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -192,7 +192,7 @@ class CustomJSCallback(MessageCallback):
         }}
 
         // Initialize Comm
-        if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
+        if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {{
           var comm_manager = Jupyter.notebook.kernel.comm_manager;
           var comms = HoloViewsWidget.comms["{comm_id}"];
           if (comms && ("{comm_id}" in comms)) {{
@@ -219,7 +219,7 @@ class CustomJSCallback(MessageCallback):
         event_name = cb_obj.event_name
         data['comm_id'] = "{comm_id}";
         timeout = comm_state.time + {timeout};
-        if ((window.Jupyter == undefined) | (Jupyter.notebook.kernel == undefined)) {{
+        if ((window.Jupyter == undefined) | (Jupyter.notebook.kernel != null)) {{
         }} else if ((comm_state.blocked && (Date.now() < timeout))) {{
             comm_state.event_buffer.unshift([event_name, data]);
         }} else {{

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -140,7 +140,7 @@ class JupyterComm(Comm):
         {msg_handler}
       }}
 
-      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
+      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {{
         comm_manager = Jupyter.notebook.kernel.comm_manager;
         comm_manager.register_target("{comm_id}", function(comm) {{ comm.on_msg(msg_handler);}});
       }}
@@ -191,7 +191,7 @@ class JupyterCommJS(JupyterComm):
         {msg_handler}
       }}
 
-      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel !== undefined)) {{
+      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {{
         var comm_manager = Jupyter.notebook.kernel.comm_manager;
         comm = comm_manager.new_comm("{comm_id}", {{}}, {{}}, {{}}, "{comm_id}");
         comm.on_msg(msg_handler);


### PR DESCRIPTION
Currently when you reload a notebook with a comm in it, displaying the plot will fail because at time of execution a kernel might not yet exist and the logic to check for it is not quite correct.