### PR TITLE
Fixed py3 bug mapping bokeh Table values

### DIFF
--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -32,7 +32,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
         data = {d: np.array([]) if empty else element.dimension_values(d)
                  for d in dims}
         mapping = {d.name: d.name for d in dims}
-        data = {d.name: values if values.dtype.kind in "if" else map(d.pprint_value, values)
+        data = {d.name: values if values.dtype.kind in "if" else list(map(d.pprint_value, values))
                 for d, values in data.items()}
         return data, mapping
 


### PR DESCRIPTION
Table values get mapped to strings using the d.pprint_value function but in py3 ``map`` returns a ``map`` object which has to be expanded to a list before it can be passed as a column to the table.