### PR TITLE
Allow aggregate to rasterize to target Image gridding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,10 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.18.1 numpy freetype nose bokeh=0.12.5 pandas=0.19.2 jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray datashader dask=0.13
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION scipy=0.18.1 numpy freetype nose bokeh=0.12.5 pandas=0.19.2 jupyter ipython=4.2.0 param pyqt=4 matplotlib=1.5.1 xarray
   - source activate test-environment
   - conda install -c conda-forge  iris sip=4.18 plotly flexx
+  - conda install -c bokeh datashader dask=0.13
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;
     fi

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -1,0 +1,59 @@
+from nose.plugins.attrib import attr
+
+import pandas as pd
+import numpy as np
+
+from holoviews import Curve, Scatter, Points, Image, Dataset
+from holoviews.element.comparison import ComparisonTestCase
+
+try:
+    from holoviews.operation.datashader import aggregate
+except:
+    aggregate = None
+
+
+@attr(optional=1)
+class DatashaderTests(ComparisonTestCase):
+    """
+    Tests for datashader aggregation
+    """
+
+    def test_aggregate_points(self):
+        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2)
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=['Count'])
+        self.assertEqual(img, expected)
+
+    def test_aggregate_points_target(self):
+        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=['Count'])
+        img = aggregate(points, dynamic=False,  target=expected)
+        self.assertEqual(img, expected)
+
+    def test_aggregate_points_sampling(self):
+        points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=['Count'])
+        img = aggregate(points, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        x_sampling=0.5, y_sampling=0.5)
+        self.assertEqual(img, expected)
+
+    def test_aggregate_curve(self):
+        curve = Curve([(0.2, 0.3), (0.4, 0.7), (0.8, 0.99)])
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [1, 1]]),
+                         vdims=['Count'])
+        img = aggregate(curve, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2)
+        self.assertEqual(img, expected)
+
+    def test_aggregate_ndoverlay(self):
+        ds = Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
+        ndoverlay = ds.to(Points, ['x', 'y'], [], 'z').overlay()
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),
+                         vdims=['Count'])
+        img = aggregate(ndoverlay, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2)
+        self.assertEqual(img, expected)


### PR DESCRIPTION
This PR allows the aggregate datashader operation to generate rasterize data onto the same grid as an existing Image. This is very useful when working with columnar and rasterized datasets and want to merge them into the same space, allowing simple arithmetic and more complex machine learning pipelines to be performed on the data.

Technically this is a complete regridding solution even for Images but hopefully we can decide what to do about a more efficient ``gridtools`` based implementation (which I already prototyped).