### PR TITLE
Fixed handling of Spacer models in sparse grid

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -18,7 +18,7 @@ from bokeh.core.json_encoder import serialize_json # noqa (API import)
 from bokeh.core.properties import value
 from bokeh.document import Document
 from bokeh.layouts import WidgetBox, Row, Column
-from bokeh.models import Model, HasProps, ToolbarBox, FactorRange, Range1d, Plot
+from bokeh.models import Model, HasProps, ToolbarBox, FactorRange, Range1d, Plot, Spacer
 from bokeh.models.widgets import DataTable, Tabs, Div
 from bokeh.plotting import Figure
 
@@ -172,7 +172,7 @@ def compute_plot_size(plot):
         width, height = w_agg(widths), h_agg(heights)
     elif isinstance(plot, (Figure, Chart)):
         width, height = plot.plot_width, plot.plot_height
-    elif isinstance(plot, (Plot, DataTable)):
+    elif isinstance(plot, (Plot, DataTable, Spacer)):
         width, height = plot.width, plot.height
     return width, height
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1306,6 +1306,13 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(overlay)
         self.assertEqual(len(plot.subplots), 1)
 
+    def test_gridspace_sparse(self):
+        grid = GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
+                            for j in range(2,4) if not (i==1 and j == 2)})
+        plot = bokeh_renderer.get_plot(grid)
+        size = bokeh_renderer.get_size(plot.state)
+        self.assertEqual(size, (302, 298))
+
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)
                              for j in range(2,4)}) +


### PR DESCRIPTION
Fixes small bug handling ``Spacer`` models, which occur in sparse GridSpaces in bokeh. Fixes issue: https://github.com/ioam/holoviews/issues/1676