### PR TITLE
Fixed bug in HeatMap aggregation when no global ordering found

### DIFF
--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -155,7 +155,8 @@ class categorical_aggregate2d(ElementOperation):
         if sort or one_to_one(orderings, ycoords):
             ycoords = np.sort(ycoords)
         elif not is_cyclic(orderings):
-            ycoords = list(itertools.chain(*sort_topologically(orderings)))
+            coords = list(itertools.chain(*sort_topologically(orderings)))
+            ycoords = coords if len(coords) == len(ycoords) else np.sort(ycoords)
         return xcoords, ycoords
 
 


### PR DESCRIPTION
When generating a HeatMap the aggregation code attempts to figure out a global ordering for the x-axis and y-axis categorical factors by considering the partial orderings of the y-coordinates for each x-coordinate using topological sort. Finding a global ordering in this way can fail in which case the entire HeatMap fails to display. If no global ordering can be found this now simply sorts the y-coordinates ensuring something is displayed.