### PR TITLE
Added support for static bokeh png rendering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.18.1 numpy freetype nose bokeh=0.12.5 pandas=0.19.2 jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader dask=0.13
   - source activate test-environment
-  - conda install -c conda-forge  -c scitools iris sip=4.18 plotly flexx
+  - conda install -c conda-forge  iris sip=4.18 plotly flexx
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;
     fi

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -9,7 +9,7 @@ from unittest import SkipTest
 from nose.plugins.attrib import attr
 import numpy as np
 
-from holoviews import HoloMap, Image, ItemTable, Store, GridSpace, Table
+from holoviews import HoloMap, Image, ItemTable, Store, GridSpace, Table, Curve
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting import Renderer
 
@@ -23,6 +23,7 @@ except:
 
 try:
     from holoviews.plotting.bokeh import BokehRenderer
+    from holoviews.plotting.bokeh.util import bokeh_version
 except:
     pass
 
@@ -146,3 +147,12 @@ class BokehRendererTest(ComparisonTestCase):
         plot = self.renderer.get_plot(table+table)
         w, h = self.renderer.get_size(plot)
         self.assertEqual((w, h), (680, 300))
+
+    def test_render_to_png(self):
+        if bokeh_version < str('0.12.6'):
+            raise SkipTest('Bokeh static png rendering requires bokeh>=0.12.6')
+        curve = Curve([])
+        renderer = BokehRenderer.instance(fig='png')
+        png, info = renderer(curve)
+        self.assertIsInstance(png, bytes)
+        self.assertEqual(info['file-ext'], 'png')


### PR DESCRIPTION
The bokeh 0.12.6 release will add static png rendering support and this PR exposes this support at the bokeh renderer level. Because rendering to png is so slow this is not particularly useful for working interactively but will be very useful for generating output which can be embedded in any document, including the thumbnails for our gallery.