### PR TITLE
Make the naming consistent

### DIFF
--- a/doc/Tutorials/Dynamic_Map.ipynb
+++ b/doc/Tutorials/Dynamic_Map.ipynb
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will now create  ``DynamicMap`` similar to the  ``HoloMap`` introduced in the [Containers Tutorial](Containers.ipynb#HoloMap). The ``HoloMap`` in that tutorial consisted of ``Image`` elements defined by a function returning NumPy arrays called ``sine_array``. Here we will define a ``waves`` function that returns an array pattern parameterized by arbitrary ``alpha`` and ``beta`` parameters inside a HoloViews [Image](Elements.ipynb#Image) element:"
+    "We will now create  ``DynamicMap`` similar to the  ``HoloMap`` introduced in the [Containers Tutorial](Containers.ipynb#HoloMap). The ``HoloMap`` in that tutorial consisted of ``Image`` elements defined by a function returning NumPy arrays called ``sine_array``. Here we will define a ``waves_image`` function that returns an array pattern parameterized by arbitrary ``alpha`` and ``beta`` parameters inside a HoloViews [Image](Elements.ipynb#Image) element:"
    ]
   },
   {
@@ -159,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the declared kdims are specifying the arguments *by position* as they do not match the argument names of the ``sine_image`` function. If you *do* match the argument names *exactly*, you can map a kdim position to any argument position of the callable. For instance, the declaration ``kdims=['freq', 'phase']`` would index first by frequency, then phase without mixing up the arguments to ``sine_image`` when indexing."
+    "Note that the declared kdims are specifying the arguments *by position* as they do not match the argument names of the ``waves_image`` function. If you *do* match the argument names *exactly*, you can map a kdim position to any argument position of the callable. For instance, the declaration ``kdims=['freq', 'phase']`` would index first by frequency, then phase without mixing up the arguments to ``waves_image`` when indexing."
    ]
   },
   {
@@ -565,7 +565,7 @@
     "       hv.Dimension('frequency', values=[0.1, 1, 2, 5, 10]),\n",
     "       hv.Dimension('amplitude', values=[0.5, 5, 10])]\n",
     "\n",
-    "sine_dmap = hv.DynamicMap(sin, kdims=kdims)"
+    "waves_dmap = hv.DynamicMap(sin, kdims=kdims)"
    ]
   },
   {
@@ -584,7 +584,7 @@
    "outputs": [],
    "source": [
     "%%opts GridSpace [show_legend=True fig_size=200]\n",
-    "sine_dmap.overlay('amplitude').grid('frequency')"
+    "waves_dmap.overlay('amplitude').grid('frequency')"
    ]
   },
   {


### PR DESCRIPTION
The other option is to rename everything in this tutorial into "waves" instead of "sine"