### PR TITLE
Fixes for bound_range utility

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1481,6 +1481,11 @@ def bound_range(vals, density):
     if not density:
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
-            density = 1./((high-low)/(len(vals)-1))
+            full_precision_density = 1./((high-low)/(len(vals)-1))
+            density = round(full_precision_density, sys.float_info.dig)
+        if density == 0:
+            density = full_precision_density
+    if density == 0:
+        raise ValueError('Could not determine Image density, ensure it has a non-zero range.')
     halfd = 0.5/density
     return low-halfd, high+halfd, density, invert

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1479,6 +1479,8 @@ def bound_range(vals, density):
     if len(vals) > 1 and vals[0] > vals[1]:
         invert = True
     if not density:
-        density = round(1./((high-low)/(len(vals)-1)), sys.float_info.dig)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('ignore', r'invalid value encountered in double_scalars')
+            density = 1./((high-low)/(len(vals)-1))
     halfd = 0.5/density
     return low-halfd, high+halfd, density, invert


### PR DESCRIPTION
Since the introduction of ``ndloc`` the precise numerical precision of Image coordinates is not a real issue anymore. This PR drops the rounding that we previously applied to the density based on the system float precision. This means that Image can handle very small values, which are currently rounded to zero. I've also filtered some warnings.