### PR TITLE
Options now drop invalid keywords from kwargs

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -364,7 +364,7 @@ class Options(param.Parameterized):
             self.warning("Invalid options %s, valid options are: %s"
                          % (repr(invalid_kws), str(allowed_keywords)))
 
-        self.kwargs = kwargs
+        self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
         self._options = self._expand_options(kwargs)
         allowed_keywords = (allowed_keywords if isinstance(allowed_keywords, Keywords)
                             else Keywords(allowed_keywords))

--- a/tests/testoptions.py
+++ b/tests/testoptions.py
@@ -28,16 +28,20 @@ class TestOptions(ComparisonTestCase):
         Options('test')
 
     def test_options_valid_keywords1(self):
-        Options('test', allowed_keywords=['kw1'], kw1='value')
+        opts = Options('test', allowed_keywords=['kw1'], kw1='value')
+        self.assertEquals(opts.kwargs, {'kw1':'value'})
 
     def test_options_valid_keywords2(self):
-        Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value')
+        opts = Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value')
+        self.assertEquals(opts.kwargs, {'kw1':'value'})
 
     def test_options_valid_keywords3(self):
-        Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value', kw2='value')
+        opts = Options('test', allowed_keywords=['kw1', 'kw2'], kw1='value1', kw2='value2')
+        self.assertEquals(opts.kwargs, {'kw1':'value1', 'kw2':'value2'})
 
     def test_options_any_keywords3(self):
-        Options('test', kw1='value', kw2='value')
+        opts = Options('test', kw1='value1', kw2='value3')
+        self.assertEquals(opts.kwargs, {'kw1':'value1', 'kw2':'value3'})
 
     def test_options_invalid_keywords1(self):
         try:


### PR DESCRIPTION

PR to fix #1463 - invalid keywords weren't actually being skipped (i.e dropped from kwargs) which meant invalid values were being set on the options tree.

If the tests go green I'll add a unit test to make sure this stays fixed.