### PR TITLE
Suppressing stream parameters with Stream.rename 

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -293,7 +293,8 @@ class Stream(param.Parameterized):
     @property
     def contents(self):
         filtered = {k:v for k,v in self.get_param_values() if k!= 'name' }
-        return {self._rename.get(k,k):v for (k,v) in filtered.items()}
+        return {self._rename.get(k,k):v for (k,v) in filtered.items()
+                if (self._rename.get(k,True) is not None)}
 
 
     def _set_stream_parameters(self, **kwargs):

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -274,6 +274,16 @@ class TestParameterRenaming(ComparisonTestCase):
         with self.assertRaisesRegexp(ValueError, regexp):
             renamed.event(ytest=8)
 
+    def test_rename_suppression(self):
+        renamed = PointerXY(x=0,y=0).rename(x=None)
+        self.assertEquals(renamed.contents, {'y':0})
+
+    def test_rename_suppression_reenable(self):
+        renamed = PointerXY(x=0,y=0).rename(x=None)
+        self.assertEquals(renamed.contents, {'y':0})
+        reenabled = renamed.rename(x='foo')
+        self.assertEquals(reenabled.contents, {'foo':0, 'y':0})
+
 
 class TestPlotSizeTransform(ComparisonTestCase):
 


### PR DESCRIPTION

Implements the suggestion in #1437 which turned out easier to implement than I anticipated:

![image](https://user-images.githubusercontent.com/890576/27344063-f32452c0-55dc-11e7-8c27-f6c6eb555b8b.png)