### PR TITLE
Bokeh colormapping fixes

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -808,6 +808,8 @@ class BarPlot(ColorbarPlot, LegendPlot):
         for name, val in mapping.items():
             if isinstance(val, basestring):
                 mapping[name] = dimension_sanitizer(mapping[name])
+            elif isinstance(val, dict) and 'field' in val:
+                val['field'] = dimension_sanitizer(val['field'])
 
         # Ensure x-values are categorical
         xname = dimension_sanitizer(xdim.name)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -726,11 +726,11 @@ class BarPlot(ColorbarPlot, LegendPlot):
 
         # Get colors
         cdim = color_dim or group_dim
-        cvals = element.dimension_values(cdim) if cdim else None
+        cvals = element.dimension_values(cdim, expanded=False) if cdim else None
         if cvals is not None:
             if cvals.dtype.kind in 'if' and no_cidx:
                 cvals = categorize_array(cvals, group_dim)
-            factors = None if cvals.dtype.kind in 'if' else list(np.unique(cvals))
+            factors = None if cvals.dtype.kind in 'if' else list(cvals)
             if cdim is xdim and factors:
                 factors = list(categorize_array(factors, xdim))
             if cmap is None and factors:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1013,7 +1013,9 @@ class ColorbarPlot(ElementPlot):
         if colors:
             palette = colors
         else:
-            palette = mplcmap_to_palette(style.pop('cmap', 'viridis'), ncolors)
+            palette = style.pop('cmap', 'viridis')
+            if not isinstance(palette, list):
+                palette = mplcmap_to_palette(palette, ncolors)
         nan_colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -5,6 +5,7 @@ import param
 import numpy as np
 import bokeh
 import bokeh.plotting
+from bokeh import palettes
 from bokeh.core.properties import value
 from bokeh.models import  HoverTool, Renderer, Range1d, DataRange1d, FactorRange
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
@@ -1013,9 +1014,21 @@ class ColorbarPlot(ElementPlot):
         if colors:
             palette = colors
         else:
-            palette = style.pop('cmap', 'viridis')
-            if not isinstance(palette, list):
-                palette = mplcmap_to_palette(palette, ncolors)
+            cmap = style.pop('cmap', 'viridis')
+            if isinstance(cmap, list):
+                palette = cmap
+            else:
+                try:
+                    # Process as matplotlib colormap
+                    palette = mplcmap_to_palette(cmap, ncolors)
+                except ValueError:
+                    # Process as bokeh palette
+                    palette = getattr(palettes, cmap, None)
+                    if isinstance(palette, dict):
+                        if ncolors in palette:
+                            palette = palette[ncolors]
+                        else:
+                            palette = sorted(palette.items())[-1][1]
         nan_colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)
 


### PR DESCRIPTION
Two colormapping fixes the first fixes a bug in assigning colors to Bars in the right order, the second allows passing a list of colors to bokeh instead of a matplotlib colormap which should always have been allowed.