### PR TITLE
BokehRenderer in server mode attaches curdoc automatically

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -110,6 +110,8 @@ class BokehRenderer(Renderer):
         combining the bokeh model with another plot.
         """
         plot = super(BokehRenderer, self_or_cls).get_plot(obj, renderer)
+        if self_or_cls.mode == 'server' and doc is None:
+            doc = curdoc()
         if doc is not None:
             plot.document = doc
         return plot

--- a/tests/testrenderclass.py
+++ b/tests/testrenderclass.py
@@ -22,6 +22,8 @@ except:
     pass
 
 try:
+    from bokeh.io import curdoc
+
     from holoviews.plotting.bokeh import BokehRenderer
     from holoviews.plotting.bokeh.util import bokeh_version
 except:
@@ -114,6 +116,11 @@ class BokehRendererTest(ComparisonTestCase):
     def test_export_widgets(self):
         bytesio = BytesIO()
         self.renderer.export_widgets(self.map1, bytesio, fmt='widgets')
+
+    def test_render_get_plot_server_doc(self):
+        renderer = self.renderer.instance(mode='server')
+        plot = renderer.get_plot(self.image1)
+        self.assertIs(plot.document, curdoc())
 
     def test_get_size_single_plot(self):
         plot = self.renderer.get_plot(self.image1)


### PR DESCRIPTION
Ensures that bokeh's curdoc is attached to the plot in server mode which is required for linked streams to communicate correctly.