### PR TITLE
Avoid xarray len implementation loading data

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -248,8 +248,8 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product(dataset[dataset.vdims[0].name].shape)
-    
+        return np.product([len(dataset.data[d.name]) for d in dataset.kdims])
+
     @classmethod
     def dframe(cls, dataset, dimensions):
         if dimensions:


### PR DESCRIPTION
XArray supports lazy loading of data but the current xarray interface uses the actual array data to determine the length of the data, which is highly inefficient. This PR instead uses the product of the coordinate array lengths which are always in memory to determine the overall length.