### PR TITLE
Fix dynamic sort

### DIFF
--- a/holoviews/util.py
+++ b/holoviews/util.py
@@ -124,6 +124,6 @@ class Dynamic(param.ParameterizedFunction):
             return DynamicMap(dynamic_fn, streams=streams)
         dim_values = zip(*hmap.data.keys())
         params = util.get_param_values(hmap)
-        kdims = [d(values=list(set(values))) for d, values in
+        kdims = [d(values=list(util.unique_iterator(values))) for d, values in
                  zip(hmap.kdims, dim_values)]
         return DynamicMap(dynamic_fn, streams=streams, **dict(params, kdims=kdims))

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -299,6 +299,12 @@ class DynamicTestOperation(ComparisonTestCase):
         dmap_with_fn = Dynamic(dmap, operation=lambda x: x.clone(x.data*2))
         self.assertEqual(dmap_with_fn[5], Image(sine_array(0,5)*2))
 
+    def test_dynamic_operation_on_hmap(self):
+        hmap = HoloMap({i: Image(sine_array(0,i)) for i in range(10)})
+        dmap = Dynamic(hmap, operation=lambda x: x)
+        self.assertEqual(dmap.kdims[0].name, hmap.kdims[0].name)
+        self.assertEqual(dmap.kdims[0].values, hmap.keys())
+
     def test_dynamic_operation_link_inputs_not_transferred_on_clone(self):
         fn = lambda i: Image(sine_array(0,i))
         dmap=DynamicMap(fn, kdims=['i'])


### PR DESCRIPTION
The Dynamic utility converts HoloMaps to DynamicMaps by setting the HoloMap key dimension values as Dimension.values on the ``DynamicMap``. Currently they are unordered, this PR ensures they retain their original order.