### PR TITLE
Alias utility update

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -347,27 +347,6 @@ def capitalize_unicode_name(s):
     return s[:index] + tail
 
 
-class Aliases(object):
-    """
-    Helper class useful for defining a set of alias tuples on a single object.
-
-    For instance, when defining a group or label with an alias, instead
-    of setting tuples in the constructor, you could use
-    ``aliases.water`` if you first define:
-
-    >>> aliases = Aliases(water='H_2O', glucose='C_6H_{12}O_6')
-    >>> aliases.water
-    ('water', 'H_2O')
-
-    This may be used to conveniently define aliases for groups, labels
-    or dimension names.
-    """
-    def __init__(self, **kwargs):
-        for k,v in kwargs.items():
-            setattr(self, k, (k,v))
-
-
-
 class sanitize_identifier_fn(param.ParameterizedFunction):
     """
     Sanitizes group/label values for use in AttrTree attribute

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -2,7 +2,7 @@ import inspect
 
 import param
 
-from .core import DynamicMap, HoloMap, ViewableElement
+from .core import Dimension, DynamicMap, HoloMap, ViewableElement
 from .core.operation import Operation
 from .core.operation import OperationCallable
 from .core.spaces import Callable
@@ -128,32 +128,26 @@ class Dynamic(param.ParameterizedFunction):
         return DynamicMap(dynamic_fn, streams=streams, **dict(params, kdims=kdims))
 
 
-class Aliases(object):
+class Dims(object):
     """
     Helper class useful for defining a collection of dimensions or
     sanitized group/labels.
 
-    To define a dimension alias, you could do something like:
+    To define a dimension alias, you can use the following:
 
-    >>> al = Aliases(male_weight='Body weight of male participants',
-                     male_height='Height of male participants')
-    >>> hv.Curve(data, kdims=[al.male_weight], vdims=[al.male_height])
+    >>> d = Dims(male_weight='Body weight of male participants',
+                 male_height='Height of male participants')
+    >>> hv.Curve(data, kdims=[d.male_weight], vdims=[d.male_height])
 
-    You can also use this to define a sanitized group or labels. Instead
-    of setting tuples in the constructor, you can use:
-
-    >>> al = Aliases(water='H_2O', glucose='C_6H_{12}O_6')
-    >>> hv.Curve(data, label=al.glucose)
 
     For defining richer dimension objects, you can also pass in a list
     of dimension instances, which are then addressed by name:
 
-    >>> al = Aliases([hv.Dimension('male_weight', unit='kg', range=(0,None))])
-    >>> hv.Curve(data, kdims=[al.male_weight])
+    >>> d = Dims([hv.Dimension('male_weight', unit='kg', range=(0,None))])
+    >>> hv.Curve(data, kdims=[d.male_weight])
     """
     def __init__(self, dims=[], **kwargs):
         for k,v in kwargs.items():
-            setattr(self, k, (k,v))
-
+            setattr(self, k, Dimension(k,label=v))
         for dim in dims:
             setattr(self, dim.name, dim)

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -4,7 +4,6 @@ import param
 
 from .core import DynamicMap, HoloMap, ViewableElement
 from .core.operation import Operation
-from .core.util import Aliases  # noqa (API import)
 from .core.operation import OperationCallable
 from .core.spaces import Callable
 from .core import util
@@ -127,3 +126,23 @@ class Dynamic(param.ParameterizedFunction):
         kdims = [d(values=list(set(values))) for d, values in
                  zip(hmap.kdims, dim_values)]
         return DynamicMap(dynamic_fn, streams=streams, **dict(params, kdims=kdims))
+
+
+class Aliases(object):
+    """
+    Helper class useful for defining a set of alias tuples on a single object.
+
+    For instance, when defining a group or label with an alias, instead
+    of setting tuples in the constructor, you could use
+    ``aliases.water`` if you first define:
+
+    >>> aliases = Aliases(water='H_2O', glucose='C_6H_{12}O_6')
+    >>> aliases.water
+    ('water', 'H_2O')
+
+    This may be used to conveniently define aliases for groups, labels
+    or dimension names.
+    """
+    def __init__(self, **kwargs):
+        for k,v in kwargs.items():
+            setattr(self, k, (k,v))

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -130,19 +130,30 @@ class Dynamic(param.ParameterizedFunction):
 
 class Aliases(object):
     """
-    Helper class useful for defining a set of alias tuples on a single object.
+    Helper class useful for defining a collection of dimensions or
+    sanitized group/labels.
 
-    For instance, when defining a group or label with an alias, instead
-    of setting tuples in the constructor, you could use
-    ``aliases.water`` if you first define:
+    To define a dimension alias, you could do something like:
 
-    >>> aliases = Aliases(water='H_2O', glucose='C_6H_{12}O_6')
-    >>> aliases.water
-    ('water', 'H_2O')
+    >>> al = Aliases(male_weight='Body weight of male participants',
+                     male_height='Height of male participants')
+    >>> hv.Curve(data, kdims=[al.male_weight], vdims=[al.male_height])
 
-    This may be used to conveniently define aliases for groups, labels
-    or dimension names.
+    You can also use this to define a sanitized group or labels. Instead
+    of setting tuples in the constructor, you can use:
+
+    >>> al = Aliases(water='H_2O', glucose='C_6H_{12}O_6')
+    >>> hv.Curve(data, label=al.glucose)
+
+    For defining richer dimension objects, you can also pass in a list
+    of dimension instances, which are then addressed by name:
+
+    >>> al = Aliases([hv.Dimension('male_weight', unit='kg', range=(0,None))])
+    >>> hv.Curve(data, kdims=[al.male_weight])
     """
-    def __init__(self, **kwargs):
+    def __init__(self, dims=[], **kwargs):
         for k,v in kwargs.items():
             setattr(self, k, (k,v))
+
+        for dim in dims:
+            setattr(self, dim.name, dim)

--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -135,16 +135,16 @@ class Dims(object):
 
     To define a dimension alias, you can use the following:
 
-    >>> d = Dims(male_weight='Body weight of male participants',
-                 male_height='Height of male participants')
-    >>> hv.Curve(data, kdims=[d.male_weight], vdims=[d.male_height])
+    d = Dims(male_weight='Body weight of male participants',
+             male_height='Height of male participants')
+    Curve(data, kdims=[d.male_weight], vdims=[d.male_height])
 
 
     For defining richer dimension objects, you can also pass in a list
     of dimension instances, which are then addressed by name:
 
-    >>> d = Dims([hv.Dimension('male_weight', unit='kg', range=(0,None))])
-    >>> hv.Curve(data, kdims=[d.male_weight])
+    d = Dims([hv.Dimension('male_weight', unit='kg', range=(0,None))])
+    Curve(data, kdims=[d.male_weight])
     """
     def __init__(self, dims=[], **kwargs):
         for k,v in kwargs.items():


### PR DESCRIPTION
This PR aims to address #1427. I realize we don't yet have a solution everybody is happy with but I think this is worth updating while the utility still exists.

Here is an example of it in use:

![image](https://cloud.githubusercontent.com/assets/890576/26117440/7f6e1652-3a5e-11e7-83d3-178704e10e4a.png)

For this example it doesn't do much but if you have a long notebook that reuses dimensions/groups/labels constantly, I think this utility really pays off, making everything more succinct and organized. It means you can specify the definitions once at the top, making the rest of the notebook more succinct.

Once we do find a good solution to defining dimensions and sanitized groups/labels without awkward repetition we should document it and probably remove the dimension preset system.