### PR TITLE
Ensure dask.array is imported

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -7,6 +7,7 @@ import xarray as xr
 
 try:
     import dask
+    import dask.array
 except ImportError:
     dask = None
 


### PR DESCRIPTION
Simple fix to ensure dask.array is actually imported, fixing issue described in

https://github.com/ioam/holoviews/issues/1710