### PR TITLE
Fixed clone on NdLayout to propagate cols properly

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -339,6 +339,18 @@ class NdLayout(UniformNdMapping):
         return self.clone(last_items)
 
 
+    def clone(self, *args, **overrides):
+        """
+        Clone method for NdLayout matches Dimensioned.clone except the
+        display mode is also propagated.
+        """
+        clone = super(NdLayout, self).clone(*args, **overrides)
+        clone._max_cols = self._max_cols
+        clone.id = self.id
+        return clone
+
+
+
 # To be removed after 1.3.0
 class Warning(param.Parameterized): pass
 collate_deprecation = Warning(name='Deprecation Warning')


### PR DESCRIPTION
PR title explains the change. My only worry is why does the ``id`` need to be copied across, doesn't super handle that?