### PR TITLE
Added datashader regridding operation

### DIFF
--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -254,7 +254,8 @@ class Comparison(ComparisonInterface):
     @classmethod
     def bounds_check(cls, el1, el2, msg=None):
         if el1.bounds.lbrt() != el2.bounds.lbrt():
-            raise cls.failureException("BoundingBoxes are mismatched.")
+            raise cls.failureException("BoundingBoxes are mismatched: %s != %s."
+                                       % (el1.bounds.lbrt(), el2.bounds.lbrt()))
 
 
     #=======================================#

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, division
 
 from collections import Callable, Iterable
 from distutils.version import LooseVersion
@@ -30,7 +30,10 @@ from ..streams import RangeXY, PlotSize
 from ..plotting.util import fire
 
 
-class resample_operation(Operation):
+class ResamplingOperation(Operation):
+    """
+    Abstract baseclass for resampling operations
+    """
 
     dynamic = param.Boolean(default=True, doc="""
        Enables dynamic processing by default.""")
@@ -123,7 +126,7 @@ class resample_operation(Operation):
 
 
 
-class aggregate(resample_operation):
+class aggregate(ResamplingOperation):
     """
     aggregate implements 2D binning for any valid HoloViews Element
     type using datashader. I.e., this operation turns a HoloViews
@@ -337,7 +340,7 @@ class aggregate(resample_operation):
 
 
 
-class regrid(resample_operation):
+class regrid(ResamplingOperation):
     """
     regrid allows resampling a HoloViews Image type using specified
     up- and downsampling functions defined using the aggregator and

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -56,8 +56,9 @@ def dataset_pipeline(dataset, schema, canvas, glyph, summary):
         agg = dask_pipeline(dataset.data, schema, canvas,
                             glyph, summary)
 
-    agg = agg.rename({'x_axis': kdims[0].name,
-                      'y_axis': kdims[1].name})
+    if 'x_axis' in agg and 'y_axis' in agg:
+        agg = agg.rename({'x_axis': kdims[0].name,
+                          'y_axis': kdims[1].name})
     return agg
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -351,6 +351,9 @@ class regrid(resample_operation):
         the requested array.""")
 
     def _process(self, element, key=None):
+        if ds_version <= '0.5.0':
+            raise RuntimeError('regrid operation requires datashader>=0.6.0')
+
         x, y = element.kdims
         (x_range, y_range), _, (width, height) = self._get_sampling(element, x, y)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -49,10 +49,10 @@ class ResamplingOperation(Operation):
        being overlaid on a much larger background.""")
 
     height = param.Integer(default=400, doc="""
-       The height of the aggregated image in pixels.""")
+       The height of the output image in pixels.""")
 
     width = param.Integer(default=400, doc="""
-       The width of the aggregated image in pixels.""")
+       The width of the output image in pixels.""")
 
     x_range  = param.NumericTuple(default=None, length=2, doc="""
        The x_range as a tuple of min and max x-value. Auto-ranges
@@ -83,9 +83,11 @@ class ResamplingOperation(Operation):
         The type of the returned Elements, must be a 2D Dataset type.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         By default, the link_inputs parameter is set to True so that
-         when applying shade, backends that support linked streams
-         update RangeXY streams on the inputs of the shade operation.""")
+        By default, the link_inputs parameter is set to True so that
+        when applying shade, backends that support linked streams
+        update RangeXY streams on the inputs of the shade operation.
+        Disable when you do not want the resulting plot to be interactive,
+        e.g. when trying to display an interactive plot a second time.""")
 
     def _get_sampling(self, element, x, y):
         target = self.p.target
@@ -371,8 +373,13 @@ class regrid(ResamplingOperation):
         Interpolation method""")
 
     upsample = param.Boolean(default=False, doc="""
-        Whether to allow upsampling if the source array is smaller than
-        the requested array.""")
+        Whether to allow upsampling if the source array is smaller
+        than the requested array. Setting this value to True will
+        enable upsampling using the interpolation method, when the
+        requested width and height are larger than what is available
+        on the source grid. If upsampling is disabled (the default)
+        the width and height are clipped to what is available on the
+        source array.""")
 
     def _process(self, element, key=None):
         if ds_version <= '0.5.0':
@@ -455,11 +462,11 @@ class shade(Operation):
         """)
 
     link_inputs = param.Boolean(default=True, doc="""
-         By default, the link_inputs parameter is set to True so that
-         when applying shade, backends that support linked streams
-         update RangeXY streams on the inputs of the shade operation.
-         Disable when you do not want the resulting plot to be interactive,
-         e.g. when trying to display an interactive plot a second time.""")
+        By default, the link_inputs parameter is set to True so that
+        when applying shade, backends that support linked streams
+        update RangeXY streams on the inputs of the shade operation.
+        Disable when you do not want the resulting plot to be interactive,
+        e.g. when trying to display an interactive plot a second time.""")
 
     @classmethod
     def concatenate(cls, overlay):
@@ -599,9 +606,11 @@ class dynspread(Operation):
         allowed.""")
 
     link_inputs = param.Boolean(default=True, doc="""
-         By default, the link_inputs parameter is set to True so that
-         when applying dynspread, backends that support linked streams
-         update RangeXY streams on the inputs of the dynspread operation.""")
+        By default, the link_inputs parameter is set to True so that
+        when applying dynspread, backends that support linked streams
+        update RangeXY streams on the inputs of the dynspread operation.
+        Disable when you do not want the resulting plot to be interactive,
+        e.g. when trying to display an interactive plot a second time.""")
 
     @classmethod
     def uint8_to_uint32(cls, img):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -364,7 +364,7 @@ class regrid(resample_operation):
     """
 
     aggregator = param.ObjectSelector(default='mean',
-        objects=['first', 'last', 'mean', 'mode', 'std', 'var'], doc="""
+        objects=['first', 'last', 'mean', 'mode', 'std', 'var', 'min', 'max'], doc="""
         Aggregation method.
         """)
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -67,6 +67,10 @@ class resample_operation(Operation):
     dynamic = param.Boolean(default=True, doc="""
        Enables dynamic processing by default.""")
 
+    expand = param.Boolean(default=True, doc="""
+       Whether the x_range and y_range should be allowed to expand
+       beyond the extent of the data.""")
+
     height = param.Integer(default=400, doc="""
        The height of the aggregated image in pixels.""")
 
@@ -116,8 +120,18 @@ class resample_operation(Operation):
                 x_range = self.p.x_range or (-0.5, 0.5)
                 y_range = self.p.y_range or (-0.5, 0.5)
             else:
-                x_range = self.p.x_range or element.range(x)
-                y_range = self.p.y_range or element.range(y)
+                if self.p.expand or not self.p.x_range:
+                    x_range = self.p.x_range or element.range(x)
+                else:
+                    x0, x1 = self.p.x_range
+                    ex0, ex1 = element.range(x)
+                    x_range = max([x0, ex0]), min([x1, ex1])
+                if self.p.expand or not self.p.y_range:
+                    y_range = self.p.y_range or element.range(y)
+                else:
+                    y0, y1 = self.p.y_range
+                    ey0, ey1 = element.range(y)
+                    y_range = max([y0, ey0]), min([y1, ey1])
             width, height = self.p.width, self.p.height
         (xstart, xend), (ystart, yend) = x_range, y_range
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -138,7 +138,7 @@ class aggregate(resample_operation):
     The bins of the aggregate are defined by the width and height and
     the x_range and y_range. If x_sampling or y_sampling are supplied
     the operation will ensure that a bin is no smaller than the minimum
-    sampling distance by reducing the width and height when the zoomed
+    sampling distance by reducing the width and height when zoomed in
     beyond the minimum sampling distance.
 
     By default, the PlotSize stream is applied when this operation

--- a/tests/testcomparisonraster.py
+++ b/tests/testcomparisonraster.py
@@ -108,7 +108,7 @@ class BasicRasterComparisonTest(RasterTestCase):
         try:
             self.assertEqual(self.mat1, self.mat4)
         except AssertionError as e:
-            self.assertEqual(str(e), 'BoundingBoxes are mismatched.')
+            self.assertEqual(str(e), 'BoundingBoxes are mismatched: (-0.5, -0.5, 0.5, 0.5) != (-0.3, -0.3, 0.3, 0.3).')
 
 
 

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -83,7 +83,7 @@ class DatashaderRegridTests(ComparisonTestCase):
 
     def test_regrid_upsampling(self):
         img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
-        regridded = regrid(img, width=4, height=4, dynamic=False)
+        regridded = regrid(img, width=4, height=4, upsample=True, dynamic=False)
         expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                           [[0, 0, 1, 1],
                            [0, 0, 1, 1],
@@ -93,7 +93,7 @@ class DatashaderRegridTests(ComparisonTestCase):
 
     def test_regrid_upsampling_linear(self):
         img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
-        regridded = regrid(img, width=4, height=4, interpolation='linear', dynamic=False)
+        regridded = regrid(img, width=4, height=4, upsample=True, interpolation='linear', dynamic=False)
         expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
                           [[0, 0, 0, 1],
                            [0, 1, 1, 1],
@@ -101,12 +101,12 @@ class DatashaderRegridTests(ComparisonTestCase):
                            [2, 2, 2, 3]]))
         self.assertEqual(regridded, expected)
 
-    def test_regrid_disable_upsampling(self):
+    def test_regrid_disabled_upsampling(self):
         img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
         regridded = regrid(img, width=3, height=3, dynamic=False, upsample=False)
         self.assertEqual(regridded, img)
 
-    def test_regrid_disable_expand(self):
+    def test_regrid_disabled_expand(self):
         img = Image(([0.5, 1.5], [0.5, 1.5], [[0., 1.], [2., 3.]]))
         regridded = regrid(img, width=2, height=2, x_range=(-2, 4), y_range=(-2, 4), expand=False,
                            dynamic=False)

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -1,3 +1,4 @@
+from unittest import SkipTest
 from nose.plugins.attrib import attr
 
 import numpy as np
@@ -5,7 +6,7 @@ from holoviews import Curve, Points, Image, Dataset
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
-    from holoviews.operation.datashader import aggregate, regrid
+    from holoviews.operation.datashader import aggregate, regrid, ds_version
 except:
     aggregate = None
 
@@ -63,6 +64,10 @@ class DatashaderRegridTests(ComparisonTestCase):
     """
     Tests for datashader aggregation
     """
+
+    def setUp(self):
+        if ds_version <= '0.5.0':
+            raise SkipTest('Regridding operations require datashader>=0.6.0')
 
     def test_regrid_mean(self):
         img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -1,15 +1,17 @@
 from nose.plugins.attrib import attr
+
+import numpy as np
 from holoviews import Curve, Points, Image, Dataset
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
-    from holoviews.operation.datashader import aggregate
+    from holoviews.operation.datashader import aggregate, regrid
 except:
     aggregate = None
 
 
 @attr(optional=1)
-class DatashaderTests(ComparisonTestCase):
+class DatashaderAggregateTests(ComparisonTestCase):
     """
     Tests for datashader aggregation
     """
@@ -53,3 +55,54 @@ class DatashaderTests(ComparisonTestCase):
         img = aggregate(ndoverlay, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
                         width=2, height=2)
         self.assertEqual(img, expected)
+
+
+
+@attr(optional=1)
+class DatashaderRegridTests(ComparisonTestCase):
+    """
+    Tests for datashader aggregation
+    """
+
+    def test_regrid_mean(self):
+        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        regridded = regrid(img, width=2, height=2, dynamic=False)
+        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        self.assertEqual(regridded, expected)
+
+    def test_regrid_max(self):
+        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
+        regridded = regrid(img, aggregator='max', width=2, height=2, dynamic=False)
+        expected = Image(([2., 7.], [0.75, 3.25], [[8, 18], [16, 36]]))
+        self.assertEqual(regridded, expected)
+
+    def test_regrid_upsampling(self):
+        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        regridded = regrid(img, width=4, height=4, dynamic=False)
+        expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+                          [[0, 0, 1, 1],
+                           [0, 0, 1, 1],
+                           [2, 2, 3, 3],
+                           [2, 2, 3, 3]]))
+        self.assertEqual(regridded, expected)
+
+    def test_regrid_upsampling_linear(self):
+        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        regridded = regrid(img, width=4, height=4, interpolation='linear', dynamic=False)
+        expected = Image(([0.25, 0.75, 1.25, 1.75], [0.25, 0.75, 1.25, 1.75],
+                          [[0, 0, 0, 1],
+                           [0, 1, 1, 1],
+                           [1, 1, 2, 2],
+                           [2, 2, 2, 3]]))
+        self.assertEqual(regridded, expected)
+
+    def test_regrid_disable_upsampling(self):
+        img = Image(([0.5, 1.5], [0.5, 1.5], [[0, 1], [2, 3]]))
+        regridded = regrid(img, width=3, height=3, dynamic=False, upsample=False)
+        self.assertEqual(regridded, img)
+
+    def test_regrid_disable_expand(self):
+        img = Image(([0.5, 1.5], [0.5, 1.5], [[0., 1.], [2., 3.]]))
+        regridded = regrid(img, width=2, height=2, x_range=(-2, 4), y_range=(-2, 4), expand=False,
+                           dynamic=False)
+        self.assertEqual(regridded, img)


### PR DESCRIPTION
As suggested and outlined in https://github.com/ioam/holoviews/issues/1552 this PR adds a ``regrid`` operation that allows dynamically downsampling and upsampling HoloViews Image, RGB and HSV types to a specified x_range, y_range, width and height. It closely mirrors the ``aggregate`` operation but operates on Images instead. I introduced a common baseclass for the two operations and have started using it in various projects. It will require some further cleanup, decisions on naming and documentation but is now fully functional.