### PR TITLE
Fixes for pandas 0.20(.1) compatibility

### DIFF
--- a/holoviews/core/__init__.py
+++ b/holoviews/core/__init__.py
@@ -27,7 +27,7 @@ Dimension.type_formatters[np.datetime64] = '%Y-%m-%d %H:%M:%S'
 
 try:
     import pandas as pd
-    Dimension.type_formatters[pd.tslib.Timestamp] = "%Y-%m-%d %H:%M:%S"
+    Dimension.type_formatters[pd.Timestamp] = "%Y-%m-%d %H:%M:%S"
 except:
     pass
 

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -188,7 +188,7 @@ class PandasInterface(Interface):
         if selection_mask is None:
             selection_mask = cls.select_mask(columns, selection)
         indexed = cls.indexed(columns, selection)
-        df = df.ix[selection_mask]
+        df = df.iloc[selection_mask]
         if indexed and len(df) == 1 and len(columns.vdims) == 1:
             return df[columns.vdims[0].name].iloc[0]
         return df

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -24,7 +24,7 @@ datetime_types = (np.datetime64, dt.datetime)
 
 try:
     import pandas as pd # noqa (optional import)
-    datetime_types = datetime_types + (pd.tslib.Timestamp,)
+    datetime_types = datetime_types + (pd.Timestamp,)
 except ImportError:
     pd = None
 


### PR DESCRIPTION
Addresses #1410 avoiding imports from ``pandas.tslib`` and replacing a usage of ``df.ix`` which have both been deprecated.