### PR TITLE
Fixed issue with option test teardown

### DIFF
--- a/tests/testmagics.py
+++ b/tests/testmagics.py
@@ -16,6 +16,7 @@ class ExtensionTestCase(IPTestCase):
         self.ip.run_line_magic("load_ext", "holoviews.ipython")
 
     def tearDown(self):
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         self.ip.run_line_magic("unload_ext", "holoviews.ipython")
         del self.ip
         super(ExtensionTestCase, self).tearDown()

--- a/tests/testoptions.py
+++ b/tests/testoptions.py
@@ -487,7 +487,7 @@ class TestOptionTreeFind(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.original_options)
-
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
 
     def test_optiontree_find1(self):
         self.assertEqual(self.options.find('MyType').options('group').options,
@@ -559,6 +559,7 @@ class TestCrossBackendOptions(ComparisonTestCase):
         Store.options(val=self.store_mpl, backend='matplotlib')
         Store.options(val=self.store_bokeh, backend='bokeh')
         Store.current_backend = 'matplotlib'
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super(TestCrossBackendOptions, self).tearDown()
 
 

--- a/tests/testoptions.py
+++ b/tests/testoptions.py
@@ -206,6 +206,7 @@ class TestStoreInheritanceDynamic(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super(TestStoreInheritanceDynamic, self).tearDown()
 
     def initialize_option_tree(self):
@@ -417,6 +418,7 @@ class TestStoreInheritance(ComparisonTestCase):
 
     def tearDown(self):
         Store.options(val=self.store_copy)
+        Store._custom_options = {k:{} for k in Store._custom_options.keys()}
         super(TestStoreInheritance, self).tearDown()
 
     def test_original_style_options(self):


### PR DESCRIPTION
Fixes this bad interaction in the tests and it might fix part/all of the issue in #1369:

![image](https://cloud.githubusercontent.com/assets/890576/25444994/e52cd308-2aa4-11e7-94a4-1748686ee0eb.png)

@philippjfr I only cleared the custom option trees where I needed to in order to fix the tests. Should I do it in all the option testing classes to be safe?
