### PR TITLE
Importing unicode_literals into histogram example notebook

### DIFF
--- a/examples/demos/bokeh/histogram_example.ipynb
+++ b/examples/demos/bokeh/histogram_example.ipynb
@@ -19,6 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import unicode_literals\n",
     "import numpy as np\n",
     "import scipy\n",
     "import scipy.special\n",

--- a/examples/demos/matplotlib/histogram_example.ipynb
+++ b/examples/demos/matplotlib/histogram_example.ipynb
@@ -19,6 +19,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from __future__ import unicode_literals\n",
     "import numpy as np\n",
     "import scipy\n",
     "import holoviews as hv\n",


### PR DESCRIPTION
PR title says it all - thumbnailing has to be run with Python 2 and this should allow the thumbnail to be generated for this example.