### PR TITLE
Bugs in bokeh Arrow implementation.

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -172,7 +172,7 @@ class ArrowPlot(CompositeElementPlot):
         """
         Returns a Bokeh glyph object.
         """
-        properties.pop('legend')
+        properties.pop('legend', None)
         if key == 'arrow':
             properties.pop('source')
             arrow_end = mapping.pop('arrow_end')


### PR DESCRIPTION
When the number of Arrow Elements in an NdOverlay exceeds the ``legend_limit`` this condition would generate an error.