### PR TITLE
Added support for reverse sort of tabular data

### DIFF
--- a/examples/user_guide/07-Tabular_Datasets.ipynb
+++ b/examples/user_guide/07-Tabular_Datasets.ipynb
@@ -463,7 +463,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once data is in columnar form, it is simple to apply a variety of operations.  For instance, Dataset can be sorted by their dimensions using the ``.sort()`` method.  By default, this method will sort by the key dimensions, but any other dimension(s) can be sorted by providing them as an argument list to the sort method:"
+    "Once data is in columnar form, it is simple to apply a variety of operations.  For instance, Dataset can be sorted by their dimensions using the ``.sort()`` method.  By default, this method will sort by the key dimensions in an ascending order, but any other dimension(s) can be sorted by providing them as an argument list to the sort method. The ``reverse`` argument also allows sorting in descending order:"
    ]
   },
   {
@@ -473,7 +473,10 @@
    "outputs": [],
    "source": [
     "bars = hv.Bars((['C', 'A', 'B', 'D'], [2, 7, 3, 4]))\n",
-    "bars + bars.sort() + bars.sort(['y'])"
+    "(bars +\n",
+    " bars.sort().relabel('sorted') +\n",
+    " bars.sort(['y']).relabel('y-sorted') +\n",
+    " bars.sort(reverse=True).relabel('reverse sorted')).cols(2)"
    ]
   },
   {

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -218,14 +218,14 @@ class Dataset(Element):
         return [xs[idx] for idx in idxs]
 
 
-    def sort(self, by=[]):
+    def sort(self, by=[], reverse=False):
         """
         Sorts the data by the values along the supplied dimensions.
         """
         if not by: by = self.kdims
         if not isinstance(by, list): by = [by]
 
-        sorted_columns = self.interface.sort(self, by)
+        sorted_columns = self.interface.sort(self, by, reverse)
         return self.clone(sorted_columns)
 
 

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -98,7 +98,7 @@ class ArrayInterface(Interface):
 
 
     @classmethod
-    def sort(cls, dataset, by=[]):
+    def sort(cls, dataset, by=[], reverse=False):
         data = dataset.data
         if len(by) == 1:
             sorting = cls.values(dataset, by[0]).argsort()
@@ -107,7 +107,8 @@ class ArrayInterface(Interface):
             sort_fields = tuple(dataset.get_dimension(d).name for d in by)
             sorting = dataset.data.view(dtypes, np.recarray).T
             sorting = sorting.argsort(order=sort_fields)[0]
-        return data[sorting]
+        sorted_data = data[sorting]
+        return sorted_data[::-1] if reverse else sorted_data
 
 
     @classmethod

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -63,7 +63,7 @@ class DaskInterface(PandasInterface):
             return dd.compute(column.min(), column.max())
 
     @classmethod
-    def sort(cls, columns, by=[]):
+    def sort(cls, columns, by=[], reverse=False):
         columns.warning('Dask dataframes do not support sorting')
         return columns.data
 

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -153,14 +153,15 @@ class DictInterface(Interface):
 
 
     @classmethod
-    def sort(cls, dataset, by=[]):
+    def sort(cls, dataset, by=[], reverse=False):
         by = [dataset.get_dimension(d).name for d in by]
         if len(by) == 1:
             sorting = cls.values(dataset, by[0]).argsort()
         else:
             arrays = [dataset.dimension_values(d) for d in by]
             sorting = util.arglexsort(arrays)
-        return OrderedDict([(d, v[sorting]) for d, v in dataset.data.items()])
+        return OrderedDict([(d, v[sorting][::-1] if reverse else v[sorting])
+                            for d, v in dataset.data.items()])
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -429,7 +429,7 @@ class GridInterface(DictInterface):
 
 
     @classmethod
-    def sort(cls, dataset, by=[]):
+    def sort(cls, dataset, by=[], reverse=False):
         if not by or by in [dataset.kdims, dataset.dimensions()]:
             return dataset.data
         else:

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -259,7 +259,7 @@ class CubeInterface(GridInterface):
 
 
     @classmethod
-    def sort(cls, columns, by=[]):
+    def sort(cls, columns, by=[], reverse=False):
         """
         Cubes are assumed to be sorted by default.
         """

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -177,14 +177,14 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def sort(cls, columns, by=[]):
+    def sort(cls, columns, by=[], reverse=False):
         import pandas as pd
         cols = [columns.get_dimension(d, strict=True).name for d in by]
 
         if (not isinstance(columns.data, pd.DataFrame) or
             LooseVersion(pd.__version__) < '0.17.0'):
-            return columns.data.sort(columns=cols)
-        return columns.data.sort_values(by=cols)
+            return columns.data.sort(columns=cols, ascending=not reverse)
+        return columns.data.sort_values(by=cols, ascending=not reverse)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -220,7 +220,7 @@ class XArrayInterface(GridInterface):
         return dataset.data
 
     @classmethod
-    def sort(cls, dataset, by=[]):
+    def sort(cls, dataset, by=[], reverse=False):
         return dataset
 
     @classmethod

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -122,6 +122,13 @@ class HomogeneousColumnTypes(object):
                             kdims=['x', 'y'], vdims=['z'])
         self.assertEqual(ds.sort(), ds_sorted)
 
+    def test_dataset_sort_reverse_hm(self):
+        ds = Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0.1, 0.2, 0.3, 0.4]),
+                     kdims=['x', 'y'], vdims=['z'])
+        ds_sorted = Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0.1, 0.3, 0.2, 0.4]),
+                            kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(ds.sort(reverse=True), ds_sorted)
+
     def test_dataset_sort_vdim_hm(self):
         xs_2 = np.array(self.xs_2)
         dataset = Dataset(np.column_stack([self.xs, -xs_2]),
@@ -129,6 +136,14 @@ class HomogeneousColumnTypes(object):
         dataset_sorted = Dataset(np.column_stack([self.xs[::-1], -xs_2[::-1]]),
                                  kdims=['x'], vdims=['y'])
         self.assertEqual(dataset.sort('y'), dataset_sorted)
+
+    def test_dataset_sort_reverse_vdim_hm(self):
+        xs_2 = np.array(self.xs_2)
+        dataset = Dataset(np.column_stack([self.xs, -xs_2]),
+                          kdims=['x'], vdims=['y'])
+        dataset_sorted = Dataset(np.column_stack([self.xs, -xs_2]),
+                                 kdims=['x'], vdims=['y'])
+        self.assertEqual(dataset.sort('y', reverse=True), dataset_sorted)
 
     def test_dataset_sort_vdim_hm_alias(self):
         xs_2 = np.array(self.xs_2)
@@ -782,6 +797,9 @@ class DaskDatasetTest(DFDatasetTest):
     def test_dataset_sort_hm(self):
         raise SkipTest("Not supported")
 
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
     def test_dataset_sort_vdim_ht(self):
         raise SkipTest("Not supported")
 
@@ -1030,11 +1048,20 @@ class GridDatasetTest(GridTests, HomogeneousColumnTypes, ComparisonTestCase):
     def test_dataset_sort_hm(self):
         raise SkipTest("Not supported")
 
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
     def test_dataset_sort_vdim_hm(self):
         exception = ('Compressed format cannot be sorted, either instantiate '
                      'in the desired order or use the expanded format.')
         with self.assertRaisesRegexp(Exception, exception):
             self.dataset_hm.sort('y')
+
+    def test_dataset_sort_reverse_vdim_hm(self):
+        exception = ('Compressed format cannot be sorted, either instantiate '
+                     'in the desired order or use the expanded format.')
+        with self.assertRaisesRegexp(Exception, exception):
+            self.dataset_hm.sort('y', reverse=True)
 
     def test_dataset_sort_vdim_hm_alias(self):
         exception = ('Compressed format cannot be sorted, either instantiate '
@@ -1194,7 +1221,13 @@ class IrisDatasetTest(GridDatasetTest):
     def test_dataset_sort_hm(self):
         raise SkipTest("Not supported")
 
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
     def test_dataset_sort_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_reverse_vdim_hm(self):
         raise SkipTest("Not supported")
 
     def test_dataset_sort_vdim_hm_alias(self):
@@ -1271,10 +1304,16 @@ class XArrayDatasetTest(GridDatasetTest):
     def test_dataset_sort_hm(self):
         raise SkipTest("Not supported")
 
+    def test_dataset_sort_reverse_hm(self):
+        raise SkipTest("Not supported")
+
     def test_dataset_sort_vdim_hm_alias(self):
         raise SkipTest("Not supported")
 
     def test_dataset_sort_vdim_hm(self):
+        raise SkipTest("Not supported")
+
+    def test_dataset_sort_reverse_vdim_hm(self):
         raise SkipTest("Not supported")
 
     def test_dataset_sample_hm(self):


### PR DESCRIPTION
Add support for reverse sort to tabular interfaces as requested in https://github.com/ioam/holoviews/issues/1167. Adds a ``reverse`` argument to the ``Dataset.sort`` method, alternatively could rename it ``ascending``.