### PR TITLE
Fixed adjoined overlay

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -201,7 +201,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 self._set_axis_limits(axis, element, subplots, ranges)
 
             # Apply aspects
-            if self.aspect is not None and self.projection != 'polar':
+            if self.aspect is not None and self.projection != 'polar' and not self.adjoined:
                 self._set_aspect(axis, self.aspect)
 
         if not subplots and not self.drawn:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -913,7 +913,7 @@ class GenericOverlayPlot(GenericElementPlot):
                             ranges=ranges, show_title=self.show_title,
                             style=style, uniform=self.uniform,
                             renderer=self.renderer, stream_sources=stream_sources,
-                            zorder=zorder, **passed_handles)
+                            zorder=zorder, adjoined=self.adjoined, **passed_handles)
 
             if not isinstance(key, tuple): key = (key,)
             subplots[key] = plottype(vmap, **plotopts)


### PR DESCRIPTION
Fix for https://github.com/ioam/holoviews/pull/1663, overlaid adjoined histograms now handled correctly:

![image](https://user-images.githubusercontent.com/1550771/30775562-f62cef62-a08d-11e7-91da-00adf60dd349.png)
