### PR TITLE
Fix for the removal of the notebook_type argument in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -282,7 +282,7 @@ class BokehRenderer(Renderer):
         """
         Loads the bokeh notebook resources.
         """
-        kwargs = {'notebook_type': 'jupyter'} if bokeh_version > '0.12.5' else {}
+        kwargs = {'notebook_type': 'jupyter'} if '0.12.9' >= bokeh_version > '0.12.5' else {}
         load_notebook(hide_banner=True, resources=INLINE if inline else CDN, **kwargs)
         from bokeh.io import _state
         _state.output_notebook()


### PR DESCRIPTION
Tiny PR for bokeh compatibility after the removal of the ``notebook_type`` argument since bokeh 0.12.9 (i.e current bokeh dev).