### PR TITLE
Reverse map renamed stream parameters in dynamic operations

### DIFF
--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -74,7 +74,8 @@ class Dynamic(param.ParameterizedFunction):
                 updates = {k: self.p.operation.p.get(k) for k, v in stream.contents.items()
                            if v is None and k in self.p.operation.p}
                 if updates:
-                    stream.update(**updates)
+                    reverse = {v: k for k, v in stream._rename.items()}
+                    stream.update(**{reverse.get(k, k): v for k, v in updates.items()})
             streams.append(stream)
         if isinstance(map_obj, DynamicMap):
             dim_streams = util.dimensioned_streams(map_obj)

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -4,7 +4,8 @@ import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
 from holoviews.element import Image, Scatter, Curve, Text, Points
-from holoviews.streams import Stream, PointerXY, PointerX, PointerY
+from holoviews.operation import histogram
+from holoviews.streams import Stream, PointerXY, PointerX, PointerY, RangeX
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -319,6 +320,19 @@ class DynamicTestOperation(ComparisonTestCase):
             return x.clone(x.data*multiplier)
         dmap_with_fn = Dynamic(dmap, operation=fn, kwargs=dict(multiplier=3))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*3))
+
+    def test_dynamic_operation_init_renamed_stream_params(self):
+        img = Image(sine_array(0,5))
+        stream = RangeX(rename={'x_range': 'bin_range'})
+        dmap_with_fn = histogram(img, bin_range=(0, 1), streams=[stream], dynamic=True)
+        self.assertEqual(stream.x_range, (0, 1))
+
+    def test_dynamic_operation_init_stream_params(self):
+        img = Image(sine_array(0,5))
+        stream = Stream.define('TestStream', bin_range=None)()
+        dmap_with_fn = histogram(img, bin_range=(0, 1), streams=[stream], dynamic=True)
+        self.assertEqual(stream.bin_range, (0, 1))
+
 
 
 


### PR DESCRIPTION
Streams can inherit parameters from dynamic operations when their values are None. However this currently breaks for renamed parameters because the operation and stream parameters do not match in those cases. This PR ensures that renamed stream parameters are reverse mapped fixing the bug.