### PR TITLE
Added Streams.define to easily define custom streams

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -15,7 +15,7 @@ from .layout import Layout, AdjointLayout, NdLayout
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream, Next
+from ..streams import Stream
 
 class HoloMap(UniformNdMapping, Overlayable):
     """
@@ -652,9 +652,10 @@ class DynamicMap(HoloMap):
             if self.kdims:
                 raise Exception(prefix + ' must be declared without key dimensions')
             if len(self.streams)> 1:
-                raise Exception(prefix + ' must have either streams=[] or streams=[Next()]')
-            if len(self.streams) == 1 and not isinstance(self.streams[0], Next):
-                raise Exception(prefix + ' can only accept a single Next() stream')
+                raise Exception(prefix + ' must have either streams=[] or a single, '
+                                + 'stream instance without any stream parameters')
+            if util.stream_parameters(self.streams) != []:
+                raise Exception(prefix + ' cannot accept any stream parameters')
 
         self._posarg_keys = util.validate_dynamic_argspec(self.callback.argspec,
                                                           self.kdims,

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -89,26 +89,27 @@ class Stream(param.Parameterized):
         """
         params = {'name':param.String(default=name)}
         for k,v in kwargs.items():
+            kws = dict(default=v, constant=True)
             if isinstance(v, param.Parameter):
                 params[k] = v
             elif isinstance(v, bool):
-                params[k] = param.Boolean(default=v)
+                params[k] = param.Boolean(**kws)
             elif isinstance(v, int):
-                params[k] = param.Integer(default=v)
+                params[k] = param.Integer(**kws)
             elif isinstance(v, float):
-                params[k] = param.Number(default=v)
+                params[k] = param.Number(**kws)
             elif isinstance(v,str):
-                params[k] = param.String(default=v)
+                params[k] = param.String(**kws)
             elif isinstance(v,dict):
-                params[k] = param.Dict(default=v)
+                params[k] = param.Dict(**kws)
             elif isinstance(v, tuple):
-                params[k] = param.Tuple(default=v)
+                params[k] = param.Tuple(**kws)
             elif isinstance(v,list):
-                params[k] = param.List(default=v)
+                params[k] = param.List(**kws)
             elif isinstance(v,np.ndarray):
-                params[k] = param.Array(default=v)
+                params[k] = param.Array(**kws)
             else:
-                params[k] = param.Parameter(default=v)
+                params[k] = param.Parameter(**kws)
 
         # Dynamic class creation using type
         return type(name, (Stream,), params)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -334,14 +334,6 @@ class Stream(param.Parameterized):
         return repr(self)
 
 
-class Next(Stream):
-    """
-    Next is a special stream used to trigger generators. It may also be
-    used to trigger DynamicMaps using callables with no arguments.
-    """
-    pass
-
-
 class Counter(Stream):
     """
     Simple stream that automatically increments an integer counter
@@ -352,36 +344,6 @@ class Counter(Stream):
 
     def transform(self):
         return {'counter': self.counter + 1}
-
-
-class X(Stream):
-    """
-    Simple numeric stream representing a position along the x-axis.
-    """
-
-    x = param.Number(default=0, constant=True, doc="""
-       Numeric position along the x-axis.""")
-
-
-class Y(Stream):
-    """
-    Simple numeric stream representing a position along the y-axis.
-    """
-
-    y = param.Number(default=0, constant=True, doc="""
-       Numeric position along the y-axis.""")
-
-
-class XY(Stream):
-    """
-    Simple numeric stream representing a position along the x- and y-axes.
-    """
-
-    x = param.Number(default=0, constant=True, doc="""
-       Numeric position along the x-axis.""")
-
-    y = param.Number(default=0, constant=True, doc="""
-       Numeric position along the y-axis.""")
 
 
 class LinkedStream(Stream):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -76,12 +76,16 @@ class Stream(param.Parameterized):
     @classmethod
     def define(cls, name, **kwargs):
         """
-        Utility to quickly and easily declare Stream classes.
+        Utility to quickly and easily declare Stream classes. Designed
+        for interactive use such as notebooks and shouldn't replace
+        parameterized class definitions in source code that is imported.
 
         Takes a stream class name and a set of keywords where each
         keyword becomes a parameter. If the value is already a
         parameter, it is simply used otherwise the appropriate parameter
         type is inferred and declared, using the value as the default.
+
+        Supported types: bool, int, float, str, dict, tuple and list
         """
         params = {'name':param.String(default=name)}
         for k,v in kwargs.items():

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -5,6 +5,7 @@ server-side or in Javascript in the Jupyter notebook (client-side).
 """
 
 import param
+import numpy as np
 from numbers import Number
 from collections import defaultdict
 from .core import util
@@ -70,6 +71,44 @@ class Stream(param.Parameterized):
     # Mapping to define callbacks by backend and Stream type.
     # e.g. Stream._callbacks['bokeh'][Stream] = Callback
     _callbacks = defaultdict(dict)
+
+
+    @classmethod
+    def define(cls, name, **kwargs):
+        """
+        Utility to quickly and easily declare Stream classes.
+
+        Takes a stream class name and a set of keywords where each
+        keyword becomes a parameter. If the value is already a
+        parameter, it is simply used otherwise the appropriate parameter
+        type is inferred and declared, using the value as the default.
+        """
+        params = {'name':param.String(default=name)}
+        for k,v in kwargs.items():
+            if isinstance(v, param.Parameter):
+                params[k] = v
+            elif isinstance(v, bool):
+                params[k] = param.Boolean(default=v)
+            elif isinstance(v, int):
+                params[k] = param.Integer(default=v)
+            elif isinstance(v, float):
+                params[k] = param.Number(default=v)
+            elif isinstance(v,str):
+                params[k] = param.String(default=v)
+            elif isinstance(v,dict):
+                params[k] = param.Dict(default=v)
+            elif isinstance(v, tuple):
+                params[k] = param.Tuple(default=v)
+            elif isinstance(v,list):
+                params[k] = param.List(default=v)
+            elif isinstance(v,np.ndarray):
+                params[k] = param.Array(default=v)
+            else:
+                params[k] = param.Parameter(default=v)
+
+        # Dynamic class creation using type
+        return type(name, (Stream,), params)
+
 
     @classmethod
     def trigger(cls, streams):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -4,9 +4,12 @@ import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
 from holoviews.element import Image, Scatter, Curve, Text, Points
-from holoviews.streams import XY, PointerXY, PointerX, PointerY
+from holoviews.streams import Stream, PointerXY, PointerX, PointerY
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
+
+
+XY = Stream.define('XY', x=0,y=0)
 
 frequencies =  np.linspace(0.5,2.0,5)
 phases = np.linspace(0, np.pi*2, 5)


### PR DESCRIPTION
I'm very excited about this PR as I think it is a huge improvement in ease-of-use for users as I suspect custom streams will be very common.

Users will no longer need to start defining class in notebooks (which is ugly!) when they require a custom stream. Compare this:

![image](https://cloud.githubusercontent.com/assets/890576/25319640/eaff8d66-2897-11e7-8c75-55c76dea1d9a.png)

to this:

![image](https://cloud.githubusercontent.com/assets/890576/25319651/08e69342-2898-11e7-99cb-bec4fa2a4edf.png)

This uses ``type`` to dynamically create a streams class and figures out an appropriate parameter type and sets the value as the default. For a more complete parameter definition, you can do:

![image](https://cloud.githubusercontent.com/assets/890576/25319701/75e31268-2898-11e7-8e0b-448bdb5d4968.png)

Some programmers might object to this dynamic class creation as being too magical (though really, the implementation of ``define`` is trivial) and I personally wouldn't recommend people use this in library code - they should define a normal ``Stream`` subclass in the usual way.

For notebook use where you want to be concise and avoid code and for anyone not familiar with Python OOP, I think this will be highly appreciated. 
