### PR TITLE
Added missing 'ms' style option to matplotlib CurvePlot

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -66,7 +66,7 @@ class CurvePlot(ChartPlot):
     show_legend = param.Boolean(default=True, doc="""
         Whether to show legend for the plot.""")
 
-    style_opts = ['alpha', 'color', 'visible', 'linewidth', 'linestyle', 'marker']
+    style_opts = ['alpha', 'color', 'visible', 'linewidth', 'linestyle', 'marker', 'ms']
 
     _plot_methods = dict(single='plot')
 


### PR DESCRIPTION
Title of the PR says it all: 'marker' was supported but 'ms' to change the size wasn't.

You can now do:

![image](https://user-images.githubusercontent.com/890576/27157807-62503c1c-515b-11e7-8626-6ff8a594c457.png)
