### PR TITLE
Updated style with new show_frame settings 

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -131,6 +131,9 @@ options.BoxWhisker = Options('style', box_fill_color=Cycle(), whisker_color='bla
                              box_line_color='black', outlier_color='black')
 options.Scatter = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)
 options.Points = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)
+if not config.style_17:
+    options.Points = Options('plot', show_frame=True)
+
 options.Histogram = Options('style', line_color='black', fill_color=Cycle())
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -55,6 +55,7 @@ associations = {Overlay: OverlayPlot,
                 Spikes: SpikesPlot,
                 Area: AreaPlot,
                 VectorField: VectorFieldPlot,
+                Histogram: HistogramPlot,
 
                 # Rasters
                 Image: RasterPlot,
@@ -62,7 +63,6 @@ associations = {Overlay: OverlayPlot,
                 HSV: HSVPlot,
                 Raster: RasterPlot,
                 HeatMap: HeatmapPlot,
-                Histogram: HistogramPlot,
                 QuadMesh: QuadMeshPlot,
 
                 # Paths
@@ -93,6 +93,15 @@ Store.register(associations, 'bokeh')
 if config.style_17:
     ElementPlot.show_grid = True
     RasterPlot.show_grid = True
+
+    ElementPlot.show_frame = True
+else:
+    # Raster types, Path types and VectorField should have frames
+    for framedcls in [VectorFieldPlot, ContourPlot, PathPlot, PolygonPlot,
+                      RasterPlot, RGBPlot, HSVPlot, QuadMeshPlot, HeatMapPlot]:
+        framedcls.show_frame = True
+
+
 
 
 AdjointLayoutPlot.registry[Histogram] = SideHistogramPlot

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -173,8 +173,7 @@ if config.style_17:
     PointPlot.show_grid = True
 
     MPLPlot.show_frame = True
-    for framelesscls in [GridPlot, AdjoinedPlot, Plot3D, CurvePlot,
-                         HistogramPlot, TimeSeriesPlot, DistributionPlot]:
+    for framelesscls in [GridPlot, AdjoinedPlot, Plot3D, CurvePlot, HistogramPlot]:
         framelesscls.show_frame = False
 else:
     # Raster types, Path types and VectorField should have frames

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -191,6 +191,10 @@ dflt_cmap = 'hot' if config.style_17 else 'fire'
 # Charts
 options.Curve = Options('style', color=Cycle(), linewidth=2)
 options.Scatter = Options('style', color=Cycle(), marker='o', cmap=dflt_cmap)
+
+if not config.style_17:
+    options.Points = Options('plot', show_frame=True)
+
 options.ErrorBars = Options('style', ecolor='k')
 options.Spread = Options('style', facecolor=Cycle(), alpha=0.6, edgecolor='k', linewidth=0.5)
 options.Bars = Options('style', ec='k', color=Cycle())

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -173,7 +173,7 @@ if config.style_17:
     PointPlot.show_grid = True
 
     MPLPlot.show_frame = True
-    for framelesscls in [GridPlot, AdjoinedPlot, Plot3D, CurvePlot, HistogramPlot]:
+    for framelesscls in [AdjoinedPlot, Plot3D, CurvePlot, HistogramPlot]:
         framelesscls.show_frame = False
 else:
     # Raster types, Path types and VectorField should have frames

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -172,6 +172,16 @@ if config.style_17:
     SideHistogramPlot.show_grid = True
     PointPlot.show_grid = True
 
+    MPLPlot.show_frame = True
+    for framelesscls in [GridPlot, AdjoinedPlot, Plot3D, CurvePlot,
+                         HistogramPlot, TimeSeriesPlot, DistributionPlot]:
+        framelesscls.show_frame = False
+else:
+    # Raster types, Path types and VectorField should have frames
+    for framedcls in [VectorFieldPlot, ContourPlot, PathPlot,
+                      RasterPlot, QuadMeshPlot, HeatMapPlot, PolygonPlot]:
+        framedcls.show_frame = True
+
 
 options = Store.options(backend='matplotlib')
 dflt_cmap = 'hot' if config.style_17 else 'fire'

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -177,8 +177,8 @@ if config.style_17:
         framelesscls.show_frame = False
 else:
     # Raster types, Path types and VectorField should have frames
-    for framedcls in [VectorFieldPlot, ContourPlot, PathPlot,
-                      RasterPlot, QuadMeshPlot, HeatMapPlot, PolygonPlot]:
+    for framedcls in [VectorFieldPlot, ContourPlot, PathPlot, RasterPlot,
+                      QuadMeshPlot, HeatMapPlot, PolygonPlot]:
         framedcls.show_frame = True
 
 
@@ -247,4 +247,3 @@ else:
 
 # Interface
 options.TimeSeries = Options('style', color=Cycle())
-

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -173,7 +173,8 @@ if config.style_17:
     PointPlot.show_grid = True
 
     MPLPlot.show_frame = True
-    for framelesscls in [AdjoinedPlot, Plot3D, CurvePlot, HistogramPlot]:
+    for framelesscls in [RasterGridPlot, GridPlot,
+                         AdjoinedPlot, Plot3D, CurvePlot, HistogramPlot]:
         framelesscls.show_frame = False
 else:
     # Raster types, Path types and VectorField should have frames

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -57,9 +57,6 @@ class CurvePlot(ChartPlot):
         If plotted quantity is cyclic and center_cyclic is enabled,
         will compute tick labels relative to the center.""")
 
-    show_frame = param.Boolean(default=False, doc="""
-        Disabled by default for clarity.""")
-
     show_grid = param.Boolean(default=False, doc="""
         Enable axis grid.""")
 
@@ -243,12 +240,6 @@ class HistogramPlot(ChartPlot):
     DataHistograms, which can be displayed as a single frame or
     animation.
     """
-
-    show_frame = param.Boolean(default=False, doc="""
-        Disabled by default for clarity.""")
-
-    show_grid = param.Boolean(default=False, doc="""
-        Whether to overlay a grid on the axis.""")
 
     style_opts = ['alpha', 'color', 'align', 'visible', 'facecolor',
                   'edgecolor', 'log', 'capsize', 'error_kw', 'hatch',

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -39,9 +39,6 @@ class Plot3D(ColorbarPlot):
     projection = param.ObjectSelector(default='3d', objects=['3d'], doc="""
         The projection of the matplotlib axis.""")
 
-    show_frame = param.Boolean(default=False, doc="""
-        Whether to draw a frame around the figure.""")
-
     show_grid = param.Boolean(default=True, doc="""
         Whether to draw a grid in the figure.""")
 

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -115,7 +115,7 @@ class MPLPlot(DimensionedPlot):
         May also supply a custom projection that is either a matplotlib
         projection type or implements the `_as_mpl_axes` method.""")
 
-    show_frame = param.Boolean(default=True, doc="""
+    show_frame = param.Boolean(default=False, doc="""
         Whether or not to show a complete frame around the plot.""")
 
     _close_figures = True
@@ -286,9 +286,6 @@ class GridPlot(CompositePlot):
     shared_yaxis = param.Boolean(default=False, doc="""
         If enabled the x-axes of the GridSpace will be drawn from the
         objects inside the Grid rather than the GridSpace dimensions.""")
-
-    show_frame = param.Boolean(default=False, doc="""
-        Whether to draw a frame around the Grid.""")
 
     show_legend = param.Boolean(default=False, doc="""
         Legends add to much clutter in a grid and are disabled by default.""")
@@ -1112,8 +1109,6 @@ class AdjoinedPlot(DimensionedPlot):
 
     border_size = param.Number(default=0.25, doc="""
         The size of the border expressed as a fraction of the main plot.""")
-
-    show_frame = param.Boolean(default=False)
 
     show_title = param.Boolean(default=False, doc="""
         Titles should be disabled on all SidePlots to avoid clutter.""")

--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -13,6 +13,7 @@ from ...interface.pandas import DFrame, DataFrameView
 from ...interface.seaborn import Regression, TimeSeries, Bivariate, Distribution
 from ...interface.seaborn import DFrame as SNSFrame
 from ...core.options import Store
+from ...core import config
 from .element import ElementPlot
 from .pandas import DFrameViewPlot
 from .plot import MPLPlot, AdjoinedPlot, mpl_rc_context
@@ -322,3 +323,8 @@ Store.register({TimeSeries: TimeSeriesPlot,
                 DataFrameView: SNSFramePlot}, 'matplotlib')
 
 MPLPlot.sideplots.update({Distribution: SideDistributionPlot})
+
+
+if config.style_17:
+    for framelesscls in [TimeSeriesPlot, DistributionPlot]:
+        framelesscls.show_frame = False

--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -105,9 +105,6 @@ class TimeSeriesPlot(SeabornPlot):
     curve.
     """
 
-    show_frame = param.Boolean(default=False, doc="""
-       Disabled by default for clarity.""")
-
     show_legend = param.Boolean(default=True, doc="""
       Whether to show legend for the plot.""")
 
@@ -137,9 +134,6 @@ class DistributionPlot(SeabornPlot):
 
     apply_ranges = param.Boolean(default=False, doc="""
         Whether to compute the plot bounds from the data itself.""")
-
-    show_frame = param.Boolean(default=False, doc="""
-       Disabled by default for clarity.""")
 
     style_opts = ['bins', 'hist', 'kde', 'rug', 'fit', 'hist_kws',
                   'kde_kws', 'rug_kws', 'fit_kws', 'color']


### PR DESCRIPTION
Talking to @philippjfr we decided that only raster types, path types and vectorfields should have frames.