### PR TITLE
Removed prepending of param to syspath

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -3,10 +3,6 @@ from __future__ import print_function, absolute_import
 import os, sys, pydoc
 
 import numpy as np # noqa (API import)
-
-_cwd = os.path.abspath(os.path.split(__file__)[0])
-sys.path.insert(0, os.path.join(_cwd, '..', 'param'))
-
 import param
 
 __version__ = param.Version(release=(1,8,4), fpath=__file__,


### PR DESCRIPTION
I think this must be leftover from some time ago, unless you can think of a reason this should still be here @jlstevens. May also fix https://github.com/ioam/holoviews/issues/1920.