### PR TITLE
Ensured notebook_extension aborts outside notebook context

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -135,8 +135,6 @@ class notebook_extension(param.ParameterizedFunction):
         using the matplotlib backend) may be used. This may be useful to
         export figures to other formats such as PDF with nbconvert. """)
 
-    ip = param.Parameter(default=None, doc="IPython kernel instance")
-
     _loaded = False
 
     # Mapping between backend name and module name
@@ -192,6 +190,7 @@ class notebook_extension(param.ParameterizedFunction):
         try:
             ip = params.pop('ip', None) or get_ipython() # noqa (get_ipython)
         except:
+            # Set current backend (usually has to wait until OutputMagic loaded)
             Store.current_backend = selected_backend
             return
 


### PR DESCRIPTION
This PR ensures that when running the notebook extension outside an IPython context it skips the notebook initialization steps. This allows for a HoloViews notebook which loads the extension to be deployed as a bokeh app.