### PR TITLE
Set SpikesPlot color index to None by default

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -139,7 +139,7 @@ options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
 options.Bars = Options('style', color=Cycle(), line_color='black', width=0.8)
 
-options.Spikes = Options('style', color='black')
+options.Spikes = Options('style', color='black', cmap='fire')
 options.Area = Options('style', color=Cycle(), line_color='black')
 options.VectorField = Options('style', color='black')
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -492,7 +492,7 @@ class ErrorPlot(PathPlot):
 
 class SpikesPlot(PathPlot, ColorbarPlot):
 
-    color_index = param.ClassSelector(default=1, allow_None=True,
+    color_index = param.ClassSelector(default=None, allow_None=True,
                                       class_=(basestring, int), doc="""
       Index of the dimension from which the color will the drawn""")
 

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -159,7 +159,8 @@ Store.register({Curve: CurvePlot,
                 Box:      PathPlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
-                Polygons: PolygonPlot}, 'matplotlib', style_aliases=style_aliases)
+                Polygons: PolygonPlot},
+               'matplotlib', style_aliases=style_aliases)
 
 
 MPLPlot.sideplots.update({Histogram: SideHistogramPlot,

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -203,7 +203,7 @@ options.Points = Options('style', color=Cycle(), marker='o', cmap=dflt_cmap)
 options.Scatter3D = Options('style', c=Cycle(), marker='o')
 options.Scatter3D = Options('plot', fig_size=150)
 options.Surface = Options('plot', fig_size=150)
-options.Spikes = Options('style', color='black')
+options.Spikes = Options('style', color='black', cmap='fire')
 options.Area = Options('style', facecolor=Cycle(), edgecolor='black')
 options.BoxWhisker = Options('style', boxprops=dict(color='k', linewidth=1.5),
                              whiskerprops=dict(color='k', linewidth=1.5))

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -159,8 +159,7 @@ Store.register({Curve: CurvePlot,
                 Box:      PathPlot,
                 Bounds:   PathPlot,
                 Ellipse:  PathPlot,
-                Polygons: PolygonPlot},
-               'matplotlib', style_aliases=style_aliases)
+                Polygons: PolygonPlot}, 'matplotlib', style_aliases=style_aliases)
 
 
 MPLPlot.sideplots.update({Histogram: SideHistogramPlot,

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -903,7 +903,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
         explicit aspect ratio as width/height as well as
         'square' and 'equal' options.""")
 
-    color_index = param.ClassSelector(default=1, allow_None=True,
+    color_index = param.ClassSelector(default=None, allow_None=True,
                                       class_=(basestring, int), doc="""
       Index of the dimension from which the color will the drawn""")
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -812,7 +812,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
 
     def test_spikes_colormapping(self):
         spikes = Spikes(np.random.rand(20, 2), vdims=['Intensity'])
-        self._test_colormapping(spikes, 1)
+        color_spikes = spikes.opts(plot=dict(color_index=1))
+        self._test_colormapping(color_spikes, 1)
 
     def test_empty_spikes_plot(self):
         spikes = Spikes([], vdims=['Intensity'])


### PR DESCRIPTION
Before:

<img src='https://user-images.githubusercontent.com/890576/27770585-10d5e3a0-5f39-11e7-84c4-5040fb2fd0de.png' width='30%'></img>

After:


<img src='https://user-images.githubusercontent.com/890576/27770596-47f702ec-5f39-11e7-9a76-7887e6ddfc79.png' width='30%'></img>

I think this is a bug fix, not a style change as before a vdim was being mapped to both height *and* color when it should only be mapped to height.