### PR TITLE
Removed automatic sorting of dimension values

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -314,7 +314,7 @@ class Dimension(param.Parameterized):
             self.warning("The 'initial' string for dimension values is no longer supported.")
             values = []
 
-        all_params['values'] = sorted(list(unique_array(values)))
+        all_params['values'] = list(unique_array(values))
         super(Dimension, self).__init__(**all_params)
 
 


### PR DESCRIPTION

Very simple PR to address issue #1383: ``Dimension`` no longer sorts the supplied values. This change *should* be ok - the notebook tests will help us decide!