### PR TITLE
Disabled single item legend on bokeh Points

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1097,7 +1097,7 @@ class LegendPlot(ElementPlot):
         if not plot.legend:
             return
         legend = plot.legend[0]
-        if not self.show_legend:
+        if (not self.overlaid and len(legend.items) == 1) or not self.show_legend:
             legend.items[:] = []
         else:
             plot.legend.orientation = 'horizontal' if self.legend_cols else 'vertical'

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -806,7 +806,14 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         fig = plot.state
-        assert len(fig.legend[0].items) == 0
+        self.assertEqual(len(fig.legend[0].items), 0)
+
+    def test_points_no_single_item_legend(self):
+        points = Points([('A', 1), ('B', 2)], label='A')
+        plot = bokeh_renderer.get_plot(points)
+        plot.initialize_plot()
+        fig = plot.state
+        self.assertEqual(len(fig.legend[0].items), 0)
 
     def test_image_boolean_array(self):
         img = Image(np.array([[True, False], [False, True]]))


### PR DESCRIPTION
Tiny PR disabling this from happening when you set a label on a single set of Points:

<img width="306" alt="screen shot 2017-04-24 at 9 03 07 pm" src="https://cloud.githubusercontent.com/assets/1550771/25356267/7794281a-2931-11e7-8633-5cd23442f45f.png">

