### PR TITLE
Handle invert_axes for all Element types

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -42,7 +42,6 @@ class TextPlot(ElementPlot):
         data['text'] = [element.text]
         return (data, mapping)
 
-
     def get_batched_data(self, element, ranges=None):
         data = defaultdict(list)
         for key, el in element.data.items():
@@ -50,7 +49,6 @@ class TextPlot(ElementPlot):
             for k, eld in eldata.items():
                 data[k].extend(eld)
         return data, elmapping
-
 
     def get_extents(self, element, ranges=None):
         return None, None, None, None
@@ -100,7 +98,10 @@ class SplinePlot(ElementPlot):
     _plot_methods = dict(single='bezier')
 
     def get_data(self, element, ranges=None):
-        data_attrs = ['x0', 'y0', 'cx0', 'cy0', 'cx1', 'cy1', 'x1', 'y1',]
+        if self.invert_axes:
+            data_attrs = ['y0', 'x0', 'cy0', 'cx0', 'cy1', 'cx1', 'y1', 'x1']
+        else:
+            data_attrs = ['x0', 'y0', 'cx0', 'cy0', 'cx1', 'cy1', 'x1', 'y1']
         verts = np.array(element.data[0])
         inds = np.where(np.array(element.data[1])==1)[0]
         data = {da: [] for da in data_attrs}

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -190,8 +190,12 @@ class VectorFieldPlot(ColorbarPlot):
         input_scale = style.pop('scale', 1.0)
 
         # Get x, y, angle, magnitude and color data
-        xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         rads = element.dimension_values(2)
+        if self.invert_axes:
+            xidx, yidx = (1, 0)
+            rads = rads+1.5*np.pi
+        else:
+            xidx, yidx = (0, 1)
         lens = self._get_lengths(element, ranges)/input_scale
         cdim = element.get_dimension(self.color_index)
         cdata, cmapping = self._get_color_data(element, ranges, style,
@@ -537,6 +541,9 @@ class SpikesPlot(PathPlot, ColorbarPlot):
                 frame = self.current_frame or self.hmap.last 
                 for el in frame.values():
                     opts = self.lookup_options(el, 'plot').options
+                frame = self.current_frame or self.hmap.last
+                for el in frame.values():
+                    opts = self.lookup_options(element, 'plot').options
                     pos = opts.get('position', self.position)
                     length = opts.get('spike_length', self.spike_length)
                     bs.append(pos)
@@ -1001,7 +1008,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         Get factors for categorical axes.
         """
         if not element.kdims:
-            return [element.label], []
+            xfactors, yfactors =  [element.label], []
         else:
             if bokeh_version < '0.12.7':
                 factors = [', '.join([d.pprint_value(v).replace(':', ';')
@@ -1011,10 +1018,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                 factors = [tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
                            for key in element.groupby(element.kdims).data.keys()]
                 factors = [f[0] if len(f) == 1 else f for f in factors]
-            if self.invert_axes:
-                return [], factors
-            else:
-                return factors, []
+            xfactors, yfactors = factors, []
+        return (yfactors, xfactors) if self.invert_axes else (xfactors, yfactors)
 
     def get_data(self, element, ranges=None):
         if element.kdims:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -541,9 +541,6 @@ class SpikesPlot(PathPlot, ColorbarPlot):
                 frame = self.current_frame or self.hmap.last 
                 for el in frame.values():
                     opts = self.lookup_options(el, 'plot').options
-                frame = self.current_frame or self.hmap.last
-                for el in frame.values():
-                    opts = self.lookup_options(element, 'plot').options
                     pos = opts.get('position', self.position)
                     length = opts.get('spike_length', self.spike_length)
                     bs.append(pos)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -33,6 +33,7 @@ class RasterPlot(ColorbarPlot):
 
         if isinstance(element, Image):
             l, b, r, t = element.bounds.lbrt()
+            if self.invert_yaxis: img = img[::-1]
         else:
             img = img.T[::-1] if self.invert_yaxis else img.T
             l, b, r, t = element.extents
@@ -43,15 +44,13 @@ class RasterPlot(ColorbarPlot):
             img = img[:, ::-1]
         if self.invert_yaxis:
             b, t = t, b
-            if type(element) is not Raster:
-                img = img[::-1]
         dh, dw = t-b, r-l
 
         if self.invert_axes:
             dh, dw, l, b = dw, dh, b, l
             if self.invert_yaxis: l = t
             if self.invert_yaxis: b = r
-            img = np.rot90(img)
+            img = img.T[::-1, ::-1]
 
         data = dict(image=[img], x=[l], y=[b], dw=[dw], dh=[dh])
         return (data, mapping)
@@ -193,7 +192,7 @@ class QuadMeshPlot(ColorbarPlot):
         widths = np.diff(element.data[0])
         heights = np.diff(element.data[1])
         if self.invert_axes:
-            zvals = zdata.flatten()
+            zvals = zdata[::-1, ::-1].flatten()
             xvals, yvals, widths, heights = yvals, xvals, heights, widths
         else:
             zvals = zdata.T.flatten()

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -45,7 +45,10 @@ class VLinePlot(AnnotationPlot):
     style_opts = ['alpha', 'color', 'linewidth', 'linestyle', 'visible']
 
     def draw_annotation(self, axis, position, opts):
-        return [axis.axvline(position, **opts)]
+        if self.invert_axes:
+            return [axis.axhline(position, **opts)]
+        else:
+            return [axis.axvline(position, **opts)]
 
 
 
@@ -56,7 +59,10 @@ class HLinePlot(AnnotationPlot):
 
     def draw_annotation(self, axis, position, opts):
         "Draw a horizontal line on the axis"
-        return [axis.axhline(position, **opts)]
+        if self.invert_axes:
+            return [axis.axvline(position, **opts)]
+        else:
+            return [axis.axhline(position, **opts)]
 
 
 class TextPlot(AnnotationPlot):
@@ -67,6 +73,7 @@ class TextPlot(AnnotationPlot):
     def draw_annotation(self, axis, data, opts):
         (x,y, text, fontsize,
          horizontalalignment, verticalalignment, rotation) = data
+        if self.invert_axes: x, y = y, x
         opts['fontsize'] = fontsize
         return [axis.text(x,y, text,
                           horizontalalignment = horizontalalignment,
@@ -85,6 +92,7 @@ class ArrowPlot(AnnotationPlot):
 
     def draw_annotation(self, axis, data, opts):
         x, y, text, direction, points, arrowstyle = data
+        if self.invert_axes: x, y = y, x
         direction = direction.lower()
         arrowprops = dict({'arrowstyle':arrowstyle},
                           **{k: opts[k] for k in self._arrow_style_opts if k in opts})

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -632,7 +632,7 @@ class VectorFieldPlot(ColorbarPlot):
         xs = element.dimension_values(xidx) if len(element.data) else []
         ys = element.dimension_values(yidx) if len(element.data) else []
         radians = element.dimension_values(2) if len(element.data) else []
-        if self.invert_axes: radians = radians+np.pi/2.
+        if self.invert_axes: radians = radians+1.5*np.pi
         angles = list(np.rad2deg(radians)) 
         if self.rescale_lengths:
             input_scale = input_scale / self._min_dist

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -632,7 +632,8 @@ class VectorFieldPlot(ColorbarPlot):
         xs = element.dimension_values(xidx) if len(element.data) else []
         ys = element.dimension_values(yidx) if len(element.data) else []
         radians = element.dimension_values(2) if len(element.data) else []
-        angles = list(np.rad2deg(radians))
+        if self.invert_axes: radians = radians+np.pi/2.
+        angles = list(np.rad2deg(radians)) 
         if self.rescale_lengths:
             input_scale = input_scale / self._min_dist
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -342,22 +342,27 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             if self.invert_xaxis or any(p.invert_xaxis for p in subplots):
                 r, l = l, r
             if l != r:
+                lims = {}
                 if valid_lim(l):
-                    axis.set_xlim(left=l)
+                    lims['left'] = l
                     scalex = False
                 if valid_lim(r):
-                    axis.set_xlim(right=r)
+                    lims['right'] = r
                     scalex = False
-
+                if lims:
+                    axis.set_xlim(**lims)
             if self.invert_yaxis or any(p.invert_yaxis for p in subplots):
                 t, b = b, t
             if b != t:
+                lims = {}
                 if valid_lim(b):
-                    axis.set_ylim(bottom=b)
+                    lims['bottom'] = b
                     scaley = False
                 if valid_lim(t):
-                    axis.set_ylim(top=t)
+                    lims['top'] = t
                     scaley = False
+                if lims:
+                    axis.set_ylim(**lims)
         axis.autoscale_view(scalex=scalex, scaley=scaley)
 
 

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -57,18 +57,20 @@ class RasterPlot(ColorbarPlot):
         if isinstance(element, RGB):
             style.pop('cmap', None)
 
+        data = get_raster_array(element)
         if type(element) is Raster:
             l, b, r, t = element.extents
-            if self.invert_yaxis:
-                b, t = t, b
+            if self.invert_axes:
+                data = data[:, ::-1]
+            else:
+                data = data[::-1]
         else:
             l, b, r, t = element.bounds.lbrt()
 
-        data = get_raster_array(element)
         if self.invert_axes:
-            data = data[::-1]
             data = data.transpose([1, 0, 2]) if isinstance(element, RGB) else data.T
             l, b, r, t = b, l, t, r
+
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)
         style['extent'] = [l, r, b, t]
@@ -222,7 +224,7 @@ class QuadMeshPlot(ColorbarPlot):
         coords = list(element.data[:2])
         if self.invert_axes:
             coords = coords[::-1]
-            data = data.T
+            data = data.T[::-1, ::-1]
         cmesh_data = coords + [data]
         style['locs'] = np.concatenate(element.data[:2])
         vdim = element.vdims[0]

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -118,15 +118,14 @@ class HeatMapPlot(RasterPlot):
     def _annotate_values(self, element):
         val_dim = element.vdims[0]
         vals = element.dimension_values(2, flat=False)
-        if not self.invert_axes:
-            vals = vals.T
-        
-        if self.invert_xaxis: vals = vals[::-1]
-        if self.invert_yaxis: vals = vals[:, ::-1]
-        vals = vals.flatten()
         d1uniq, d2uniq = [element.dimension_values(i, False) for i in range(2)]
         if self.invert_axes:
             d1uniq, d2uniq = d2uniq, d1uniq
+        else:
+            vals = vals.T
+        if self.invert_xaxis: vals = vals[::-1]
+        if self.invert_yaxis: vals = vals[:, ::-1]
+        vals = vals.flatten()
         num_x, num_y = len(d1uniq), len(d2uniq)
         xpos = np.linspace(0.5, num_x-0.5, num_x)
         ypos = np.linspace(0.5, num_y-0.5, num_y)
@@ -169,9 +168,9 @@ class HeatMapPlot(RasterPlot):
 
         data = np.flipud(element.gridded.dimension_values(2, flat=False))
         data = np.ma.array(data, mask=np.logical_not(np.isfinite(data)))
+        if self.invert_axes: data = data.T[::-1, ::-1]
         if self.invert_xaxis: data = data[:, ::-1]
         if self.invert_yaxis: data = data[::-1]
-        if self.invert_axes: data = data.T[::-1, ::-1]
         shape = data.shape
         style['aspect'] = shape[0]/shape[1]
         style['extent'] = (0, shape[1], 0, shape[0])
@@ -237,7 +236,7 @@ class QuadMeshPlot(ColorbarPlot):
         coords = list(element.data[:2])
         if self.invert_axes:
             coords = coords[::-1]
-            data = data.T[::-1, ::-1]
+            data = data.T
         cmesh_data = coords + [data]
         style['locs'] = np.concatenate(element.data[:2])
         vdim = element.vdims[0]

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1224,7 +1224,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         raster = Image(arr).opts(plot=dict(invert_axes=True))
         plot = bokeh_renderer.get_plot(raster)
         source = plot.handles['source']
-        self.assertEqual(source.data['image'][0], np.rot90(arr))
+        self.assertEqual(source.data['image'][0], np.rot90(arr)[::-1, ::-1])
         self.assertEqual(source.data['x'][0], -.5)
         self.assertEqual(source.data['y'][0], -.5)
         self.assertEqual(source.data['dw'][0], 1)
@@ -1238,6 +1238,16 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False)[::-1, ::-1].flatten())
         self.assertEqual(source.data['x'], qmesh.dimension_values(0))
         self.assertEqual(source.data['y'], qmesh.dimension_values(1))
+
+    def test_heatmap_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        hm = HeatMap(Image(arr)).opts(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(hm)
+        xdim, ydim = hm.kdims
+        source = plot.handles['source']
+        self.assertEqual(source.data['zvalues'], hm.dimension_values(2, flat=False).T.flatten())
+        self.assertEqual(source.data['x'], [xdim.pprint_value(v) for v in hm.dimension_values(0)])
+        self.assertEqual(source.data['y'], [ydim.pprint_value(v) for v in hm.dimension_values(1)])
 
     def test_box_whisker_datetime(self):
         times = np.arange(dt.datetime(2017,1,1), dt.datetime(2017,2,1),

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -315,6 +315,38 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
             self.assertEqual(artist.get_array(), np.array([j]))
             self.assertEqual(artist.get_clim(), (0, 4))
 
+    def test_raster_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        raster = Raster(arr).opts(plot=dict(invert_axes=True))
+        plot = mpl_renderer.get_plot(raster)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array().data, arr.T[::-1])
+        self.assertEqual(artist.get_extent(), [0, 2, 0, 3])
+
+    def test_image_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        raster = Image(arr).opts(plot=dict(invert_axes=True))
+        plot = mpl_renderer.get_plot(raster)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array().data, arr.T[::-1, ::-1])
+        self.assertEqual(artist.get_extent(), [-0.5, 0.5, -0.5, 0.5])
+
+    def test_quadmesh_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True))
+        plot = mpl_renderer.get_plot(qmesh)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array().data, arr.T[:, ::-1].flatten())
+
+    def test_heatmap_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        hm = HeatMap(Image(arr)).opts(plot=dict(invert_axes=True))
+        plot = mpl_renderer.get_plot(hm)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array().data, arr.T[::-1, ::-1])
+        self.assertEqual(artist.get_extent(), (0, 2, 0, 3))
+
+
 
 
 class TestBokehPlotInstantiation(ComparisonTestCase):
@@ -1216,8 +1248,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(source.data['image'][0], np.rot90(arr))
         self.assertEqual(source.data['x'][0], 0)
         self.assertEqual(source.data['y'][0], 3)
-        self.assertEqual(source.data['dw'][0], -2)
-        self.assertEqual(source.data['dh'][0], 3)
+        self.assertEqual(source.data['dw'][0], 2)
+        self.assertEqual(source.data['dh'][0], -3)
 
     def test_image_invert_axes(self):
         arr = np.array([[0, 1, 2], [3, 4,  5]])
@@ -1235,7 +1267,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True))
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
-        self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False)[::-1, ::-1].flatten())
+        self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False).flatten())
         self.assertEqual(source.data['x'], qmesh.dimension_values(0))
         self.assertEqual(source.data['y'], qmesh.dimension_values(1))
 

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -19,7 +19,7 @@ from holoviews.core.util import pd
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
                                Scatter3D, Path, Polygons, Bars, Text,
-                               BoxWhisker, HLine, RGB)
+                               BoxWhisker, HLine, RGB, Raster)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import Stream, PointerXY, PointerX
 from holoviews.operation import gridmatrix
@@ -1207,6 +1207,37 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         span = plot.handles['glyph']
         self.assertEqual(span.dimension, 'height')
         self.assertEqual(span.location, 1.1)
+
+    def test_raster_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        raster = Raster(arr).opts(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(raster)
+        source = plot.handles['source']
+        self.assertEqual(source.data['image'][0], np.rot90(arr))
+        self.assertEqual(source.data['x'][0], 0)
+        self.assertEqual(source.data['y'][0], 3)
+        self.assertEqual(source.data['dw'][0], -2)
+        self.assertEqual(source.data['dh'][0], 3)
+
+    def test_image_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        raster = Image(arr).opts(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(raster)
+        source = plot.handles['source']
+        self.assertEqual(source.data['image'][0], np.rot90(arr))
+        self.assertEqual(source.data['x'][0], -.5)
+        self.assertEqual(source.data['y'][0], -.5)
+        self.assertEqual(source.data['dw'][0], 1)
+        self.assertEqual(source.data['dh'][0], 1)
+
+    def test_quadmesh_invert_axes(self):
+        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True))
+        plot = bokeh_renderer.get_plot(qmesh)
+        source = plot.handles['source']
+        self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False)[::-1, ::-1].flatten())
+        self.assertEqual(source.data['x'], qmesh.dimension_values(0))
+        self.assertEqual(source.data['y'], qmesh.dimension_values(1))
 
     def test_box_whisker_datetime(self):
         times = np.arange(dt.datetime(2017,1,1), dt.datetime(2017,2,1),


### PR DESCRIPTION
We never implemented ``invert_axes`` for all Element types. This code does that ensuring that any plot can now be adjoined.

Fixes: 

* https://github.com/ioam/holoviews/issues/1033
* https://github.com/ioam/holoviews/issues/780
* https://github.com/ioam/holoviews/issues/358