### PR TITLE
Fixed batched Spike overlay extents bug

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -514,7 +514,8 @@ class SpikesPlot(PathPlot, ColorbarPlot):
                 bs, ts = [], []
                 # Iterate over current NdOverlay and compute extents
                 # from position and length plot options
-                for el in self.current_frame.values():
+                frame = self.current_frame or self.hmap.last 
+                for el in frame.values():
                     opts = self.lookup_options(el, 'plot').options
                     pos = opts.get('position', self.position)
                     length = opts.get('spike_length', self.spike_length)


### PR DESCRIPTION
Fixes https://github.com/ioam/holoviews/issues/1480, the SpikePlot was iterating over the ``current_frame`` in batched mode for no reason causing issues when the plot was overlaid and the ``current_frame`` isn't initialized.