### PR TITLE
Attach linked streams in batched mode

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -750,9 +750,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self._update_plot(key, plot, style_element)
             self._update_ranges(style_element, ranges)
 
-        if not self.batched:
-            for cb in self.callbacks:
-                cb.initialize()
+        for cb in self.callbacks:
+            cb.initialize()
 
         if not self.overlaid:
             self._process_legend()


### PR DESCRIPTION
In batched mode linked streams weren't being attached, previously this would have been handled by the OverlayPlot wrapping the batched plot. I think this fix won't cause any issues but I'll run through examples now to double check.