### PR TITLE
Add support for datashader Graph layouts

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -14,14 +14,14 @@ except:
     ds_layout = None
 
 
-class graph_redim(redim):
+class redim_graph(redim):
     """
     Extension for the redim utility that allows re-dimensioning
     Graph objects including their nodes and edgepaths.
     """
 
     def __call__(self, specs=None, **dimensions):
-        redimmed = super(graph_redim, self).__call__(specs, **dimensions)
+        redimmed = super(redim_graph, self).__call__(specs, **dimensions)
         new_data = (redimmed.data,)
         if self.parent.nodes:
             new_data = new_data + (self.parent.nodes.redim(specs, **dimensions),)
@@ -46,7 +46,7 @@ class layout_nodes(Operation):
     LayoutAlgorithm function provided in datashader layouts.
     """
 
-    as_graph = param.Boolean(default=False, doc="""
+    only_nodes = param.Boolean(default=False, doc="""
         Whether to return Nodes or Graph.""")
 
     layout = param.Callable(default=None, doc="""
@@ -69,10 +69,10 @@ class layout_nodes(Operation):
                 nodes = nodes[['x', 'y', 'index']]
             else:
                 nodes = circular_layout(nodes)
-        if self.p.as_graph:
-            return element.clone((element.data, nodes))
-        return Nodes(nodes)
-
+        if self.p.only_nodes:
+            return Nodes(nodes)
+        return element.clone((element.data, nodes))
+        
 
 
 class Graph(Dataset, Element2D):
@@ -132,7 +132,7 @@ class Graph(Dataset, Element2D):
             if mismatch:
                 raise ValueError('Ensure that the first two key dimensions on '
                                  'Nodes and EdgePaths match: %s' % ', '.join(mismatch))
-        self.redim = graph_redim(self, mode='dataset')
+        self.redim = redim_graph(self, mode='dataset')
 
 
     def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
@@ -224,7 +224,7 @@ class Graph(Dataset, Element2D):
         if no explicit node information was supplied.
         """
         if self._nodes is None:
-            self._nodes = layout_nodes(self)
+            self._nodes = layout_nodes(self, only_nodes=True)
         return self._nodes
 
 


### PR DESCRIPTION
The ``layout_nodes`` operation now supports datashader LayoutAlgorithm functions and allows returning a Graph containing the newly computed node positions.