### PR TITLE
Do not warn about unfilled subplots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -524,16 +524,15 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
 
             # Generate the axes and create the subplots with the appropriate
             # axis objects, handling any Empty objects.
-            obj = layouts[(r, c)]
-            empty = isinstance(obj.main, Empty)
-            if empty:
+            empty = isinstance(view.main, Empty)
+            if empty or view.main is None:
                 continue
-            elif view is None or not view.traverse(lambda x: x, [Element]):
-                self.warning('%s is empty, skipping subplot.' % obj.main)
+            elif not view.traverse(lambda x: x, [Element]):
+                self.warning('%s is empty, skipping subplot.' % view.main)
                 continue
             else:
                 layout_count += 1
-            subplot_data = self._create_subplots(obj, positions,
+            subplot_data = self._create_subplots(view, positions,
                                                  layout_dimensions, frame_ranges,
                                                  num=0 if empty else layout_count)
             subplots, adjoint_layout = subplot_data

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -919,9 +919,11 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
             # axis objects, handling any Empty objects.
             obj = layouts[(r, c)]
             empty = isinstance(obj.main, Empty)
-            if empty:
+            if view.main is None:
+                continue
+            elif empty:
                 obj = AdjointLayout([])
-            elif view is None or not view.traverse(lambda x: x, [Element]):
+            elif not view.traverse(lambda x: x, [Element]):
                 self.warning('%s is empty, skipping subplot.' % obj.main)
                 continue
             elif self.transpose:


### PR DESCRIPTION
Currently creating a layout where some plots are unfilled generates warnings as described in https://github.com/ioam/holoviews/issues/1390.