### PR TITLE
Fixed flakes in mpl and plotly backend

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -3,7 +3,7 @@ from distutils.version import LooseVersion
 
 from matplotlib import rc_params_from_file
 
-from ...core import Layout, NdOverlay, Collator, GridMatrix
+from ...core import Layout, Collator, GridMatrix
 from ...core.options import Cycle, Palette, Options
 from ...core.overlay import NdOverlay, Overlay
 from ...element import * # noqa (API import)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -9,19 +9,17 @@ from matplotlib import cm
 from matplotlib import pyplot as plt
 from matplotlib.collections import LineCollection
 from matplotlib.path import Path as MPLPath
-from matplotlib.dates import date2num, DateFormatter
+from matplotlib.dates import DateFormatter
 
 mpl_version = LooseVersion(mpl.__version__)
 
 import param
 
 from ...core import OrderedDict, Dimension
-from ...core.util import (match_spec, unique_iterator, bytes_to_unicode,
-                          basestring, max_range, unicode)
+from ...core.util import match_spec, unique_iterator, basestring, max_range
 from ...element import Points, Raster, Polygons, HeatMap
 from ...operation import interpolate_curve
-from ..util import (compute_sizes, get_sideplot_ranges, map_colors,
-                    get_min_distance)
+from ..util import compute_sizes, get_sideplot_ranges, get_min_distance
 from .element import ElementPlot, ColorbarPlot, LegendPlot
 from .path  import PathPlot
 from .plot import AdjoinedPlot, mpl_rc_context

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -534,7 +534,6 @@ class PointPlot(ChartPlot, ColorbarPlot):
             cs = element.dimension_values(self.color_index)
             # Check if numeric otherwise treat as categorical
             if cs.dtype.kind in 'if':
-                crange = ranges.get(cdim.name, element.range(cdim.name))
                 style['c'] = cs
             else:
                 categories = np.unique(cs)

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -11,13 +11,12 @@ from matplotlib import gridspec, animation
 import param
 from ...core import (OrderedDict, HoloMap, AdjointLayout, NdLayout,
                      GridSpace, Element, CompositeOverlay, Empty,
-                     Collator, GridMatrix, Layout, ViewableElement)
+                     Collator, GridMatrix, Layout)
 from ...core.options import Store, Compositor, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
-from ...core import traversal
 from ..plot import (DimensionedPlot, GenericLayoutPlot, GenericCompositePlot,
                     GenericElementPlot)
-from ..util import get_dynamic_mode, attach_streams
+from ..util import attach_streams
 from .util import compute_ratios, fix_aspect
 
 
@@ -130,7 +129,6 @@ class MPLPlot(DimensionedPlot):
                                for i in self.fig_inches]
         else:
             self.fig_inches *= self.fig_scale
-        rc_params = self.fig_rcparams
         if self.fig_latex:
             self.fig_rcparams['text.usetex'] = True
 
@@ -1084,10 +1082,10 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             traverse_fn = lambda x: x.handles.get('bbox_extra_artists', None)
             extra_artists = list(chain(*[artists for artists in self.traverse(traverse_fn)
                                          if artists is not None]))
-            aspect = fix_aspect(fig, self.rows, self.cols,
-                                title_obj, extra_artists,
-                                vspace=self.vspace*self.fig_scale,
-                                hspace=self.hspace*self.fig_scale)
+            fix_aspect(fig, self.rows, self.cols,
+                       title_obj, extra_artists,
+                       vspace=self.vspace*self.fig_scale,
+                       hspace=self.hspace*self.fig_scale)
             colorbars = self.traverse(specs=[lambda x: hasattr(x, 'colorbar')])
             for cbar_plot in colorbars:
                 if cbar_plot.colorbar:

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -1,9 +1,6 @@
-import copy
 from itertools import product
 
 import numpy as np
-from matplotlib import pyplot as plt
-
 import param
 
 from ...core import CompositeOverlay, Element

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -1,5 +1,4 @@
 import sys
-
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 from contextlib import contextmanager
@@ -7,12 +6,9 @@ from itertools import chain
 
 import matplotlib as mpl
 from matplotlib import pyplot as plt
-
-from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
-
-import param
 from param.parameterized import bothmethod
 
+import param
 from ...core import HoloMap
 from ...core.options import Store
 
@@ -133,7 +129,7 @@ class MPLRenderer(Renderer):
         try:
             plots = []
             objects = obj if isinstance(obj, list) else [obj]
-            for o in obj:
+            for o in objects:
                 plots.append(self.get_plot(o))
             plt.show()
         except:

--- a/holoviews/plotting/mpl/tabular.py
+++ b/holoviews/plotting/mpl/tabular.py
@@ -3,7 +3,6 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.table import Table as mpl_Table
 import param
 
-from ...core.util import bytes_to_unicode, unicode
 from .element import ElementPlot
 from .plot import mpl_rc_context
 
@@ -81,7 +80,6 @@ class TablePlot(ElementPlot):
     def _cell_value(self, element, row, col):
         summarize = element.rows > self.max_rows
         half_rows = self.max_rows//2
-        rows = min([self.max_rows, element.rows])
         if summarize and row == half_rows:
             cell_text = "..."
         else:

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -1,4 +1,4 @@
-import uuid, json, warnings
+import json
 import param
 
 from ..widgets import NdWidget, SelectionWidget, ScrubberWidget

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -1,15 +1,16 @@
 from ...core.options import Store, Cycle, Options
 from ...core import (Overlay, NdOverlay, Layout, NdLayout, GridSpace,
                      GridMatrix)
-from ...interface.seaborn import *
-from ...element import * 
+from ...interface.seaborn import *    # noqa (Element import for registration)
+from ...element import *              # noqa (Element import for registration)
 from .renderer import PlotlyRenderer
-from .element import *
-from .chart import *
-from .chart3d import *
-from .raster import *
-from .plot import *
-from .tabular import *
+
+from .element import *                # noqa (API import)
+from .chart import *                 # noqa (API import)
+from .chart3d import *               # noqa (API import)
+from .raster import *                # noqa (API import)
+from .plot import *                  # noqa (API import)
+from .tabular import *               # noqa (API import)
 
 Store.renderers['plotly'] = PlotlyRenderer.instance()
 

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -1,6 +1,5 @@
 import param
 import plotly.graph_objs as go
-from plotly.tools import FigureFactory as FF
 
 from ...core import util
 from ...operation import interpolate_curve
@@ -36,7 +35,6 @@ class PointPlot(ScatterPlot):
     def get_data(self, element, ranges):
         data = dict(x=element.dimension_values(0),
                     y=element.dimension_values(1))
-        cdim = element.get_dimension(self.color_index)
         return (), data
 
 
@@ -142,7 +140,6 @@ class BarPlot(ElementPlot):
         element = self._get_frame(key)
         ranges = self.compute_ranges(self.hmap, key, ranges)
         ranges = util.match_spec(element, ranges)
-        opts = self.graph_options(element, ranges)
 
         cat_dim = element.get_dimension(self.category_index)
         stack_dim = element.get_dimension(self.stack_index)
@@ -198,7 +195,6 @@ class BoxWhiskerPlot(ElementPlot):
         element = self._get_frame(key)
         ranges = self.compute_ranges(self.hmap, key, ranges)
         ranges = util.match_spec(element, ranges)
-        opts = self.graph_options(element, ranges)
 
         style = self.style[self.cyclic_index]
         orientation = 'h' if self.invert_axes else 'v'

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -12,7 +12,6 @@ except ImportError:
 
 import param
 
-from ...core.spaces import DynamicMap
 from ...core.options import SkipRendering
 from .element import ElementPlot, ColorbarPlot
 from .chart import ScatterPlot

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -1,8 +1,6 @@
 import plotly.graph_objs as go
-from plotly.tools import FigureFactory as FF
 import param
 
-from ...core.options import Store
 from .plot import PlotlyPlot
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from .. import util
@@ -237,7 +235,6 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
         element = self._get_frame(key)
 
         ranges = self.compute_ranges(self.hmap, key, ranges)
-        graphs = []
         figure = None
         for okey, subplot in self.subplots.items():
             fig = subplot.generate_plot(key, ranges)

--- a/holoviews/plotting/plotly/raster.py
+++ b/holoviews/plotting/plotly/raster.py
@@ -3,7 +3,7 @@ import plotly.graph_objs as go
 
 from ...core.options import SkipRendering
 from ...core.util import unique_array
-from ...element import Image, Raster
+from ...element import Image
 from .element import ColorbarPlot
 
 

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -5,7 +5,6 @@ with param.logging_level('CRITICAL'):
     from plotly.offline.offline import utils, get_plotlyjs
 
 from ..renderer import Renderer, MIME_TYPES
-from ..widgets import NdWidget
 from ...core.options import Store
 from ...core import HoloMap
 from ..comms import JupyterComm

--- a/holoviews/plotting/plotly/tabular.py
+++ b/holoviews/plotting/plotly/tabular.py
@@ -1,8 +1,5 @@
 import param
-import plotly.graph_objs as go
 from plotly.tools import FigureFactory as FF
-
-from ..plot import GenericElementPlot 
 from .element import ElementPlot
 
 
@@ -17,7 +14,7 @@ class TablePlot(ElementPlot):
         data = list(zip(*((d.pprint_value(v) for v in element.dimension_values(d))
                         for d in element.dimensions())))
         return (headings+data,), {}
-    
+
     def init_graph(self, plot_args, plot_kwargs):
         return FF.create_table(*plot_args, **plot_kwargs)
 
@@ -27,7 +24,7 @@ class TablePlot(ElementPlot):
         properties = self.style[self.cyclic_index]
         return properties
 
-    
+
     def init_layout(self, key, element, ranges):
         return dict(width=self.width, height=self.height,
                     title=self._format_title(key, separator=' '),

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -9,7 +9,7 @@ def add_figure(fig, subfig, r, c, idx):
     """
     ref = fig._grid_ref[r][c][0][1:]
     layout = replace_refs(subfig['layout'], ref)
-    
+
     fig['layout']['xaxis%s'%ref].update(layout.get('xaxis', {}))
     fig['layout']['yaxis%s'%ref].update(layout.get('yaxis', {}))
     fig['layout']['annotations'].extend(layout.get('annotations', []))
@@ -27,7 +27,7 @@ def replace_refs(obj, ind):
         new_obj = {}
         for k, v in obj.items():
             if k in ['xref', 'yref']:
-                v = '{ax}{ind}'.format(ax=k[0], ref=ref)
+                v = '{ax}{ind}'.format(ax=k[0], ind=ind)
             new_obj[k] = replace_refs(v, ind)
         return new_obj
     else:

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -274,9 +274,6 @@ class SelectionWidget(NdWidget):
 
             # Hide widget if it has 1-to-1 mapping to next widget
             visible = True
-            dim_nesting = hierarchy[idx-1].values() if idx and isinstance(hierarchy, list) else {}
-            many_to_one = any(len(v) > 1 for v in dim_nesting)
-
             if self.plot.dynamic:
                 if dim.values:
                     if all(isnumeric(v) for v in dim.values):

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -4,7 +4,7 @@ import param
 
 from .core import DynamicMap, HoloMap, ViewableElement
 from .core.operation import ElementOperation
-from .core.util import Aliases
+from .core.util import Aliases  # noqa (API import)
 from .core.operation import OperationCallable
 from .core.spaces import Callable
 from .core import util

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -41,11 +41,9 @@ class MockLoggingHandler(logging.Handler):
 
     def reset(self):
         self.acquire()
-        try:
-            for message_list in self.messages.values():
-                message_list = []
-        finally:
-            self.release()
+        self.messages = {'DEBUG': [], 'INFO': [], 'WARNING': [],
+                         'ERROR': [], 'CRITICAL': [], 'VERBOSE':[]}
+        self.release()
 
     def tail(self, level, n=1):
         "Returns the last n lines captured at the given level"

--- a/tests/testannotations.py
+++ b/tests/testannotations.py
@@ -1,6 +1,4 @@
-import numpy as np
-
-from holoviews import Image, HLine, VLine, Text, Arrow, Annotation
+from holoviews import HLine, VLine, Text, Arrow, Annotation
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Points
 
@@ -12,7 +10,7 @@ class AnnotationTests(ComparisonTestCase):
 
     def test_hline_invalid_constructor(self):
         with self.assertRaises(Exception):
-            hline = HLine(None)
+            HLine(None)
 
     # NOTE: This is the correct version of the test above but it will
     # not work until the fix in param PR #149 is available.

--- a/tests/testbokehcallbacks.py
+++ b/tests/testbokehcallbacks.py
@@ -1,6 +1,7 @@
 from unittest import SkipTest
 
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.core.options import Store
 
 try:
     from holoviews.plotting.bokeh.callbacks import Callback

--- a/tests/testbokehutils.py
+++ b/tests/testbokehutils.py
@@ -1,16 +1,10 @@
-from collections import defaultdict
 from unittest import SkipTest
-
-import numpy as np
-
 from holoviews.core import Store
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.element import Curve, Points, Path
 
 try:
     from holoviews.plotting.bokeh.util import (
-        bokeh_version, expand_batched_style, filter_batched_data
-    )
+        expand_batched_style, filter_batched_data )
     bokeh_renderer = Store.renderers['bokeh']
 except:
     bokeh_renderer = None

--- a/tests/testbokehwidgets.py
+++ b/tests/testbokehwidgets.py
@@ -6,10 +6,7 @@ from holoviews.core import Dimension, NdMapping
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
-    from holoviews.plotting.bokeh.callbacks import Callback
     from holoviews.plotting.bokeh.widgets import BokehServerWidgets
-    from holoviews.plotting.bokeh.util import bokeh_version
-
     from bokeh.models.widgets import Select, Slider, AutocompleteInput, TextInput, Div
 except:
     BokehServerWidgets = None
@@ -113,7 +110,7 @@ class TestBokehServerWidgets(ComparisonTestCase):
         self.assertEqual(label.value, '3.1')
         self.assertEqual(mapping, [(v, dim.pprint_value(v)) for v in values])
 
-    def test_bokeh_server_dynamic_values_str(self):
+    def test_bokeh_server_dynamic_values_str_1(self):
         values = [chr(65+i) for i in range(10)]
         dim = Dimension('x', values=values)
         widget, label, mapping = BokehServerWidgets.create_widget(dim, editable=True)
@@ -124,9 +121,20 @@ class TestBokehServerWidgets(ComparisonTestCase):
         self.assertIs(mapping, None)
         self.assertIs(label, None)
 
+    def test_bokeh_server_dynamic_values_str_2(self):
+        keys = [chr(65+i) for i in range(10)]
+        ndmap = NdMapping({i: None for i in keys}, kdims=['x'])
+        dim = Dimension('x')
+        widget, label, mapping = BokehServerWidgets.create_widget(dim, ndmap, editable=True)
+        self.assertIsInstance(widget, Select)
+        self.assertEqual(widget.value, 'A')
+        self.assertEqual(widget.options, list(zip(keys, keys)))
+        self.assertEqual(widget.title, dim.pprint_label)
+        self.assertEqual(mapping, list(zip(keys, keys)))
+
     def test_bokeh_server_static_numeric_values(self):
         dim = Dimension('x')
-        ndmap = NdMapping({i: None for i in range(3, 12)}, kdims=['x']) 
+        ndmap = NdMapping({i: None for i in range(3, 12)}, kdims=['x'])
         widget, label, mapping = BokehServerWidgets.create_widget(dim, ndmap, editable=True)
         self.assertIsInstance(widget, Slider)
         self.assertEqual(widget.value, 0)
@@ -137,14 +145,3 @@ class TestBokehServerWidgets(ComparisonTestCase):
         self.assertEqual(label.title, dim.pprint_label)
         self.assertEqual(label.value, '3')
         self.assertEqual(mapping, [(k, dim.pprint_value(k)) for k in ndmap.keys()])
-
-    def test_bokeh_server_dynamic_values_str(self):
-        keys = [chr(65+i) for i in range(10)]
-        ndmap = NdMapping({i: None for i in keys}, kdims=['x'])
-        dim = Dimension('x') 
-        widget, label, mapping = BokehServerWidgets.create_widget(dim, ndmap, editable=True)
-        self.assertIsInstance(widget, Select)
-        self.assertEqual(widget.value, 'A')
-        self.assertEqual(widget.options, list(zip(keys, keys)))
-        self.assertEqual(widget.title, dim.pprint_label)
-        self.assertEqual(mapping, list(zip(keys, keys)))

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -232,7 +232,7 @@ class TestDynamicMapInvocation(ComparisonTestCase):
 
         regexp="Callable accepts more positional arguments than there are kdims and stream parameters"
         with self.assertRaisesRegexp(KeyError, regexp):
-            dmap = DynamicMap(fn, kdims=['A'])
+            DynamicMap(fn, kdims=['A'])
 
 
     def test_dynamic_kdims_args_only(self):

--- a/tests/testcollation.py
+++ b/tests/testcollation.py
@@ -1,10 +1,7 @@
 """
 Test cases for Collator
 """
-
 import itertools
-import unittest
-
 import numpy as np
 
 from holoviews.core import Collator, HoloMap, NdOverlay, Overlay, GridSpace

--- a/tests/testcomms.py
+++ b/tests/testcomms.py
@@ -1,6 +1,4 @@
 import json
-from nose.tools import *
-
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting.comms import Comm, JupyterComm
 

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -47,12 +47,12 @@ class DimensionNameLabelTest(LoggingComparisonTestCase):
     def test_dimension_invalid_name(self):
         regexp = 'Dimension name must only be passed as the positional argument'
         with self.assertRaisesRegexp(KeyError, regexp):
-            dim = Dimension('test', name='something else')
+            Dimension('test', name='something else')
 
     def test_dimension_invalid_name_tuple(self):
         regexp = 'Dimension name must only be passed as the positional argument'
         with self.assertRaisesRegexp(KeyError, regexp):
-            dim = Dimension(('test', 'test dimension'), name='something else')
+            Dimension(('test', 'test dimension'), name='something else')
 
 
 class DimensionReprTest(ComparisonTestCase):

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -210,7 +210,7 @@ class DynamicMapMethods(ComparisonTestCase):
         exception = ("DynamicMap does not allow dropping dimensions, "
                      "reindex may only be used to reorder dimensions.")
         with self.assertRaisesRegexp(ValueError, exception):
-            reindexed = dmap.reindex(['x'])
+            dmap.reindex(['x'])
 
 
 class DynamicMapUnboundedProperty(ComparisonTestCase):
@@ -285,7 +285,7 @@ class DynamicTransferStreams(ComparisonTestCase):
         exception = ("The supplied stream objects PointerX\(x=None\) and "
                      "PointerX\(x=0\) clash on the following parameters: \['x'\]")
         with self.assertRaisesRegexp(Exception, exception):
-            hist = Dynamic(self.dmap, streams=[PointerX])
+            Dynamic(self.dmap, streams=[PointerX])
 
 
 
@@ -563,7 +563,7 @@ class DynamicCollate(ComparisonTestCase):
         cb_callable = Callable(callback)
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         with self.assertRaisesRegexp(ValueError, 'The following streams are set to be automatically linked'):
-            layout = dmap.collate()
+            dmap.collate()
 
     def test_dynamic_collate_layout_raise_ambiguous_remapping_error(self):
         def callback(x, y):
@@ -572,7 +572,7 @@ class DynamicCollate(ComparisonTestCase):
         cb_callable = Callable(callback, stream_mapping={'Image': [stream]})
         dmap = DynamicMap(cb_callable, kdims=[], streams=[stream])
         with self.assertRaisesRegexp(ValueError, 'The stream_mapping supplied on the Callable is ambiguous'):
-            layout = dmap.collate()
+            dmap.collate()
 
     def test_dynamic_collate_layout_with_integer_stream_mapping(self):
         def callback(x, y):

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -39,10 +39,6 @@ class ImageInterfaceTest(ComparisonTestCase):
         self.assertEqual(self.image.dimension_values(1, expanded=False),
                          np.linspace(0.5, 9.5, 10))
 
-    def test_dimension_values_ys(self):
-        self.assertEqual(self.image.dimension_values(1, expanded=False),
-                         np.linspace(0.5, 9.5, 10))
-
     def test_dimension_values_vdim(self):
         self.assertEqual(self.image.dimension_values(2, flat=False),
                          self.array)
@@ -231,10 +227,6 @@ class RGBInterfaceTest(ComparisonTestCase):
     def test_dimension_values_xs(self):
         self.assertEqual(self.rgb.dimension_values(0, expanded=False),
                          np.linspace(-9, 9, 10))
-
-    def test_dimension_values_ys(self):
-        self.assertEqual(self.rgb.dimension_values(1, expanded=False),
-                         np.linspace(0.5, 9.5, 10))
 
     def test_dimension_values_ys(self):
         self.assertEqual(self.rgb.dimension_values(1, expanded=False),

--- a/tests/testlayouts.py
+++ b/tests/testlayouts.py
@@ -1,4 +1,3 @@
-import unittest
 from holoviews import AdjointLayout, NdLayout, GridSpace, Layout, Element, HoloMap
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -57,16 +56,16 @@ class AdjointLayoutTest(CompositeTest):
         self.assertEqual(layout.main, self.view3 * self.view1)
         self.assertEqual(layout.right, self.view2)
 
-    def test_adjointlayout_overlay_main_and_right(self):
+    def test_adjointlayout_overlay_main_and_right_v1(self):
         layout = (self.view1 << self.view2) * (self.view1 << self.view3)
         self.assertEqual(layout.main, self.view1 * self.view1)
         self.assertEqual(layout.right, self.view2 * self.view3)
 
-    def test_adjointlayout_overlay_main_and_right(self):
+    def test_adjointlayout_overlay_main_and_right_v2(self):
         layout = (self.view1 << self.view3) * (self.view1 << self.view2)
         self.assertEqual(layout.main, self.view1 * self.view1)
         self.assertEqual(layout.right, self.view3 * self.view2)
-        
+
     def test_adjointlayout_overlay_holomap(self):
         layout = self.hmap * (self.view1 << self.view3)
         self.assertEqual(layout.main, self.hmap * self.view1)
@@ -107,7 +106,7 @@ class AdjointLayoutTest(CompositeTest):
             (self.view1 << self.view2 << self.view3) * (self.hmap << dim_view)
 
 
-        
+
 class NdLayoutTest(CompositeTest):
 
     def test_ndlayout_init(self):

--- a/tests/testparsers.py
+++ b/tests/testparsers.py
@@ -153,7 +153,6 @@ class OptsSpecStyleOptionsTests(ComparisonTestCase):
         values = np.array([[ 0.37454012,  0.95071431,  0.73199394],
                            [ 0.59865848,  0.15601864,  0.15599452],
                            [ 0.05808361,  0.86617615,  0.60111501]])
-        expected = {'Curve': {'style': Options(color=Cycle(values=list(values)))}}
         self.assertEqual(np.array(options['Curve']['style'].kwargs['color'].values),
                          values)
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -7,7 +7,7 @@ import logging
 import datetime as dt
 from collections import deque
 from unittest import SkipTest
-from io import BytesIO, StringIO
+from io import StringIO
 
 import param
 import numpy as np
@@ -47,7 +47,7 @@ try:
     from holoviews.plotting.bokeh.callbacks import Callback
     from bokeh.models import (
         Div, ColumnDataSource, FactorRange, Range1d, Row, Column,
-        ToolbarBox, Spacer, FixedTicker, FuncTickFormatter
+        ToolbarBox, FixedTicker, FuncTickFormatter
     )
     from bokeh.models.mappers import (LinearColorMapper, LogColorMapper,
                                       CategoricalColorMapper)
@@ -57,7 +57,7 @@ except:
     bokeh_renderer = None
 
 try:
-    import holoviews.plotting.plotly
+    import holoviews.plotting.plotly # noqa (Activate backend)
     plotly_renderer = Store.renderers['plotly']
 except:
     plotly_renderer = None
@@ -113,7 +113,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
             raise SkipTest("Seaborn required to test Regression plot")
         reg = Regression(np.random.rand(20,2))
         plot = mpl_renderer.get_plot(reg)
-        axis = plot.handles['axis']
+        plot.handles['axis']
         plot.initialize_plot()
 
     def test_dynamic_nonoverlap(self):
@@ -183,7 +183,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
 
     def test_curve_pandas_timestamps(self):
         if not pd:
-            raise SkipError("Pandas not available")
+            raise SkipTest("Pandas not available")
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
         curve = Curve((dates, np.random.rand(10)))
         plot = mpl_renderer.get_plot(curve)
@@ -205,7 +205,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
 
     def test_curve_heterogeneous_datetime_types_with_pd_overlay(self):
         if not pd:
-            raise SkipError("Pandas not available")
+            raise SkipTest("Pandas not available")
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
@@ -291,7 +291,7 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
     def test_points_rcparams_do_not_persist(self):
         opts = dict(fig_rcparams={'text.usetex': True})
         points = Points(([0, 1], [0, 3]))(plot=opts)
-        plot = mpl_renderer.get_plot(points)
+        mpl_renderer.get_plot(points)
         self.assertFalse(pyplot.rcParams['text.usetex'])
 
     def test_points_rcparams_used(self):
@@ -600,7 +600,6 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
     def _test_colormapping(self, element, dim, log=False):
         plot = bokeh_renderer.get_plot(element)
         plot.initialize_plot()
-        fig = plot.state
         cmapper = plot.handles['color_mapper']
         low, high = element.range(dim)
         self.assertEqual(cmapper.low, low)
@@ -657,7 +656,6 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                          vdims=['a', 'b'])(plot=dict(color_index='b'))
         plot = bokeh_renderer.get_plot(points)
         plot.initialize_plot()
-        fig = plot.state
         cmapper = plot.handles['color_mapper']
         self.assertIsInstance(cmapper, CategoricalColorMapper)
         self.assertEqual(cmapper.factors, list(points['b']))
@@ -1029,7 +1027,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(x_range, Range1d)
         self.assertIsInstance(y_range, FactorRange)
         self.assertEqual(y_range.factors, ['A', 'B', 'C', 'D', 'E'])
-    
+
     def test_box_whisker_datetime(self):
         times = np.arange(dt.datetime(2017,1,1), dt.datetime(2017,2,1),
                           dt.timedelta(days=1))
@@ -1050,7 +1048,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
 
     def test_curve_pandas_timestamps(self):
         if not pd:
-            raise SkipError("Pandas not available")
+            raise SkipTest("Pandas not available")
         dates = pd.date_range('2016-01-01', '2016-01-10', freq='D')
         curve = Curve((dates, np.random.rand(10)))
         plot = bokeh_renderer.get_plot(curve)
@@ -1075,7 +1073,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
 
     def test_curve_heterogeneous_datetime_types_with_pd_overlay(self):
         if not pd:
-            raise SkipError("Pandas not available")
+            raise SkipTest("Pandas not available")
         dates_pd = pd.date_range('2016-01-04', '2016-01-13', freq='D')
         dates64 = [np.datetime64(dt.datetime(2016,1,i)) for i in range(1, 11)]
         dates = [dt.datetime(2016,1,i) for i in range(2, 12)]
@@ -1238,16 +1236,6 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         overlay = (Curve(range(10)) * Curve(range(10)))(plot=dict(show_frame=False))
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.outline_line_alpha, 0)
-
-    def test_element_no_xaxis(self):
-        curve = Curve(range(10))(plot=dict(xaxis=None))
-        plot = bokeh_renderer.get_plot(curve).state
-        self.assertFalse(plot.xaxis[0].visible)
-
-    def test_element_no_yaxis(self):
-        curve = Curve(range(10))(plot=dict(yaxis=None))
-        plot = bokeh_renderer.get_plot(curve).state
-        self.assertFalse(plot.yaxis[0].visible)
 
     def test_element_no_xaxis(self):
         curve = Curve(range(10))(plot=dict(xaxis=None))

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -10,7 +10,6 @@ from unittest import SkipTest
 import numpy as np
 
 from holoviews import HoloMap, Image, ItemTable, Store, GridSpace, Table
-from holoviews.core.util import unicode
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting import Renderer
 

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -252,14 +252,14 @@ class TestParameterRenaming(ComparisonTestCase):
         xy = PointerXY(x=0, y=4)
         regexp = '(.+?)is not a stream parameter'
         with self.assertRaisesRegexp(KeyError, regexp):
-            renamed = xy.rename(x='xtest', z='ytest')
+            xy.rename(x='xtest', z='ytest')
 
 
     def test_clashing_rename_method(self):
         xy = PointerXY(x=0, y=4)
         regexp = '(.+?)parameter of the same name'
         with self.assertRaisesRegexp(KeyError, regexp):
-            renamed = xy.rename(x='xtest', y='x')
+            xy.rename(x='xtest', y='x')
 
     def test_update_rename_valid(self):
         xy = PointerXY(x=0, y=4)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -46,18 +46,18 @@ class TestDeepHash(ComparisonTestCase):
     def test_deephash_set_inequality(self):
         self.assertNotEqual(deephash(set([1,2,3])), deephash(set([1,3,4])))
 
-    def test_deephash_dict_equality(self):
+    def test_deephash_dict_equality_v1(self):
         self.assertEqual(deephash({1:'a',2:'b'}), deephash({2:'b', 1:'a'}))
 
-    def test_deephash_dict_equality(self):
+    def test_deephash_dict_equality_v2(self):
         self.assertNotEqual(deephash({1:'a',2:'b'}), deephash({2:'b', 1:'c'}))
 
-    def test_deephash_odict_equality(self):
+    def test_deephash_odict_equality_v1(self):
         odict1 = OrderedDict([(1,'a'), (2,'b')])
         odict2 = OrderedDict([(1,'a'), (2,'b')])
         self.assertEqual(deephash(odict1), deephash(odict2))
 
-    def test_deephash_odict_equality(self):
+    def test_deephash_odict_equality_v2(self):
         odict1 = OrderedDict([(1,'a'), (2,'b')])
         odict2 = OrderedDict([(1,'a'), (2,'c')])
         self.assertNotEqual(deephash(odict1), deephash(odict2))


### PR DESCRIPTION
This PR fixes the remaining flakes issues raised with:

```
flake8 --ignore=E,W,F999  .
```