### PR TITLE
Filter style opts for plots not declaring style_opts

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -78,7 +78,7 @@ class Plot(param.Parameterized):
             style_opts = None
 
         node = Store.lookup_options(cls.backend, obj, group)
-        if group == 'style' and style_opts:
+        if group == 'style' and style_opts is not None:
             return node.filtered(style_opts)
         elif group == 'plot' and plot_class:
             return node.filtered(list(plot_class.params().keys()))


### PR DESCRIPTION
The logic here was slightly wrong in that plots can declare that they have no valid ``style_opts`` and filtering should still be applied.