### PR TITLE
Define Palettes and Cycles from backend specific colormaps/palettes

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -252,7 +252,12 @@ class Cycle(param.Parameterized):
 
     default_cycles = {'default_colors': []}
 
-    def __init__(self, **params):
+    def __init__(self, cycle=None, **params):
+        if cycle is not None:
+            if isinstance(cycle, basestring):
+                params['key'] = cycle
+            else:
+                params['values'] = cycle
         super(Cycle, self).__init__(**params)
         self.values = self._get_values()
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import numpy as np
+from bokeh.palettes import all_palettes
 
 from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
                      GridSpace, GridMatrix, NdLayout, config)
@@ -9,7 +10,7 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         Box, Bounds, Ellipse, Polygons, BoxWhisker,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField)
-from ...core.options import Options, Cycle
+from ...core.options import Options, Cycle, Palette
 
 try:
     from ...interface import DFrame
@@ -105,6 +106,16 @@ except ImportError:
 point_size = np.sqrt(6) # Matches matplotlib default
 Cycle.default_cycles['default_colors'] =  ['#30a2da', '#fc4f30', '#e5ae38',
                                            '#6d904f', '#8b8b8b']
+
+# Register bokeh.palettes with Palette and Cycle
+def colormap_generator(palette):
+    return lambda value: palette[int(value*(len(palette)-1))]
+
+Palette.colormaps.update({name: colormap_generator(p[max(p.keys())])
+                          for name, p in all_palettes.items()})
+
+Cycle.default_cycles.update({name: p[max(p.keys())] for name, p in all_palettes.items()
+                             if max(p.keys()) < 256})
 
 dflt_cmap = 'hot' if config.style_17 else 'fire'
 options = Store.options(backend='bokeh')

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -2,6 +2,7 @@ import os
 from distutils.version import LooseVersion
 
 from matplotlib import rc_params_from_file
+from matplotlib.colors import ListedColormap
 
 from ...core import Layout, Collator, GridMatrix, config
 from ...core.options import Cycle, Palette, Options
@@ -73,10 +74,11 @@ else:
     Cycle.default_cycles['default_colors'] =  ['#30a2da', '#fc4f30', '#e5ae38',
                                                '#6d904f', '#8b8b8b']
 
-
-# Filter spectral colormaps to avoid warning in mpl 2.0
+# Define Palettes and cycles from matplotlib colormaps
 Palette.colormaps.update({cm: plt.get_cmap(cm) for cm in plt.cm.datad
                           if 'spectral' not in cm and 'Vega' not in cm})
+listed_cmaps = [cm for cm in Palette.colormaps.values() if isinstance(cm, ListedColormap)]
+Cycle.default_cycles.update({cm.name: list(cm.colors) for cm in listed_cmaps})
 
 style_aliases = {'edgecolor': ['ec', 'ecolor'], 'facecolor': ['fc'],
                  'linewidth': ['lw'], 'edgecolors': ['ec', 'edgecolor'],


### PR DESCRIPTION
Since we no longer import the matplotlib backend the list of Palettes are only populated if that particular backend is imported. This PR does several things:

1) A Cycle can be instantiated with a key or a list of values without having to specify the parameter name, i.e. before you had to do ``Cycle(values=['red', 'green', 'blue'])`` or ``Cycle(key='default_colors')`` now you can do ``Cycle(['red', 'green', 'blue'])`` or ``Cycle('default_colors')``.
2) We now define a number of default Cycles for both matplotlib and bokeh, since there is at least some overlap we can always rely on things like ``Set1-3``, ``Dark2`` and a few others to be there.
3) We also define default Palettes in bokeh.

The behavior of ``Palette`` has always been a bit odd and we should probably discuss/address that for 2.0, since it samples the provided function like a colormap and therefore does not cycle. I think that distinction still makes sense as cycling is what Cycle is for but we need to document this at some point. For the time being this is 1) completely backward compatible, 2) allows using categorical colormaps as Cycles and 3) ensures that at least a subset of categorical colormaps/palettes are available for both matplotlib and bokeh.