### PR TITLE
Fix for Graph edge hover labels

### DIFF
--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -59,7 +59,9 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
         if self.inspection_policy == 'nodes':
             dims = element.nodes.dimensions()[2:]
         elif self.inspection_policy == 'edges':
-            dims = element.kdims+element.vdims
+            kdims = [(kd.pprint_label, '@{%s}' % ref)
+                     for kd, ref in zip(element.kdims, ['start', 'end'])]
+            dims = kdims+element.vdims
         else:
             dims = []
         return dims, {}

--- a/tests/testbokehgraphs.py
+++ b/tests/testbokehgraphs.py
@@ -84,6 +84,15 @@ class BokehGraphPlotTests(ComparisonTestCase):
         self.assertEqual(hover.tooltips, [('start', '@{start}'), ('end', '@{end}')])
         self.assertIn(renderer, hover.renderers)
 
+    def test_graph_inspection_policy_edges_non_default_names(self):
+        graph = self.graph.redim(start='source', end='target')
+        plot = bokeh_renderer.get_plot(graph.opts(plot=dict(inspection_policy='edges')))
+        renderer = plot.handles['glyph_renderer']
+        hover = plot.handles['hover']
+        self.assertIsInstance(renderer.inspection_policy, EdgesAndLinkedNodes)
+        self.assertEqual(hover.tooltips, [('source', '@{start}'), ('target', '@{end}')])
+        self.assertIn(renderer, hover.renderers)
+
     def test_graph_inspection_policy_none(self):
         plot = bokeh_renderer.get_plot(self.graph.opts(plot=dict(inspection_policy=None)))
         renderer = plot.handles['glyph_renderer']


### PR DESCRIPTION
Fixes bug where it would not find hover info because edge start/end points in datasource is always start/end while Graph.kdims can be any names.