### PR TITLE
Non-blocking periodic_events method on DynamicMap

### DIFF
--- a/doc/Tutorials/Streams.ipynb
+++ b/doc/Tutorials/Streams.ipynb
@@ -601,6 +601,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Stream event update loops"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now we can simply use ``event()`` to drive the generator forward and update the plot, showing how the two Gaussian distributions converge as the number of samples increase."
    ]
   },
@@ -620,7 +627,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This approach of using an empty stream works in an exactly analogous fashion for callables that take no arguments. In both cases, the ``DynamicMap`` ``next()`` method is enabled:"
+    "Note that there is a better way to run loops that drive ``dmap.event()`` which supports a ``period`` (in seconds) between updates and a ``timeout`` argument (also in seconds):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dmap.periodic(0.1, 1000, timeout=3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this generator example, ``event`` does not require any arguments but you can set the ``param_fn`` argument to a callable that takes an iteration counter and returns a dictionary for setting the stream parameters. In addition you can use ``block=False`` to avoid blocking the notebook using a threaded loop. This can be very useful although there can have two downsides 1. all running visualizations using non-blocking updates will be competing for computing resources 2. if you override a variable that the thread is actively using, there can be issues with maintaining consistent state in the notebook.\n",
+    "\n",
+    "Generally, the ``periodic`` utility is recommended for all such event update loops and it will be used instead of explicit loops in the rest of the tutorials involving streams.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using ``next()``"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The approach shown above of using an empty stream works in an exactly analogous fashion for callables that take no arguments. In both cases, the ``DynamicMap`` ``next()`` method is enabled:"
    ]
   },
   {

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -566,7 +566,7 @@ def get_nested_dmaps(dmap):
     dmaps = [dmap]
     for o in dmap.callback.inputs:
         if isinstance(o, DynamicMap):
-            dmaps.extend(get_nested_streams(o))
+            dmaps.extend(get_nested_dmaps(o))
     return list(set(dmaps))
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -760,7 +760,8 @@ class DynamicMap(HoloMap):
     def periodic_events(self, period, count, param_fn=None):
         """
         Run a non-blocking loop that updates the stream parameters using
-        the event method. Runs count times with the specified period.
+        the event method. Runs count times with the specified period. If
+        count is None, runs indefinitely.
 
         If param_fn is not specified, the event method is called without
         arguments. If it is specified, it must be a callable accepting a
@@ -768,7 +769,7 @@ class DynamicMap(HoloMap):
         of the new stream values to be passed to the event method.
 
         The returned object allows the loop to be stopped at any time
-        using the stop() method.
+        by calling its stop() method.
         """
         def inner(i):
             kwargs = {} if param_fn is None else param_fn(i)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -618,8 +618,9 @@ class periodic(object):
 
         If param_fn is not specified, the event method is called without
         arguments. If it is specified, it must be a callable accepting a
-        single argument (the iteration count) that returns a dictionary
-        of the new stream values to be passed to the event method.
+        single argument (the iteration count, starting at 1) that
+        returns a dictionary of the new stream values to be passed to
+        the event method.
         """
 
         if self.instance is not None and not self.instance.completed:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -622,7 +622,7 @@ class periodic(object):
         of the new stream values to be passed to the event method.
         """
 
-        if self.instance is not None and not self.instance.completed.is_set():
+        if self.instance is not None and not self.instance.completed:
             raise RuntimeError('Periodic process already running. '
                                'Wait until it completes or call '
                                'stop() before running a new periodic process')

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -635,7 +635,7 @@ class periodic(object):
         self.instance= instance
 
     def stop(self):
-        "Stop and the periodic process."
+        "Stop the periodic process."
         self.instance.stop()
 
     def __str__(self):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -559,18 +559,23 @@ class Generator(Callable):
             raise
 
 
+def get_nested_dmaps(dmap):
+    """
+    Get all DynamicMaps referenced by the supplied DynamicMap's callback.
+    """
+    dmaps = [dmap]
+    for o in dmap.callback.inputs:
+        if isinstance(o, DynamicMap):
+            dmaps.extend(get_nested_streams(o))
+    return list(set(dmaps))
+
+
 def get_nested_streams(dmap):
     """
     Get all (potentially nested) streams from DynamicMap with Callable
     callback.
     """
-    layer_streams = list(dmap.streams)
-    if not isinstance(dmap.callback, Callable):
-        return list(set(layer_streams))
-    for o in dmap.callback.inputs:
-        if isinstance(o, DynamicMap):
-            layer_streams += get_nested_streams(o)
-    return list(set(layer_streams))
+    return list({s for dmap in get_nested_dmaps(dmap) for s in dmap.streams})
 
 
 @contextmanager

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -610,7 +610,7 @@ class periodic(object):
         self.dmap = dmap
         self.instance = None
 
-    def __call__(self, period, count, param_fn=None):
+    def __call__(self, period, count, param_fn=None, timeout=None, block=True):
         """
         Run a non-blocking loop that updates the stream parameters using
         the event method. Runs count times with the specified period. If
@@ -630,7 +630,8 @@ class periodic(object):
             kwargs = {} if param_fn is None else param_fn(i)
             self.dmap.event(**kwargs)
 
-        instance = self._periodic_util(period, count, inner)
+        instance = self._periodic_util(period, count, inner,
+                                       timeout=timeout, block=block)
         instance.start()
         self.instance= instance
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -630,7 +630,7 @@ class periodic(object):
             kwargs = {} if param_fn is None else param_fn(i)
             self.dmap.event(**kwargs)
 
-        instance = self._periodic_util(inner, period, count)
+        instance = self._periodic_util(period, count, inner)
         instance.start()
         self.instance= instance
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -84,7 +84,7 @@ class periodic(Thread):
     Run a callback count times with a given period without blocking.
     """
 
-    def __init__(self, callback, period, count):
+    def __init__(self, period, count, callback):
 
         if isinstance(count, int):
             if count < 0: raise ValueError('Count value must be positive')
@@ -107,8 +107,8 @@ class periodic(Thread):
 
     def __repr__(self):
         return 'periodic(%s, %s, %s)' % (self.period,
-                                         callable_name(self.callback),
-                                         self.count)
+                                         self.count,
+                                         callable_name(self.callback))
     def __str__(self):
         return repr(self)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -96,10 +96,14 @@ class periodic(Thread):
         self.callback = callback
         self.count = count
         self.counter = 0
-        self.completed = Event()
+        self._completed = Event()
+
+    @property
+    def completed(self):
+        return self._completed.is_set()
 
     def stop(self):
-        self.completed.set()
+        self._completed.set()
 
     def __repr__(self):
         return 'periodic(%s, %s, %s)' % (self.period,
@@ -109,13 +113,13 @@ class periodic(Thread):
         return repr(self)
 
     def run(self):
-        while not self.completed.is_set():
-            self.completed.wait(self.period)
+        while not self.completed:
+            self._completed.wait(self.period)
             self.callback(self.counter)
             self.counter += 1
 
             if self.counter == self.count:
-                self.completed.set()
+                self._completed.set()
 
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -126,7 +126,9 @@ class periodic(Thread):
 
     def run(self):
         while not self.completed:
-            if not self.block:
+            if self.block:
+                time.sleep(self.period)
+            else:
                 self._completed.wait(self.period)
             self.callback(self.counter)
             self.counter += 1

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -85,6 +85,12 @@ class periodic(Thread):
     """
 
     def __init__(self, callback, period, count):
+
+        if isinstance(count, int):
+            if count < 0: raise ValueError('Count value must be positive')
+        elif not type(count) is type(None):
+            raise ValueError('Count value must be a positive integer or None')
+
         super(periodic, self).__init__()
         self.period = period
         self.callback = callback

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -102,7 +102,7 @@ class periodic(Thread):
         self.completed.set()
 
     def __repr__(self):
-        return 'periodic(%s, %s, %d)' % (self.period,
+        return 'periodic(%s, %s, %s)' % (self.period,
                                          callable_name(self.callback),
                                          self.count)
     def __str__(self):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -130,8 +130,8 @@ class periodic(Thread):
                 time.sleep(self.period)
             else:
                 self._completed.wait(self.period)
-            self.callback(self.counter)
             self.counter += 1
+            self.callback(self.counter)
 
             if self.timeout is not None:
                 dt = (time.time() - self._start_time)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -97,7 +97,6 @@ class periodic(Thread):
         self.count = count
         self.counter = 0
         self.completed = Event()
-        self.start()
 
     def stop(self):
         self.completed.set()

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -16,9 +16,10 @@ from bokeh.resources import CDN, INLINE
 
 from ...core import Store, HoloMap
 from ..comms import JupyterComm, Comm
+from ..plot import GenericElementPlot
 from ..renderer import Renderer, MIME_TYPES
 from .widgets import BokehScrubberWidget, BokehSelectionWidget, BokehServerWidgets
-from .util import compute_static_patch, serialize_json
+from .util import compute_static_patch, serialize_json, attach_periodic
 
 
 
@@ -122,9 +123,11 @@ class BokehRenderer(Renderer):
         if doc is None:
             doc = curdoc()
         if isinstance(plot, BokehServerWidgets):
-            plot.plot.document = doc
-        else:
-            plot.document = doc
+            plot = plot.plot
+        plot.document = doc
+        plot.traverse(lambda x: attach_periodic(plot),
+                      [GenericElementPlot])
+
         doc.add_root(plot.state)
         return doc
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -586,7 +586,7 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
         # Add stream subscriber mocking plot
         xval.add_subscriber(lambda **kwargs: dmap[()])
         dmap.periodic(0.01, 100, param_fn=lambda i: {'x':i})
-        self.assertEqual(xval.x, 99)
+        self.assertEqual(xval.x, 100)
 
     def test_periodic_param_fn_non_blocking(self):
         def callback(x): return Curve([1,2,3])
@@ -602,7 +602,7 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
             if dmap.periodic.instance.completed:
                 break
         dmap.periodic.stop()
-        self.assertEqual(xval.x, 999)
+        self.assertEqual(xval.x, 1000)
 
     def test_periodic_param_fn_blocking_period(self):
         def callback(x):
@@ -614,7 +614,6 @@ class TestPeriodicStreamUpdate(ComparisonTestCase):
         start = time.time()
         dmap.periodic(0.5, 10, param_fn=lambda i: {'x':i}, block=True)
         end = time.time()
-        print end-start
         self.assertEqual((end - start) > 5, True)
 
 


### PR DESCRIPTION
This PR aims to address #1428 and replaces the Periodic stream prototype we were testing. It should be possible for the bokeh renderer to install a bokeh appropriate utility when running as a bokeh app.


## Action items

- [x] Add general periodic utility to core (simple threaded approach)
- [x] Add periodic_events method to DynamicMap.  
- [x] All count of None to run indefinitely
- [x] Bokeh server support (i.e when running as a bokeh app)
- [x] Update tutorials to mention this and use it
- [x] Unit tests

