### PR TITLE
Added simpler .hist example

### DIFF
--- a/examples/reference/elements/bokeh/Histogram.ipynb
+++ b/examples/reference/elements/bokeh/Histogram.ipynb
@@ -67,7 +67,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``.hist`` method is an easy way to compute a histogram from an existing Element. The method effectively just calls the ``histogram`` operation, which lets you compute a histogram from an Element, and then adjoins the resulting histogram. Here we will create two sets of ``Points``, compute a ``Histogram`` for the 'x' and 'y' dimension on each, which we then overlay and adjoin to the plot."
+    "The ``.hist`` method is an easy way to compute a histogram from an existing Element:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points = hv.Points(np.random.randn(100,2))\n",
+    "\n",
+    "points.hist(dimension=['x','y'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``.hist`` method is just a convenient wrapper around the ``histogram`` operation that computes a histogram from an Element, and then adjoins the resulting histogram to the main plot. You can also do this process manually; here we create an additional set of ``Points``, compute a ``Histogram`` for the 'x' and 'y' dimension on each, and then overlay them and adjoin to the plot."
    ]
   },
   {
@@ -78,12 +96,12 @@
    "source": [
     "%%opts Histogram (alpha=0.3)\n",
     "from holoviews.operation import histogram\n",
-    "points1 = hv.Points(np.random.randn(100,2)*2+1)\n",
-    "points2 = hv.Points(np.random.randn(100,2))\n",
-    "xhist, yhist = (histogram(points1, bin_range=(-5, 5), dimension=dim) *\n",
-    "                histogram(points2, bin_range=(-5, 5), dimension=dim) \n",
+    "points2 = hv.Points(np.random.randn(100,2)*2+1)\n",
+    "\n",
+    "xhist, yhist = (histogram(points2, bin_range=(-5, 5), dimension=dim) *\n",
+    "                histogram(points,  bin_range=(-5, 5), dimension=dim) \n",
     "                for dim in 'xy')\n",
-    "(points1 * points2) << yhist(plot=dict(width=125)) << xhist(plot=dict(height=125))"
+    "(points2 * points) << yhist(plot=dict(width=125)) << xhist(plot=dict(height=125))"
    ]
   }
  ],

--- a/examples/reference/elements/matplotlib/Histogram.ipynb
+++ b/examples/reference/elements/matplotlib/Histogram.ipynb
@@ -67,7 +67,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``.hist`` method is an easy way to compute a histogram from an existing Element. The method effectively just calls the ``histogram`` operation, which lets you compute a histogram from an Element, and then adjoins the resulting histogram. Here we will create two sets of ``Points``, compute a ``Histogram`` for the 'x' and 'y' dimension on each, which we then overlay and adjoin to the plot."
+    "The ``.hist`` method is an easy way to compute a histogram from an existing Element:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "points = hv.Points(np.random.randn(100,2))\n",
+    "\n",
+    "points.hist(dimension=['x','y'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``.hist`` method is just a convenient wrapper around the ``histogram`` operation that computes a histogram from an Element, and then adjoins the resulting histogram to the main plot. You can also do this process manually; here we create an additional set of ``Points``, compute a ``Histogram`` for the 'x' and 'y' dimension on each, and then overlay them and adjoin to the plot."
    ]
   },
   {
@@ -78,12 +96,12 @@
    "source": [
     "%%opts Histogram (alpha=0.3)\n",
     "from holoviews.operation import histogram\n",
-    "points1 = hv.Points(np.random.randn(100,2)*2+1)\n",
-    "points2 = hv.Points(np.random.randn(100,2))\n",
-    "xhist, yhist = (histogram(points1, bin_range=(-5, 5), dimension=dim) *\n",
-    "                histogram(points2, bin_range=(-5, 5), dimension=dim) \n",
+    "points2 = hv.Points(np.random.randn(100,2)*2+1)\n",
+    "\n",
+    "xhist, yhist = (histogram(points2, bin_range=(-5, 5), dimension=dim) *\n",
+    "                histogram(points,  bin_range=(-5, 5), dimension=dim) \n",
     "                for dim in 'xy')\n",
-    "(points1 * points2) << yhist(plot=dict(width=125)) << xhist(plot=dict(height=125))"
+    "(points2 * points) << yhist(plot=dict(width=125)) << xhist(plot=dict(height=125))"
    ]
   }
  ],

--- a/examples/reference/elements/matplotlib/Histogram.ipynb
+++ b/examples/reference/elements/matplotlib/Histogram.ipynb
@@ -96,7 +96,7 @@
    "source": [
     "%%opts Histogram (alpha=0.3)\n",
     "from holoviews.operation import histogram\n",
-    "points2 = hv.Points(np.random.randn(100,2)*2+1)\n",
+    "points2 = hv.Points(np.random.randn(100,2)*2+1).redim.range(x=(-5, 5), y=(-5, 5))\n",
     "\n",
     "xhist, yhist = (histogram(points2, bin_range=(-5, 5), dimension=dim) *\n",
     "                histogram(points,  bin_range=(-5, 5), dimension=dim) \n",


### PR DESCRIPTION
The Histogram page in the Reference Gallery didn't have a simple example of using '.hist()', which is typically much more convenient than the complex example shown.  Added this simple example:

![image](https://user-images.githubusercontent.com/1695496/27754225-14f21ae8-5daf-11e7-9779-2384342f0893.png)

Works fine for Bokeh, but in mpl there is a strange colormap:

![image](https://user-images.githubusercontent.com/1695496/27754242-2bf9c434-5daf-11e7-833c-0e47ca42281f.png)

The last example on that page (not really modified in this PR)  is also aligned and sized very strangely for matplotlib, though it works fine for bokeh:

![image](https://user-images.githubusercontent.com/1695496/27754268-4174ff90-5daf-11e7-9e5f-7678ac5d642f.png)
