### PR TITLE
Fixed bug plotting empty bokeh SpikesPlot

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -537,7 +537,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
 
         pos = self.position
         mapping = dict(xs='xs', ys='ys')
-        if empty:
+        if len(element) == 0:
             xs, ys = [], []
         elif len(dims) > 1:
             xs, ys = zip(*((np.array([x, x]), np.array([pos+y, pos]))

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -805,6 +805,13 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
         self._test_colormapping(spikes, 1)
 
+    def test_empty_spikes_plot(self):
+        spikes = Spikes([], vdims=['Intensity'])
+        plot = bokeh_renderer.get_plot(spikes)
+        source = plot.handles['source']
+        self.assertEqual(len(source.data['xs']), 0)
+        self.assertEqual(len(source.data['ys']), 0)
+
     def test_side_histogram_no_cmapper(self):
         points = Points(np.random.rand(100, 2))
         plot = bokeh_renderer.get_plot(points.hist())


### PR DESCRIPTION
As outlined in https://github.com/ioam/holoviews/issues/1497, the bokeh SpikesPlot breaks when the Spikes Element is empty at the moment. This ensures it works correctly and adds a unit test.