### PR TITLE
Ignore Vega cmaps when defining palettes

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -71,7 +71,7 @@ Cycle.default_cycles.update({'default_colors': get_color_cycle()})
 
 # Filter spectral colormaps to avoid warning in mpl 2.0
 Palette.colormaps.update({cm: plt.get_cmap(cm) for cm in plt.cm.datad
-                          if cm not in ['spectral', 'spectral_r']})
+                          if 'spectral' not in cm and 'Vega' not in cm})
 
 style_aliases = {'edgecolor': ['ec', 'ecolor'], 'facecolor': ['fc'],
                  'linewidth': ['lw'], 'edgecolors': ['ec', 'edgecolor'],


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/1402 importing the matplotlib backend with matplotlib 2.0.1b1 raises deprecation warnings about vega colormaps, which will now be ignored.