### PR TITLE
Optimized datashader aggregation of NdOverlays

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -198,7 +198,8 @@ class aggregate(Operation):
         x, y = element.last.dimensions()[0:2]
         xstart, xend = self.p.x_range if self.p.x_range else element.range(x)
         ystart, yend = self.p.y_range if self.p.y_range else element.range(y)
-        agg_params = dict(self.p.items(), x_range=(xstart, xend), y_range=(ystart, yend))
+        agg_params = dict({k: v for k, v in self.p.items() if k in aggregate.params()},
+                          x_range=(xstart, xend), y_range=(ystart, yend))
 
         # Optimize categorical counts by aggregating them individually
         if isinstance(agg_fn, ds.count_cat):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -221,10 +221,10 @@ class aggregate(Operation):
             if agg_fn2:
                 new_agg2 = agg_fn2.process_element(v, None)
 
-            # Accumulate into aggregates and mask
             if agg is None:
                 agg = new_agg
                 if is_sum: mask = new_mask
+                if agg_fn2: agg2 = new_agg2
             else:
                 agg.data += new_agg.data
                 if is_sum: mask &= new_mask
@@ -233,7 +233,8 @@ class aggregate(Operation):
         # Divide sum by count to compute mean
         if agg2 is not None:
             agg2.data.rename({'Count': agg_fn.column}, inplace=True)
-            agg.data /= agg2.data
+            with np.errstate(divide='ignore', invalid='ignore'):
+                agg.data /= agg2.data
 
         # Fill masked with with NaNs
         agg.data[column].values[mask] = np.NaN


### PR DESCRIPTION
This PR provides major optimizations when using the datashader operations to aggregate multiple objects in an NdOverlay using the ``count``, ``sum``, and ``mean`` operations. Each Element is aggregated separately and the individual aggregates are summed. A small complication is that ``NaNs`` have to be replaced by zeros and masked at the end. ``mean`` is supported by dividing ``sum`` and ``count`` aggregates. This avoids the large memory and performance overhead of concatenating multiple dataframes together. I'm still working on adding an optimization for ``count_cat`` but it should also be fairly straightforward.