### PR TITLE
Small fixes for dynamic select

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -316,7 +316,10 @@ class Dataset(Element):
         supplied, which will ensure the selection is only applied if the
         specs match the selected object.
         """
-        if selection_specs and not any(self.matches(sp) for sp in selection_specs):
+        selection = {dim: sel for dim, sel in selection.items()
+                     if dim in self.dimensions()+['selection_mask']}
+        if (selection_specs and not any(self.matches(sp) for sp in selection_specs)
+            or not selection):
             return self
 
         data = self.interface.select(self, **selection)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -129,12 +129,12 @@ class HoloMap(UniformNdMapping, Overlayable):
             key_map = {d.name: k for d, k in zip(dimensions, key)}
             layers = []
             try:
-                self_el = self.select(**key_map) if self.kdims else self[()]
+                self_el = self.select(HoloMap, **key_map) if self.kdims else self[()]
                 layers.append(self_el)
             except KeyError:
                 pass
             try:
-                other_el = other.select(**key_map) if other.kdims else other[()]
+                other_el = other.select(HoloMap, **key_map) if other.kdims else other[()]
                 layers.append(other_el)
             except KeyError:
                 pass


### PR DESCRIPTION
There was two small issues with select, dynamic overlaying was not specifying which objects it wants to be selecting on and secondly Datasets weren't validating selections applied to them.