### PR TITLE
Drop HLine/VLine zorder to annotation level

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -65,7 +65,7 @@ class LineAnnotationPlot(ElementPlot):
         """
         Returns a Bokeh glyph object.
         """
-        box = Span(level='overlay', **mapping)
+        box = Span(level='annotation', **mapping)
         plot.renderers.append(box)
         return None, box
 


### PR DESCRIPTION
HLine/VLine now no longer go outside the space inside the axes.