### PR TITLE
Fixed bug in canonicalizing xarray data

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -154,16 +154,16 @@ class GridInterface(DictInterface):
         dims = [name for name in coord_dims[::-1]
                 if isinstance(cls.coords(dataset, name), np.ndarray)]
         dropped = [dims.index(d) for d in dims if d not in dataset.kdims]
-        inds = [dims.index(kd.name) for kd in dataset.kdims]
-        inds += dropped
+        inds = [dims.index(kd.name)for kd in dataset.kdims]
+        inds = [i - sum([1 for d in dropped if i>=d]) for i in inds]
+        if dropped:
+            data = data.squeeze(axis=tuple(dropped))
         if inds:
             data = data.transpose(inds)
 
         # Allow lower dimensional views into data
         if len(dataset.kdims) < 2:
             data = data.flatten()
-        elif dropped:
-            data = data.squeeze(axis=tuple(range(len(dropped))))
         return data
 
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -50,7 +50,8 @@ class XArrayInterface(GridInterface):
             elif len(vdim_param.default) == 1:
                 vdim = vdim_param.default[0]
             vdims = [vdim]
-            kdims = [Dimension(d) for d in data.dims[::-1]]
+            if not kdims:
+                kdims = [Dimension(d) for d in data.dims[::-1]]
             data = data.to_dataset(name=vdim.name)
         elif not isinstance(data, xr.Dataset):
             if kdims is None:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -148,7 +148,6 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def coords(cls, dataset, dim, ordered=False, expanded=False):
-        dim = dataset.get_dimension(dim, strict=True).name
         if expanded:
             return util.expand_grid_coords(dataset, dim)
         data = np.atleast_1d(dataset.data[dim].data)
@@ -162,7 +161,7 @@ class XArrayInterface(GridInterface):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name].data
         if dim in dataset.vdims:
-            coord_dims = dataset.data[dim.name].dims
+            coord_dims = list(dataset.data.dims.keys())[::-1]
             if dask and isinstance(data, dask.array.Array):
                 data = data.compute()
             data = cls.canonicalize(dataset, data, coord_dims=coord_dims)

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -1055,6 +1055,15 @@ class XArrayDatasetTest(GridDatasetTest):
         self.init_column_data()
         self.init_grid_data()
 
+    def test_xarray_dataset_with_scalar_dim_canonicalize(self):
+        import xarray as xr
+        xs = [0, 1]
+        ys = [0.1, 0.2, 0.3]
+        zs = np.array([[[0, 1], [2, 3], [4, 5]]])
+        xrarr = xr.DataArray(zs, coords={'x': xs, 'y': ys, 't': [1]}, dims=['t', 'y', 'x'])
+        ds = Dataset(xrarr, kdims=['x', 'y'], vdims=['z'], datatype=['xarray'])
+        self.assertEqual(ds.dimension_values(2, flat=False).ndim, 2)
+
     # Disabled tests for NotImplemented methods
     def test_dataset_add_dimensions_values_hm(self):
         raise SkipTest("Not supported")


### PR DESCRIPTION
There is a bug in how xarray arrays are canonicalized which occurs when there is scalar dimension in the dataset which is not referenced in the kdims. This fixes that bug and also fixes another bug that ignores explicitly supplied kdims when constructing an Element from a xr.DataArray.

Fixes bug https://github.com/ioam/geoviews/issues/72