### PR TITLE
Label bokeh tabs with subplot title if possible

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1302,7 +1302,9 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             if self.batched:
                 self.handles['plot'] = child
             if self.tabs:
-                title = get_tab_title(key, frame, self.hmap.last)
+                title = subplot._format_title(key, dimensions=False)
+                if not title:
+                    title = get_tab_title(key, frame, self.hmap.last)
                 panels.append(Panel(child=child, title=title))
             self._merge_tools(subplot)
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -661,16 +661,14 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
                 if len(subplots) == 1 and c in insert_cols:
                     plots[r+offset].append(None)
                 passed_plots.append(subplots[0])
+                if self.tabs:
+                    title = subplot.subplots['main']._format_title(self.keys[-1],
+                                                                   dimensions=False)
+                    if not title:
+                        title = ' '.join(self.paths[r,c])
+                    tab_titles[r, c] = title
             else:
                 plots[r+offset] += [empty_plot(0, 0)]
-
-            if self.tabs:
-                if isinstance(self.layout, Layout):
-                    tab_titles[r, c] = ' '.join(self.paths[r,c])
-                else:
-                    dim_vals = zip(self.layout.kdims, self.paths[r, c])
-                    tab_titles[r, c] = ', '.join([d.pprint_value_string(k)
-                                                  for d, k in dim_vals])
 
         # Replace None types with empty plots
         # to avoid bokeh bug

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -725,17 +725,21 @@ class GenericElementPlot(DimensionedPlot):
         return xlabel, ylabel, zlabel
 
 
-    def _format_title(self, key, separator='\n'):
+    def _format_title(self, key, dimensions=True, separator='\n'):
         frame = self._get_frame(key)
         if frame is None: return None
         type_name = type(frame).__name__
         group = frame.group if frame.group != type_name else ''
         label = frame.label
 
-        dim_title = self._frame_title(key, separator=separator)
         if self.layout_dimensions:
+            dim_title = self._frame_title(key, separator=separator)
             title = dim_title
         else:
+            if dimensions:
+                dim_title = self._frame_title(key, separator=separator)
+            else:
+                dim_title = ''
             title_format = util.bytes_to_unicode(self.title_format)
             title = title_format.format(label=util.bytes_to_unicode(label),
                                         group=util.bytes_to_unicode(group),
@@ -995,8 +999,8 @@ class GenericCompositePlot(DimensionedPlot):
         return len(self.keys)
 
 
-    def _format_title(self, key, separator='\n'):
-        dim_title = self._frame_title(key, 3, separator)
+    def _format_title(self, key, dimensions=True, separator='\n'):
+        dim_title = self._frame_title(key, 3, separator) if dimensions else ''
         layout = self.layout
         type_name = type(self.layout).__name__
         group = util.bytes_to_unicode(layout.group if layout.group != type_name else '')


### PR DESCRIPTION
As outlined in https://github.com/ioam/holoviews/issues/1425, this PR uses the subplots ``_format_title`` method to compute tab titles. This is more consistent affords better control over the title using the ``title_format`` plot option and by setting just a ``label``. The tab titles do not contain information about the current frame, i.e. HoloMap/DynamicMap key dimension information. If no label, group or custom title_format is set it will revert back to using the Layout/Overlay path to compute the title.