### PR TITLE
Fix warning.

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -215,8 +215,8 @@ class aggregate(ResamplingOperation):
 
         for d in (x, y):
             if df[d].dtype.kind == 'M':
-                param.warning('Casting %s dimension data to integer '
-                              'datashader cannot process datetime data ')
+                param.main.warning('Casting %s dimension data to integer; '
+                                   'datashader cannot process datetime data', d)
                 df[d] = df[d].astype('int64') / 1000000.
 
         return x, y, Dataset(df, kdims=kdims, vdims=vdims), glyph


### PR DESCRIPTION
As far as I know, there's no `param.warning()`. Also there's a missing argument.

I'm not hugely familiar with param's logging since it was switched to use python's stdlib logging, so I might be wrong. Or maybe holoviews does something to make there be a `param.warning()`? When I grepped for other occurrences, I found this:

```
tests/__init__.py:        self.param_methods = {'WARNING':'param.warning()',
```

If you can explain what that's about (I can't run the tests for hv in any useful way right now...but that's another story), I could check for and fix any other occurrences of param.warning(), message(), etc.

Meanwhile, I also noticed that holoviews tends to do `parameterized_object.warning("message %s"%x)`; I just wanted to point out that param's logging allows you to avoid processing strings that will not be shown:

```
    def warning(self,msg,*args,**kw):
        """
        Print msg merged with args as a warning, [...]
```

That could in some circumstances be important, because maybe `x` is something with an expensive-to-compute repr. Probably that would never be an issue in holoviews, but thought it was worth mentioning (because the reason's not documented in param as far as I know...).
