### PR TITLE
Miscellaneous fixes

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -180,6 +180,11 @@ class OperationCallable(Callable):
     operation = param.ClassSelector(class_=ElementOperation, doc="""
         The ElementOperation being wrapped.""")
 
+    def __init__(self, callable, **kwargs):
+        if 'operation' not in kwargs:
+            raise ValueError('An OperationCallable must have an operation specified')
+        super(OperationCallable, self).__init__(callable, **kwargs)
+
 
 class MapOperation(param.ParameterizedFunction):
     """

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -557,7 +557,7 @@ class Generator(Callable):
             raise
         except Exception:
             msg = 'Generator {name} raised the following exception:'
-            self.warning(msg.format(name=self.name)
+            self.warning(msg.format(name=self.name))
             raise
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -551,7 +551,14 @@ class Generator(Callable):
         return ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
 
     def __call__(self):
-        return next(self.callable)
+        try:
+            return next(self.callable)
+        except StopIteration:
+            raise
+        except Exception:
+            msg = 'Generator {name} raised the following exception:'
+            self.warning(msg.format(name=self.name)
+            raise
 
 
 def get_nested_streams(dmap):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -456,7 +456,8 @@ class Callable(param.Parameterized):
          the Callable, e.g. when it returns a Layout.""")
 
     def __init__(self, callable, **params):
-        super(Callable, self).__init__(callable=callable, **params)
+        super(Callable, self).__init__(callable=callable,
+                                       **dict(params, name=util.callable_name(callable)))
         self._memoized = {}
         self._is_overlay = False
 
@@ -524,7 +525,7 @@ class Callable(param.Parameterized):
             argstr = ', '.join([el for el in [posstr, kwstr] if el])
             message = ("Exception raised in callable '{name}' of type '{ctype}'.\n"
                        "Invoked as {name}({argstr})")
-            self.warning(message.format(name=util.callable_name(self.callable),
+            self.warning(message.format(name=self.name,
                                         ctype = type(self.callable).__name__,
                                         argstr=argstr))
             raise

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1,4 +1,5 @@
 import os, sys, warnings, operator
+import types
 import numbers
 import inspect
 import itertools
@@ -201,7 +202,7 @@ def validate_dynamic_argspec(argspec, kdims, streams):
 
 def callable_name(callable_obj):
     """
-    Attempts to return a meaningful name identifying a callable
+    Attempt to return a meaningful name identifying a callable or generator
     """
     try:
         if (isinstance(callable_obj, type)
@@ -222,9 +223,11 @@ def callable_name(callable_obj):
                 owner =  meth.__self__
             if meth.__name__ == '__call__':
                 return type(owner).__name__
-            return '.'.join([type(owner).__name__, meth.__name__])
-        else:
+            return '.'.join([owner.__name__, meth.__name__])
+        elif isinstance(callable_obj, types.GeneratorType):
             return callable_obj.__name__
+        else:
+            return type(callable_obj).__name__
     except:
         return str(callable_obj)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -199,6 +199,35 @@ def validate_dynamic_argspec(argspec, kdims, streams):
                                                        kdims=kdims))
 
 
+def callable_name(callable_obj):
+    """
+    Attempts to return a meaningful name identifying a callable
+    """
+    try:
+        if (isinstance(callable_obj, type)
+            and issubclass(callable_obj, param.ParameterizedFunction)):
+            return callable_obj.__name__
+        elif (isinstance(callable_obj, param.Parameterized)
+              and 'operation' in callable_obj.params()):
+            return callable_obj.operation.__name__
+        elif isinstance(callable_obj, partial):
+            return str(callable_obj)
+        elif inspect.isfunction(callable_obj):  # functions and staticmethods
+            return callable_obj.__name__
+        elif inspect.ismethod(callable_obj):    # instance and class methods
+            meth = callable_obj
+            if sys.version_info < (3,0):
+                owner =  meth.im_class if meth.im_self is None else meth.im_self
+            else:
+                owner =  meth.__self__
+            if meth.__name__ == '__call__':
+                return type(owner).__name__
+            return '.'.join([type(owner).__name__, meth.__name__])
+        else:
+            return callable_obj.__name__
+    except:
+        return str(callable_obj)
+
 
 def process_ellipses(obj, key, vdim_selection=False):
     """

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -186,8 +186,6 @@ class Arrow(Annotation):
             self.data = (x, y, text, direction, points, arrowstyle)
 
 
-        return self.__class__(*args, **settings)
-
     def dimension_values(self, dimension, expanded=True, flat=True):
         index = self.get_dimension_index(dimension)
         if index == 0:

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -1,7 +1,8 @@
+from numbers import Number
 import numpy as np
-
 import param
 
+from ..core.util import datetime_types
 from ..core import Dimension, Element2D
 
 
@@ -73,7 +74,8 @@ class VLine(Annotation):
 
     group = param.String(default='VLine', constant=True)
 
-    x = param.Number(default=0, doc="The x-position of the VLine.")
+    x = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The x-position of the VLine which make be numeric or a timestamp.""")
 
     __pos_params = ['x']
 
@@ -87,7 +89,8 @@ class HLine(Annotation):
 
     group = param.String(default='HLine', constant=True)
 
-    y = param.Number(default=0, doc="The y-position of the HLine.")
+    y = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The y-position of the VLine which make be numeric or a timestamp.""")
 
     __pos_params = ['y']
 
@@ -143,9 +146,11 @@ class Arrow(Annotation):
     specified as well as the arrow head style.
     """
 
-    x = param.Number(default=0, doc="The x-position of the arrow.")
+    x = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The x-position of the arrow which make be numeric or a timestamp.""")
 
-    y = param.Number(default=0, doc="The y-position of the arrow.")
+    y = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The y-position of the arrow which make be numeric or a timestamp.""")
 
     text = param.String(default='', doc="Text associated with the arrow.")
 
@@ -202,10 +207,11 @@ class Text(Annotation):
     Draw a text annotation at the specified position with custom
     fontsize, alignment and rotation.
     """
+    x = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The x-position of the arrow which make be numeric or a timestamp.""")
 
-    x = param.Parameter(default=0, doc="The x-position of the text.")
-
-    y = param.Parameter(default=0, doc="The y-position of text.")
+    y = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+       The y-position of the arrow which make be numeric or a timestamp.""")
 
     text = param.String(default='', doc="The text to be displayed.")
 

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -2,7 +2,7 @@ from numbers import Number
 import numpy as np
 import param
 
-from ..core.util import datetime_types
+from ..core.util import datetime_types, basestring
 from ..core import Dimension, Element2D
 
 
@@ -207,10 +207,10 @@ class Text(Annotation):
     Draw a text annotation at the specified position with custom
     fontsize, alignment and rotation.
     """
-    x = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+    x = param.ClassSelector(default=0, class_= (Number, basestring) + datetime_types, doc="""
        The x-position of the arrow which make be numeric or a timestamp.""")
 
-    y = param.ClassSelector(default=0, class_= (Number, ) + datetime_types, doc="""
+    y = param.ClassSelector(default=0, class_= (Number, basestring) + datetime_types, doc="""
        The y-position of the arrow which make be numeric or a timestamp.""")
 
     text = param.String(default='', doc="The text to be displayed.")

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -56,14 +56,29 @@ class Annotation(Element2D):
         else:
             return super(Annotation, self).dimension_values(dimension)
 
+    # Note: This version of clone is identical in path.BaseShape
+    # Consider implementing a mix-in class if it is needed again.
+    def clone(self, *args, **overrides):
+        if len(args) == 1 and isinstance(args[0], tuple):
+            args = args[0]
+        # Apply name mangling for __ attribute
+        pos_args = getattr(self, '_' + type(self).__name__ + '__pos_params', [])
+        settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
+                    if k not in pos_args[:len(args)]}
+        return self.__class__(*args, **settings)
+
 
 class VLine(Annotation):
     "Vertical line annotation at the given position"
 
     group = param.String(default='VLine', constant=True)
 
+    x = param.Number(default=0, doc="The x-position of the VLine.")
+
+    __pos_params = ['x']
+
     def __init__(self, x, **params):
-        super(VLine, self).__init__(x, **params)
+        super(VLine, self).__init__(x, x=x, **params)
 
 
 
@@ -72,8 +87,12 @@ class HLine(Annotation):
 
     group = param.String(default='HLine', constant=True)
 
+    y = param.Number(default=0, doc="The y-position of the HLine.")
+
+    __pos_params = ['y']
+
     def __init__(self, y, **params):
-        super(HLine, self).__init__(y, **params)
+        super(HLine, self).__init__(y, y=y, **params)
 
     def dimension_values(self, dimension):
         index = self.get_dimension_index(dimension)
@@ -145,6 +164,8 @@ class Arrow(Annotation):
 
     group = param.String(default='Arrow', constant=True)
 
+    __pos_params = ['x', 'y', 'text', 'direction', 'points', 'arrowstyle']
+
     def __init__(self, x, y, text='', direction='<',
                  points=40, arrowstyle='->', **params):
 
@@ -165,14 +186,6 @@ class Arrow(Annotation):
             self.data = (x, y, text, direction, points, arrowstyle)
 
 
-    # Note: This version of clone is identical in Text and path.BaseShape
-    # Consider implementing a mix-in class if it is needed again.
-    def clone(self, *args, **overrides):
-        if len(args) == 1 and isinstance(args[0], tuple):
-            args = args[0]
-        arg_names = ['x', 'y', 'text', 'direction', 'points', 'arrowstyle']
-        settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
-                    if k not in arg_names[:len(args)]}
         return self.__class__(*args, **settings)
 
     def dimension_values(self, dimension, expanded=True, flat=True):
@@ -214,17 +227,11 @@ class Text(Annotation):
 
     group = param.String(default='Text', constant=True)
 
+    __pos_params = ['x', 'y', 'text', 'fontsize', 'halign', 'valign', 'rotation']
+
     def __init__(self, x,y, text, fontsize=12,
                  halign='center', valign='center', rotation=0, **params):
         info = (x,y, text, fontsize, halign, valign, rotation)
         super(Text, self).__init__(info, x=x, y=y, text=text,
                                    fontsize=fontsize, rotation=rotation,
                                    halign=halign, valign=valign, **params)
-
-    def clone(self, *args, **overrides):
-        if len(args) == 1 and isinstance(args[0], tuple):
-            args = args[0]
-        arg_names = ['x', 'y', 'text', 'fontsize', 'halign', 'valign', 'rotation']
-        settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
-                    if k not in arg_names[:len(args)]}
-        return self.__class__(*args, **settings)

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -179,7 +179,7 @@ def element_display(element, max_frames):
 @display_hook
 def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
-    if len(vmap) == 0  and isinstance(vmap, DynamicMap) and vmap.unbounded:
+    if  isinstance(vmap, DynamicMap) and vmap.unbounded:
         dims = ', '.join('%r' % dim for dim in  vmap.unbounded)
         msg = ('DynamicMap cannot be displayed without explicit indexing '
                'as {dims} dimension(s) are unbounded. '

--- a/tests/testannotations.py
+++ b/tests/testannotations.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from holoviews import Image, HLine, VLine, Text, Arrow, Annotation
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.element import Points
 
 class AnnotationTests(ComparisonTestCase):
     """
@@ -20,6 +21,11 @@ class AnnotationTests(ComparisonTestCase):
     #     regexp = "Parameter 'y' only takes numeric values"
     #     with self.assertRaisesRegexp(ValueError, regexp):
     #         hline = HLine(None)
+
+    def test_text_string_position(self):
+        text = Text('A', 1, 'A')
+        Points([('A', 1)]) * text
+        self.assertEqual(text.x, 'A')
 
     def test_hline_dimension_values(self):
         hline = HLine(0)

--- a/tests/testannotations.py
+++ b/tests/testannotations.py
@@ -10,9 +10,16 @@ class AnnotationTests(ComparisonTestCase):
     """
 
     def test_hline_invalid_constructor(self):
-        regexp = "Parameter 'y' only takes numeric values"
-        with self.assertRaisesRegexp(ValueError, regexp):
+        with self.assertRaises(Exception):
             hline = HLine(None)
+
+    # NOTE: This is the correct version of the test above but it will
+    # not work until the fix in param PR #149 is available.
+
+    # def test_hline_invalid_constructor(self):
+    #     regexp = "Parameter 'y' only takes numeric values"
+    #     with self.assertRaisesRegexp(ValueError, regexp):
+    #         hline = HLine(None)
 
     def test_hline_dimension_values(self):
         hline = HLine(0)

--- a/tests/testannotations.py
+++ b/tests/testannotations.py
@@ -9,6 +9,11 @@ class AnnotationTests(ComparisonTestCase):
     the basic Element types.
     """
 
+    def test_hline_invalid_constructor(self):
+        regexp = "Parameter 'y' only takes numeric values"
+        with self.assertRaisesRegexp(ValueError, regexp):
+            hline = HLine(None)
+
     def test_hline_dimension_values(self):
         hline = HLine(0)
         self.assertEqual(hline.range(0), (None, None))

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -47,7 +47,9 @@ class TestCallableName(ComparisonTestCase):
         self.assertEqual(Callable(lambda x: x).name, '<lambda>')
 
     def test_partial_name(self):
-        match = '<functools.partial object'
+        py2match = '<functools.partial object'
+        py3match = 'functools.partial('
+        match = py2match if sys.version_info < (3,0) else py3match
         cb = Callable(partial(lambda x,y: x, y=4))
         self.assertEqual(cb.name.startswith(match), True)
 

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -143,6 +143,21 @@ class TestDynamicMapInvocation(ComparisonTestCase):
         dmap = DynamicMap(fn, kdims=['A','B'])
         self.assertEqual(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
 
+    def test_dynamic_kdims_only_by_position(self):
+        def fn(A,B):
+            return Scatter([(A,2)], label=A)
+
+        dmap = DynamicMap(fn, kdims=['A-dim','B-dim'])
+        self.assertEqual(dmap['Test', 1], Scatter([(1, 2)], label='Test'))
+
+    def test_dynamic_kdims_swapped_by_name(self):
+        def fn(A,B):
+            return Scatter([(A,2)], label=A)
+
+        dmap = DynamicMap(fn, kdims=['B','A'])
+        self.assertEqual(dmap[1,'Test'], Scatter([(1, 2)], label='Test'))
+
+
     def test_dynamic_kdims_only_invalid(self):
         def fn(A,B):
             return Scatter([(A,2)], label=A)

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -4,15 +4,24 @@ Unit tests of the Callable object that wraps user callbacks. Also test
 how DynamicMap validates and invokes Callable based on its signature.
 """
 import param
+import sys
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Scatter
 from holoviews import streams
-from holoviews.core.spaces import Callable, DynamicMap
+from holoviews.core.spaces import Callable, Generator, DynamicMap
+from holoviews.core.operation import OperationCallable
+from holoviews.operation import contours
 from functools import partial
 
 from . import LoggingComparisonTestCase
 
 class CallableClass(object):
+
+    @staticmethod
+    def somestaticmethod(): pass
+
+    @classmethod
+    def someclsmethod(cls): pass
 
     def __call__(self, *testargs):
         return sum(testargs)
@@ -26,6 +35,63 @@ class ParamFunc(param.ParameterizedFunction):
     def __call__(self, a, **params):
         p = param.ParamOverrides(self, params)
         return a * p.b
+
+
+class TestCallableName(ComparisonTestCase):
+
+    def test_simple_function_name(self):
+        def foo(x,y): pass
+        self.assertEqual(Callable(foo).name, 'foo')
+
+    def test_simple_lambda_name(self):
+        self.assertEqual(Callable(lambda x: x).name, '<lambda>')
+
+    def test_partial_name(self):
+        match = '<functools.partial object'
+        cb = Callable(partial(lambda x,y: x, y=4))
+        self.assertEqual(cb.name.startswith(match), True)
+
+    def test_generator_expression_name(self):
+        if sys.version_info < (3,0):
+            cb = Generator((i for i in xrange(10)))
+        else:
+            cb = Generator((i for i in range(10)))
+        self.assertEqual(cb.name, '<genexpr>')
+
+    def test_generator_name(self):
+        def innergen(): yield
+        cb = Generator(innergen())
+        self.assertEqual(cb.name, 'innergen')
+
+    def test_callable_class_name(self):
+        self.assertEqual(Callable(CallableClass()).name, 'CallableClass')
+
+    def test_callable_class_call_method(self):
+        self.assertEqual(Callable(CallableClass().__call__).name, 'CallableClass')
+
+    def test_classmethod_name(self):
+        self.assertEqual(Callable(CallableClass().someclsmethod).name,
+                         'CallableClass.someclsmethod')
+
+    def test_staticmethod_name(self):
+        self.assertEqual(Callable(CallableClass().somestaticmethod).name,
+                         'somestaticmethod')
+
+    def test_parameterized_fn_name(self):
+        self.assertEqual(Callable(ParamFunc).name, 'ParamFunc')
+
+    def test_parameterized_fn_instance_name(self):
+        self.assertEqual(Callable(ParamFunc.instance()).name, 'ParamFunc')
+
+    def test_operation_name(self):
+        self.assertEqual(Callable(contours).name, 'contours')
+
+    def test_operation_instance_name(self):
+        self.assertEqual(Callable(contours.instance()).name, 'contours')
+
+    def test_operation_callable_name(self):
+        opcallable = OperationCallable(lambda x: x, operation=contours.instance())
+        self.assertEqual(Callable(opcallable).name, 'contours')
 
 
 class TestSimpleCallableInvocation(LoggingComparisonTestCase):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -78,6 +78,33 @@ class DynamicMapMethods(ComparisonTestCase):
         dmap = DynamicMap(fn, kdims=['i']).redim.range(i=(0,1))
         self.assertEqual(dmap.kdims[0].range, (0,1))
 
+    def test_redim_dimension_values_cache_reset_1D(self):
+        # Setting the values should drop mismatching keys from the cache
+        fn = lambda i: Curve([i,i])
+        dmap = DynamicMap(fn, kdims=['i'])[{0,1,2,3,4,5}]
+        self.assertEqual(dmap.keys(), [0,1,2,3,4,5])
+        redimmed = dmap.redim.values(i=[2,3,5,6,8])
+        self.assertEqual(redimmed.keys(), [2,3,5])
+
+    def test_redim_dimension_values_cache_reset_2D_single(self):
+        # Setting the values should drop mismatching keys from the cache
+        fn = lambda i,j: Curve([i,j])
+        keys = [(0,1),(1,0),(2,2),(2,5), (3,3)]
+        dmap = DynamicMap(fn, kdims=['i','j'])[keys]
+        self.assertEqual(dmap.keys(), keys)
+        redimmed = dmap.redim.values(i=[2,10,50])
+        self.assertEqual(redimmed.keys(), [(2,2),(2,5)])
+
+    def test_redim_dimension_values_cache_reset_2D_multi(self):
+        # Setting the values should drop mismatching keys from the cache
+        fn = lambda i,j: Curve([i,j])
+        keys = [(0,1),(1,0),(2,2),(2,5), (3,3)]
+        dmap = DynamicMap(fn, kdims=['i','j'])[keys]
+        self.assertEqual(dmap.keys(), keys)
+        redimmed = dmap.redim.values(i=[2,10,50], j=[5,50,100])
+        self.assertEqual(redimmed.keys(), [(2,5)])
+
+
     def test_redim_dimension_unit_aux(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap = DynamicMap(fn, kdims=['i']).redim.unit(i='m/s')


### PR DESCRIPTION
This PR contains an assortment of fixes for issues I encountered while updating the documentation. I will update the descriptions of what I've fixed as I go:

* Added some unit tests for swapping positional kdim arguments when listed by name.
* Unbounded DynamicMaps no longer display regardless of cache size. This is more consistent with the old behavior and less confusing.
* Applying redim on values now filters the DynamicMap cache accordingly. Some nasty errors occurred without this.
* Validated HLines and VLine constructors by declaring appropriate parameters.
* Fixed clone on annotations accordingly.
* Generalized the x,y parameters of annotations to support time types.
* Improved Callable names and improved exception handling in Callables.
* Enforced that OperationCallables have a supplied operation.
