### PR TITLE
Bokeh SplinePlot handles multiple cubic splines

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -88,13 +88,26 @@ class SplinePlot(ElementPlot):
 
     def get_data(self, element, ranges=None, empty=False):
         data_attrs = ['x0', 'y0', 'x1', 'y1',
-                      'cx0', 'cx1', 'cy0', 'cy1']
-        if empty:
-            data = {attr: [] for attr in data_attrs}
-        else:
-            verts = np.array(element.data[0])
-            xs, ys = verts[:, 0], verts[:, 1]
-            data = dict(x0=[xs[0]], y0=[ys[0]], x1=[xs[-1]], y1=[ys[-1]],
-                        cx0=[xs[1]], cy0=[ys[1]], cx1=[xs[2]], cy1=[ys[2]])
-
+                      'cx0', 'cy0', 'cx1', 'cy1']
+        verts = np.array(element.data[0])
+        inds = np.where(np.array(element.data[1])==1)[0]
+        data = {da: [] for da in data_attrs}
+        skipped = False
+        for vs in np.split(verts, inds[1:]):
+            if len(vs) != 4:
+                skipped = len(vs) > 1
+                continue
+            xs, ys = vs[:, 0], vs[:, 1]
+            data['x0'].append(xs[0])
+            data['y0'].append(ys[0])
+            data['x1'].append(xs[-1])
+            data['y1'].append(ys[-1])
+            data['cx0'].append(xs[1])
+            data['cy0'].append(ys[1])
+            data['cx1'].append(xs[2])
+            data['cy1'].append(ys[2])
+        if skipped:
+            self.warning('Bokeh SplitPlot only support cubic splines, '
+                         'unsupported splines were skipped during plotting.')
+        data = {da: data[da] for da in data_attrs}
         return (data, dict(zip(data_attrs, data_attrs)))

--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -87,8 +87,7 @@ class SplinePlot(ElementPlot):
     _plot_methods = dict(single='bezier')
 
     def get_data(self, element, ranges=None, empty=False):
-        data_attrs = ['x0', 'y0', 'x1', 'y1',
-                      'cx0', 'cy0', 'cx1', 'cy1']
+        data_attrs = ['x0', 'y0', 'cx0', 'cy0', 'cx1', 'cy1', 'x1', 'y1',]
         verts = np.array(element.data[0])
         inds = np.where(np.array(element.data[1])==1)[0]
         data = {da: [] for da in data_attrs}
@@ -97,15 +96,9 @@ class SplinePlot(ElementPlot):
             if len(vs) != 4:
                 skipped = len(vs) > 1
                 continue
-            xs, ys = vs[:, 0], vs[:, 1]
-            data['x0'].append(xs[0])
-            data['y0'].append(ys[0])
-            data['x1'].append(xs[-1])
-            data['y1'].append(ys[-1])
-            data['cx0'].append(xs[1])
-            data['cy0'].append(ys[1])
-            data['cx1'].append(xs[2])
-            data['cy1'].append(ys[2])
+            for x, y, xl, yl in zip(vs[:, 0], vs[:, 1], data_attrs[::2], data_attrs[1::2]):
+                data[xl].append(x)
+                data[yl].append(y)
         if skipped:
             self.warning('Bokeh SplitPlot only support cubic splines, '
                          'unsupported splines were skipped during plotting.')

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -106,6 +106,8 @@ class SplinePlot(AnnotationPlot):
 
     def draw_annotation(self, axis, data, opts):
         verts, codes = data
+        if not len(verts):
+            return []
         patch = patches.PathPatch(matplotlib.path.Path(verts, codes),
                                   facecolor='none', **opts)
         axis.add_patch(patch)


### PR DESCRIPTION
The bokeh bezier glyph supports cubic splines, by reading the matplotlib based spline codes we can easily split a set of cubic splines and draw them correctly with bokeh. This PR adds supports for drawing multiple cubic splines in this way. Splines of length 1 are simply ignored, while any other splines will raise warning. Briefly I thought I could handle quadratic and linear splines as well but that does not seem to be the case. Also adds support for instantiating and plotting empty splines with ``hv.Spline(([], []))``.

Here's an example:

![bokeh_plot 66](https://user-images.githubusercontent.com/1550771/27033303-98e9bb28-4f70-11e7-8428-183af7a6ca1a.png)
