### PR TITLE
Correctly categorize Path data (including ErrorBars)

### DIFF
--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1126,8 +1126,12 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         x_range = plot.handles['x_range']
         y_range = plot.handles['y_range']
         self.assertIsInstance(x_range, FactorRange)
+        factors = ['A', 'B', 'C', 'D', 'E']
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D', 'E'])
         self.assertIsInstance(y_range, Range1d)
+        error_plot = plot.subplots[('ErrorBars', 'I')]
+        for xs, factor in zip(error_plot.handles['source'].data['xs'], factors):
+            self.assertEqual([factor, factor], xs)
 
     def test_points_errorbars_text_ndoverlay_categorical_xaxis_invert_axes(self):
         overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))


### PR DESCRIPTION
Fix for plotting Path plots on categorical axes, specifically fixes https://github.com/ioam/holoviews/issues/1470, which involves ErrorBars not showing up on categorical plots.

![bokeh_plot 76](https://user-images.githubusercontent.com/1550771/27253646-588f396e-5370-11e7-831e-ecba2fa9e791.png)

![bokeh_plot 77](https://user-images.githubusercontent.com/1550771/27253653-6abddd70-5370-11e7-9d4f-b916ac8a2dd0.png)

