### PR TITLE
Added case_sensitive_completion option to extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /release
 /doc/Tutorials-WIP/*.ipynb
 .idea
+holoviews.rc

--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -46,13 +46,14 @@ except ImportError as e:
         def __call__(self, *args, **opts):
             raise Exception("IPython notebook not available: use hv.extension instead.")
 
-
 # A single holoviews.rc file may be executed if found.
 for rcfile in [os.environ.get("HOLOVIEWSRC", ''),
                "~/.holoviews.rc",
-               "~/.config/holoviews/holoviews.rc"]:
-    try:
-        filename = os.path.expanduser(rcfile)
+               "~/.config/holoviews/holoviews.rc",
+               os.path.abspath(os.path.join(os.path.split(__file__)[0],
+                                            '..', 'holoviews.rc'))]:
+    filename = os.path.expanduser(rcfile)
+    if os.path.isfile(filename):
         with open(filename) as f:
             code = compile(f.read(), filename, 'exec')
             try:
@@ -60,9 +61,6 @@ for rcfile in [os.environ.get("HOLOVIEWSRC", ''),
             except Exception as e:
                 print("Warning: Could not load %r [%r]" % (filename, str(e)))
         break
-    except IOError:
-        pass
-
 
 def help(obj, visualization=True, ansi=True, backend=None,
          recursive=False, pattern=None):


### PR DESCRIPTION
This fixes a bug with recent IPython versions, namely the fact that completions are listed in a case-insensitive order (ignoring both the default behavior of ``dir`` and ``__dir__`` as well as the semantic importance of case in Python identifiers).

As this monkey patches a particular function in IPython, the default of this parameter is False but you can enable it by adding a ``~/.holoviews.rc``:

```
import holoviews as hv
hv.extension.case_sensitive_completion=True
```

This is highly recommended as it allows you to index into ``Layout`` and ``Overlay``as originally intended. Hopefully, this fix will make it's way into the next IPython release.