### PR TITLE
Escaping braces in opts preprocessor

### DIFF
--- a/holoviews/ipython/preprocessors.py
+++ b/holoviews/ipython/preprocessors.py
@@ -111,8 +111,9 @@ class OptsMagicProcessor(Preprocessor):
                                         template='hv.util.opts({line!r})')
             source, opts_lines = filter_magic(source, '%%opts')
             if opts_lines:
+                # Escape braces e.g normalization options as they pass through format
                 template = 'hv.util.opts({options!r}, {{expr}})'.format(
-                    options=' '.join(opts_lines))
+                    options=' '.join(opts_lines).replace('{','{{').replace('}','}}'))
                 source = wrap_cell_expression(source, template)
             cell['source'] = source
         return cell, resources

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -459,7 +459,7 @@ class Renderer(Exporter):
         supplied format or to the appropriate default.
         """
         if info or key:
-            raise Exception('MPLRenderer does not support saving metadata to file.')
+            raise Exception('Renderer does not support saving metadata to file.')
 
         with StoreOptions.options(obj, options, **kwargs):
             plot = self_or_cls.get_plot(obj)


### PR DESCRIPTION
Tiny PR where I fix an escaping issue in the opts preprocessor (e.g when normalization options are used) as well as an outdated exception message I spotted in ``Renderer``.