### PR TITLE
Cleaned up Element range handling

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -710,6 +710,18 @@ def max_range(ranges):
         return (np.NaN, np.NaN)
 
 
+def dimension_range(lower, upper, dimension):
+    """
+    Computes the range along a dimension by combining the data range
+    with the Dimension soft_range and range.
+    """
+    lower, upper = max_range([(lower, upper), dimension.soft_range])
+    dmin, dmax = dimension.range
+    lower = lower if dmin is None or not np.isfinite(dmin) else dmin
+    upper = upper if dmax is None or not np.isfinite(dmax) else dmax
+    return lower, upper
+
+
 def max_extents(extents, zrange=False):
     """
     Computes the maximal extent in 2D and 3D space from

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -88,23 +88,19 @@ class ErrorBars(Chart):
 
 
     def range(self, dim, data_range=True):
-        drange = super(ErrorBars, self).range(dim, data_range)
         didx = self.get_dimension_index(dim)
         dim = self.get_dimension(dim)
-        if didx == 1 and data_range:
+        if didx == 1 and data_range and len(self):
             mean = self.dimension_values(1)
             neg_error = self.dimension_values(2)
-            pos_idx = 3 if len(self.dimensions()) > 3 else 2
-            pos_error = self.dimension_values(pos_idx)
+            if len(self.dimensions()) > 3:
+                pos_error = self.dimension_values(3)
+            else:
+                pos_error = neg_error
             lower = np.nanmin(mean-neg_error)
             upper = np.nanmax(mean+pos_error)
-            lower, upper = util.max_range([(lower, upper), drange])
-            dmin, dmax = dim.range
-            lower = lower if dmin is None or not np.isfinite(dmin) else dmin
-            upper = upper if dmax is None or not np.isfinite(dmax) else dmax
-            return lower, upper
-        else:
-            return drange
+            return util.dimension_range(lower, upper, dim)
+        return super(ErrorBars, self).range(dim, data_range)
 
 
 
@@ -248,11 +244,7 @@ class Histogram(Element2D):
         if self.get_dimension_index(dimension) == 0 and data_range:
             dim = self.get_dimension(dimension)
             lower, upper = np.min(self.edges), np.max(self.edges)
-            lower, upper = util.max_range([(lower, upper), dim.soft_range])
-            dmin, dmax = dim.range
-            lower = lower if dmin is None or not np.isfinite(dmin) else dmin
-            upper = upper if dmax is None or not np.isfinite(dmax) else dmax
-            return lower, upper
+            return util.dimension_range(lower, upper, dim)
         else:
             return super(Histogram, self).range(dimension, data_range)
 

--- a/tests/testannotations.py
+++ b/tests/testannotations.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from holoviews import HLine, VLine, Text, Arrow, Annotation
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Points
@@ -27,13 +29,13 @@ class AnnotationTests(ComparisonTestCase):
 
     def test_hline_dimension_values(self):
         hline = HLine(0)
-        self.assertEqual(hline.range(0), (None, None))
+        self.assertEqual(hline.range(0), (np.NaN, np.NaN))
         self.assertEqual(hline.range(1), (0, 0))
 
     def test_vline_dimension_values(self):
         hline = VLine(0)
         self.assertEqual(hline.range(0), (0, 0))
-        self.assertEqual(hline.range(1), (None, None))
+        self.assertEqual(hline.range(1), (np.NaN, np.NaN))
 
     def test_arrow_redim_range_aux(self):
         annotations = Arrow(0, 0)


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/1870, QuadMesh is currently not handling explicitly set dimension ranges. This PR adds a utility to combine the data range with the dimension ranges and uses it in various Element.range implementations.