### PR TITLE
Compatibility fixes for bokeh 0.12.6 release

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -2,10 +2,6 @@ from collections import defaultdict
 
 import numpy as np
 import param
-try:
-    from bokeh.charts import BoxPlot as BokehBoxPlot
-except:
-    BokehBoxPlot = None, None
 from bokeh.models import (GlyphRenderer, ColumnDataSource, DataRange1d,
                           Range1d, CategoricalColorMapper, CustomJS,
                           HoverTool)
@@ -23,6 +19,14 @@ from .element import (ElementPlot, ColorbarPlot, LegendPlot, line_properties,
                       fill_properties)
 from .path import PathPlot, PolygonPlot
 from .util import update_plot, bokeh_version, expand_batched_style, categorize_array
+
+try:
+    if bokeh_version > '0.12.5':
+        from bkcharts import BoxPlot as BokehBoxPlot
+    else:
+        from bokeh.charts import BoxPlot as BokehBoxPlot
+except:
+    BokehBoxPlot = None, None
 
 
 class PointPlot(LegendPlot, ColorbarPlot):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -5,7 +5,6 @@ from param.parameterized import bothmethod
 
 from bokeh.application.handlers import FunctionHandler
 from bokeh.application import Application
-from bokeh.charts import Chart
 from bokeh.document import Document
 from bokeh.embed import notebook_div, autoload_server
 from bokeh.io import load_notebook, curdoc, show as bkshow
@@ -22,6 +21,13 @@ from ..renderer import Renderer, MIME_TYPES
 from .widgets import BokehScrubberWidget, BokehSelectionWidget, BokehServerWidgets
 from .util import compute_static_patch, serialize_json, attach_periodic, bokeh_version
 
+try:
+    if bokeh_version > '0.12.5':
+        from bkcharts import Chart
+    else:
+        from bokeh.charts import Chart
+except:
+    Chart = None
 
 
 class BokehRenderer(Renderer):
@@ -259,3 +265,5 @@ class BokehRenderer(Renderer):
         """
         kwargs = {'notebook_type': 'jupyter'} if bokeh_version > '0.12.5' else {}
         load_notebook(hide_banner=True, resources=INLINE if inline else CDN, **kwargs)
+        from bokeh.io import _state
+        _state.output_notebook()


### PR DESCRIPTION
Bokeh compatibility fixes based for the latest bokeh 0.12.6 dev release. With conditional imports for the remaining bokeh chart, hopefully we can drop it soon after our 1.8 release.