### PR TITLE
Fix for initializing batched plot with empty element

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -583,7 +583,7 @@ class GenericElementPlot(DimensionedPlot):
 
         plot_element = self.hmap.last
         if self.batched and not isinstance(self, GenericOverlayPlot):
-            plot_element = [el for el in plot_element if el][-1]
+            plot_element = plot_element.last
 
         self.top_level = keys is None
         if self.top_level:


### PR DESCRIPTION
Since we now support empty elements the previous approach in this code to get a non-empty element breaks if you're trying to initialize a batched plot with an empty element.