### PR TITLE
hv.output can now warn if an object is supplied without a filename

### DIFF
--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -118,8 +118,13 @@ class output(param.ParameterizedFunction):
     are ignored.
     """
 
-    def __call__(self, *args, **options):
+    filename_warning = param.Boolean(default=True, doc="""
+       Whether to warn if the output utility is called on an object and
+       a filename is not given (in which case the utility has no
+       effect)""" )
 
+    def __call__(self, *args, **options):
+        warn = options.pop('filename_warning', self.filename_warning)
         help_prompt = 'For help with hv.util.output call help(hv.util.output)'
         line, obj = None,None
         if len(args) > 2:
@@ -141,6 +146,9 @@ class output(param.ParameterizedFunction):
                 def save_fn(obj, renderer): renderer.save(obj, options['filename'])
                 Store.output_settings.output(line=line, cell=obj, cell_runner=save_fn,
                                              help_prompt=help_prompt, **options)
+            elif warn:
+                self.warning("hv.output not supplied a filename to export the "
+                             "given object. This call will have no effect." )
             return obj
         elif obj is not None:
             return obj


### PR DESCRIPTION
Simple PR that allows the ``hv.output`` utility to warn about object supplied without an export filename. The ``filename_warning`` parameter can be set at the class level or supplied as a keyword:

![image](https://user-images.githubusercontent.com/890576/27200383-68ce6bac-5211-11e7-85d9-677fa83ab4f1.png)
