### PR TITLE
Fixed bug in renderer size scaling for bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -410,7 +410,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         """
         Returns a dictionary of plot properties.
         """
-        size_multiplier = Store.renderers[self.renderer.backend].size/100.
+        size_multiplier = self.renderer.size/100.
         plot_props = dict(plot_height=int(self.height*size_multiplier),
                           plot_width=int(self.width*size_multiplier))
         if bokeh_version < '0.12':

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -247,15 +247,14 @@ class BokehRenderer(Renderer):
         utility. Note that this can be overridden explicitly per object
         using the fig_size and size plot options.
         """
-        factor = percent_size / 100.0
         obj = obj.last if isinstance(obj, HoloMap) else obj
         plot = Store.registry[cls.backend].get(type(obj), None)
         if not hasattr(plot, 'width') or not hasattr(plot, 'height'):
             from .plot import BokehPlot
             plot = BokehPlot
         options = plot.lookup_options(obj, 'plot').options
-        width = options.get('width', plot.width) * factor
-        height = options.get('height', plot.height) * factor
+        width = options.get('width', plot.width)
+        height = options.get('height', plot.height)
         return dict(options, **{'width':int(width), 'height': int(height)})
 
 


### PR DESCRIPTION
Since the plot sizes are defined "inside out" in bokeh (i.e. each component defines its own size) the size scaling should be applied on bokeh's ElementPlot unlike matplotlib where it can be applied on the renderer. Before this fix it was applied twice, which was obviously wrong.