### PR TITLE
Periodic utility now stops when StopIteration is raised

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -164,7 +164,10 @@ class periodic(Thread):
             else:
                 self._completed.wait(self.period)
             self.counter += 1
-            self.callback(self.counter)
+            try:
+                self.callback(self.counter)
+            except Exception as e:
+                self.stop()
 
             if self.timeout is not None:
                 dt = (time.time() - self._start_time)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -179,7 +179,7 @@ def initialize_dynamic(obj):
 def get_plot_frame(map_obj, key_map, cached=False):
     """
     Returns an item in a HoloMap or DynamicMap given a mapping key
-    dimensons and their values.
+    dimensions and their values.
     """
     if map_obj.kdims and len(map_obj.kdims) == 1 and map_obj.kdims[0] == 'Frame':
         # Special handling for static plots
@@ -192,6 +192,8 @@ def get_plot_frame(map_obj, key_map, cached=False):
             return map_obj[key]
         except KeyError:
             return None
+        except StopIteration as e:
+            raise e
         except Exception:
             print(traceback.format_exc())
             return None


### PR DESCRIPTION
What is hopefully a simple fix to stop the periodic utility automatically when ``StopIteration`` is raised e.g when using a generator in a ``DynamicMap``.

I understand why you might want to skip ``KeyError`` in ``get_plot_frame`` but I don't get why it is blocking all exceptions and simply printing them. For now I am just catching ``StopIteration`` specifically and re-raising those exceptions. 

@philippjfr Why can't exceptions other than ``KeyError`` be left alone and allowed to bubble up?