### PR TITLE
Fixes for the PlotSize stream

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -641,7 +641,7 @@ class PlotSizeCallback(Callback):
 
     def _process_msg(self, msg):
         if msg.get('width') and msg.get('height'):
-            return {}
+            return msg
         else:
             return {}
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -416,9 +416,9 @@ class PlotSize(LinkedStream):
     Returns the dimensions of a plot once it has been displayed.
     """
 
-    width = param.Integer(300, constant=True, doc="The width of the plot in pixels")
+    width = param.Integer(None, constant=True, doc="The width of the plot in pixels")
 
-    height = param.Integer(300, constant=True, doc="The height of the plot in pixels")
+    height = param.Integer(None, constant=True, doc="The height of the plot in pixels")
 
     scale = param.Number(default=1.0, constant=True, doc="""
        Scale factor to scale width and height values reported by the stream""")


### PR DESCRIPTION
I accidentally left the PlotSize stream in my previous PR disabled, I also set the default width/height to None so the user specified datashade operation width/height end up overriding it on initialization.