### PR TITLE
Fixes for changes to categorical handling in bokeh 0.12.7

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -799,9 +799,10 @@ class BarPlot(ColorbarPlot, LegendPlot):
             xs = ds.dimension_values(xdim)
             ys = ds.dimension_values(ydim)
             k = k[0] if isinstance(k, tuple) else k
-            gval = k if isinstance(k, basestring) else group_dim.pprint_value(k)
-            if bokeh_version < '0.12.7':
-                gval = gval.replace(':', ';')
+            if group_dim:
+                gval = k if isinstance(k, basestring) else group_dim.pprint_value(k)
+                if bokeh_version < '0.12.7':
+                    gval = gval.replace(':', ';')
 
             # Apply stacking or grouping
             if grouping == 'stacked':

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -681,8 +681,11 @@ class BarPlot(ColorbarPlot, LegendPlot):
         element = self.current_frame
         if self.batched:
             element = element.last
-        return (dim_axis_label(element.kdims[0]),
-                dim_axis_label(element.vdims[0]), None)
+        xlabel = dim_axis_label(element.kdims[0])
+        gdim = element.get_dimension(self.group_index)
+        if bokeh_version >= '0.12.7' and gdim:
+            xlabel = ', '.join([xlabel, dim_axis_label(gdim)])
+        return (xlabel, dim_axis_label(element.vdims[0]), None)
 
     def get_group(self, xvals, nshift, ngroups, width, xdim):
         """

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -951,9 +951,13 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         if not element.kdims:
             return [element.label], []
         else:
-            factors = [', '.join([d.pprint_value(v).replace(':', ';')
-                                  for d, v in zip(element.kdims, key)])
-                       for key in element.groupby(element.kdims).data.keys()]
+            if bokeh_version < '0.12.7':
+                factors = [', '.join([d.pprint_value(v).replace(':', ';')
+                                      for d, v in zip(element.kdims, key)])
+                           for key in element.groupby(element.kdims).data.keys()]
+            else:
+                factors = [tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
+                           for key in element.groupby(element.kdims).data.keys()]
             if self.invert_axes:
                 return [], factors
             else:
@@ -998,8 +1002,11 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         for key, g in groups.items():
             # Compute group label
             if element.kdims:
-                label = ', '.join([d.pprint_value(v).replace(':', ';')
-                                   for d, v in zip(element.kdims, key)])
+                if bokeh_version < '0.12.7':
+                    label = ', '.join([d.pprint_value(v).replace(':', ';')
+                                       for d, v in zip(element.kdims, key)])
+                else:
+                    label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
             else:
                 label = key
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -614,8 +614,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         xdim, ydim = element.dimensions()[:2]
         xvals, yvals = [element.dimension_values(i, False)
                         for i in range(2)]
-        coords = ([x if xvals.dtype.kind in 'SU' else xdim.pprint_value(x).replace(':', ';') for x in xvals],
-                  [y if yvals.dtype.kind in 'SU' else ydim.pprint_value(y).replace(':', ';') for y in yvals])
+        coords = ([v if vals.dtype.kind in 'SU' else dim.pprint_value(v) for v in vals]
+                  for dim, vals in [(xdim, xvals), (ydim, yvals)])
+        if bokeh_version < '0.12.7':
+            coords = tuple([v.replace(':', ';') for v in vals] for vals in coords)
         if self.invert_axes: coords = coords[::-1]
         return coords
 


### PR DESCRIPTION
Addresses https://github.com/ioam/holoviews/issues/1839 by adding support for the new categorical handling to bokeh Bar plots.

Old Bars:

<img width="304" alt="screen shot 2017-09-04 at 2 00 35 pm" src="https://user-images.githubusercontent.com/1550771/30027581-7947862e-9179-11e7-847c-0885100009a6.png">

New Bars:

<img width="304" alt="screen shot 2017-09-04 at 2 14 29 pm" src="https://user-images.githubusercontent.com/1550771/30028056-68c1d730-917b-11e7-8d2b-63482602ff7c.png">

Old BoxWhisker:

<img width="613" alt="screen shot 2017-09-04 at 2 15 04 pm" src="https://user-images.githubusercontent.com/1550771/30028068-7aa3988a-917b-11e7-97b4-f2b705c7015d.png">

New BoxWhisker:

<img width="607" alt="screen shot 2017-09-04 at 2 12 14 pm" src="https://user-images.githubusercontent.com/1550771/30028073-8156aafa-917b-11e7-96be-7befe21125aa.png">