### PR TITLE
Made count None by default in DynamicMap.periodic

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -611,7 +611,7 @@ class periodic(object):
         self.dmap = dmap
         self.instance = None
 
-    def __call__(self, period, count, param_fn=None, timeout=None, block=True):
+    def __call__(self, period, count=None, param_fn=None, timeout=None, block=True):
         """
         Run a non-blocking loop that updates the stream parameters using
         the event method. Runs count times with the specified period. If

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -88,6 +88,8 @@ class HashableJSON(json.JSONEncoder):
 class periodic(Thread):
     """
     Run a callback count times with a given period without blocking.
+
+    If count is None, will run till timeout (which may be forever if None).
     """
 
     def __init__(self, period, count, callback, timeout=None, block=False):
@@ -96,6 +98,10 @@ class periodic(Thread):
             if count < 0: raise ValueError('Count value must be positive')
         elif not type(count) is type(None):
             raise ValueError('Count value must be a positive integer or None')
+
+        if block is False and count is None and timeout is None:
+            raise ValueError('When using a non-blocking thread, please specify '
+                             'either a count or a timeout')
 
         super(periodic, self).__init__()
         self.period = period


### PR DESCRIPTION
Simple PR that allows me to use:

```
dmap.periodic(0.01, timeout=60)
```

Without the awkward:

```
dmap.periodic(0.01, count=None, timeout=60)
```

Only the first argument (the period) is mandatory so if you supply nothing else it will run forever. This is fine for the blocking version (now the default) and bokeh server and this combination is only disabled for the threaded version where killing threads can be a problem.

