### PR TITLE
Added a groupby argument to the histogram operation

### DIFF
--- a/examples/gallery/demos/bokeh/autompg_histogram.ipynb
+++ b/examples/gallery/demos/bokeh/autompg_histogram.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends, this example is also available for:\n",
+    "\n",
+    "* [Matplotlib - autompg_histogram](../matplotlib/autompg_histogram.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "hv.extension('bokeh','matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declaring data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from bokeh.sampledata.autompg import autompg\n",
+    "\n",
+    "autompg_ds = hv.Dataset(autompg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Histogram (alpha=0.9) [width=600]\n",
+    "autompg_ds.hist(dimension='mpg', groupby='cyl', adjoin=False)"
+   ]
+  }
+ ],
+ "metadata": {
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/gallery/demos/matplotlib/autompg_histogram.ipynb
+++ b/examples/gallery/demos/matplotlib/autompg_histogram.ipynb
@@ -1,0 +1,66 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends, this example is also available for:\n",
+    "\n",
+    "* [Bokeh - autompg_histogram](../bokeh/autompg_histogram.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "hv.extension('matplotlib')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declaring data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "from bokeh.sampledata.autompg import autompg\n",
+    "\n",
+    "autompg_ds = hv.Dataset(autompg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Histogram [fig_size=200 aspect=2]\n",
+    "autompg_ds.hist(dimension='mpg', groupby='cyl', adjoin=False)"
+   ]
+  }
+ ],
+ "metadata": {
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/1716 we should have an easier way to generate a grouped/faceted histogram. The current approach is as follows:

```
hv.Dataset(autompg).groupby('cyl').hist(dimension='mpg', adjoin=False).overlay()
```

For simplicities sake I suggest adding this:

```
hv.Dataset(autompg).hist(dimension='mpg', groupby='cyl', adjoin=False)
```

OR

```
histogram(hv.Dataset(autompg), dimension='mpg', groupby='cyl')
```

![bokeh_plot 90](https://user-images.githubusercontent.com/1550771/28221199-feb68a14-6887-11e7-9f33-e052dd84f007.png)


Going to add gallery demos before this is ready to merge.