### PR TITLE
Simplified NotebookArchive and fixed Python 3 issue

### DIFF
--- a/doc/Tutorials/Exporting.ipynb
+++ b/doc/Tutorials/Exporting.ipynb
@@ -442,10 +442,10 @@
     "import os\n",
     "from holoviews.core.io import Unpickler\n",
     "c, a = None,None\n",
-    "path = \"Exporting/Levels_0.1-0.8,Overlay,Image,Level.hvz\"\n",
+    "path = \"Exporting/Overlay,Image,Level.hvz\"\n",
     "\n",
     "if os.path.isfile(path):\n",
-    "    o = Unpickler.load(open(path,\"r\"))\n",
+    "    o = Unpickler.load(open(path,\"rb\"))\n",
     "    c = o.Image\n",
     "print(c)"
    ]

--- a/holoviews/core/io.py
+++ b/holoviews/core/io.py
@@ -25,7 +25,7 @@ from param.parameterized import bothmethod
 
 from .dimension import LabelledData
 from .element import Collator, Element
-from .layout import Layout
+from .overlay import Overlay, Layout
 from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
 from .options import Store
 from .util import unique_iterator, group_sanitizer, label_sanitizer
@@ -340,7 +340,7 @@ class Pickler(Exporter):
         filename = self_or_cls._filename(filename) if isinstance(filename, str) else filename
         with zipfile.ZipFile(filename, 'w', compression=compression) as f:
 
-            if isinstance(obj, Layout):
+            if isinstance(obj, Layout) and not isinstance(obj, Overlay):
                 entries = ['.'.join(k) for k in obj.data.keys()]
                 components = list(obj.data.values())
                 entries = entries if len(entries) > 1 else [entries[0]+'(L)']

--- a/holoviews/ipython/archive.py
+++ b/holoviews/ipython/archive.py
@@ -163,11 +163,10 @@ class NotebookArchive(FileArchive):
             return
 
         self.export_success = None
-        self._notebook_data = io.StringIO()
         name = self.get_namespace()
         # Unfortunate javascript hacks to get at notebook data
-        capture_cmd = ((r"var capture = '%s._notebook_data.write(r\"\"\"'" % name)
-                       + r"+json_string+'\"\"\".decode(\'utf-8\'))'; ")
+        capture_cmd = ((r"var capture = '%s._notebook_data=r\"\"\"'" % name)
+                       + r"+json_string+'\"\"\"'; ")
         cmd = (r'var kernel = IPython.notebook.kernel; '
                + r'var json_data = IPython.notebook.toJSON(); '
                + r'var json_string = JSON.stringify(json_data); '
@@ -278,14 +277,11 @@ class NotebookArchive(FileArchive):
 
     def _get_notebook_node(self):                   # pragma: no cover
         "Load captured notebook node"
-        self._notebook_data.seek(0, os.SEEK_END)
-        size = self._notebook_data.tell()
+        size = len(self._notebook_data)
         if size == 0:
             raise Exception("Captured buffer size for notebook node is zero.")
-        self._notebook_data.seek(0)
-        node = reader.reads(self._notebook_data.read())
+        node = reader.reads(self._notebook_data)
         self.nbversion = reader.get_version(node)
-        self._notebook_data.close()
         return node
 
 


### PR DESCRIPTION

This PR fixes issue #1441 where ``StringIO`` was not working properly on Python3. Thankfully this fix helps *simplify* ``NotebookArchive`` while fixing the Python 3 issue.