### PR TITLE
Fix for BokehRenderer.server_doc for plots with widgets

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -161,13 +161,13 @@ class BokehRenderer(Renderer):
         """
         if doc is None:
             doc = curdoc()
+        root = plot.state
         if isinstance(plot, BokehServerWidgets):
             plot = plot.plot
         plot.document = doc
         plot.traverse(lambda x: attach_periodic(plot),
                       [GenericElementPlot])
-
-        doc.add_root(plot.state)
+        doc.add_root(root)
         return doc
 
 


### PR DESCRIPTION
This fixes a bug in the ``BokehRenderer.server_doc`` method, which resulted in the bokeh widgets not being added to the Document and therefore not appearing.