### PR TITLE
Miscellaneous stream improvements

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -3,7 +3,7 @@ from bokeh.models import CustomJS
 
 from ...core import OrderedDict
 from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
-                        RangeY, PointerX, PointerY, Bounds, Tap,
+                        RangeY, PointerX, PointerY, Bounds, Tap, SingleTap,
                         DoubleTap, MouseEnter, MouseLeave, PlotSize)
 from ...streams import PositionX, PositionY, PositionXY # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS
@@ -541,6 +541,17 @@ class PointerYCallback(PointerXYCallback):
 class TapCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on tap event.
+
+    Note: As of bokeh 0.12.5, there is no way to distinguish the
+    individual tap events within a doubletap event.
+    """
+
+    on_events = ['tap', 'doubletap']
+
+
+class SingleTapCallback(PointerXYCallback):
+    """
+    Returns the mouse x/y-position on tap event.
     """
 
     on_events = ['tap']
@@ -680,10 +691,11 @@ class Selection1DCallback(Callback):
 
 callbacks = Stream._callbacks['bokeh']
 
-callbacks[PointerXY]  = PointerXYCallback
-callbacks[PointerX]   = PointerXCallback
-callbacks[PointerY]   = PointerYCallback
+callbacks[PointerXY]   = PointerXYCallback
+callbacks[PointerX]    = PointerXCallback
+callbacks[PointerY]    = PointerYCallback
 callbacks[Tap]         = TapCallback
+callbacks[SingleTap]   = SingleTapCallback
 callbacks[DoubleTap]   = DoubleTapCallback
 callbacks[MouseEnter]  = MouseEnterCallback
 callbacks[MouseLeave]  = MouseLeaveCallback

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -518,8 +518,10 @@ class PointerXYCallback(Callback):
     """
 
     attributes = {'x': 'cb_obj.x', 'y': 'cb_obj.y'}
-    models = ['plot']
+    models = ['plot', 'x_range', 'y_range']
     on_events = ['mousemove']
+    code = ("if (x_range.type.endsWith('Range1d')) { if (cb_obj.x < x_range.start) { data['x'] = x_range.start } else if (cb_obj.x > x_range.end) { data['x'] = x_range.end }}; "
+            + "if (y_range.type.endsWith('Range1d')) { if (cb_obj.y < y_range.start) { data['y'] = y_range.start } else if (cb_obj.y > y_range.end) { data['y'] = y_range.end }}")
 
 
 class PointerXCallback(PointerXYCallback):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -541,7 +541,7 @@ class PointerYCallback(PointerXYCallback):
 class DrawCallback(PointerXYCallback):
     on_events = ['pan', 'panstart', 'panend']
     models = ['plot', 'pan', 'box_zoom']
-    skip = ['pan.attributes.active', 'box_zoom.attributes.active']
+    skip = ['pan && pan.attributes.active', 'box_zoom && box_zoom.attributes.active']
     attributes = {'x': 'cb_obj.x', 'y': 'cb_obj.y', 'event': 'cb_obj.event_name'}
 
     def __init__(self, *args, **kwargs):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -520,8 +520,19 @@ class PointerXYCallback(Callback):
     attributes = {'x': 'cb_obj.x', 'y': 'cb_obj.y'}
     models = ['plot', 'x_range', 'y_range']
     on_events = ['mousemove']
-    code = ("if (x_range.type.endsWith('Range1d')) { if (cb_obj.x < x_range.start) { data['x'] = x_range.start } else if (cb_obj.x > x_range.end) { data['x'] = x_range.end }}; "
-            + "if (y_range.type.endsWith('Range1d')) { if (cb_obj.y < y_range.start) { data['y'] = y_range.start } else if (cb_obj.y > y_range.end) { data['y'] = y_range.end }}")
+    # Clip x and y values to available axis range
+    code = """
+           if (x_range.type.endsWith('Range1d')) {
+             if (cb_obj.x < x_range.start) {
+               data['x'] = x_range.start }
+             else if (cb_obj.x > x_range.end) {
+               data['x'] = x_range.end }}
+           if (y_range.type.endsWith('Range1d')) {
+             if (cb_obj.y < y_range.start) {
+               data['y'] = y_range.start }
+             else if (cb_obj.y > y_range.end) {
+               data['y'] = y_range.end }}
+           """
 
 
 class PointerXCallback(PointerXYCallback):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -518,7 +518,9 @@ class PointerXYCallback(Callback):
     """
 
     attributes = {'x': 'cb_obj.x', 'y': 'cb_obj.y'}
-    models = ['plot', 'x_range', 'y_range']
+    models = ['plot']
+    extra_models= ['x_range', 'y_range']
+
     on_events = ['mousemove']
     # Clip x and y values to available axis range
     code = """
@@ -553,7 +555,8 @@ class PointerYCallback(PointerXYCallback):
 
 class DrawCallback(PointerXYCallback):
     on_events = ['pan', 'panstart', 'panend']
-    models = ['plot', 'pan', 'box_zoom']
+    models = ['plot']
+    extra_models=['pan', 'box_zoom', 'x_range', 'y_range']
     skip = ['pan && pan.attributes.active', 'box_zoom && box_zoom.attributes.active']
     attributes = {'x': 'cb_obj.x', 'y': 'cb_obj.y', 'event': 'cb_obj.event_name'}
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -412,6 +412,12 @@ class PointerXY(LinkedStream):
            Pointer position along the y-axis in data coordinates""")
 
 
+class SingleTap(PointerXY):
+    """
+    The x/y-position of a single tap or click in data coordinates.
+    """
+
+
 class Tap(PointerXY):
     """
     The x/y-position of a tap or click in data coordinates.

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -412,6 +412,16 @@ class PointerXY(LinkedStream):
            Pointer position along the y-axis in data coordinates""")
 
 
+class Draw(PointerXY):
+    """
+    A series of updating x/y-positions when drawing, together with the
+    current stroke count
+    """
+
+    stroke_count = param.Integer(default=0, constant=True, doc="""
+       The current drawing stroke count. Increments every time a new
+       stroke is started.""")
+
 class SingleTap(PointerXY):
     """
     The x/y-position of a single tap or click in data coordinates.


### PR DESCRIPTION
This PR aims to implement the suggestions in issue #1426. 

The first commit distinguishes ``SingleTap`` from ``Tap`` and ``DoubleTap`` where ``Tap`` is supposed to capture all tap events.

@bryevdv Unfortunately I can't quite implement the intended semantics for ``Tap`` as a double tap event should resolve into two taps. As far as I can tell, the way hammer is used in bokeh does not allow for this. 

Is this correct? Would it be reasonable to add a bokeh event that reflects all taps, whether single or part of a double tap?