### PR TITLE
Added Reset stream

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -7,7 +7,7 @@ from ...core import OrderedDict
 from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         RangeY, PointerX, PointerY, BoundsX, BoundsY,
                         Tap, SingleTap, DoubleTap, MouseEnter, MouseLeave,
-                        PlotSize, Draw, BoundsXY)
+                        PlotSize, Draw, BoundsXY, PlotReset)
 from ...streams import PositionX, PositionY, PositionXY, Bounds # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS, Comm
 from .util import convert_timestamp
@@ -807,6 +807,18 @@ class Selection1DCallback(Callback):
             return {}
 
 
+class ResetCallback(Callback):
+    """
+    Signals the Reset stream if an event has been triggered.
+    """
+
+    models = ['plot']
+    on_events = ['reset']
+
+    def _process_msg(self, msg):
+        return {'reset': True}
+
+
 callbacks = Stream._callbacks['bokeh']
 
 callbacks[PointerXY]   = PointerXYCallback
@@ -821,12 +833,13 @@ callbacks[RangeXY]     = RangeXYCallback
 callbacks[RangeX]      = RangeXCallback
 callbacks[RangeY]      = RangeYCallback
 callbacks[Bounds]      = BoundsCallback
-callbacks[BoundsXY]     = BoundsCallback
+callbacks[BoundsXY]    = BoundsCallback
 callbacks[BoundsX]     = BoundsXCallback
 callbacks[BoundsY]     = BoundsYCallback
 callbacks[Selection1D] = Selection1DCallback
 callbacks[PlotSize]    = PlotSizeCallback
-callbacks[Draw] = DrawCallback
+callbacks[Draw]        = DrawCallback
+callbacks[PlotReset]   = ResetCallback
 
 # Aliases for deprecated streams
 callbacks[PositionXY]  = PointerXYCallback

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -590,6 +590,18 @@ class Selection1D(LinkedStream):
         Indices into a 1D datastructure.""")
 
 
+class PlotReset(LinkedStream):
+    """
+    A stream signalling when a plot reset event has been triggered.
+    """
+
+    reset = param.Boolean(default=False, constant=True, doc="""
+        Whether a reset event is being signalled.""")
+
+    def __init__(self, *args, **params):
+        super(PlotReset, self).__init__(self, *args, **dict(params, transient=True))
+
+
 class ParamValues(Stream):
     """
     A Stream based on the parameter values of some other parameterized
@@ -652,3 +664,4 @@ class PositionXY(PointerXY):
     def __init__(self, **params):
         self.warning('PositionXY stream deprecated: use PointerXY instead')
         super(PositionXY, self).__init__(**params)
+


### PR DESCRIPTION
A Reset stream triggered when the reset tool has been hit in bokeh can be quite useful to reset selections and other custom interactive behavior. 