### PR TITLE
Fixed bug dropping duplicate HoverTools

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1215,7 +1215,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                         for name, spec in hover.tooltips]
             tool = self.handles['hover_tools'].get(tuple(tooltips))
             if tool:
-                tool.renderers += hover.renderers
+                renderers = tool.renderers+hover.renderers
+                tool.renderers = list(util.unique_iterator(renderers))
 
     def _get_factors(self, overlay):
         xfactors, yfactors = [], []

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1189,7 +1189,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                         tool_type = type(tool)
                     if isinstance(tool, HoverTool):
                         if tuple(tool.tooltips) in hover_tools:
-                            hover_tools[tuple(tool.tooltips)].renderers += tool.renderers
+                            continue
                         else:
                             hover_tools[tuple(tool.tooltips)] = tool
                     elif tool_type in tool_types:
@@ -1205,14 +1205,17 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         """
         Merges tools on the overlay with those on the subplots.
         """
-        if 'hover' in subplot.handles and 'hover_tools' in self.handles:
+        if self.batched and 'hover' in subplot.handles:
+            self.handles['hover'] = subplot.handles['hover']
+        elif 'hover' in subplot.handles and 'hover_tools' in self.handles:
             hover = subplot.handles['hover']
-            tool = self.handles['hover_tools'].get(tuple(hover.tooltips))
+            # Datetime formatter may have been applied, remove _dt_strings
+            # to match on the hover tooltips, then merge tool renderers
+            tooltips = [(name, spec.replace('_dt_strings', ''))
+                        for name, spec in hover.tooltips]
+            tool = self.handles['hover_tools'].get(tuple(tooltips))
             if tool:
                 tool.renderers += hover.renderers
-        elif self.batched and 'hover' in subplot.handles:
-            self.handles['hover'] = subplot.handles['hover']
-
 
     def _get_factors(self, overlay):
         xfactors, yfactors = [], []


### PR DESCRIPTION
HoverTools with the same tooltips should be merged and duplicates dropped, unfortunately I forgot to drop them after they are merged originally. Fixes https://github.com/ioam/holoviews/issues/1404