### PR TITLE
Ellipse parameter now supports major/minor axis lengths

### DIFF
--- a/examples/elements/bokeh/Box.ipynb
+++ b/examples/elements/bokeh/Box.ipynb
@@ -30,7 +30,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A ``Box`` is an annotation that takes a center x-position, a center y-position and a width:"
+    "A ``Box`` is an annotation that takes a center x-position, a center y-position and a size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Box (line_width=5 color='red') Image (cmap='gray')\n",
+    "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
+    "data[range(40, 60) + range(40,50), range(20, 40)+ range(70,80)] = -3\n",
+    "hv.Image(data) * hv.Box(-0.2, 0, 0.2 ) * hv.Box(-0, 0, (0.4,0.9) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to these arguments, it supports an optional ``aspect ratio``:\n",
+    "\n",
+    "By default, the size argument results in a square such as the small square shown above. Alternatively, the size can be given as the tuple ``(width, height)`` resulting in a rectangle. If you only supply a size value, you can still specify a rectangle by specifying an optional aspect value. In addition, you can also set the orientation (in radians, rotating anticlockwise):"
    ]
   },
   {
@@ -44,26 +67,7 @@
     "%%opts Box (line_width=5 color='purple') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
     "data[range(30, 70), range(30, 70)] = -3\n",
-    "hv.Image(data) * hv.Box(-0, 0, 0.5 )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In addition to these arguments, it supports an optional ``aspect ratio``:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%%opts Box (line_width=5 color='purple') Image (cmap='gray')\n",
-    "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3)"
+    "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3, orientation=-np.pi/4)"
    ]
   }
  ],

--- a/examples/elements/bokeh/Box.ipynb
+++ b/examples/elements/bokeh/Box.ipynb
@@ -43,8 +43,9 @@
    "source": [
     "%%opts Box (line_width=5 color='red') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
-    "data[range(40, 60) + range(40,50), range(20, 40)+ range(70,80)] = -3\n",
-    "hv.Image(data) * hv.Box(-0.2, 0, 0.2 ) * hv.Box(-0, 0, (0.4,0.9) )"
+    "data[np.arange(40, 60), np.arange(20, 40)] = -1\n",
+    "data[np.arange(40, 50), np.arange(70, 80)] = -3    \n",
+    "hv.Image(data) * hv.Box(-0.2, 0, 0.25 ) * hv.Box(-0, 0, (0.4,0.9) )"
    ]
   },
   {
@@ -66,7 +67,7 @@
    "source": [
     "%%opts Box (line_width=5 color='purple') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
-    "data[range(30, 70), range(30, 70)] = -3\n",
+    "data[np.arange(30, 70), np.arange(30, 70)] = -3\n",
     "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3, orientation=-np.pi/4)"
    ]
   }

--- a/examples/elements/bokeh/Ellipse.ipynb
+++ b/examples/elements/bokeh/Ellipse.ipynb
@@ -7,8 +7,8 @@
     "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
     "<dl class=\"dl-horizontal\">\n",
     "  <dt>Title</dt> <dd> Ellipse Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
-    "  <dt>Backends</dt> <dd>[Matplotlib](./Ellipse.ipynb)</dd> <dd>[Bokeh](../bokeh/Ellipse.ipynb)</dd>\n",
+    "  <dt>Dependencies</dt> <dd>Bokeh</dd>\n",
+    "  <dt>Backends</dt> <dd>[Bokeh](./Ellipse.ipynb)</dd> <dd>[Matplotlib](../matplotlib/Ellipse.ipynb)</dd>\n",
     "</dl>\n",
     "</div>"
    ]
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value and you can also set the orientation (in radians, rotatinf anticlockwise):"
+    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value. In addition, you can also set the orientation (in radians, rotating anticlockwise):"
    ]
   },
   {

--- a/examples/elements/bokeh/Ellipse.ipynb
+++ b/examples/elements/bokeh/Ellipse.ipynb
@@ -7,8 +7,8 @@
     "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
     "<dl class=\"dl-horizontal\">\n",
     "  <dt>Title</dt> <dd> Ellipse Element</dd>\n",
-    "  <dt>Dependencies</dt> <dd>Bokeh</dd>\n",
-    "  <dt>Backends</dt> <dd>[Bokeh](./Ellipse.ipynb)</dd> <dd>[Matplotlib](../matplotlib/Ellipse.ipynb)</dd>\n",
+    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
+    "  <dt>Backends</dt> <dd>[Matplotlib](./Ellipse.ipynb)</dd> <dd>[Bokeh](../bokeh/Ellipse.ipynb)</dd>\n",
     "</dl>\n",
     "</div>"
    ]
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An ``Ellipse`` is an annotation that takes a center x-position, a center y-position, a width and an optional aspect ratio:"
+    "An ``Ellipse`` is an annotation that takes a center x-position, a center y-position, a size:"
    ]
   },
   {
@@ -49,7 +49,27 @@
     "c3 = np.random.normal(loc=0, scale=1.5, size=(400,400))\n",
     "# Create an overlay of points and ellipses\n",
     "clusters = hv.Points(c1) * hv.Points((c2x, c2y)) * hv.Points(c3)\n",
-    "clusters * hv.Ellipse(-2,-2, 0.2*12, aspect=1.5) * hv.Ellipse(2,2, 0.6*4)"
+    "clusters * hv.Ellipse(2,2, 2) * hv.Ellipse(-2,-2, (4,2)) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value and you can also set the orientation (in radians, rotatinf anticlockwise):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Ellipse (line_width=6)\n",
+    "clusters = hv.Points(c1) * hv.Points((c2x, c2y)) * hv.Points(c3)\n",
+    "clusters *  hv.Ellipse(0,0, 4, orientation=np.pi/5, aspect=2) "
    ]
   }
  ],

--- a/examples/elements/matplotlib/Box.ipynb
+++ b/examples/elements/matplotlib/Box.ipynb
@@ -30,7 +30,30 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A ``Box`` is an annotation that takes a center x-position, a center y-position and a width:"
+    "A ``Box`` is an annotation that takes a center x-position, a center y-position and a size:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Box (linewidth=5 color='red') Image (cmap='gray')\n",
+    "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
+    "data[range(40, 60) + range(40,50), range(20, 40)+ range(70,80)] = -3\n",
+    "hv.Image(data) * hv.Box(-0.2, 0, 0.2 ) * hv.Box(-0, 0, (0.4,0.9) )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to these arguments, it supports an optional ``aspect ratio``:\n",
+    "\n",
+    "By default, the size argument results in a square such as the small square shown above. Alternatively, the size can be given as the tuple ``(width, height)`` resulting in a rectangle. If you only supply a size value, you can still specify a rectangle by specifying an optional aspect value. In addition, you can also set the orientation (in radians, rotating anticlockwise):"
    ]
   },
   {
@@ -44,26 +67,7 @@
     "%%opts Box (linewidth=5 color='purple') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
     "data[range(30, 70), range(30, 70)] = -3\n",
-    "hv.Image(data) * hv.Box(-0, 0, 0.5 )"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "In addition to these arguments, it supports an optional ``aspect ratio``:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "%%opts Box (linewidth=5 color='purple') Image (cmap='gray')\n",
-    "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3)"
+    "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3, orientation=-np.pi/4)"
    ]
   }
  ],

--- a/examples/elements/matplotlib/Box.ipynb
+++ b/examples/elements/matplotlib/Box.ipynb
@@ -43,8 +43,9 @@
    "source": [
     "%%opts Box (linewidth=5 color='red') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
-    "data[range(40, 60) + range(40,50), range(20, 40)+ range(70,80)] = -3\n",
-    "hv.Image(data) * hv.Box(-0.2, 0, 0.2 ) * hv.Box(-0, 0, (0.4,0.9) )"
+    "data[np.arange(40, 60), np.arange(20, 40)] = -1\n",
+    "data[np.arange(40, 50), np.arange(70, 80)] = -3    \n",
+    "hv.Image(data) * hv.Box(-0.2, 0, 0.25 ) * hv.Box(-0, 0, (0.4,0.9) )"
    ]
   },
   {
@@ -66,7 +67,7 @@
    "source": [
     "%%opts Box (linewidth=5 color='purple') Image (cmap='gray')\n",
     "data = np.sin(np.mgrid[0:100,0:100][1]/10.0)\n",
-    "data[range(30, 70), range(30, 70)] = -3\n",
+    "data[np.arange(30, 70), np.arange(30, 70)] = -3\n",
     "hv.Image(data) * hv.Box(-0, 0, 0.25, aspect=3, orientation=-np.pi/4)"
    ]
   }

--- a/examples/elements/matplotlib/Ellipse.ipynb
+++ b/examples/elements/matplotlib/Ellipse.ipynb
@@ -30,7 +30,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "An ``Ellipse`` is an annotation that takes a center x-position, a center y-position, a width and an optional aspect ratio:"
+    "An ``Ellipse`` is an annotation that takes a center x-position, a center y-position, a size:"
    ]
   },
   {
@@ -49,7 +49,27 @@
     "c3 = np.random.normal(loc=0, scale=1.5, size=(400,400))\n",
     "# Create an overlay of points and ellipses\n",
     "clusters = hv.Points(c1) * hv.Points((c2x, c2y)) * hv.Points(c3)\n",
-    "clusters * hv.Ellipse(-2,-2, 0.2*12, aspect=1.5) * hv.Ellipse(2,2, 0.6*4)"
+    "clusters * hv.Ellipse(2,2, 2) * hv.Ellipse(-2,-2, (4,2)) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value and you can also set the orientation (in radians, rotatinf anticlockwise):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%opts Ellipse (linewidth=6)\n",
+    "clusters = hv.Points(c1) * hv.Points((c2x, c2y)) * hv.Points(c3)\n",
+    "clusters *  hv.Ellipse(0,0, 4, orientation=np.pi/5, aspect=2) "
    ]
   }
  ],

--- a/examples/elements/matplotlib/Ellipse.ipynb
+++ b/examples/elements/matplotlib/Ellipse.ipynb
@@ -56,7 +56,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value and you can also set the orientation (in radians, rotatinf anticlockwise):"
+    "By default, the size is just a diameter, resulting in a circle such as the blue circle above. Alternatively, the size can be given as the tuple ``(width, height)`` as shown for the red ellipse above. If you only supply a diameter, you can still specify an ellipse by specifying an optional aspect value.  In addition, you can also set the orientation (in radians, rotating anticlockwise):"
    ]
   },
   {

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -218,7 +218,7 @@ class Ellipse(BaseShape):
 
     orientation = param.Number(default=0, doc="""
        Orientation in the Cartesian coordinate system, the
-       counterclockwise angle in radian between the first axis and the
+       counterclockwise angle in radians between the first axis and the
        horizontal.""")
 
     samples = param.Number(default=100, doc="The sample count used to draw the ellipse.")

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -208,7 +208,8 @@ class Ellipse(BaseShape):
     width = param.Number(default=1, doc="The width of the ellipse.")
 
     aspect= param.Number(default=1.0, doc="""
-       Final multiplier applied to the width.""")
+       Optional multiplier applied to the height to compute the width
+       in cases where only the height value is set.""")
 
     orientation = param.Number(default=0, doc="""
        Orientation in the Cartesian coordinate system, the
@@ -222,6 +223,9 @@ class Ellipse(BaseShape):
     def __init__(self, x, y, spec, **params):
 
         if isinstance(spec, tuple):
+            if 'aspect' in params:
+                raise ValueError('Aspect parameter not supported when supplying '
+                                 '(width, height) specification.')
             (height, width) = spec
         else:
             width, height = spec, spec

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -210,18 +210,18 @@ class Ellipse(BaseShape):
 
     y = param.Number(default=0, doc="The y-position of the ellipse center.")
 
-    height = param.Number(default=1, doc="The height of the ellipse.")
-
     width = param.Number(default=1, doc="The width of the ellipse.")
 
-    aspect= param.Number(default=1.0, doc="""
-       Optional multiplier applied to the height to compute the width
-       in cases where only the height value is set.""")
+    height = param.Number(default=1, doc="The height of the ellipse.")
 
     orientation = param.Number(default=0, doc="""
        Orientation in the Cartesian coordinate system, the
        counterclockwise angle in radians between the first axis and the
        horizontal.""")
+
+    aspect= param.Number(default=1.0, doc="""
+       Optional multiplier applied to the diameter to compute the width
+       in cases where only the diameter value is set.""")
 
     samples = param.Number(default=100, doc="The sample count used to draw the ellipse.")
 
@@ -235,7 +235,7 @@ class Ellipse(BaseShape):
             if 'aspect' in params:
                 raise ValueError('Aspect parameter not supported when supplying '
                                  '(width, height) specification.')
-            (height, width) = spec
+            (width, height) = spec
         else:
             width, height = params.get('width', spec), spec
 

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -167,21 +167,45 @@ class Box(BaseShape):
 
     y = param.Number(default=0, doc="The y-position of the box center.")
 
+    width = param.Number(default=1, doc="The width of the box.")
+
     height = param.Number(default=1, doc="The height of the box.")
 
-    aspect= param.Number(default=1, doc=""""
-        The aspect ratio of the box if supplied, otherwise an aspect
-        of 1.0 is used.""")
+    orientation = param.Number(default=0, doc="""
+       Orientation in the Cartesian coordinate system, the
+       counterclockwise angle in radians between the first axis and the
+       horizontal.""")
+
+    aspect= param.Number(default=1.0, doc="""
+       Optional multiplier applied to the box length to compute the
+       width in cases where only the length value is set.""")
 
     group = param.String(default='Box', constant=True, doc="The assigned group name.")
 
     __pos_params = ['x','y', 'height']
 
-    def __init__(self, x, y, height, **params):
-        super(Box, self).__init__([], x=x,y =y, height=height, **params)
-        width = height * self.aspect
-        (l,b,r,t) = (x-width/2.0, y-height/2, x+width/2.0, y+height/2)
-        self.data = [np.array([(l, b), (l, t), (r, t), (r, b),(l, b)])]
+    def __init__(self, x, y, spec, **params):
+
+        if isinstance(spec, tuple):
+            if 'aspect' in params:
+                raise ValueError('Aspect parameter not supported when supplying '
+                                 '(width, height) specification.')
+            (height, width) = spec
+        else:
+            width, height = params.get('width', spec), spec
+
+        params['width']=params.get('width',width)
+        super(Box, self).__init__([], x=x, y=y, height=height, **params)
+
+        half_width = (self.width * self.aspect)/ 2.0
+        half_height = self.height / 2.0
+        (l,b,r,t) = (x-half_width, y-half_height, x+half_width, y+half_height)
+
+        box = np.array([(l, b), (l, t), (r, t), (r, b),(l, b)])
+        rot = np.array([[np.cos(self.orientation), -np.sin(self.orientation)],
+                        [np.sin(self.orientation), np.cos(self.orientation)]])
+
+        self.data = [np.tensordot(rot, box.T, axes=[1,0]).T]
 
 
 class Ellipse(BaseShape):
@@ -243,8 +267,8 @@ class Ellipse(BaseShape):
         super(Ellipse, self).__init__([], x=x, y=y, height=height, **params)
 
         angles = np.linspace(0, 2*np.pi, self.samples)
-        half_height = self.height / 2.0
         half_width = (self.width * self.aspect)/ 2.0
+        half_height = self.height / 2.0
         #create points
         ellipse = np.array(
             list(zip(half_width*np.sin(angles),

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -208,7 +208,7 @@ class Ellipse(BaseShape):
     width = param.Number(default=1, doc="The width of the ellipse.")
 
     aspect= param.Number(default=1.0, doc="""
-       Final divisor only applied to the final height.""")
+       Final multiplier applied to the width.""")
 
     orientation = param.Number(default=0, doc="""
        Orientation in the Cartesian coordinate system, the

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -177,7 +177,7 @@ class Box(BaseShape):
        horizontal.""")
 
     aspect= param.Number(default=1.0, doc="""
-       Optional multiplier applied to the box length to compute the
+       Optional multiplier applied to the box size to compute the
        width in cases where only the length value is set.""")
 
     group = param.String(default='Box', constant=True, doc="The assigned group name.")
@@ -220,7 +220,7 @@ class Ellipse(BaseShape):
     A circle is a degenerate ellipse where the width and height are
     equal. To specify these explicitly, you can use:
 
-    Ellipse(x,y, (height, width))
+    Ellipse(x,y, (width, height))
 
     There is also an apect parameter allowing you to generate an ellipse
     by specifying a multiplicating factor that will be applied to the

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -184,16 +184,16 @@ class Ellipse(BaseShape):
 
     The simplest (default) Ellipse is a circle, specified using:
 
-    Ellipse(x,y, radius)
+    Ellipse(x,y, diameter)
 
-    A circle is a degenerate ellipse where the major axis and minor axis
-    lengths are equal. To specify these explicitly, you can use:
+    A circle is a degenerate ellipse where the width and height are
+    equal. To specify these explicitly, you can use:
 
-    Ellipse(x,y, (major-axis-length, minor-axis-length))
+    Ellipse(x,y, (height, width))
 
     There is also an apect parameter allowing you to generate an ellipse
     by specifying a multiplicating factor that will be applied to the
-    major axis length only.
+    height only.
 
     Note that as a subclass of Path, internally an Ellipse is a
     sequency of (x,y) sample positions. Ellipse could also be
@@ -203,18 +203,12 @@ class Ellipse(BaseShape):
 
     y = param.Number(default=0, doc="The y-position of the ellipse center.")
 
-    height = param.Number(default=1, doc="""
-       The height of the ellipse. Will be deprecated in HoloViews 2.0:
-       use the major_axis_length parameter instead.""")
+    height = param.Number(default=1, doc="The height of the ellipse.")
 
-    major_axis_length = param.Number(default=1, doc="The length of the ellipse major axis")
-
-    minor_axis_length = param.Number(default=1, doc="The length of the ellipse minor axis")
+    width = param.Number(default=1, doc="The width of the ellipse.")
 
     aspect= param.Number(default=1.0, doc="""
-       Final multipler only applied to the minor axis length. Allows
-       ellipses to be specified without the (major axis length, minor
-       axis length) tuple format.""")
+       Final divisor only applied to the final height.""")
 
     orientation = param.Number(default=0, doc="""
        Orientation in the Cartesian coordinate system, the
@@ -227,28 +221,20 @@ class Ellipse(BaseShape):
 
     def __init__(self, x, y, spec, **params):
 
-        if 'height' in params:
-            spec = params['height']
-
         if isinstance(spec, tuple):
-            (major, minor) = spec
-            if major < minor:
-                raise ValueError('Minor axis length must be less than major axis length')
-            params['height'] = major
+            (height, width) = spec
         else:
-            major, minor = spec, spec
+            width, height = spec, spec
 
-        params['major_axis_length']= major
-        params['minor_axis_length']= minor
-        super(Ellipse, self).__init__([], x=x, y=y, **params)
+        super(Ellipse, self).__init__([], x=x, y=y, height=height, width=width, **params)
 
         angles = np.linspace(0, 2*np.pi, self.samples)
-        half_major = self.major_axis_length / 2.0
-        half_minor = (self.minor_axis_length * self.aspect)/ 2.0
+        half_height = self.height / 2.0
+        half_width = (self.width * self.aspect)/ 2.0
         #create points
         ellipse = np.array(
-            list(zip(half_minor*np.sin(angles),
-                     half_major*np.cos(angles))))
+            list(zip(half_width*np.sin(angles),
+                     half_height*np.cos(angles))))
         #rotate ellipse and add offset
         rot = np.array([[np.cos(self.orientation), -np.sin(self.orientation)],
                [np.sin(self.orientation), np.cos(self.orientation)]])

--- a/tests/testpaths.py
+++ b/tests/testpaths.py
@@ -1,0 +1,70 @@
+"""
+Unit tests of Path types.
+"""
+import numpy as np
+from holoviews import Ellipse, Box, Bounds
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class EllipseTests(ComparisonTestCase):
+
+    def setUp(self):
+        self.pentagon = np.array([[  0.00000000e+00,   5.00000000e-01],
+                                  [  4.75528258e-01,   1.54508497e-01],
+                                  [  2.93892626e-01,  -4.04508497e-01],
+                                  [ -2.93892626e-01,  -4.04508497e-01],
+                                  [ -4.75528258e-01,   1.54508497e-01],
+                                  [ -1.22464680e-16,   5.00000000e-01]])
+
+        self.squashed = np.array([[  0.00000000e+00,   1.00000000e+00],
+                                  [  4.75528258e-01,   3.09016994e-01],
+                                  [  2.93892626e-01,  -8.09016994e-01],
+                                  [ -2.93892626e-01,  -8.09016994e-01],
+                                  [ -4.75528258e-01,   3.09016994e-01],
+                                  [ -1.22464680e-16,   1.00000000e+00]])
+
+
+    def test_ellipse_simple_constructor(self):
+        ellipse = Ellipse(0,0,1, samples=100)
+        self.assertEqual(len(ellipse.data[0]), 100)
+
+    def test_ellipse_simple_constructor_pentagon(self):
+        ellipse = Ellipse(0,0,1, samples=6)
+        self.assertEqual(np.allclose(ellipse.data[0], self.pentagon), True)
+
+    def test_ellipse_tuple_constructor_squashed(self):
+        ellipse = Ellipse(0,0,(1,2), samples=6)
+        self.assertEqual(np.allclose(ellipse.data[0], self.squashed), True)
+
+    def test_ellipse_simple_constructor_squashed_aspect(self):
+        ellipse = Ellipse(0,0,2, aspect=0.5, samples=6)
+        self.assertEqual(np.allclose(ellipse.data[0], self.squashed), True)
+
+
+class BoxTests(ComparisonTestCase):
+
+    def setUp(self):
+        self.rotated_square = np.array([[-0.27059805, -0.65328148],
+                                        [-0.65328148,  0.27059805],
+                                        [ 0.27059805,  0.65328148],
+                                        [ 0.65328148, -0.27059805],
+                                        [-0.27059805, -0.65328148]])
+
+        self.rotated_rect = np.array([[-0.73253782, -0.8446232 ],
+                                      [-1.11522125,  0.07925633],
+                                      [ 0.73253782,  0.8446232 ],
+                                      [ 1.11522125, -0.07925633],
+                                      [-0.73253782, -0.8446232 ]])
+
+    def test_box_simple_constructor_rotated(self):
+        box = Box(0,0,1, orientation=np.pi/8)
+        self.assertEqual(np.allclose(box.data[0], self.rotated_square), True)
+
+
+    def test_box_tuple_constructor_rotated(self):
+        box = Box(0,0,(1,2), orientation=np.pi/8)
+        self.assertEqual(np.allclose(box.data[0], self.rotated_rect), True)
+
+    def test_box_aspect_constructor_rotated(self):
+        box = Box(0,0,1, aspect=2, orientation=np.pi/8)
+        self.assertEqual(np.allclose(box.data[0], self.rotated_rect), True)


### PR DESCRIPTION
Implements a suggestion by @ea42gh that is backwards compatible with the old behavior. Needs testing and final discussion on whether this is useful before I add unit tests.

**Edit:** I'll also update the new element notebook for ellipse if we decide this is useful.