### PR TITLE
Disable shared axes when +axiswise

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -318,7 +318,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         plot_ranges = {}
         # Try finding shared ranges in other plots in the same Layout
-        if plots and self.shared_axes:
+        norm_opts = self.lookup_options(el, 'norm').options
+        if plots and self.shared_axes and not norm_opts.get('axiswise', False):
             plot_ranges = self._merge_ranges(plots, xlabel, ylabel)
 
         if el.get_dimension_type(0) in util.datetime_types:


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/issues/1906, setting axiswise=True should force shared axes to be disabled.