### PR TITLE
Box spec is now matches Ellipse

### DIFF
--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -190,7 +190,7 @@ class Box(BaseShape):
             if 'aspect' in params:
                 raise ValueError('Aspect parameter not supported when supplying '
                                  '(width, height) specification.')
-            (height, width) = spec
+            (width, height ) = spec
         else:
             width, height = params.get('width', spec), spec
 

--- a/tests/testpaths.py
+++ b/tests/testpaths.py
@@ -62,7 +62,7 @@ class BoxTests(ComparisonTestCase):
 
 
     def test_box_tuple_constructor_rotated(self):
-        box = Box(0,0,(1,2), orientation=np.pi/8)
+        box = Box(0,0,(2,1), orientation=np.pi/8)
         self.assertEqual(np.allclose(box.data[0], self.rotated_rect), True)
 
     def test_box_aspect_constructor_rotated(self):


### PR DESCRIPTION
This is a simple fix to ``Box`` so it uses the (width, height) spec, matching ``Ellipse``. I think what happened is I fixed the flip in ``Ellipse`` but forgot to make the same fix in ``Box``.