### PR TITLE
Output files generated with hv.output now respect all settings

### DIFF
--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -91,7 +91,7 @@ class OutputMagic(Magics):
             print("\nFor help with the %output magic, call %output?")
             return
 
-        def cell_runner(cell):
+        def cell_runner(cell,renderer):
             self.shell.run_cell(cell, store_history=STORE_HISTORY)
 
         def warnfn(msg):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -134,8 +134,13 @@ class output(param.ParameterizedFunction):
         if isinstance(obj, Dimensioned):
             if line:
                 options = Store.output_settings.extract_keywords(line, {})
+            for k in options.keys():
+                if k not in Store.output_settings.allowed:
+                    raise KeyError('Invalid keyword: %s' % k)
             if 'filename' in options:
-                Store.renderers[Store.current_backend].save(obj, options['filename'])
+                def save_fn(obj, renderer): renderer.save(obj, options['filename'])
+                Store.output_settings.output(line=line, cell=obj, cell_runner=save_fn,
+                                             help_prompt=help_prompt, **options)
             return obj
         elif obj is not None:
             return obj

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -295,7 +295,7 @@ class OutputSettings(KeywordSettings):
             return
 
         if cell is not None:
-            if cell_runner: cell_runner(cell)
+            if cell_runner: cell_runner(cell,renderer)
             # After cell restore previous options and restore
             # temporarily selected renderer
             OutputSettings.options = prev_restore


### PR DESCRIPTION
My initial approach was too simplistic and didn't use all the supplied keywords. For instance this now correctly outputs an SVG file:

![image](https://user-images.githubusercontent.com/890576/27196474-78d79d7a-5202-11e7-956c-36483b29944c.png)

In addition I added keyword validation to make sure only the appropriate keywords are supplied.