### PR TITLE
Only colormap adjoined Histogram when dimensions match

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -422,7 +422,7 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
         color_dims = self.adjoined.traverse(lambda x: x.handles.get('color_dim'))
         dim = color_dims[0] if color_dims else None
         cmapper = self._get_colormapper(dim, element, {}, {})
-        if cmapper:
+        if cmapper and dim in element.dimensions():
             data[dim.name] = [] if empty else element.dimension_values(dim)
             mapping['fill_color'] = {'field': dim.name,
                                      'transform': cmapper}


### PR DESCRIPTION
Fixes dimension lookup error with this example:

```python
%%opts Scatter [color_index=2 size_index=3 scaling_factor=50]
np.random.seed(10)
data = np.random.rand(100,4)

scatter = hv.Scatter(data, vdims=['y', 'z', 'size'])
scatter + scatter[0.3:0.7, 0.3:0.7].hist()
```