### PR TITLE
Updated BoxWhisker in Bokeh to have Tukey-style whisker bounds.

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1024,8 +1024,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             vals = g.dimension_values(g.vdims[0])
             qmin, q1, q2, q3, qmax = (np.percentile(vals, q=q) for q in range(0,125,25))
             iqr = q3 - q1
-            upper = q3 + 1.5*iqr
-            lower = q1 - 1.5*iqr
+            upper = min(q3 + 1.5*iqr, vals.max())
+            lower = max(q1 - 1.5*iqr, vals.min())
             outliers = vals[(vals>upper) | (vals<lower)]
 
             # Add to CDS data


### PR DESCRIPTION
The Bokeh version of BoxWhisker currently uses the following definitions:

- Top of box: 75th percentile
- Bottom of box: 25th percentile
- Middle of box: 50th percentile (median)
- Bottom whisker: 25th percentile, minus 1.5 times the interquartile region (75th - 25th percentile)
- Top whisker: 75th percentile, plus 1.5 times the interquartile region
- Outliers: Anything that is 1.5 IQRs away from top or bottom of box

While the definitions for the box and the outliers is pretty standard (and definitely what I would choose), I have never seen that definition of the whisker. Rather, the "most standard" definition is what [Tukey proposed](https://en.wikipedia.org/wiki/Box_plot).

- Bottom whisker: The larger of:  (25th percentile minus 1.5 times the IQR, smallest data point)
- Top whisker: The smaller of:  (75th percentile plus 1.5 times the IQR, largest data point)

In fact, this is what we get using `hv.BoxWhisker` with Matplotlib and Plotly renderers. So, I think it is a bug in the Bokeh version. This PR fixes that bug.

This is also relevant for #1838.