### PR TITLE
Stream clear method now supports policies by precedence

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -296,7 +296,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
 
 
@@ -490,7 +490,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
 
     def _init_layout(self, layout):

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -334,7 +334,7 @@ class GridPlot(CompositePlot):
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
 
     def _get_size(self):
@@ -755,7 +755,7 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
 
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -792,7 +792,7 @@ class GenericOverlayPlot(GenericElementPlot):
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
-            self.traverse(lambda x: attach_streams(self, x.hmap, 1),
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
                           [GenericElementPlot])
 
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -408,7 +408,7 @@ def dim_axis_label(dimensions, separator=', '):
     return separator.join([d.pprint_label for d in dimensions])
 
 
-def attach_streams(plot, obj, precedence=0):
+def attach_streams(plot, obj, precedence=1.1):
     """
     Attaches plot refresh to all streams on the object.
     """

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -172,6 +172,12 @@ class Stream(param.Parameterized):
         Register a callable subscriber to this stream which will be
         invoked either when event is called or when this stream is
         passed to the trigger classmethod.
+
+        Precedence allows the subscriber ordering to be
+        controlled. Users should only add subscribers with precedence
+        between zero and one while HoloViews itself reserves the use of
+        higher precedence values. Subscribers with high precedence are
+        invoked later than ones with low precedence.
         """
         if not callable(subscriber):
             raise TypeError('Subscriber must be a callable.')

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -150,11 +150,26 @@ class Stream(param.Parameterized):
         return [s for p, s in sorted(self._subscribers)]
 
 
-    def clear(self):
+    def clear(self, policy='all'):
         """
         Clear all subscribers registered to this stream.
+
+        The default policy of 'all' clears all subscribers. If policy is
+        set to 'user', only subscribers defined by the user are cleared
+        (precedence between zero and one). A policy of 'internal' clears
+        subscribers with precedence greater than unity used internally
+        by HoloViews.
         """
-        self._subscribers = []
+        policies = ['all', 'user', 'internal']
+        if policy not in policies:
+            raise ValueError('Policy for clearing subscribers must be one of %s' % policies)
+        if policy == 'all':
+            remaining = []
+        elif policy == 'user':
+            remaining = [s for (p,s) in self._subscribers if p <= 1]
+        else:
+            remaining = [s for (p,s) in self._subscribers if p > 1]
+        self._subscribers = remaining
 
 
     def reset(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -166,9 +166,9 @@ class Stream(param.Parameterized):
         if policy == 'all':
             remaining = []
         elif policy == 'user':
-            remaining = [s for (p,s) in self._subscribers if p <= 1]
+            remaining = [(p,s) for (p,s) in self._subscribers if p > 1]
         else:
-            remaining = [s for (p,s) in self._subscribers if p > 1]
+            remaining = [(p,s) for (p,s) in self._subscribers if p <= 1]
         self._subscribers = remaining
 
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -444,6 +444,45 @@ class DynamicCallableMemoize(ComparisonTestCase):
         self.assertEqual(dmap[()], Curve([1, 1, 1, 2, 2, 2]))
 
 
+class StreamSubscribersAddandClear(ComparisonTestCase):
+
+    def setUp(self):
+        self.fn1 = lambda x: x
+        self.fn2 = lambda x: x**2
+        self.fn3 = lambda x: x**3
+        self.fn4 = lambda x: x**4
+
+    def test_subscriber_clear_all(self):
+        pointerx = PointerX(x=2)
+        pointerx.add_subscriber(self.fn1, precedence=0)
+        pointerx.add_subscriber(self.fn2, precedence=1)
+        pointerx.add_subscriber(self.fn3, precedence=1.5)
+        pointerx.add_subscriber(self.fn4, precedence=10)
+        self.assertEqual(pointerx.subscribers,  [self.fn1,self.fn2,self.fn3,self.fn4])
+        pointerx.clear('all')
+        self.assertEqual(pointerx.subscribers,  [])
+
+    def test_subscriber_clear_user(self):
+        pointerx = PointerX(x=2)
+        pointerx.add_subscriber(self.fn1, precedence=0)
+        pointerx.add_subscriber(self.fn2, precedence=1)
+        pointerx.add_subscriber(self.fn3, precedence=1.5)
+        pointerx.add_subscriber(self.fn4, precedence=10)
+        self.assertEqual(pointerx.subscribers,  [self.fn1,self.fn2,self.fn3,self.fn4])
+        pointerx.clear('user')
+        self.assertEqual(pointerx.subscribers,  [self.fn3,self.fn4])
+
+
+    def test_subscriber_clear_internal(self):
+        pointerx = PointerX(x=2)
+        pointerx.add_subscriber(self.fn1, precedence=0)
+        pointerx.add_subscriber(self.fn2, precedence=1)
+        pointerx.add_subscriber(self.fn3, precedence=1.5)
+        pointerx.add_subscriber(self.fn4, precedence=10)
+        self.assertEqual(pointerx.subscribers,  [self.fn1,self.fn2,self.fn3,self.fn4])
+        pointerx.clear('internal')
+        self.assertEqual(pointerx.subscribers,  [self.fn1,self.fn2])
+
 
 class DynamicStreamReset(ComparisonTestCase):
 


### PR DESCRIPTION
This PR improves the clear method to make it easier for users to use their own subscribers and clear them without clobbering the subscribers installed by HoloViews. Currently the default policy is 'all' but I might consider making it 'user' instead.