### PR TITLE
Added support for updating and replacing axis properties

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -537,10 +537,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         props = {axis: self._axis_properties(axis, key, plot, dim)
                  for axis, dim in zip(['x', 'y'], dimensions)}
         xlabel, ylabel, zlabel = self._get_axis_labels(dimensions)
-        if self.invert_axes:
-            xlabel, ylabel = ylabel, xlabel
+        if self.invert_axes: xlabel, ylabel = ylabel, xlabel
         props['x']['axis_label'] = xlabel
-        props['y']['axis_label'] = xlabel
+        props['y']['axis_label'] = ylabel
         recursive_model_update(plot.xaxis[0], props.get('x', {}))
         recursive_model_update(plot.yaxis[0], props.get('y', {}))
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -656,6 +656,27 @@ def filter_batched_data(data, mapping):
             pass
 
 
+def recursive_model_update(model, props):
+    """
+    Recursively updates attributes on a model including other
+    models. If the type of the new model matches the old model
+    properties are simply updated, otherwise the model is replaced.
+    """
+    updates = {}
+    valid_properties = model.properties_with_values()
+    for k, v in props.items():
+        if isinstance(v, Model):
+            nested_model = getattr(model, k)
+            if type(v) is type(nested_model):
+                nested_props = v.properties_with_values(include_defaults=False)
+                recursive_model_update(nested_model, nested_props)
+            else:
+                setattr(model, k, v)
+        elif k in valid_properties and v != valid_properties[k]:
+            updates[k] = v
+    model.update(**updates)
+
+
 def update_shared_sources(f):
     """
     Context manager to ensures data sources shared between multiple


### PR DESCRIPTION
As I was investigating getting the MercatorTicker working in GeoViews I realized that the code that handles updating of axis properties never correctly handled updating of ticker and formatter models. I have now added a utility which handles recursive updates to bokeh models, preventing unnecessary updates and even handling cases where the model is being replaced (which we now allow in live and dynamic modes as well as on the server). Once I've figured out whether we can use the new bokeh protocol to embed data we may eventually be able to switch out models at will and use this update function everywhere, e.g. to replace a linear axis with a log or categorical axis on the fly.

Turns out this was also the reason why I had to filter ticker and formatter model updates from the static json patches before, allowing me to simplify that now.