### PR TITLE
Correctly associate hover tool instances with plot renderer

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -250,9 +250,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         tools = [t for t in cb_tools + self.default_tools + self.tools
                  if t not in tool_names]
+        hover_tools = [t for t in tools if isinstance(t, HoverTool)]
         if 'hover' in tools:
             hover = HoverTool(tooltips=tooltips, **hover_opts)
             tools[tools.index('hover')] = hover
+        elif any(hover_tools):
+            hover = hover_tools[0]
         if hover:
             self.handles['hover'] = hover
         return tools

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -686,6 +686,15 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         obj = obj(plot=opts)
         self._test_hover_info(obj, [('Test', '@{Test}'), ('z', '@{z}')])
 
+    def test_hover_tool_instance_renderer_association(self):
+        hover = HoverTool(tooltips=[("index", "$index")])
+        opts = dict(tools=[hover])
+        overlay = Curve(np.random.rand(10,2))(plot=opts) * Points(np.random.rand(10,2))
+        plot = bokeh_renderer.get_plot(overlay)
+        curve_plot = plot.subplots[('Curve', 'I')]
+        self.assertEqual(len(curve_plot.handles['hover'].renderers), 1)
+        self.assertIn(curve_plot.handles['glyph_renderer'], curve_plot.handles['hover'].renderers)
+
     def _test_colormapping(self, element, dim, log=False):
         plot = bokeh_renderer.get_plot(element)
         plot.initialize_plot()


### PR DESCRIPTION
When passing an explicit HoverTool instance to an ElementPlot it should associate that tool with only that subplot. This PR fixes the issue described in https://github.com/ioam/holoviews/issues/1449 and adds a unit test.