### PR TITLE
Small fixes for computing spreadfn aggregates

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -488,7 +488,7 @@ class Dataset(Element):
             combined = self.clone(aggregated, kdims=kdims, new_type=Dataset)
             for i, d in enumerate(vdims):
                 dim = d('_'.join([d.name, spread_name]))
-                dvals = error.dimension_values(d, False, False)
+                dvals = error.dimension_values(d, flat=False)
                 combined = combined.add_dimension(dim, ndims+i, dvals, True)
             return combined.clone(new_type=Dataset if generic_type else type(self))
 

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -397,6 +397,15 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
                           kdims=['x'], vdims=['z'])
         self.assertEqual(dataset.reduce(['y'], np.mean), reduced)
 
+    def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
+        dataset = Dataset({'x': np.array([0, 0, 1, 1]), 'y': np.array([0, 1, 2, 3]),
+                           'z': np.array([1, 2, 3, 4])},
+                          kdims=['x', 'y'], vdims=['z'])
+        agg = dataset.aggregate('x', function=np.mean, spreadfn=np.var)
+        self.assertEqual(agg, Dataset({'x': np.array([0, 1]), 'z': np.array([1.5, 3.5]),
+                                       'z_var': np.array([0.25, 0.25])},
+                                      kdims=['x'], vdims=['z', 'z_var']))
+
     def test_dataset_aggregate_ht(self):
         aggregated = Dataset({'Gender':['M', 'F'], 'Weight':[16.5, 10], 'Height':[0.7, 0.8]},
                              kdims=self.kdims[:1], vdims=self.vdims)
@@ -582,6 +591,9 @@ class DaskDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         raise SkipTest("Not supported")
 
     def test_dataset_add_dimensions_values_ht(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_2D_aggregate_spread_fn_with_duplicates(self):
         raise SkipTest("Not supported")
 
     def test_dataset_sort_hm(self):


### PR DESCRIPTION
Fixed a small bug when aggregating with a spreadfn. In writing unit tests for this I also noticed that pandas uses ddof=1 (delta degrees of freedom) while the numpy default is ddof=0. I've adjusted the code to catch those cases and change the pandas version to ddof=0.