### PR TITLE
Bokeh bar plot

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -110,6 +110,7 @@ options.Points = Options('style', color=Cycle(), size=point_size, cmap='hot')
 options.Histogram = Options('style', line_color='black', fill_color=Cycle())
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
+options.Bars = Options('style', color=Cycle(), line_color='black', width=0.8)
 
 options.Spikes = Options('style', color='black')
 options.Area = Options('style', color=Cycle(), line_color='black')

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -6,7 +6,7 @@ try:
     from bokeh.charts import BoxPlot as BokehBoxPlot
 except:
     BokehBoxPlot = None, None
-from bokeh.models import (GlyphRenderer, ColumnDataSource, Range1d,
+from bokeh.models import (GlyphRenderer, ColumnDataSource, DataRange1d,
                           CategoricalColorMapper, CustomJS, HoverTool)
 from bokeh.models.tools import BoxSelectTool
 
@@ -653,7 +653,7 @@ class ChartPlot(LegendPlot):
 
     @property
     def current_handles(self):
-        return self.state.select(type=(ColumnDataSource, Range1d))
+        return self.state.select(type=(ColumnDataSource, DataRange1d))
 
 
 class BoxPlot(ChartPlot):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -748,7 +748,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         if y0 < 0:
             y1 = max([y1, 0])
         else:
-            y0 = 0
+            y0 = None if self.logy else 0
 
         # Ensure x-axis is picked up as categorical
         x0 = xdim.pprint_value(extents[0])

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -787,7 +787,6 @@ class BarPlot(ColorbarPlot, LegendPlot):
             tops.append(top)
         return bottoms, tops
 
-
     def _glyph_properties(self, *args):
         props = super(BarPlot, self)._glyph_properties(*args)
         del props['width']
@@ -824,7 +823,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
             grouped = {0: element}
         else:
             grouped = element.groupby(group_dim, group_type=Dataset,
-                                  container_type=OrderedDict)
+                                      container_type=OrderedDict)
 
         # Map attributes to data
         if grouping == 'stacked':
@@ -835,9 +834,6 @@ class BarPlot(ColorbarPlot, LegendPlot):
                        'width': width / float(len(grouped))}
         else:
             mapping = {'x': xdim.name, 'top': ydim.name, 'bottom': 0, 'width': width}
-
-        data = defaultdict(list)
-        baselines = defaultdict(float)
 
         # Get colors
         cdim = color_dim or group_dim
@@ -854,7 +850,9 @@ class BarPlot(ColorbarPlot, LegendPlot):
         else:
             factors, colors = None, None
 
-        # Iterate over stacks and groups and accumulate
+        # Iterate over stacks and groups and accumulate data
+        data = defaultdict(list)
+        baselines = defaultdict(float)
         for i, (k, ds) in enumerate(grouped.items()):
             xs = ds.dimension_values(xdim)
             ys = ds.dimension_values(ydim)
@@ -896,7 +894,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
             # Merge data and mappings
             mapping.update(cmapping)
             for k, cd in cdata.items():
-                # If y-value data has already been added skip
+                # If values have already been added, skip
                 if not len(data[k]) == i+1:
                     data[k].append(cd)
 
@@ -908,7 +906,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         for col, vals in data.items():
             if len(vals) == 1:
                 data[col] = vals[0]
-            if vals:
+            elif vals:
                 data[col] = np.concatenate(vals)
             else:
                 del data[col]
@@ -916,6 +914,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         # Ensure x-values are categorical
         data[xdim.name] = [xdim.pprint_value(x).replace(':', ';') for x in data[xdim.name]]
 
+        # If axes inverted change mapping to match hbar signature
         if self.invert_axes:
             mapping.update({'y': mapping.pop('x'), 'left': mapping.pop('bottom'),
                             'right': mapping.pop('top'), 'height': mapping.pop('width')})

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -7,7 +7,8 @@ try:
 except:
     BokehBoxPlot = None, None
 from bokeh.models import (GlyphRenderer, ColumnDataSource, DataRange1d,
-                          CategoricalColorMapper, CustomJS, HoverTool)
+                          Range1d, CategoricalColorMapper, CustomJS,
+                          HoverTool)
 from bokeh.models.tools import BoxSelectTool
 
 from ...core import Dataset, OrderedDict
@@ -653,7 +654,7 @@ class ChartPlot(LegendPlot):
 
     @property
     def current_handles(self):
-        return self.state.select(type=(ColumnDataSource, DataRange1d))
+        return self.state.select(type=(ColumnDataSource, DataRange1d, Range1d))
 
 
 class BoxPlot(ChartPlot):
@@ -718,6 +719,9 @@ class BarPlot(ColorbarPlot, LegendPlot):
     style_opts = line_properties + fill_properties + ['width', 'cmap']
 
     _plot_methods = dict(single=('vbar', 'hbar'), batched=('vbar', 'hbar'))
+
+    # Declare that y-range should auto-range if not bounded
+    _y_range_type = DataRange1d
 
     def get_extents(self, element, ranges):
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -6,7 +6,7 @@ import numpy as np
 import bokeh
 import bokeh.plotting
 from bokeh.core.properties import value
-from bokeh.models import  HoverTool, Renderer, Range1d, FactorRange
+from bokeh.models import  HoverTool, Renderer, Range1d, DataRange1d, FactorRange
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
@@ -341,13 +341,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             x_axis_type = 'auto'
             plot_ranges['x_range'] = FactorRange()
         elif 'x_range' not in plot_ranges:
-            plot_ranges['x_range'] = Range1d()
+            plot_ranges['x_range'] = DataRange1d()
 
         if categorical or categorical_y:
             y_axis_type = 'auto'
             plot_ranges['y_range'] = FactorRange()
         elif 'y_range' not in plot_ranges:
-            plot_ranges['y_range'] = Range1d()
+            plot_ranges['y_range'] = DataRange1d()
 
         return (x_axis_type, y_axis_type), (xlabel, ylabel, zlabel), plot_ranges
 
@@ -523,7 +523,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         y_range = self.handles['y_range']
 
         l, b, r, t = None, None, None, None
-        if any(isinstance(r, Range1d) for r in [x_range, y_range]):
+        if any(isinstance(r, DataRange1d) for r in [x_range, y_range]):
             l, b, r, t = self.get_extents(element, ranges)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
@@ -539,7 +539,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
 
     def _update_range(self, axis_range, low, high, factors, invert, shared):
-        if isinstance(axis_range, Range1d):
+        if isinstance(axis_range, DataRange1d) and self.apply_ranges:
             if (low == high and low is not None and
                 not isinstance(high, util.datetime_types)):
                 offset = abs(low*0.1 if low else 0.5)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -610,6 +610,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         properties = mpl_to_bokeh(properties)
         plot_method = self._plot_methods.get('batched' if self.batched else 'single')
+        if isinstance(plot_method, tuple):
+            # Handle alternative plot method for flipped axes
+            plot_method = plot_method[int(self.invert_axes)]
         renderer = getattr(plot, plot_method)(**dict(properties, **mapping))
         return renderer, renderer.glyph
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -167,6 +167,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     _update_handles = ['source', 'glyph', 'glyph_renderer']
     _categorical = False
 
+    # Declares the default types for continuous x- and y-axes
+    _x_range_type = Range1d
+    _y_range_type = Range1d
+
     def __init__(self, element, plot=None, **params):
         self.current_ranges = None
         super(ElementPlot, self).__init__(element, **params)
@@ -341,13 +345,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             x_axis_type = 'auto'
             plot_ranges['x_range'] = FactorRange()
         elif 'x_range' not in plot_ranges:
-            plot_ranges['x_range'] = DataRange1d()
+            plot_ranges['x_range'] = self._x_range_type()
 
         if categorical or categorical_y:
             y_axis_type = 'auto'
             plot_ranges['y_range'] = FactorRange()
         elif 'y_range' not in plot_ranges:
-            plot_ranges['y_range'] = DataRange1d()
+            plot_ranges['y_range'] = self._y_range_type()
 
         return (x_axis_type, y_axis_type), (xlabel, ylabel, zlabel), plot_ranges
 
@@ -523,7 +527,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         y_range = self.handles['y_range']
 
         l, b, r, t = None, None, None, None
-        if any(isinstance(r, DataRange1d) for r in [x_range, y_range]):
+        if any(isinstance(r, (Range1d, DataRange1d)) for r in [x_range, y_range]):
             l, b, r, t = self.get_extents(element, ranges)
             if self.invert_axes:
                 l, b, r, t = b, l, t, r
@@ -539,7 +543,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
 
     def _update_range(self, axis_range, low, high, factors, invert, shared):
-        if isinstance(axis_range, DataRange1d) and self.apply_ranges:
+        if isinstance(axis_range, (Range1d, DataRange1d)) and self.apply_ranges:
             if (low == high and low is not None and
                 not isinstance(high, util.datetime_types)):
                 offset = abs(low*0.1 if low else 0.5)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -585,8 +585,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xdim, ydim = element.dimensions()[:2]
         xvals, yvals = [element.dimension_values(i, False)
                         for i in range(2)]
-        coords = ([x if xvals.dtype.kind in 'SU' else xdim.pprint_value(x) for x in xvals],
-                  [y if yvals.dtype.kind in 'SU' else ydim.pprint_value(y) for y in yvals])
+        coords = ([x if xvals.dtype.kind in 'SU' else xdim.pprint_value(x).replace(':', ';') for x in xvals],
+                  [y if yvals.dtype.kind in 'SU' else ydim.pprint_value(y).replace(':', ';') for y in yvals])
         if self.invert_axes: coords = coords[::-1]
         return coords
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -55,7 +55,7 @@ IGNORED_MODELS = ['LinearAxis', 'LogAxis', 'DatetimeAxis', 'DatetimeTickFormatte
 IGNORED_ATTRIBUTES = ['data', 'palette', 'image', 'x', 'y', 'factors']
 
 # Model priority order to ensure some types are updated before others
-MODEL_PRIORITY = ['Range1d', 'Title', 'Image', 'LinearColorMapper',
+MODEL_PRIORITY = ['DataRange1d', 'Title', 'Image', 'LinearColorMapper',
                   'Plot', 'Range1d', 'FactorRange', 'CategoricalAxis',
                   'LinearAxis', 'ColumnDataSource']
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -55,10 +55,9 @@ IGNORED_MODELS = ['LinearAxis', 'LogAxis', 'DatetimeAxis', 'DatetimeTickFormatte
 IGNORED_ATTRIBUTES = ['data', 'palette', 'image', 'x', 'y', 'factors']
 
 # Model priority order to ensure some types are updated before others
-MODEL_PRIORITY = ['DataRange1d', 'Title', 'Image', 'LinearColorMapper',
-                  'Plot', 'Range1d', 'FactorRange', 'CategoricalAxis',
-                  'LinearAxis', 'ColumnDataSource']
-
+MODEL_PRIORITY = ['DataRange1d', 'Range1d', 'Title', 'Image', 'LinearColorMapper',
+                  'Plot', 'FactorRange', 'CategoricalAxis', 'LinearAxis',
+                  'ColumnDataSource']
 
 
 def rgba_tuple(rgba):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -810,7 +810,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(bars)
         plot.initialize_plot()
         fig = plot.state
-        self.assertEqual(len(fig.legend[0].items), 0)
+        self.assertEqual(len(fig.legend), 0)
 
     def test_points_no_single_item_legend(self):
         points = Points([('A', 1), ('B', 2)], label='A')


### PR DESCRIPTION
In https://github.com/ioam/holoviews/issues/1407 I outlined the way forward for the Bar plot implementations. Since bokeh charts will be split out imminently and I'll be using Bars in at least one project I thought it would be worth replacing the bokeh charts based implementation immediately. This new implementation retains all the functionality of the charts based implementation, while adding more features and improvements:

* Better control over legends
* Better support for updating barplots as part of HoloMaps/DynamicMaps
* **Much** better performance (at least 10x faster for more complex charts) because this implementation uses one vectorized glyph rather than a bunch of individual glyphs like the chart based implementation did.
* Support for colormapping bars
* Better support for overlaying bars
* Support for horizontal bars via the ``invert_axes`` plot option
* Support for log mapping bar heights

[Here](https://anaconda.org/philippjfr/bars/notebook) is the notebook I used to develop the plotting class with an extensive list of examples.