### PR TITLE
Added separate color_key for datashader shade to use color cycle by default

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -445,7 +445,13 @@ class shade(Operation):
     """
 
     cmap = param.ClassSelector(default=fire, class_=(Iterable, Callable, dict), doc="""
-        Iterable or callable which returns colors as hex colors.
+        Iterable or callable which returns colors as hex colors, to
+        be used for the colormap of single-layer datashader output. 
+        Callable type must allow mapping colors between 0 and 1.""")
+
+    color_key = param.ClassSelector(class_=(Iterable, Callable, dict), doc="""
+        Iterable or callable which returns colors as hex colors, to
+        be used for the color key of categorical datashader output.
         Callable type must allow mapping colors between 0 and 1.""")
 
     normalization = param.ClassSelector(default='eq_hist',
@@ -519,15 +525,15 @@ class shade(Operation):
         if element.ndims > 2:
             kdims = element.kdims[1:]
             categories = array.shape[-1]
-            if not self.p.cmap:
+            if not self.p.color_key:
                 pass
-            elif isinstance(self.p.cmap, dict):
-                shade_opts['color_key'] = self.p.cmap
-            elif isinstance(self.p.cmap, Iterable):
+            elif isinstance(self.p.color_key, dict):
+                shade_opts['color_key'] = self.p.color_key
+            elif isinstance(self.p.color_key, Iterable):
                 shade_opts['color_key'] = [c for i, c in
-                                           zip(range(categories), self.p.cmap)]
+                                           zip(range(categories), self.p.color_key)]
             else:
-                colors = [self.p.cmap(s) for s in np.linspace(0, 1, categories)]
+                colors = [self.p.color_key(s) for s in np.linspace(0, 1, categories)]
                 shade_opts['color_key'] = map(self.rgb2hex, colors)
         elif not self.p.cmap:
             pass


### PR DESCRIPTION
PR https://github.com/ioam/holoviews/pull/1697 changed the default cmap for datashader's ``shade()`` operation to "fire".  @philippjfr wanted this replace datashader's default blue ``cmap``, but it also replaced datashader's default ``color_key`` of Sets1to3, causing all categorical datashded output to be mapped to the first few colors of the fire colormap, which all look nearly identical  (as reported in #1834).  

The original behavior for categories can be restored by explicitly passing ``Sets1to3`` to ``shade.cmap`` whenever a category is used, but that's awkward and mysterious; the defaults should not be covering up categories. 

This PR adds a separate ``color_key`` parameter, defaulting to None (and thus falling through to Sets1to3), leaving ``cmap`` at the default ``fire`` value for now. 

Personally, I think ``cmap`` should not be defaulting to ``fire`` either, because ``fire`` is intended only for black backgrounds, and the Bokeh defaults consistently use white backgrounds. So I wonder whether we should remove the "fire" default?  E.g. if we set ``shade.cmap="#30a2da"``, we get behavior that is similar to the non-datashaded colors used by hv/bokeh:

![image](https://user-images.githubusercontent.com/1695496/30040131-6038b62c-91a0-11e7-806f-ac8f196f0a65.png)

It's not very pretty, but seems better than fire:

![image](https://user-images.githubusercontent.com/1695496/30040121-3d638fc8-91a0-11e7-92a0-b6253c5f8efb.png)
