### PR TITLE
Switched to Whisker and Band glyphs for ErrorBars and Spread

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -145,7 +145,7 @@ options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
 options.Bars = Options('style', color=Cycle(), line_color='black', width=0.8)
 
 options.Spikes = Options('style', color='black', cmap='fire')
-options.Area = Options('style', color=Cycle(), line_color='black')
+options.Area = Options('style', color=Cycle(), alpha=1, line_color='black')
 options.VectorField = Options('style', color='black')
 
 # Paths

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -300,36 +300,6 @@ class CurvePlot(ElementPlot):
         return data, mapping
 
 
-class AreaPlot(PolygonPlot):
-
-    def get_extents(self, element, ranges):
-        vdims = element.vdims
-        vdim = vdims[0].name
-        if len(vdims) > 1:
-            ranges[vdim] = max_range([ranges[vd.name] for vd in vdims])
-        else:
-            vdim = vdims[0].name
-            ranges[vdim] = (np.nanmin([0, ranges[vdim][0]]), ranges[vdim][1])
-        return super(AreaPlot, self).get_extents(element, ranges)
-
-    def get_data(self, element, ranges=None, empty=False):
-        mapping = dict(self._mapping)
-        if empty: return {'xs': [], 'ys': []}
-        xs = element.dimension_values(0)
-        x2 = np.hstack((xs[::-1], xs))
-
-        if len(element.vdims) > 1:
-            bottom = element.dimension_values(2)
-        else:
-            bottom = np.zeros(len(element))
-        ys = np.hstack((bottom[::-1], element.dimension_values(1)))
-
-        if self.invert_axes:
-            data = dict(xs=[ys], ys=[x2])
-        else:
-            data = dict(xs=[x2], ys=[ys])
-        return data, mapping
-
 
 class HistogramPlot(ElementPlot):
 
@@ -430,6 +400,7 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
         return ret
 
 
+
 class ErrorPlot(ElementPlot):
 
     style_opts = line_properties
@@ -485,6 +456,36 @@ class SpreadPlot(ErrorPlot):
 
     style_opts = line_properties + fill_properties
     _plot_methods = dict(single=Band)
+
+
+
+class AreaPlot(SpreadPlot):
+
+    def get_extents(self, element, ranges):
+        vdims = element.vdims
+        vdim = vdims[0].name
+        if len(vdims) > 1:
+            ranges[vdim] = max_range([ranges[vd.name] for vd in vdims])
+        else:
+            vdim = vdims[0].name
+            ranges[vdim] = (np.nanmin([0, ranges[vdim][0]]), ranges[vdim][1])
+        return super(AreaPlot, self).get_extents(element, ranges)
+
+    def get_data(self, element, ranges=None, empty=False):
+        xs = element.dimension_values(0)
+        if len(element.vdims) > 1:
+            lower = element.dimension_values(2)
+        else:
+            lower = np.zeros(len(element))
+        upper = element.dimension_values(1)
+        data = dict(base=xs, upper=upper, lower=lower)
+
+        mapping = dict(self._mapping)
+        if self.invert_axes:
+            mapping['dimension'] = 'width'
+        else:
+            mapping['dimension'] = 'height'
+        return data, mapping
 
 
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1142,8 +1142,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(x_range.factors, ['A', 'B', 'C', 'D', 'E'])
         self.assertIsInstance(y_range, Range1d)
         error_plot = plot.subplots[('ErrorBars', 'I')]
-        for xs, factor in zip(error_plot.handles['source'].data['xs'], factors):
-            self.assertEqual([factor, factor], xs)
+        for xs, factor in zip(error_plot.handles['source'].data['base'], factors):
+            self.assertEqual(factor, xs)
 
     def test_points_errorbars_text_ndoverlay_categorical_xaxis_invert_axes(self):
         overlay = NdOverlay({i: Points(([chr(65+i)]*10,np.random.randn(10)))


### PR DESCRIPTION
Bokeh introduced glyphs for errorbars and confidence bands a while ago, which both look better and are more efficient than the ``multi_line`` and ``patches`` implementation we were using previously. Since the categorical overhaul this is also the only way these elements will work with categorical axes.

Fixes: https://github.com/ioam/holoviews/issues/1893

Old ErrorBars:

<img width="306" alt="screen shot 2017-09-23 at 3 54 35 pm" src="https://user-images.githubusercontent.com/1550771/30774247-8f4f7708-a077-11e7-91b3-12a5a267f2b0.png">

New ErrorBars (note the addition of whiskers):

<img width="306" alt="screen shot 2017-09-23 at 3 54 46 pm" src="https://user-images.githubusercontent.com/1550771/30774248-8f69ebe2-a077-11e7-882d-3bd9b194cc23.png">

Old Spread:

<img width="306" alt="screen shot 2017-09-23 at 3 56 10 pm" src="https://user-images.githubusercontent.com/1550771/30774262-c36aebf8-a077-11e7-8e00-f570053283ae.png">

New Spread (note the lack of border lines one left and right):

<img width="300" alt="screen shot 2017-09-23 at 3 55 42 pm" src="https://user-images.githubusercontent.com/1550771/30774266-cc0d2c08-a077-11e7-9104-462b8acdd222.png">
