### PR TITLE
Exposing inargs and inkwargs as Callable.args and .kwargs

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -458,7 +458,8 @@ class Callable(param.Parameterized):
                                        **dict(params, name=util.callable_name(callable)))
         self._memoized = {}
         self._is_overlay = False
-
+        self.args = None
+        self.kwargs = None
 
     @property
     def argspec(self):
@@ -485,7 +486,7 @@ class Callable(param.Parameterized):
 
     def __call__(self, *args, **kwargs):
         # Nothing to do for callbacks that accept no arguments
-        (inargs, inkwargs) = (args, kwargs)
+        (self.args, self.kwargs) = (args, kwargs)
         if not args and not kwargs: return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []
@@ -518,8 +519,8 @@ class Callable(param.Parameterized):
         try:
             ret = self.callable(*args, **kwargs)
         except:
-            posstr = ', '.join(['%r' % el for el in inargs]) if inargs else ''
-            kwstr = ', '.join('%s=%r' % (k,v) for k,v in inkwargs.items())
+            posstr = ', '.join(['%r' % el for el in self.args]) if self.args else ''
+            kwstr = ', '.join('%s=%r' % (k,v) for k,v in self.kwargs.items())
             argstr = ', '.join([el for el in [posstr, kwstr] if el])
             message = ("Exception raised in callable '{name}' of type '{ctype}'.\n"
                        "Invoked as {name}({argstr})")

--- a/tests/testcallable.py
+++ b/tests/testcallable.py
@@ -198,6 +198,27 @@ class TestMixedCallableInvocation(ComparisonTestCase):
         self.assertEqual(Callable(mixed_example)(3,5,5), 33)
 
 
+class TestLastArgsKwargs(ComparisonTestCase):
+
+    def test_args_none_before_invocation(self):
+        c = Callable(lambda x,y: x+y)
+        self.assertEqual(c.args, None)
+
+    def test_kwargs_none_before_invocation(self):
+        c = Callable(lambda x,y: x+y)
+        self.assertEqual(c.kwargs, None)
+
+    def test_args_invocation(self):
+        c = Callable(lambda x,y: x+y)
+        c(1,2)
+        self.assertEqual(c.args, (1,2))
+
+    def test_kwargs_invocation(self):
+        c = Callable(lambda x,y: x+y)
+        c(x=1,y=4)
+        self.assertEqual(c.kwargs, dict(x=1,y=4))
+
+
 class TestDynamicMapInvocation(ComparisonTestCase):
     """
     Test that DynamicMap passes kdims and stream parameters correctly to


### PR DESCRIPTION
Simple PR to address #1307 - before it is called the callable ``.args`` and ``.kwargs`` attributes are None, afterwards they reflect how the callable was invoked.