### PR TITLE
Datashade paths interface fix

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -677,6 +677,7 @@ class bundle_graph(Operation, hammer_bundle):
         or concatenated with NaN separators.""")
 
     def _process(self, element, key=None):
+        from datashader.bundling import hammer_bundle
         index = element.nodes.kdims[2].name
         position_df = element.nodes.dframe([0, 1, 2]).set_index(index)
         rename = {d.name: v for d, v in zip(element.kdims[:2], ['source', 'target'])}

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -174,11 +174,8 @@ class aggregate(ResamplingOperation):
         dims = obj.dimensions()[:2]
         if isinstance(obj, Path):
             glyph = 'line'
-            for p in obj.data:
-                df = pd.DataFrame(p, columns=obj.dimensions('key', True))
-                if isinstance(obj, Contours) and obj.vdims and obj.level:
-                    df[obj.vdims[0].name] = p.level
-                paths.append(df)
+            for p in obj.split():
+                paths.append(PandasInterface.as_dframe(p))
         elif isinstance(obj, CompositeOverlay):
             element = None
             for key, el in obj.data.items():

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -2,13 +2,13 @@ from unittest import SkipTest
 from nose.plugins.attrib import attr
 
 import numpy as np
-from holoviews import Curve, Points, Image, Dataset, RGB
+from holoviews import Curve, Points, Image, Dataset, RGB, Path
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
     from holoviews.operation.datashader import aggregate, regrid, ds_version
 except:
-    aggregate = None
+    ds_version = None
 
 
 @attr(optional=1)
@@ -57,6 +57,23 @@ class DatashaderAggregateTests(ComparisonTestCase):
                         width=2, height=2)
         self.assertEqual(img, expected)
 
+    def test_aggregate_path(self):
+        path = Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]])
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
+                         vdims=['Count'])
+        img = aggregate(path, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2)
+        self.assertEqual(img, expected)
+
+    def test_aggregate_dframe_nan_path(self):
+        path = Path([Path([[(0.2, 0.3), (0.4, 0.7)], [(0.4, 0.7), (0.8, 0.99)]]).dframe()])
+        expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 1]]),
+                         vdims=['Count'])
+        img = aggregate(path, dynamic=False,  x_range=(0, 1), y_range=(0, 1),
+                        width=2, height=2)
+        self.assertEqual(img, expected)
+
+
 
 
 @attr(optional=1)
@@ -66,7 +83,7 @@ class DatashaderRegridTests(ComparisonTestCase):
     """
 
     def setUp(self):
-        if ds_version <= '0.5.0':
+        if ds_version is None or ds_version <= '0.5.0':
             raise SkipTest('Regridding operations require datashader>=0.6.0')
 
     def test_regrid_mean(self):


### PR DESCRIPTION
When introducing the path interface I did not update the datashade operation. This adds that support. I also included an inline import for ``hammer_bundle`` to ensure it raises an exception when dependencies are not met.