### PR TITLE
Add stack operation for compositing RGBs

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -618,6 +618,11 @@ class stack(Operation):
             coords = {kd.name: rgb.dimension_values(kd, False)
                       for kd in rgb.kdims}
             imgs.append(tf.Image(self.uint8_to_uint32(rgb), coords=coords, dims=dims))
+        try:
+            imgs = xr.align(*imgs, join='exact')
+        except ValueError:
+            raise ValueError('RGB inputs to stack operation could not be aligned, '
+                             'ensure they share the same grid sampling.')
         stacked = tf.stack(*imgs, how=self.p.compositor)
         arr = shade.uint32_to_uint8(stacked.data)[::-1]
         data = (coords[dims[1]], coords[dims[0]], arr[:, :, 0],

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -619,12 +619,12 @@ class stack(Operation):
                       for kd in rgb.kdims}
             imgs.append(tf.Image(self.uint8_to_uint32(rgb), coords=coords, dims=dims))
         stacked = tf.stack(*imgs, how=self.p.compositor)
-        arr = shade.uint32_to_uint8(stacked.data)
+        arr = shade.uint32_to_uint8(stacked.data)[::-1]
         data = (coords[dims[1]], coords[dims[0]], arr[:, :, 0],
                 arr[:, :, 1], arr[:, :, 2])
         if arr.shape[-1] == 4:
             data = data + (arr[:, :, 3],)
-        return rgb.clone(data)
+        return rgb.clone(data, datatype=[rgb.interface.datatype]+rgb.datatype)
 
 
 

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -6,7 +6,7 @@ from holoviews import Curve, Points, Image, Dataset, RGB, Path
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
-    from holoviews.operation.datashader import aggregate, regrid, ds_version
+    from holoviews.operation.datashader import aggregate, regrid, ds_version, stack
 except:
     ds_version = None
 
@@ -136,3 +136,41 @@ class DatashaderRegridTests(ComparisonTestCase):
         regridded = regrid(img, width=2, height=2, x_range=(-2, 4), y_range=(-2, 4), expand=False,
                            dynamic=False)
         self.assertEqual(regridded, img)
+
+
+
+@attr(optional=1)
+class DatashaderStackTests(ComparisonTestCase):
+
+    def setUp(self):
+        self.rgb1_arr = np.array([[[0, 1], [1, 0]],
+                                  [[1, 0], [0, 1]],
+                                  [[0, 0], [0, 0]]], dtype=np.uint8).T*255
+        self.rgb2_arr = np.array([[[0, 0], [0, 0]],
+                                  [[0, 0], [0, 0]],
+                                  [[1, 0], [0, 1]]], dtype=np.uint8).T*255
+        self.rgb1 = RGB(self.rgb1_arr)
+        self.rgb2 = RGB(self.rgb2_arr)
+
+
+    def test_stack_add_compositor(self):
+        combined = stack(self.rgb1*self.rgb2, compositor='add')
+        arr = np.array([[[0, 255, 255], [255,0, 0]], [[255, 0, 0], [0, 255, 255]]], dtype=np.uint8)
+        expected = RGB(arr)
+        self.assertEqual(combined, expected)
+
+    def test_stack_over_compositor(self):
+        combined = stack(self.rgb1*self.rgb2, compositor='over')
+        self.assertEqual(combined, self.rgb2)
+    
+    def test_stack_over_compositor_reverse(self):
+        combined = stack(self.rgb2*self.rgb1, compositor='over')
+        self.assertEqual(combined, self.rgb1)
+
+    def test_stack_saturate_compositor(self):
+        combined = stack(self.rgb1*self.rgb2, compositor='saturate')
+        self.assertEqual(combined, self.rgb1)
+
+    def test_stack_saturate_compositor_reverse(self):
+        combined = stack(self.rgb2*self.rgb1, compositor='saturate')
+        self.assertEqual(combined, self.rgb2)


### PR DESCRIPTION
Wraps around the datashader stack operation adding support for compositing multiple RGBs one of the defined compositor operations. The operation takes an Nd(Overlay) of RGBs as input and spits out a single composited RGB.