### PR TITLE
Histogram data fixes

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -123,7 +123,7 @@ class Spread(ErrorBars):
 
 
 
-class Bars(Dataset, Element2D):
+class Bars(Chart):
     """
     Bars is an Element type, representing a number of stacked and
     grouped bars, depending the dimensionality of the key and value
@@ -223,10 +223,10 @@ class Histogram(Element2D):
         """
         settings = {}
         (values, edges) = values if isinstance(values, tuple) else (values, edges)
-        if isinstance(values, Element2D):
+        if isinstance(values, Chart):
             settings = dict(values.get_param_values(onlychanged=True))
-            edges = values.data[:, 0].copy()
-            values = values.data[:, 1].copy()
+            edges = values.dimension_values(0)
+            values = values.dimension_values(1)
         elif isinstance(values, np.ndarray) and len(values.shape) == 2:
             edges = values[:, 0]
             values = values[:, 1]

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -34,6 +34,8 @@ def compute_edges(edges):
     throwing an exception if the edges are not
     evenly spaced.
     """
+    if edges.dtype.kind == 'i':
+        edges = edges.astype('f')
     widths = np.diff(edges)
     if np.allclose(widths, widths[0]):
         width = widths[0]

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -34,6 +34,7 @@ def compute_edges(edges):
     throwing an exception if the edges are not
     evenly spaced.
     """
+    edges = np.asarray(edges)
     if edges.dtype.kind == 'i':
         edges = edges.astype('f')
     widths = np.diff(edges)

--- a/tests/testelementconstructors.py
+++ b/tests/testelementconstructors.py
@@ -36,14 +36,24 @@ class ElementConstructorTest(ComparisonTestCase):
     def test_path_ziplist_construct(self):
         self.assertEqual(Path([list(zip(self.xs, self.sin)), list(zip(self.xs, self.cos))]), self.path)
 
-    def test_chart_zip_construct(self):
+    def test_hist_zip_construct(self):
         self.assertEqual(Histogram(list(zip(self.hxs, self.sin))), self.histogram)
 
-    def test_chart_array_construct(self):
+    def test_hist_array_construct(self):
         self.assertEqual(Histogram(np.column_stack((self.hxs, self.sin))), self.histogram)
 
-    def test_chart_yvalues_construct(self):
+    def test_hist_yvalues_construct(self):
         self.assertEqual(Histogram(self.sin), self.histogram)
+
+    def test_hist_curve_construct(self):
+        hist = Histogram(Curve(([0.1, 0.3, 0.5], [2.1, 2.2, 3.3])))
+        self.assertEqual(hist.data[0], np.array([2.1, 2.2, 3.3]))
+        self.assertEqual(hist.data[1], np.array([0, 0.2, 0.4, 0.6]))
+
+    def test_hist_curve_int_edges_construct(self):
+        hist = Histogram(Curve(range(3)))
+        self.assertEqual(hist.data[0], np.arange(3))
+        self.assertEqual(hist.data[1], np.array([-.5, .5, 1.5, 2.5]))
 
     def test_heatmap_construct(self):
         hmap = HeatMap([('A', 'a', 1), ('B', 'b', 2)])


### PR DESCRIPTION
Fixes two bugs in the Histogram constructor:

1) Updated old code assuming that Chart data is always arrays, fixing how Charts are cast to a Histogram.

2) Fixed code to compute bin edges from bin centers when centers are defined as integers.