### PR TITLE
Added safety margin for grid axis constraint issue

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -208,7 +208,7 @@ def font_size_to_pixels(size):
 
 
 def make_axis(axis, size, factors, dim, flip=False, rotation=0,
-              label_size=None, tick_size=None, axis_height=25):
+              label_size=None, tick_size=None, axis_height=35):
     factors = list(map(dim.pprint_value, factors))
     nchars = np.max([len(f) for f in factors])
     ranges = FactorRange(factors=factors)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1312,7 +1312,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                             for j in range(2,4) if not (i==1 and j == 2)})
         plot = bokeh_renderer.get_plot(grid)
         size = bokeh_renderer.get_size(plot.state)
-        self.assertEqual(size, (289, 283))
+        self.assertEqual(size, (299, 293))
 
     def test_layout_gridspaces(self):
         layout = (GridSpace({(i, j): Curve(range(i+j)) for i in range(1, 3)

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -134,7 +134,7 @@ class BokehRendererTest(ComparisonTestCase):
         grid = GridSpace({(i, j): self.image1 for i in range(3) for j in range(3)})
         plot = self.renderer.get_plot(grid)
         w, h = self.renderer.get_size(plot)
-        self.assertEqual((w, h), (409, 403))
+        self.assertEqual((w, h), (419, 413))
 
     def test_get_size_table(self):
         table = Table(range(10), kdims=['x'])


### PR DESCRIPTION
Once again fixes https://github.com/ioam/holoviews/issues/1675, several constraints seem to have been off by exactly 1 pixel. This adds a safety margin of 10 pixels. As the issue already states we need to find a better way to deal with this.