### PR TITLE
Choose better magic values for GridSpace plot label offsets

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -208,7 +208,7 @@ def font_size_to_pixels(size):
 
 
 def make_axis(axis, size, factors, dim, flip=False, rotation=0,
-              label_size=None, tick_size=None, axis_height=40):
+              label_size=None, tick_size=None, axis_height=25):
     factors = list(map(dim.pprint_value, factors))
     nchars = np.max([len(f) for f in factors])
     ranges = FactorRange(factors=factors)
@@ -233,7 +233,7 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0,
         align = 'center'
         # Adjust height to compensate for label rotation
         height = int(axis_height + np.abs(np.sin(rotation)) *
-                     ((nchars*tick_px)*0.5)) + tick_px + label_px
+                     ((nchars*tick_px)*0.82)) + tick_px + label_px
         opts = dict(x_axis_type='auto', x_axis_label=axis_label,
                     x_range=ranges, y_range=ranges2, plot_height=height,
                     plot_width=size)
@@ -241,7 +241,7 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0,
         # Adjust width to compensate for label rotation
         align = 'left' if flip else 'right'
         width = int(axis_height + np.abs(np.cos(rotation)) *
-                    ((nchars*tick_px)*0.5)) + tick_px + label_px
+                    ((nchars*tick_px)*0.82)) + tick_px + label_px
         opts = dict(y_axis_label=axis_label, x_range=ranges2,
                     y_range=ranges, plot_width=width, plot_height=size)
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1311,7 +1311,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                             for j in range(2,4) if not (i==1 and j == 2)})
         plot = bokeh_renderer.get_plot(grid)
         size = bokeh_renderer.get_size(plot.state)
-        self.assertEqual(size, (302, 298))
+        self.assertEqual(size, (289, 283))
 
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -134,7 +134,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (422, 418))
+        self.assertEqual((w, h), (409, 403))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])


### PR DESCRIPTION
The GridSpace plot has to appropriately expand the sizes of the axes when the label length changes. This code is never going to be perfectly robust but it appears the magic values I chose initially weren't very good and resulted in errors for even fairly short labels, as seen here:

https://github.com/ioam/holoviews/issues/1675

Tested the new values with GridSpaces of varying size, varying fontsize with tick labels ranging from 1 to 100 characters.