### PR TITLE
Using hv.extension() consistently in element notebooks

### DIFF
--- a/examples/demos/bokeh/area_chart.ipynb
+++ b/examples/demos/bokeh/area_chart.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/bachelors_degrees_by_gender.ipynb
+++ b/examples/demos/bokeh/bachelors_degrees_by_gender.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh', 'matplotlib')"
+    "hv.extension('bokeh', 'matplotlib')"
    ]
   },
   {

--- a/examples/demos/bokeh/boxplot_chart.ipynb
+++ b/examples/demos/bokeh/boxplot_chart.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/dot_example.ipynb
+++ b/examples/demos/bokeh/dot_example.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/histogram_example.ipynb
+++ b/examples/demos/bokeh/histogram_example.ipynb
@@ -23,7 +23,7 @@
     "import scipy\n",
     "import scipy.special\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/iris_example.ipynb
+++ b/examples/demos/bokeh/iris_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/iris_splom_example.ipynb
+++ b/examples/demos/bokeh/iris_splom_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh', width=95)"
+    "hv.extension('bokeh', width=95)"
    ]
   },
   {

--- a/examples/demos/bokeh/legend_example.ipynb
+++ b/examples/demos/bokeh/legend_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/lesmis_example.ipynb
+++ b/examples/demos/bokeh/lesmis_example.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/lorenz_attractor_example.ipynb
+++ b/examples/demos/bokeh/lorenz_attractor_example.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh', 'matplotlib')"
+    "hv.extension('bokeh', 'matplotlib')"
    ]
   },
   {

--- a/examples/demos/bokeh/measles_example.ipynb
+++ b/examples/demos/bokeh/measles_example.ipynb
@@ -22,7 +22,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import pandas as pd\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/quiver_demo.ipynb
+++ b/examples/demos/bokeh/quiver_demo.ipynb
@@ -1206,7 +1206,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/step_chart_example.ipynb
+++ b/examples/demos/bokeh/step_chart_example.ipynb
@@ -1206,7 +1206,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/stocks_example.ipynb
+++ b/examples/demos/bokeh/stocks_example.ipynb
@@ -1207,7 +1207,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/texas_choropleth_example.ipynb
+++ b/examples/demos/bokeh/texas_choropleth_example.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/topographic_hillshading.ipynb
+++ b/examples/demos/bokeh/topographic_hillshading.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/bokeh/us_unemployment_example.ipynb
+++ b/examples/demos/bokeh/us_unemployment_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import pandas as pd\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/demos/matplotlib/area_chart.ipynb
+++ b/examples/demos/matplotlib/area_chart.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/bachelors_degrees_by_gender.ipynb
+++ b/examples/demos/matplotlib/bachelors_degrees_by_gender.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/boxplot_chart.ipynb
+++ b/examples/demos/matplotlib/boxplot_chart.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/histogram_example.ipynb
+++ b/examples/demos/matplotlib/histogram_example.ipynb
@@ -22,7 +22,7 @@
     "import numpy as np\n",
     "import scipy\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/iris_example.ipynb
+++ b/examples/demos/matplotlib/iris_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/iris_splom_example.ipynb
+++ b/examples/demos/matplotlib/iris_splom_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/legend_example.ipynb
+++ b/examples/demos/matplotlib/legend_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/lorenz_attractor_example.ipynb
+++ b/examples/demos/matplotlib/lorenz_attractor_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/measles_example.ipynb
+++ b/examples/demos/matplotlib/measles_example.ipynb
@@ -22,7 +22,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import pandas as pd\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/polar_scatter_demo.ipynb
+++ b/examples/demos/matplotlib/polar_scatter_demo.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/quiver_demo.ipynb
+++ b/examples/demos/matplotlib/quiver_demo.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/step_chart_example.ipynb
+++ b/examples/demos/matplotlib/step_chart_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/stocks_example.ipynb
+++ b/examples/demos/matplotlib/stocks_example.ipynb
@@ -22,7 +22,7 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg' dpi=120"
    ]
   },

--- a/examples/demos/matplotlib/surface_3d.ipynb
+++ b/examples/demos/matplotlib/surface_3d.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/matplotlib/texas_choropleth_example.ipynb
+++ b/examples/demos/matplotlib/texas_choropleth_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/topographic_hillshading.ipynb
+++ b/examples/demos/matplotlib/topographic_hillshading.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output fig='svg'"
    ]
   },

--- a/examples/demos/matplotlib/trisurf3d_demo.ipynb
+++ b/examples/demos/matplotlib/trisurf3d_demo.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')\n",
+    "hv.extension('matplotlib')\n",
     "%output backend='matplotlib' size=200"
    ]
   },

--- a/examples/demos/matplotlib/us_unemployment_example.ipynb
+++ b/examples/demos/matplotlib/us_unemployment_example.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import pandas as pd\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/demos/plotly/surface_3d.ipynb
+++ b/examples/demos/plotly/surface_3d.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('plotly')"
+    "hv.extension('plotly')"
    ]
   },
   {

--- a/examples/demos/plotly/trisurf3d_demo.ipynb
+++ b/examples/demos/plotly/trisurf3d_demo.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('plotly')"
+    "hv.extension('plotly')"
    ]
   },
   {

--- a/examples/elements/bokeh/Area.ipynb
+++ b/examples/elements/bokeh/Area.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Bars.ipynb
+++ b/examples/elements/bokeh/Bars.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Bounds.ipynb
+++ b/examples/elements/bokeh/Bounds.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Box.ipynb
+++ b/examples/elements/bokeh/Box.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/BoxWhisker.ipynb
+++ b/examples/elements/bokeh/BoxWhisker.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Contours.ipynb
+++ b/examples/elements/bokeh/Contours.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Curve.ipynb
+++ b/examples/elements/bokeh/Curve.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Ellipse.ipynb
+++ b/examples/elements/bokeh/Ellipse.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/ErrorBars.ipynb
+++ b/examples/elements/bokeh/ErrorBars.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/HLine.ipynb
+++ b/examples/elements/bokeh/HLine.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/HSV.ipynb
+++ b/examples/elements/bokeh/HSV.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/HeatMap.ipynb
+++ b/examples/elements/bokeh/HeatMap.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Histogram.ipynb
+++ b/examples/elements/bokeh/Histogram.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Image.ipynb
+++ b/examples/elements/bokeh/Image.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/ItemTable.ipynb
+++ b/examples/elements/bokeh/ItemTable.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Path.ipynb
+++ b/examples/elements/bokeh/Path.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Points.ipynb
+++ b/examples/elements/bokeh/Points.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Polygons.ipynb
+++ b/examples/elements/bokeh/Polygons.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/QuadMesh.ipynb
+++ b/examples/elements/bokeh/QuadMesh.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/RGB.ipynb
+++ b/examples/elements/bokeh/RGB.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Raster.ipynb
+++ b/examples/elements/bokeh/Raster.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Scatter.ipynb
+++ b/examples/elements/bokeh/Scatter.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Spikes.ipynb
+++ b/examples/elements/bokeh/Spikes.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Spline.ipynb
+++ b/examples/elements/bokeh/Spline.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Spread.ipynb
+++ b/examples/elements/bokeh/Spread.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Table.ipynb
+++ b/examples/elements/bokeh/Table.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/Text.ipynb
+++ b/examples/elements/bokeh/Text.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/VLine.ipynb
+++ b/examples/elements/bokeh/VLine.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/bokeh/VectorField.ipynb
+++ b/examples/elements/bokeh/VectorField.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Area.ipynb
+++ b/examples/elements/matplotlib/Area.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Arrow.ipynb
+++ b/examples/elements/matplotlib/Arrow.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Bars.ipynb
+++ b/examples/elements/matplotlib/Bars.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension('matplotlib')"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Bounds.ipynb
+++ b/examples/elements/matplotlib/Bounds.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Box.ipynb
+++ b/examples/elements/matplotlib/Box.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/BoxWhisker.ipynb
+++ b/examples/elements/matplotlib/BoxWhisker.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Contours.ipynb
+++ b/examples/elements/matplotlib/Contours.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Curve.ipynb
+++ b/examples/elements/matplotlib/Curve.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Ellipse.ipynb
+++ b/examples/elements/matplotlib/Ellipse.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/ErrorBars.ipynb
+++ b/examples/elements/matplotlib/ErrorBars.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/HLine.ipynb
+++ b/examples/elements/matplotlib/HLine.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/HSV.ipynb
+++ b/examples/elements/matplotlib/HSV.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/HeatMap.ipynb
+++ b/examples/elements/matplotlib/HeatMap.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Histogram.ipynb
+++ b/examples/elements/matplotlib/Histogram.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Image.ipynb
+++ b/examples/elements/matplotlib/Image.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/ItemTable.ipynb
+++ b/examples/elements/matplotlib/ItemTable.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Path.ipynb
+++ b/examples/elements/matplotlib/Path.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Points.ipynb
+++ b/examples/elements/matplotlib/Points.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Polygons.ipynb
+++ b/examples/elements/matplotlib/Polygons.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/QuadMesh.ipynb
+++ b/examples/elements/matplotlib/QuadMesh.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/RGB.ipynb
+++ b/examples/elements/matplotlib/RGB.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Raster.ipynb
+++ b/examples/elements/matplotlib/Raster.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Scatter.ipynb
+++ b/examples/elements/matplotlib/Scatter.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Spikes.ipynb
+++ b/examples/elements/matplotlib/Spikes.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Spline.ipynb
+++ b/examples/elements/matplotlib/Spline.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Spread.ipynb
+++ b/examples/elements/matplotlib/Spread.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Table.ipynb
+++ b/examples/elements/matplotlib/Table.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/Text.ipynb
+++ b/examples/elements/matplotlib/Text.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/VLine.ipynb
+++ b/examples/elements/matplotlib/VLine.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/elements/matplotlib/VectorField.ipynb
+++ b/examples/elements/matplotlib/VectorField.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "hv.notebook_extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {

--- a/examples/streams/bokeh/bounds_selection.ipynb
+++ b/examples/streams/bokeh/bounds_selection.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/boundsx_selection.ipynb
+++ b/examples/streams/bokeh/boundsx_selection.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/boundsy_selection.ipynb
+++ b/examples/streams/bokeh/boundsy_selection.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/heatMap_tap.ipynb
+++ b/examples/streams/bokeh/heatMap_tap.ipynb
@@ -24,7 +24,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/linked_pointer_crosssection.ipynb
+++ b/examples/streams/bokeh/linked_pointer_crosssection.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/multiple_selection.ipynb
+++ b/examples/streams/bokeh/multiple_selection.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/point_selection1D.ipynb
+++ b/examples/streams/bokeh/point_selection1D.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/pointer_crosshair.ipynb
+++ b/examples/streams/bokeh/pointer_crosshair.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/streams/bokeh/range_histogram.ipynb
+++ b/examples/streams/bokeh/range_histogram.ipynb
@@ -23,7 +23,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews import streams\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {

--- a/examples/topics/simulation/boids.ipynb
+++ b/examples/topics/simulation/boids.ipynb
@@ -30,7 +30,7 @@
     "import holoviews as hv\n",
     "import numpy as np\n",
     "\n",
-    "hv.notebook_extension('bokeh')"
+    "hv.extension('bokeh')"
    ]
   },
   {


### PR DESCRIPTION
Updated the example notebooks to use ``hv.extension`` and to be explicit when using matplotlib (i.e avoiding ``hv.extension()`` and using ``hv.extension('matplotlib')``)