### PR TITLE
Added support for supplying fixed ticks with labels

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -481,7 +481,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 axis_props['ticker'] = BasicTicker(desired_num_ticks=ticker)
             elif isinstance(ticker, (tuple, list)):
                 if all(isinstance(t, tuple) for t in ticker):
-                    pass
+                    ticks, labels = zip(*ticker)
+                    axis_props['ticker'] = FixedTicker(ticks=ticks)
+                    if bokeh_version > '0.12.5':
+                        axis_props['major_label_overrides'] = dict(ticker)
+                    else:
+                        self.warning('Explicit tick labels not supported until'
+                                     'bokeh 0.12.6, please upgrade')
                 else:
                     axis_props['ticker'] = FixedTicker(ticks=ticker)
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1401,11 +1401,29 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(plot.xaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.xaxis[0].ticker.ticks, [0, 5, 10])
 
+    def test_element_xticks_list_of_tuples(self):
+        if bokeh_version < str('0.12.6'):
+            raise SkipTest('Bokeh 0.12.6 required for specifying explicit tick labels')
+        ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
+        curve = Curve(range(10))(plot=dict(xticks=ticks))
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertIsInstance(plot.xaxis[0].ticker, FixedTicker)
+        self.assertEqual(plot.xaxis[0].major_label_overrides, dict(ticks))
+
     def test_element_yticks_list(self):
         curve = Curve(range(10))(plot=dict(yticks=[0, 5, 10]))
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].ticker, FixedTicker)
         self.assertEqual(plot.yaxis[0].ticker.ticks, [0, 5, 10])
+
+    def test_element_xticks_list_of_tuples(self):
+        if bokeh_version < str('0.12.6'):
+            raise SkipTest('Bokeh 0.12.6 required for specifying explicit tick labels')
+        ticks = [(0, 'zero'), (5, 'five'), (10, 'ten')]
+        curve = Curve(range(10))(plot=dict(yticks=ticks))
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertIsInstance(plot.yaxis[0].ticker, FixedTicker)
+        self.assertEqual(plot.yaxis[0].major_label_overrides, dict(ticks))
 
     def test_overlay_xticks_list(self):
         overlay = (Curve(range(10)) * Curve(range(10)))(plot=dict(xticks=[0, 5, 10]))


### PR DESCRIPTION
Finally adds ticking support with fixed labels to the bokeh backend, e.g.:

```python
%%opts Curve [xticks=[(0, 'Foo'), (1, 'Bar'), (2, 'Baz')]]
hv.Curve([1,2,3])
```

![bokeh_plot 60](https://cloud.githubusercontent.com/assets/1550771/26645346/9c963746-462f-11e7-995b-9926b43b54d5.png)

Will be available when 0.12.6 is released, both the code and the tests are appropriately guarded to work only with bokeh version > 0.12.5.