### PR TITLE
fix for Matplotlib-2.1.0rc1

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -180,7 +180,7 @@ class MPLPlot(DimensionedPlot):
     def _subplot_label(self, axis):
         layout_num = self.layout_num if self.subplot else 1
         if self.sublabel_format and not self.adjoined and layout_num > 0:
-            from mpl_toolkits.axes_grid1.anchored_artists import AnchoredText
+            from matplotlib.offsetbox import AnchoredText
             labels = {}
             if '{Alpha}' in self.sublabel_format:
                 labels['Alpha'] = int_to_alpha(layout_num-1)


### PR DESCRIPTION
AnchoredText unused import was removed from mpl_toolkit by https://github.com/matplotlib/matplotlib/commit/efb3f5ad446c3172eaf0af3343d3cc74e37c2c79.

 fix https://github.com/ioam/holoviews/issues/1840