### PR TITLE
Switched Lissajous example to use Path instead of Curve

### DIFF
--- a/doc/Tutorials/Streams.ipynb
+++ b/doc/Tutorials/Streams.ipynb
@@ -38,7 +38,7 @@
     "%opts Ellipse [bgcolor='w'] (color='b')\n",
     "%opts Image (cmap='viridis')\n",
     "%opts VLine (color='r' linewidth=2) HLine (color='r' linewidth=1)\n",
-    "%opts Curve [show_grid=False bgcolor='w'] (color='k' linestyle='-.')\n",
+    "%opts Path [show_grid=False bgcolor='w'] (color='k' linestyle='-.')\n",
     "%opts Area (hatch='\\\\' facecolor='cornsilk' linewidth=2 edgecolor='k')"
    ]
   },
@@ -71,7 +71,7 @@
     "\n",
     "def lissajous_curve(t, a=3,b=5, delta=np.pi/2):\n",
     "    (x,y) = lissajous(t,a,b,delta)\n",
-    "    return hv.Curve(lissajous(lin,a,b,delta)) * hv.VLine(x) * hv.HLine(y)\n",
+    "    return hv.Path(lissajous(lin,a,b,delta)) * hv.VLine(x) * hv.HLine(y)\n",
     "\n",
     "hv.DynamicMap(lissajous_curve, kdims=['t']).redim.range(t=(-3.,3.))"
    ]
@@ -881,7 +881,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "version": "2.7.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Tiny fix to use ``Path`` instead of ``Curve`` for the first example in the streams tutorial as I think ``Path`` is more appropriate.