### PR TITLE
Improved BokehRenderer.app API

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -84,10 +84,24 @@ class BokehRenderer(Renderer):
         elif fmt == 'json':
             return self.diff(plot), info
 
+
     @bothmethod
-    def get_widget(self_or_cls, plot, widget_type, **kwargs):
+    def get_plot(self_or_cls, obj, doc=None, renderer=None):
+        """
+        Given a HoloViews Viewable return a corresponding plot instance.
+        Allows supplying a document attach the plot to, useful when
+        combining the bokeh model with another plot.
+        """
+        plot = super(BokehRenderer, self_or_cls).get_plot(obj, renderer)
+        if doc is not None:
+            plot.document = doc
+        return plot
+
+
+    @bothmethod
+    def get_widget(self_or_cls, plot, widget_type, doc=None, **kwargs):
         if not isinstance(plot, Plot):
-            plot = self_or_cls.get_plot(plot)
+            plot = self_or_cls.get_plot(plot, doc)
         if self_or_cls.mode == 'server':
             return BokehServerWidgets(plot, renderer=self_or_cls.instance(), **kwargs)
         else:

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -19,7 +19,7 @@ from ..comms import JupyterComm, Comm
 from ..plot import GenericElementPlot
 from ..renderer import Renderer, MIME_TYPES
 from .widgets import BokehScrubberWidget, BokehSelectionWidget, BokehServerWidgets
-from .util import compute_static_patch, serialize_json, attach_periodic
+from .util import compute_static_patch, serialize_json, attach_periodic, bokeh_version
 
 
 
@@ -217,4 +217,5 @@ class BokehRenderer(Renderer):
         """
         Loads the bokeh notebook resources.
         """
-        load_notebook(hide_banner=True, resources=INLINE if inline else CDN)
+        kwargs = {'notebook_type': 'jupyter'} if bokeh_version > '0.12.5' else {}
+        load_notebook(hide_banner=True, resources=INLINE if inline else CDN, **kwargs)


### PR DESCRIPTION
The BokehRenderer.app method now has three ways of working:

1) By default it just returns a document with plot attached to it, this can be used in a script to deploy it with ``bokeh serve``.

2) When using the ``show`` option it will create an Application instance, if the notebook extension has been loaded it will start a server and display it inline.

3) When using the ``show`` option when the notebook extension has not been loaded or if the ``new_window`` option is supplied it will create the app and open it in a new window. This may be used from an IPython terminal or within the notebook.

Suggestions for improving the naming of the ``show`` and ``new_window`` arguments or other suggestions for improving the API welcome.