### PR TITLE
Pinned pandas version on travis to 0.19.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.18.1 numpy freetype nose bokeh=0.12.5 pandas jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader dask=0.13
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.18.1 numpy freetype nose bokeh=0.12.5 pandas=0.19.2 jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader dask=0.13
   - source activate test-environment
   - conda install -c conda-forge  -c scitools iris sip=4.18 plotly flexx
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then


### PR DESCRIPTION
Tests are failing because pandas 0.20.1 is incompatible with dask 0.13. Might also consider pinning pandas to 0.19.2 instead.