### PR TITLE
Allowed using xarray with dask arrays

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -5,6 +5,11 @@ import types
 import numpy as np
 import xarray as xr
 
+try:
+    import dask
+except ImportError:
+    dask = None
+
 from .. import util
 from ..dimension import Dimension
 from ..ndmapping import NdMapping, item_check, sorted_context
@@ -156,6 +161,8 @@ class XArrayInterface(GridInterface):
         data = dataset.data[dim.name].data
         if dim in dataset.vdims:
             coord_dims = dataset.data[dim.name].dims
+            if dask and isinstance(data, dask.array.Array):
+                data = data.compute()
             data = cls.canonicalize(dataset, data, coord_dims=coord_dims)
             return data.T.flatten() if flat else data
         elif expanded:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -97,6 +97,8 @@ class XArrayInterface(GridInterface):
         if dim in dataset.data:
             data = dataset.data[dim]
             dmin, dmax = data.min().data, data.max().data
+            if dask and isinstance(dmin, dask.array.Array):
+                dmin, dmax = dmin.compute(), dmax.compute()
             dmin = dmin if np.isscalar(dmin) else dmin.item()
             dmax = dmax if np.isscalar(dmax) else dmax.item()
             return dmin, dmax
@@ -248,9 +250,18 @@ class XArrayInterface(GridInterface):
 
         if (indexed and len(data.data_vars) == 1 and
             len(data[dataset.vdims[0].name].shape) == 0):
-            return data[dataset.vdims[0].name].item()
+            value = data[dataset.vdims[0].name]
+            if dask and isinstance(value.data, dask.array.Array):
+                value = value.compute()
+            return value.item()
         elif indexed:
-            return np.array([data[vd.name].item() for vd in dataset.vdims])
+            values = []
+            for vd in dataset.vdims:
+                value = data[vd.name]
+                if dask and isinstance(value.data, dask.array.Array):
+                    value = value.compute()
+                values.append(value.item())
+            return np.array(values)
         return data
 
     @classmethod

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -1075,6 +1075,43 @@ class XArrayDatasetTest(GridDatasetTest):
         raise SkipTest("Not supported")
 
 
+@attr(optional=1)
+class XArrayDaskArrayDatasetTest(XArrayDatasetTest):
+    """
+    Tests for Iris interface
+    """
+
+    datatype = 'xarray'
+
+    def init_data(self):
+        import dask.array
+        self.xs = range(11)
+        self.xs_2 = [el**2 for el in self.xs]
+
+        self.y_ints = [i*2 for i in range(11)]
+        dask_y = dask.array.from_array(np.array(self.y_ints), 2)
+        self.dataset_hm = Dataset((self.xs, dask_y),
+                                  kdims=['x'], vdims=['y'])
+        self.dataset_hm_alias = Dataset((self.xs, dask_y),
+                                        kdims=[('x', 'X')], vdims=[('y', 'Y')])
+
+    def init_grid_data(self):
+        import dask.array
+        self.grid_xs = [0, 1]
+        self.grid_ys = [0.1, 0.2, 0.3]
+        self.grid_zs = [[0, 1], [2, 3], [4, 5]]
+        dask_zs = dask.array.from_array(np.array(self.grid_zs), 2)
+        self.dataset_grid = self.eltype((self.grid_xs, self.grid_ys,
+                                         dask_zs), kdims=['x', 'y'],
+                                        vdims=['z'])
+        self.dataset_grid_alias = self.eltype((self.grid_xs, self.grid_ys,
+                                               dask_zs), kdims=[('x', 'X'), ('y', 'Y')],
+                                              vdims=[('z', 'Z')])
+        self.dataset_grid_inv = self.eltype((self.grid_xs[::-1], self.grid_ys[::-1],
+                                             dask_zs), kdims=['x', 'y'],
+                                            vdims=['z'])
+
+
 class RasterDatasetTest(GridTests, ComparisonTestCase):
     """
     Tests for Iris interface

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -663,7 +663,7 @@ class GridTests(object):
         self.data_instance_type = dict
         self.init_data()
 
-    def init_data(self):
+    def init_column_data(self):
         self.xs = range(11)
         self.xs_2 = [el**2 for el in self.xs]
 
@@ -1083,7 +1083,7 @@ class XArrayDaskArrayDatasetTest(XArrayDatasetTest):
 
     datatype = 'xarray'
 
-    def init_data(self):
+    def init_column_data(self):
         import dask.array
         self.xs = range(11)
         self.xs_2 = [el**2 for el in self.xs]


### PR DESCRIPTION
XArray supports wrapping around dask arrays. Generally this doesn't cause any issues but the ``dimension_values`` method should always return an in-memory NumPy array so this PR is sufficient for us to have full support for dask arrays via xarray.