### PR TITLE
Bokeh renderer now saves necessary HTML assets to file

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -93,6 +93,12 @@ class BokehRenderer(Renderer):
         elif fmt == 'json':
             return self.diff(plot), info
 
+    @bothmethod
+    def _save_prefix(self_or_cls, ext):
+        "Hook to prefix content for instance JS when saving HTML"
+        if ext == 'html':
+            return '\n'.join(self_or_cls.html_assets()).encode('utf8')
+        return
 
     @bothmethod
     def get_plot(self_or_cls, obj, doc=None, renderer=None):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -474,6 +474,9 @@ class Renderer(Exporter):
         if rendered is None: return
         (data, info) = rendered
         encoded = self_or_cls.encode(rendered)
+        prefix = self_or_cls._save_prefix(info['file-ext'])
+        if prefix:
+            encoded = prefix + encoded
         if isinstance(basename, BytesIO):
             basename.write(encoded)
             basename.seek(0)
@@ -481,6 +484,11 @@ class Renderer(Exporter):
             filename ='%s.%s' % (basename, info['file-ext'])
             with open(filename, 'wb') as f:
                 f.write(encoded)
+
+    @bothmethod
+    def _save_prefix(self_or_cls, ext):
+        "Hook to prefix content for instance JS when saving HTML"
+        return
 
 
     @bothmethod


### PR DESCRIPTION

I did the simplest thing that I could think of to address issue #1411. I'm happy to hear any suggestions on how to improve it and I just need to test on Python 2: I get nervous when I see anything relating to unicode!

```python
%%output filename="output"
x = [1, 2, 3, 4, 5]
y = [6, 7, 2, 4, 5]
hv.Curve((x,y),label="Temp")
```

Now generates a self-contained HTML file:

![image](https://user-images.githubusercontent.com/890576/27194748-acee9764-51fb-11e7-9037-ef36822248b6.png)
