### PR TITLE
Fixed bokeh BarPlot implementation

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -603,7 +603,11 @@ class ChartPlot(LegendPlot):
         self.handles['plot'] = plot
         self.handles['glyph_renderers'] = [r for r in plot.renderers
                                            if isinstance(r, GlyphRenderer)]
-        self._update_chart(key, element, ranges)
+        if self.dynamic and not self.static:
+            self._update_chart(key, element, ranges)
+        else:
+            properties = self._plot_properties(key, plot, element)
+            plot.update(**properties)
 
         # Update plot, source and glyph
         self.drawn = True


### PR DESCRIPTION
We've been discussing the Bars element quite a lot recently and that its behavior was confusing. Having had to use Bars extensively I now realize the reason for that is that the current implementation doesn't really make any sense and is completely inconsistent with what the matplotlib version does.

While we will deprecate this bokeh charts plot implementation in favor of our own very soon, I still think this is worth fixing for the time being. In future we have plans to allow grouping and stacking of Bars by overlaying them. However as we move away from a bokeh charts based interface the behavior it has now is probably reasonable for a transitional period while we solve issues surrounding categorical axes in the matplotlib backend and issues surrounding nested coordinate systems in bokeh. The matplotlib plot should still be simplified to disallow simultaneous grouping and stacking, resulting in a horrendously complicated plotting class.