### PR TITLE
Element extents fixes

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -245,18 +245,16 @@ class Histogram(Element2D):
 
 
     def range(self, dimension, data_range=True):
-        drange = super(Histogram, self).range(dimension, data_range)
-        dimidx = self.get_dimension_index(dimension)
-        dim    = self.get_dimension(dimension)
-        if dimidx == 0 and data_range:
+        if self.get_dimension_index(dimension) == 0 and data_range:
+            dim = self.get_dimension(dimension)
             lower, upper = np.min(self.edges), np.max(self.edges)
-            lower, upper = util.max_range([(lower, upper), drange])
+            lower, upper = util.max_range([(lower, upper), dim.soft_range])
             dmin, dmax = dim.range
             lower = lower if dmin is None or not np.isfinite(dmin) else dmin
             upper = upper if dmax is None or not np.isfinite(dmax) else dmax
             return lower, upper
         else:
-            return drange
+            return super(Histogram, self).range(dimension, data_range)
 
 
     def dimension_values(self, dim):

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -90,6 +90,7 @@ class ErrorBars(Chart):
     def range(self, dim, data_range=True):
         drange = super(ErrorBars, self).range(dim, data_range)
         didx = self.get_dimension_index(dim)
+        dim = self.get_dimension(dim)
         if didx == 1 and data_range:
             mean = self.dimension_values(1)
             neg_error = self.dimension_values(2)
@@ -97,7 +98,11 @@ class ErrorBars(Chart):
             pos_error = self.dimension_values(pos_idx)
             lower = np.nanmin(mean-neg_error)
             upper = np.nanmax(mean+pos_error)
-            return util.max_range([(lower, upper), drange])
+            lower, upper = util.max_range([(lower, upper), drange])
+            dmin, dmax = dim.range
+            lower = lower if dmin is None or not np.isfinite(dmin) else dmin
+            upper = upper if dmax is None or not np.isfinite(dmax) else dmax
+            return lower, upper
         else:
             return drange
 
@@ -163,13 +168,10 @@ class Histogram(Element2D):
 
     vdims = param.List(default=[Dimension('Frequency')], bounds=(1,1))
 
-    def __init__(self, values, edges=None, extents=None, **params):
+    def __init__(self, values, edges=None, **params):
         self.values, self.edges, settings = self._process_data(values, edges)
         settings.update(params)
         super(Histogram, self).__init__((self.values, self.edges), **settings)
-        self._width = None
-        self._extents = (None, None, None, None) if extents is None else extents
-
 
     def __getitem__(self, key):
         """
@@ -242,17 +244,19 @@ class Histogram(Element2D):
         return values, edges, settings
 
 
-    @property
-    def extents(self):
-        if any(lim is not None for lim in self._extents):
-            return self._extents
+    def range(self, dimension, data_range=True):
+        drange = super(Histogram, self).range(dimension, data_range)
+        dimidx = self.get_dimension_index(dimension)
+        dim    = self.get_dimension(dimension)
+        if dimidx == 0 and data_range:
+            lower, upper = np.min(self.edges), np.max(self.edges)
+            lower, upper = util.max_range([(lower, upper), drange])
+            dmin, dmax = dim.range
+            lower = lower if dmin is None or not np.isfinite(dmin) else dmin
+            upper = upper if dmax is None or not np.isfinite(dmax) else dmax
+            return lower, upper
         else:
-            return (np.min(self.edges), None, np.max(self.edges), None)
-
-
-    @extents.setter
-    def extents(self, extents):
-        self._extents = extents
+            return drange
 
 
     def dimension_values(self, dim):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -357,8 +357,9 @@ class HistogramPlot(ElementPlot):
 
     def get_extents(self, element, ranges):
         x0, y0, x1, y1 = super(HistogramPlot, self).get_extents(element, ranges)
-        y0 = np.nanmin([0, y0])
-        y1 = np.nanmax([0, y1])
+        ylow, yhigh = element.get_dimension(1).range
+        y0 = np.nanmin([0, y0]) if ylow is None or not np.isfinite(ylow) else ylow
+        y1 = np.nanmax([0, y1]) if yhigh is None or not np.isfinite(yhigh) else yhigh
         return (x0, y0, x1, y1)
 
 

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -441,12 +441,6 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         return bars
 
 
-    def get_extents(self, element, ranges):
-        x0, _, x1, _ = element.extents
-        _, y1 = element.range(1)
-        return (x0, 0, x1, y1)
-
-
     def _colorize_bars(self, cmap, bars, element, main_range, dim):
         """
         Use the given cmap to color the bars, applying the correct

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -458,8 +458,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             return
 
         ranges = self.compute_ranges(self.hmap, key, ranges)
-        if not self.adjoined:
-            ranges = util.match_spec(element, ranges)
+        ranges = util.match_spec(element, ranges)
 
         label = element.label if self.show_legend else ''
         style = dict(label=label, zorder=self.zorder, **self.style[self.cyclic_index])

--- a/tests/testelementranges.py
+++ b/tests/testelementranges.py
@@ -1,0 +1,90 @@
+"""
+Test cases for computing ranges on elements which are not simply
+the (min, max) of the dimension values array.
+"""
+import numpy as np
+from holoviews import Dimension, Histogram, ErrorBars
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class HistogramRangeTests(ComparisonTestCase):
+
+    def test_histogram_range_x(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3]).range(0)
+        self.assertEqual(r, (0., 3.0))
+
+    def test_histogram_range_x_explicit(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      kdims=[Dimension('x', range=(-1, 4.))]).range(0)
+        self.assertEqual(r, (-1., 4.))
+
+    def test_histogram_range_x_explicit_upper(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      kdims=[Dimension('x', range=(None, 4.))]).range(0)
+        self.assertEqual(r, (0, 4.))
+
+    def test_histogram_range_x_explicit_lower(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      kdims=[Dimension('x', range=(-1, None))]).range(0)
+        self.assertEqual(r, (-1., 3.))
+
+    def test_histogram_range_y(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3]).range(1)
+        self.assertEqual(r, (1., 3.0))
+
+    def test_histogram_range_y_explicit(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      vdims=[Dimension('y', range=(0, 4.))]).range(1)
+        self.assertEqual(r, (0., 4.))
+
+    def test_histogram_range_y_explicit_upper(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      vdims=[Dimension('y', range=(None, 4.))]).range(1)
+        self.assertEqual(r, (1., 4.))
+
+    def test_histogram_range_y_explicit_lower(self):
+        r = Histogram([1,2,3], [0, 1, 2, 3],
+                      vdims=[Dimension('y', range=(0., None))]).range(1)
+        self.assertEqual(r, (0., 3.))
+
+
+
+class ErrorBarsRangeTests(ComparisonTestCase):
+
+    def test_errorbars_range_x(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(0)
+        self.assertEqual(r, (1., 3.0))
+
+    def test_errorbars_range_x_explicit(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[Dimension('x', range=(-1, 4.))]).range(0)
+        self.assertEqual(r, (-1., 4.))
+
+    def test_errorbars_range_x_explicit_upper(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[Dimension('x', range=(None, 4.))]).range(0)
+        self.assertEqual(r, (1, 4.))
+
+    def test_errorbars_range_x_explicit_lower(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      kdims=[Dimension('x', range=(-1, None))]).range(0)
+        self.assertEqual(r, (-1., 3.))
+
+    def test_errorbars_range_y(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5])).range(1)
+        self.assertEqual(r, (1.5, 4.5))
+
+    def test_errorbars_range_y_explicit(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[Dimension('y', range=(0, 4.)), 'yerr']).range(1)
+        self.assertEqual(r, (0., 4.))
+
+    def test_errorbars_range_y_explicit_upper(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[Dimension('y', range=(None, 4.)), 'yerr']).range(1)
+        self.assertEqual(r, (1.5, 4.))
+
+    def test_errorbars_range_y_explicit_lower(self):
+        r = ErrorBars(([1, 2, 3], [2, 3, 4], [0.5, 0.5, 0.5]),
+                      vdims=[Dimension('y', range=(0., None)), 'yerr']).range(1)
+        self.assertEqual(r, (0., 4.5))


### PR DESCRIPTION
Certain Elements have special semantics for dimension ranges, e.g. on ErrorBars/Spread the y-range is determined by the combination of y-values and y-errors. This is handled correctly but it currently completely ignores explicitly set ranges, which should always override auto-computed ranges. Additionally ``Histogram`` uses extents to compute the bin ranges when it should simply use ``.range`` like all other Elements.

Fixes:

https://github.com/ioam/holoviews/issues/1432
https://github.com/ioam/holoviews/issues/1433
https://github.com/ioam/holoviews/issues/1445