### PR TITLE
Added support for Empty adjoint plots in bokeh

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -31,7 +31,7 @@ class Composable(object):
 
 
     def __lshift__(self, other):
-        if isinstance(other, (ViewableElement, NdMapping)):
+        if isinstance(other, (ViewableElement, NdMapping, Empty)):
             return AdjointLayout([self, other])
         elif isinstance(other, AdjointLayout):
             return AdjointLayout(other.data.values()+[self])

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -262,6 +262,8 @@ class DimensionedPlot(Plot):
         # Assumes composite objects are iterables
         if hasattr(self, 'subplots') and self.subplots:
             for el in self.subplots.values():
+                if el is None:
+                    continue
                 accumulator += el.traverse(fn, specs, full_breadth)
                 if not full_breadth: break
         return accumulator

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -14,7 +14,7 @@ import param
 import numpy as np
 from holoviews import (Dimension, Overlay, DynamicMap, Store, Dataset,
                        NdOverlay, GridSpace, HoloMap, Layout, Cycle,
-                       Palette, Element)
+                       Palette, Element, Empty)
 from holoviews.core.util import pd
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
@@ -1478,6 +1478,18 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         x_range, y_range = plot.handles['x_range'], plot.handles['y_range']
         self.assertEqual((x_range.start, x_range.end), (-.5, .5))
         self.assertEqual((y_range.start, y_range.end), (-.5, .5))
+
+    def test_empty_adjoint_plot(self):
+        adjoint = Curve([0,1,1,2,3]) << Empty() << Curve([0,1,1,0,1])
+        plot = bokeh_renderer.get_plot(adjoint)
+        adjoint_plot = plot.subplots[(0, 0)]
+        self.assertEqual(len(adjoint_plot.subplots), 3)
+        column = plot.state.children[1]
+        row1, row2 = column.children
+        self.assertEqual(row1.children[0].plot_height, row1.children[1].plot_height)
+        self.assertEqual(row1.children[1].plot_width, 0)
+        self.assertEqual(row2.children[1].plot_width, 0)
+        self.assertEqual(row2.children[0].plot_height, row2.children[1].plot_height)
 
     def test_layout_shared_source_synced_update(self):
         hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)


### PR DESCRIPTION
This was already handled correctly by matplotlib but https://github.com/ioam/holoviews/issues/1478 highlighted that bokeh did not handle padding for empty adjoints correctly. Also added a unit test, and here is an example:

```python
hv.AdjointLayout([hv.Curve([0,1,1,2,3]), hv.Empty() ,hv.Curve([0,1,1,0,1])(plot=dict(height=100))])
```

<img width="318" alt="screen shot 2017-06-17 at 2 10 35 pm" src="https://user-images.githubusercontent.com/1550771/27253139-c6b40c12-5366-11e7-9aad-774c77d99984.png">
