### PR TITLE
Updated the website search to search holoviews rather than bokeh

### DIFF
--- a/doc/holoviews_theme/search.html
+++ b/doc/holoviews_theme/search.html
@@ -21,19 +21,17 @@
   </form>
 
   <div id="search-results">
-
-    <script>
-      (function() {
-        var cx = '007519673294607119974:n9uana_s26m';
-        var gcse = document.createElement('script');
-        gcse.type = 'text/javascript';
-        gcse.async = true;
-        gcse.src = (document.location.protocol == 'https:' ? 'https:' : 'http:') +
-            '//cse.google.com/cse.js?cx=' + cx;
-        var s = document.getElementsByTagName('script')[0];
-        s.parentNode.insertBefore(gcse, s);
-      })();
-    </script>
+	<script>
+	  (function() {
+      var cx = '006807479272082416678:p6n_f0d8taw';
+      var gcse = document.createElement('script');
+      gcse.type = 'text/javascript';
+      gcse.async = true;
+      gcse.src = 'https://cse.google.com/cse.js?cx=' + cx;
+      var s = document.getElementsByTagName('script')[0];
+      s.parentNode.insertBefore(gcse, s);
+	  })();
+	</script>
     <gcse:searchresults-only></gcse:searchresults-only>
 
   </div>


### PR DESCRIPTION
As title says, the new theme relied on a custom Google search which was still pointing at bokeh. I've now set up a custom search for holoviews.