### PR TITLE
Bokeh protocol improvements

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1161,8 +1161,12 @@ class ColorbarPlot(ElementPlot):
 
         if 'color_mapper' in self.handles:
             cmapper = self.handles['color_mapper']
-            cmapper.palette = palette
-            cmapper.update(**opts)
+            if cmapper.palette != palette:
+                cmapper.palette = palette
+            opts = {k: opt for k, opt in opts.items()
+                    if getattr(cmapper, k) != opt}
+            if opts:
+                cmapper.update(**opts)
         else:
             cmapper = colormapper(palette=palette, **opts)
             self.handles['color_mapper'] = cmapper

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -115,6 +115,8 @@ class BokehPlot(DimensionedPlot):
 
         if bokeh_version > '0.12.9':
             msg = self.renderer.diff(self, binary=True)
+            if msg is None:
+                return
             self.comm.send(msg.header_json)
             self.comm.send(msg.metadata_json)
             self.comm.send(msg.content_json)

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -236,6 +236,8 @@ class BokehRenderer(Renderer):
         """
         if binary:
             events = list(plot.document._held_events)
+            if not events:
+                return None
             msg = Protocol("1.0").create("PATCH-DOC", events)
             plot.document._held_events = []
             return msg

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -210,8 +210,6 @@ class BokehRenderer(Renderer):
     def figure_data(self, plot, fmt='html', doc=None, **kwargs):
         model = plot.state
         doc = Document() if doc is None else doc
-        if bokeh_version > '0.12.9':
-            doc.hold()
         for m in model.references():
             m._document = None
         doc.add_root(model)
@@ -227,6 +225,7 @@ class BokehRenderer(Renderer):
             raise
         logger.disabled = False
         plot.document = doc
+        if bokeh_version > '0.12.9': doc.hold()
         return div
 
 


### PR DESCRIPTION
Three small fixes to improve event handling with bokeh protocol:

* Place hold on Document after adding root (avoid RootAdded events)
* Avoid sending updates without events entirely
* Only update colormapper if attributes have changed (avoid ModelChanged events and glyph redraws)