### PR TITLE
Add support for colormapping Contours

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -23,7 +23,7 @@ from .element import OverlayPlot
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
                     AreaPlot, VectorFieldPlot)
-from .path import PathPlot, PolygonPlot
+from .path import PathPlot, PolygonPlot, ContourPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
 from .raster import (RasterPlot, RGBPlot, HeatmapPlot,
                      HSVPlot, QuadMeshPlot)
@@ -66,7 +66,7 @@ associations = {Overlay: OverlayPlot,
 
                 # Paths
                 Path: PathPlot,
-                Contours: PathPlot,
+                Contours: ContourPlot,
                 Path:     PathPlot,
                 Box:      PathPlot,
                 Bounds:   PathPlot,

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -67,7 +67,7 @@ class ContourPlot(ColorbarPlot, PathPlot):
         data, mapping = super(ContourPlot, self).get_data(element, ranges, empty)
         ncontours = len(list(data.values())[0])
         style = self.style[self.cyclic_index]
-        if element.vdims and element.level is not None:
+        if element.vdims and element.level is not None and 'cmap' in style:
             cdim = element.vdims[0]
             dim_name = util.dimension_sanitizer(cdim.name)
             cmapper = self._get_colormapper(cdim, element, ranges, style)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -1,5 +1,7 @@
 from collections import defaultdict
+
 import param
+import numpy as np
 
 from bokeh.models import HoverTool
 
@@ -55,6 +57,24 @@ class PathPlot(ElementPlot):
                 data[k].extend(list(v))
 
         return data, elmapping
+
+
+class ContourPlot(ColorbarPlot, PathPlot):
+
+    style_opts = line_properties + ['cmap']
+
+    def get_data(self, element, ranges=None, empty=False):
+        data, mapping = super(ContourPlot, self).get_data(element, ranges, empty)
+        ncontours = len(list(data.values())[0])
+        style = self.style[self.cyclic_index]
+        if element.vdims and element.level is not None:
+            cdim = element.vdims[0]
+            dim_name = util.dimension_sanitizer(cdim.name)
+            cmapper = self._get_colormapper(cdim, element, ranges, style)
+            data[dim_name] = [] if empty else np.full(ncontours, float(element.level))
+            mapping['line_color'] = {'field': dim_name,
+                                     'transform': cmapper}
+        return data, mapping
 
 
 class PolygonPlot(ColorbarPlot, PathPlot):

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -147,7 +147,7 @@ Store.register({Curve: CurvePlot,
                 Text: TextPlot,
 
                 # Path plots
-                Contours: PathPlot,
+                Contours: ContourPlot,
                 Path:     PathPlot,
                 Box:      PathPlot,
                 Bounds:   PathPlot,

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -33,6 +33,29 @@ class PathPlot(ElementPlot):
         return axis_kwargs
 
 
+class ContourPlot(PathPlot, ColorbarPlot):
+
+    style_opts = PathPlot.style_opts + ['cmap']
+
+    def get_data(self, element, ranges, style):
+        args, style, axis_kwargs = super(ContourPlot, self).get_data(element, ranges, style)
+        value = element.level
+        if element.vdims and value is not None and np.isfinite(value) and 'cmap' in style:
+            self._norm_kwargs(element, ranges, style, element.vdims[0])
+            style['clim'] = style.pop('vmin'), style.pop('vmax')
+            style['array'] = np.array([value]*len(args[0]))
+        return args, style, axis_kwargs
+
+
+    def update_handles(self, key, axis, element, ranges, style):
+        artist = self.handles['artist']
+        axis_kwargs = super(ContourPlot, self).update_handles(key, axis, element, ranges, style)
+        if 'array' in style:
+            artist.set_array(style['array'])
+            artist.set_clim(style['clim'])
+        return axis_kwargs
+
+
 class PolygonPlot(ColorbarPlot):
     """
     PolygonPlot draws the polygon paths in the supplied Polygons


### PR DESCRIPTION
Turns out ``Contours`` in bokeh did not support colormapping, which I noticed as I was reworking the Contours element example. Since colormapping is handled on a baseclass this was an easy addition:

```
%%opts Contours (cmap='viridis')
hv.operation.contours(hv.Image(np.sin(x**2+y**2)), levels=np.linspace(0, 1, 9),
                      overlaid=False)
```

![bokeh_plot 59](https://cloud.githubusercontent.com/assets/1550771/26627386/3b6c7e72-45f2-11e7-827f-9a9c9d000d27.png)
