### PR TITLE
Allow redim.label if no custom label set

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -161,7 +161,7 @@ class redim(object):
     def label(self, specs=None, **values):
         for k, v in values.items():
             dim = self.parent.get_dimension(k)
-            if dim.name != dim.label and dim.name != v:
+            if dim and dim.name != dim.label and dim.name != v:
                 raise ValueError('Cannot override an existing Dimension label')
         return self._redim('label', specs, **values)
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -158,6 +158,13 @@ class redim(object):
     def range(self, specs=None, **values):
         return self._redim('range', specs, **values)
 
+    def label(self, specs=None, **values):
+        for k, v in values.items():
+            dim = self.parent.get_dimension(k)
+            if dim.name != dim.label and dim.name != v:
+                raise ValueError('Cannot override an existing Dimension label')
+        return self._redim('label', specs, **values)
+
     def soft_range(self, specs=None, **values):
         return self._redim('soft_range', specs, **values)
 

--- a/tests/testdimensions.py
+++ b/tests/testdimensions.py
@@ -245,6 +245,16 @@ class DimensionedTest(ComparisonTestCase):
         redimensioned = dimensioned.clone(kdims=['Test'])
         self.assertEqual(redimensioned, dimensioned.redim(x='Test'))
 
+    def test_dimensioned_redim_dict_label(self):
+        dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
+        redimensioned = dimensioned.clone(kdims=[('x', 'Test')])
+        self.assertEqual(redimensioned, dimensioned.redim.label(x='Test'))
+
+    def test_dimensioned_redim_dict_label_existing_error(self):
+        dimensioned = Dimensioned('Arbitrary Data', kdims=[('x', 'Test1')])
+        with self.assertRaisesRegexp(ValueError, 'Cannot override an existing Dimension label'):
+            dimensioned.redim.label(x='Test2')
+
     def test_dimensioned_redim_dimension(self):
         dimensioned = Dimensioned('Arbitrary Data', kdims=['x'])
         redimensioned = dimensioned.clone(kdims=['Test'])


### PR DESCRIPTION
As the title says this allows using redim.relabel to set a custom label as long as the current label is the same as the name, i.e. no custom label has been supplied previously.