### PR TITLE
Support for using bokeh protocol in the notebook including binary transfer

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -10,9 +10,7 @@ from bokeh.application import Application
 from bokeh.document import Document
 from bokeh.embed import notebook_div
 from bokeh.io import curdoc, show as bkshow
-from bokeh.io.notebook import load_notebook
 from bokeh.models import Model
-from bokeh.protocol import Protocol
 from bokeh.resources import CDN, INLINE
 from bokeh.server.server import Server
 
@@ -23,6 +21,12 @@ from ..renderer import Renderer, MIME_TYPES
 from .widgets import BokehScrubberWidget, BokehSelectionWidget, BokehServerWidgets
 from .util import (compute_static_patch, serialize_json, attach_periodic,
                    bokeh_version, compute_plot_size)
+
+if bokeh_version > '0.12.9':
+    from bokeh.io.notebook import load_notebook
+    from bokeh.protocol import Protocol
+else:
+    from bokeh.io import load_notebook
 
 
 class BokehRenderer(Renderer):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -232,9 +232,9 @@ class BokehRenderer(Renderer):
         the latest plot data.
         """
         if binary:
-            events = list(self.document._held_events)
+            events = list(plot.document._held_events)
             msg = Protocol("1.0").create("PATCH-DOC", events)
-            self.document._held_events = []
+            plot.document._held_events = []
             return msg
         else:
             plotobjects = [h for handles in plot.traverse(lambda x: x.current_handles, [lambda x: x._updated])

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -67,7 +67,7 @@ class Comm(object):
         """
 
 
-    def send(self, data):
+    def send(self, data=None, buffers=[]):
         """
         Sends data to the frontend
         """
@@ -165,13 +165,13 @@ class JupyterComm(Comm):
         return msg['content']['data']
 
 
-    def send(self, data):
+    def send(self, data=None, buffers=[]):
         """
         Pushes data across comm socket.
         """
         if not self._comm:
             self.init()
-        self.comm.send(data)
+        self.comm.send(data, buffers=buffers)
 
 
 
@@ -216,9 +216,9 @@ class JupyterCommJS(JupyterComm):
         self._comm.on_msg(self._handle_msg)
 
 
-    def send(self, data):
+    def send(self, data=None, buffers=[]):
         """
         Pushes data across comm socket.
         """
-        self.comm.send(data)
+        self.comm.send(data, buffers=buffers)
 


### PR DESCRIPTION
The https://github.com/bokeh/bokeh/pull/6945 PR adds support for sending bokeh events in the notebook using the regular bokeh protocol. This means we can now take advantage of binary transfer for arrays providing a ~5x speedup, which is particularly noticeable for images. Additionally this will allow us to dynamically add new glyphs to a plot, which means a DynamicMap will be able to return varying numbers of layers with a bit of work.

For now I've left in support for the old way of generating JSON patches and moved some small deprecated bokeh functions into holoviews, as it's not quite clear to me yet whether we can use the protocol for statically embedded data.