### PR TITLE
Added strict class attribute to OptsMagic

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -353,7 +353,6 @@ class Options(param.Parameterized):
         for kwarg in sorted(kwargs.keys()):
             if allowed_keywords and kwarg not in allowed_keywords:
                 if self.skip_invalid:
-                    kwargs.pop(kwarg)
                     invalid_kws.append(kwarg)
                 else:
                     raise OptionError(kwarg, allowed_keywords)

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -664,16 +664,21 @@ class OptsMagic(Magics):
             loaded=' in loaded backends {0} and {1!r}'.format(backend_list,
                                                             loaded_backends[-1])
 
+        suggestion = ("If you believe this keyword is correct, please make sure "
+                      "the backend hasbeen imported or loaded with the "
+                      "notebook_extension.")
+
         group = '{0} option'.format(err.group_name) if err.group_name else 'keyword'
         msg=('Unexpected {group} {kw} {target}{loaded}.<br><br>'
              '{similarity} keywords in the currently active '
-             '{current_backend} backend are: {matches}')
+             '{current_backend} backend are: {matches}<br><br>{suggestion}')
         return msg.format(kw="'%s'" % err.invalid_keyword,
                           target=target,
                           group=group,
                           loaded=loaded, similarity=similarity,
                           current_backend=repr(Store.current_backend),
-                          matches=matches)
+                          matches=matches,
+                          suggestion=suggestion)
 
     @classmethod
     def register_custom_spec(cls, spec):

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -665,7 +665,7 @@ class OptsMagic(Magics):
                                                             loaded_backends[-1])
 
         suggestion = ("If you believe this keyword is correct, please make sure "
-                      "the backend hasbeen imported or loaded with the "
+                      "the backend has been imported or loaded with the "
                       "notebook_extension.")
 
         group = '{0} option'.format(err.group_name) if err.group_name else 'keyword'

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -170,10 +170,10 @@ class BokehRenderer(Renderer):
         factor = percent_size / 100.0
         obj = obj.last if isinstance(obj, HoloMap) else obj
         plot = Store.registry[cls.backend].get(type(obj), None)
-        options = Store.lookup_options(cls.backend, obj, 'plot').options
         if not hasattr(plot, 'width') or not hasattr(plot, 'height'):
             from .plot import BokehPlot
             plot = BokehPlot
+        options = plot.lookup_options(obj, 'plot').options
         width = options.get('width', plot.width) * factor
         height = options.get('height', plot.height) * factor
         return dict(options, **{'width':int(width), 'height': int(height)})

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -160,7 +160,7 @@ class MPLRenderer(Renderer):
         fig_size = options.get('fig_size', MPLPlot.fig_size)*factor
 
         return dict({'fig_size':fig_size},
-                    **Store.lookup_options(cls.backend, obj, 'plot').options)
+                    **MPLPlot.lookup_options(obj, 'plot').options)
 
 
     @bothmethod

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -70,6 +70,7 @@ class Plot(param.Parameterized):
 
     @classmethod
     def lookup_options(cls, obj, group):
+        plot_class = None
         try:
             plot_class = Store.renderers[cls.backend].plotting_class(obj)
             style_opts = plot_class.style_opts
@@ -79,7 +80,7 @@ class Plot(param.Parameterized):
         node = Store.lookup_options(cls.backend, obj, group)
         if group == 'style' and style_opts:
             return node.filtered(style_opts)
-        elif group == 'plot':
+        elif group == 'plot' and plot_class:
             return node.filtered(list(plot_class.params().keys()))
         else:
             return node

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -79,6 +79,8 @@ class Plot(param.Parameterized):
         node = Store.lookup_options(cls.backend, obj, group)
         if group == 'style' and style_opts:
             return node.filtered(style_opts)
+        elif group == 'plot':
+            return node.filtered(list(plot_class.params().keys()))
         else:
             return node
 

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -129,7 +129,7 @@ class PlotlyRenderer(Renderer):
         factor = percent_size / 100.0
         obj = obj.last if isinstance(obj, HoloMap) else obj
         plot = Store.registry[cls.backend].get(type(obj), None)
-        options = Store.lookup_options(cls.backend, obj, 'plot').options
+        options = plot.lookup_options(obj, 'plot').options
         width = options.get('width', plot.width) * factor
         height = options.get('height', plot.height) * factor
         return dict(options, **{'width':int(width), 'height': int(height)})


### PR DESCRIPTION
This PR addresses the issue raised in #1373 

With ``strict=True``:

![image](https://cloud.githubusercontent.com/assets/890576/25439447/600d969a-2a94-11e7-9857-da61bd09e0cb.png)

And ``strict=False`` (default):

![image](https://cloud.githubusercontent.com/assets/890576/25439491/7913116a-2a94-11e7-8e0d-ca74a2a20fc9.png)

I used ``sys.stderr`` because the magic classes are not parameterized and the root param logger adds very little of value and would make this type of warning a lot uglier than necessary.