### PR TITLE
Added DynamicMap.opts method to apply opts to returned object

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -820,7 +820,7 @@ class DynamicMap(HoloMap):
         if self.id not in Store.custom_options():
             return retval
         spec = StoreOptions.tree_to_dict(Store.custom_options()[self.id])
-        return retval(spec)
+        return retval.opts(spec)
 
 
     def _execute_callback(self, *args):
@@ -845,6 +845,17 @@ class DynamicMap(HoloMap):
         with dynamicmap_memoization(self.callback, self.streams):
             retval = self.callback(*args, **kwargs)
         return self._style(retval)
+
+
+    def opts(self, options=None, **kwargs):
+        """
+        Apply the supplied options to a clone of the DynamicMap which is
+        then returned. Note that if no options are supplied at all,
+        all ids are reset.
+        """
+        from ..util import Dynamic
+        return Dynamic(self, operation=lambda obj, **dynkwargs: obj.opts(options, **kwargs),
+                       streams=self.streams, shared_data=True, link_inputs=True)
 
 
     def clone(self, data=None, shared_data=True, new_type=None, link_inputs=True,

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -537,7 +537,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
         sdim = element.get_dimension(self.size_index)
         if sdim:
             sizes = element.dimension_values(self.size_index)
-            ms = style['s'] if 's' in style else plt.rcParams['lines.markersize']
+            ms = style['s'] if 's' in style else mpl.rcParams['lines.markersize']
             sizes = compute_sizes(sizes, self.size_fn, self.scaling_factor,
                                   self.scaling_method, ms)
             if sizes is None:

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -25,12 +25,13 @@ def _rc_context(rcparams):
     """
     Context manager that temporarily overrides the pyplot rcParams.
     """
-    old_rcparams = plt.rcParams.copy()
-    plt.rcParams.update(rcparams)
+    old_rcparams = mpl.rcParams.copy()
+    mpl.rcParams.update(rcparams)
     try:
         yield
     finally:
-        plt.rcParams = old_rcparams
+        mpl.rcParams.clear()
+        mpl.rcParams.update(old_rcparams)
 
 def mpl_rc_context(f):
     """
@@ -138,8 +139,7 @@ class MPLPlot(DimensionedPlot):
         elif not self.renderer.notebook_context:
             plt.ioff()
 
-        with mpl.rc_context(rc=self.fig_rcparams):
-            fig, axis = self._init_axis(fig, axis)
+        fig, axis = self._init_axis(fig, axis)
 
         self.handles['fig'] = fig
         self.handles['axis'] = axis
@@ -151,6 +151,7 @@ class MPLPlot(DimensionedPlot):
         self.handles['bbox_extra_artists'] = []
 
 
+    @mpl_rc_context
     def _init_axis(self, fig, axis):
         """
         Return an axis which may need to be initialized from

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -257,7 +257,7 @@ class MPLRenderer(Renderer):
                 fig.set_dpi(self.dpi)
                 fig.canvas.draw()
                 extra_artists = kw.pop("bbox_extra_artists", [])
-                pad = plt.rcParams['savefig.pad_inches']
+                pad = mpl.rcParams['savefig.pad_inches']
                 bbox_inches = get_tight_bbox(fig, extra_artists, pad=pad)
                 MPLRenderer.drawn[fig_id] = bbox_inches
                 kw['bbox_inches'] = bbox_inches
@@ -272,7 +272,8 @@ class MPLRenderer(Renderer):
             cls._rcParams = dict(mpl.rcParams)
             yield
         finally:
-            mpl.rcParams = cls._rcParams
+            mpl.rcParams.clear()
+            mpl.rcParams.update(cls._rcParams)
 
     @classmethod
     def validate(cls, options):

--- a/tests/testmagics.py
+++ b/tests/testmagics.py
@@ -29,7 +29,7 @@ class TestOptsMagic(ExtensionTestCase):
     def setUp(self):
         super(TestOptsMagic, self).setUp()
         self.cell("import numpy as np")
-        self.cell("from holoviews.element import Image")
+        self.cell("from holoviews import DynamicMap, Curve, Image")
 
     def tearDown(self):
         Store.custom_options(val = {})
@@ -48,6 +48,19 @@ class TestOptsMagic(ExtensionTestCase):
         self.assertEqual(
             Store.lookup_options('matplotlib',
                                  self.get_object('mat1'), 'style').options.get('cmap',None),'hot')
+
+    def test_cell_opts_style_dynamic(self):
+
+        self.cell("dmap = DynamicMap(lambda X: Curve(np.random.rand(5,2), name='dmap'), kdims=['x'])"
+                  ".redim.range(x=(0, 10)).opts(style={'Curve': dict(linewidth=2, color='black')})")
+
+        self.assertEqual(self.get_object('dmap').id, None)
+        self.cell_magic('opts', " Curve (linewidth=3 alpha=0.5)", 'dmap')
+        self.assertEqual(self.get_object('dmap').id, 0)
+
+        assert 0 in Store.custom_options(), "Custom OptionTree creation failed"
+        opts = Store.lookup_options('matplotlib', self.get_object('dmap')[0], 'style').options
+        self.assertEqual(opts, {'linewidth': 3, 'alpha': 0.5, 'color': 'black'})
 
 
     def test_cell_opts_plot_float_division(self):
@@ -78,6 +91,20 @@ class TestOptsMagic(ExtensionTestCase):
                                  self.get_object('mat1'), 'plot').options.get('show_title',True),False)
 
 
+    def test_cell_opts_plot_dynamic(self):
+
+        self.cell("dmap = DynamicMap(lambda X: Image(np.random.rand(5,5), name='dmap'), kdims=['x'])"
+                  ".redim.range(x=(0, 10)).opts(plot={'Image': dict(xaxis='top', xticks=3)})")
+
+        self.assertEqual(self.get_object('dmap').id, None)
+        self.cell_magic('opts', " Image [xaxis=None yaxis='right']", 'dmap')
+        self.assertEqual(self.get_object('dmap').id, 0)
+
+        assert 0 in Store.custom_options(), "Custom OptionTree creation failed"
+        opts = Store.lookup_options('matplotlib', self.get_object('dmap')[0], 'plot').options
+        self.assertEqual(opts, {'xticks': 3, 'xaxis': None, 'yaxis': 'right'})
+
+
     def test_cell_opts_norm(self):
 
         self.cell("mat1 = Image(np.random.rand(5,5), name='mat1')")
@@ -90,7 +117,6 @@ class TestOptsMagic(ExtensionTestCase):
         self.assertEqual(
             Store.lookup_options('matplotlib',
                                  self.get_object('mat1'), 'norm').options.get('axiswise',True), True)
-
 
 
 


### PR DESCRIPTION
When applying opts to a DynamicMap using the ``.opts`` method the options sometimes aren't applied correctly. By mapping the applied opts on the DynamicMap the opts are applied directly to the returned Elements. I think the issue may be that the ``id`` doesn't get copied or applied correctly, which means that the ``DynamicMap._style`` method doesn't apply the options correctly.