### PR TITLE
Ensure that title_format plot option is inherited by OverlayPlot

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1277,7 +1277,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'bgcolor', 'fontsize', 'invert_axes', 'show_frame',
                           'show_grid', 'logx', 'logy', 'xticks', 'toolbar',
                           'yticks', 'xrotation', 'yrotation', 'lod',
-                          'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode']
+                          'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
+                          'title_format']
 
     def _process_legend(self):
         plot = self.handles['plot']

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -759,7 +759,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                           'show_frame', 'show_grid', 'logx', 'logy', 'logz',
                           'xticks', 'yticks', 'zticks', 'xrotation', 'yrotation'
                           'zrotation', 'invert_xaxis', 'invert_yaxis',
-                          'invert_zaxis']
+                          'invert_zaxis', 'title_format']
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:


### PR DESCRIPTION
As outlined in https://github.com/ioam/holoviews/issues/1859, the ``title_format`` plot option should be propagated upwards to the OverlayPlot so that it is not ignored when overlaying an Element.