### PR TITLE
Switched from deprecated GridImage to Image in conversion interface

### DIFF
--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -55,7 +55,7 @@ class ElementConversion(DataConversion):
         return self(HeatMap, kdims, vdims, groupby, **kwargs)
 
     def image(self, kdims=None, vdims=None, groupby=None, **kwargs):
-        return self(GridImage, kdims, vdims, groupby, **kwargs)
+        return self(Image, kdims, vdims, groupby, **kwargs)
 
     def points(self, kdims=None, vdims=None, groupby=None, **kwargs):
         return self(Points, kdims, vdims, groupby, **kwargs)


### PR DESCRIPTION
Simple PR to address some of the issues in #1745. Fixes to the image conversion interface should probably go into this PR too.