### PR TITLE
Improved stream resolution to allow collapsed (Nd)Overlays

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1062,11 +1062,13 @@ class DynamicMap(HoloMap):
         self[key] = val
 
 
-    def map(self, map_fn, specs=None, clone=True):
+    def map(self, map_fn, specs=None, clone=True, link_inputs=True):
         """
         Recursively replaces elements using a map function when the
         specification applies. Extends regular map with functionality
-        to dynamically apply functions.
+        to dynamically apply functions. By default all streams are
+        still linked to the mapped object, to disable linked streams
+        set linked_inputs=False.
         """
         deep_mapped = super(DynamicMap, self).map(map_fn, specs, clone)
         if isinstance(deep_mapped, type(self)):
@@ -1074,7 +1076,8 @@ class DynamicMap(HoloMap):
             def apply_map(obj, **dynkwargs):
                 return obj.map(map_fn, specs, clone)
             dmap = Dynamic(deep_mapped, operation=apply_map,
-                           streams=self.streams, shared_data=True)
+                           streams=self.streams, shared_data=True,
+                           link_inputs=link_inputs)
             return dmap
         return deep_mapped
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -130,10 +130,10 @@ def compute_overlayable_zorders(obj, path=[]):
     # Process the inputs of the DynamicMap callback
     dmap_inputs = obj.callback.inputs if obj.callback.link_inputs else []
     for z, inp in enumerate(dmap_inputs):
-        no_increment = False
+        no_zorder_increment = False
         if any(not (isoverlay_fn(p) or p.last is None) for p in path) and isoverlay_fn(inp):
             # If overlay has been collapsed do not increment zorder
-            no_increment = True
+            no_zorder_increment = True
 
         input_depth = overlay_depth(inp)
         if depth is not None and input_depth is not None and depth < input_depth:
@@ -142,14 +142,14 @@ def compute_overlayable_zorders(obj, path=[]):
             if depth > 1:
                 continue
             else:
-                no_increment = True
+                no_zorder_increment = True
 
         # Recurse into DynamicMap.callback.inputs and update zorder_map
         z = z if isdynoverlay else 0
         deep_zorders = compute_overlayable_zorders(inp, path=path)
         offset = max(zorder_map.keys())
         for dz, objs in deep_zorders.items():
-            global_z = offset+z if no_increment else offset+dz+z
+            global_z = offset+z if no_zorder_increment else offset+dz+z
             zorder_map[global_z] = list(unique_iterator(zorder_map[global_z]+objs))
 
     # If object branches but does not declare inputs (e.g. user defined

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -130,23 +130,26 @@ def compute_overlayable_zorders(obj, path=[]):
     # Process the inputs of the DynamicMap callback
     dmap_inputs = obj.callback.inputs if obj.callback.link_inputs else []
     for z, inp in enumerate(dmap_inputs):
+        no_increment = False
         if any(not (isoverlay_fn(p) or p.last is None) for p in path) and isoverlay_fn(inp):
-            # Skips branches of graph that collapse Overlay layers
-            # to avoid adding layers that have been reduced or removed
-            continue
+            # If overlay has been collapsed do not increment zorder
+            no_increment = True
 
         input_depth = overlay_depth(inp)
         if depth is not None and input_depth is not None and depth < input_depth:
             # Skips branch of graph where the number of elements in an
-            # overlay has been reduced
-            continue
+            # overlay has been reduced but still contains more than one layer
+            if depth > 1:
+                continue
+            else:
+                no_increment = True
 
         # Recurse into DynamicMap.callback.inputs and update zorder_map
         z = z if isdynoverlay else 0
         deep_zorders = compute_overlayable_zorders(inp, path=path)
         offset = max(zorder_map.keys())
         for dz, objs in deep_zorders.items():
-            global_z = offset+dz+z
+            global_z = offset+z if no_increment else offset+dz+z
             zorder_map[global_z] = list(unique_iterator(zorder_map[global_z]+objs))
 
     # If object branches but does not declare inputs (e.g. user defined

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -250,8 +250,10 @@ class TestPlotUtils(ComparisonTestCase):
         combined1[()]
         sources = compute_overlayable_zorders(combined1)
 
-        self.assertNotIn(curve_redim, sources[0])
-        self.assertNotIn(curve, sources[0])
+        self.assertIn(curve_redim, sources[0])
+        self.assertIn(curve, sources[0])
+        self.assertIn(area_redim, sources[0])
+        self.assertIn(area, sources[0])
         self.assertNotIn(curve2_redim, sources[0])
         self.assertNotIn(curve2, sources[0])
 


### PR DESCRIPTION
The code that resolves which plot to attach a linked stream to previously gave up when some part of the graph reduces an (Nd)Overlay by one or more layers since it cannot easily determine which layers were dropped. However in the case of operations that collapse multiple input layers into a single layer, e.g. the new datashader stack operation which combines multiple RGBs into one, there is no ambiguity since information from all the input layers persists. This means that an operation like this:

```python
stream = [RangeXY()]
stack(datashade(points1, streams=[stream]) * datashade(points2, streams=[stream]))
```

now correctly resolves the linked stream and therefore responds to zoom events. In order to provide more flexibility I've also exposed the ``link_inputs`` argument on the ``DynamicMap.map`` method in case linking is not desired.

Here's an example:

![collapse_streams](https://user-images.githubusercontent.com/1550771/30772508-c76f6d8c-a054-11e7-912c-33526c2beed6.gif)

```
   Points              Points
     |                   |
 datashade           datashade
     |                   |
    RGB ----- * ------- RGB
              |
           Overlay          <-- Previously gave up resolving streams here
              |      ^
            stack    |
              |      |  Direction of resolution
             RGB     |
```