### PR TITLE
Fixed bug regridding RGB/HSV types

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -400,8 +400,8 @@ class regrid(ResamplingOperation):
                 arrays.append(element.dimension_values(vd, flat=False))
             if len(arrays) > 1:
                 array = np.dstack(arrays).transpose([2, 0, 1])
-                coords['layer'] = range(len(arrays))
-                dims = ['layer'] + dims
+                coord_dict['temp_vdim_layer'] = range(len(arrays))
+                dims = ['temp_vdim_layer'] + dims
             else:
                 array = arrays[0]
             xarr = xr.DataArray(array, coords=coord_dict, dims=dims)
@@ -422,13 +422,13 @@ class regrid(ResamplingOperation):
                                downsample_method=self.p.aggregator)
 
         if regridded.ndim > 2:
-            regridded = xr.Dataset({vd.name: regridded[i] for i, vd in enumerate(element.vdims)})
+            regridded = xr.Dataset({vd.name: regridded[i].drop('temp_vdim_layer')
+                                    for i, vd in enumerate(element.vdims)})
         bbox = BoundingBox(points=[(xstart, ystart), (xend, yend)])
         xd = float(width) / xspan
         yd = float(height) / yspan
         return element.clone(regridded, datatype=['xarray'], bounds=bbox,
-                             new_type=self.p.element_type, xdensity=xd,
-                             ydensity=yd)
+                             xdensity=xd, ydensity=yd)
 
 
 class shade(Operation):

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -2,7 +2,7 @@ from unittest import SkipTest
 from nose.plugins.attrib import attr
 
 import numpy as np
-from holoviews import Curve, Points, Image, Dataset
+from holoviews import Curve, Points, Image, Dataset, RGB
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
@@ -73,6 +73,14 @@ class DatashaderRegridTests(ComparisonTestCase):
         img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T))
         regridded = regrid(img, width=2, height=2, dynamic=False)
         expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        self.assertEqual(regridded, expected)
+    
+    def test_regrid_rgb_mean(self):
+        arr = (np.arange(10) * np.arange(5)[np.newaxis].T).astype('f')
+        rgb = RGB((range(10), range(5), arr, arr*2, arr*2))
+        regridded = regrid(rgb, width=2, height=2, dynamic=False)
+        new_arr = np.array([[1.6, 5.6], [6.4, 22.4]])
+        expected = RGB(([2., 7.], [0.75, 3.25], new_arr, new_arr*2, new_arr*2), datatype=['xarray'])
         self.assertEqual(regridded, expected)
 
     def test_regrid_max(self):


### PR DESCRIPTION
Fixes https://github.com/ioam/holoviews/issues/1857, ensuring that RGB and HSV types can be regridded correctly.