### PR TITLE
Fixed pretty printed repr output on Python 3

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -4,7 +4,7 @@ axis or map dimension. Also supplies the Dimensioned abstract
 baseclass for classes that accept Dimension values.
 """
 from __future__ import unicode_literals
-import sys, re
+import re
 import datetime as dt
 from operator import itemgetter
 
@@ -1065,11 +1065,7 @@ class Dimensioned(LabelledData):
 
 
     def __repr__(self):
-        reprval = PrettyPrinter.pprint(self)
-        if sys.version_info.major == 2:
-            return str(reprval.encode("utf8"))
-        else:
-            return str(reprval)
+        return PrettyPrinter.pprint(self)
 
     def __str__(self):
         return repr(self)

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -4,7 +4,7 @@ axis or map dimension. Also supplies the Dimensioned abstract
 baseclass for classes that accept Dimension values.
 """
 from __future__ import unicode_literals
-import re
+import sys, re
 import datetime as dt
 from operator import itemgetter
 
@@ -1066,7 +1066,7 @@ class Dimensioned(LabelledData):
 
     def __repr__(self):
         reprval = PrettyPrinter.pprint(self)
-        if isinstance(reprval, unicode):
+        if sys.version_info.major == 2:
             return str(reprval.encode("utf8"))
         else:
             return str(reprval)

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -13,7 +13,7 @@ your data.
 In addition, there are several different ways of
 """
 
-import re
+import sys, re
 import param
 # IPython not required to import ParamPager
 from param.ipython import ParamPager
@@ -267,7 +267,12 @@ class PrettyPrinter(object):
 
     @classmethod
     def pprint(cls, node):
-        return  cls.serialize(cls.recurse(node))
+        reprval = cls.serialize(cls.recurse(node))
+        if sys.version_info.major == 2:
+            return str(reprval.encode("utf8"))
+        else:
+            return str(reprval)
+
 
     @classmethod
     def serialize(cls, lines):

--- a/tests/testprettyprint.py
+++ b/tests/testprettyprint.py
@@ -4,7 +4,7 @@ Test cases for the pretty printing system.
 
 
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews import Element
+from holoviews import Element, Curve
 from holoviews.core.pprint import PrettyPrinter
 
 
@@ -23,3 +23,9 @@ class PrettyPrintTest(ComparisonTestCase):
         o = self.element1 * self.element2
         r = PrettyPrinter.pprint(o)
         self.assertEqual(r, expected)
+
+    def test_curve_pprint_repr(self):
+        # Ensure it isn't a bytes object with the 'b' prefix
+        expected = "':Curve   [x]   (y)'"
+        r = PrettyPrinter.pprint(Curve([1,2,3]))
+        self.assertEqual(repr(r), expected)


### PR DESCRIPTION
This fixes the issue with Python 3 showing the repr as a bytes object with the ``b`` prefix.