### PR TITLE
Various Graph improvements

### DIFF
--- a/examples/user_guide/Network_Graphs.ipynb
+++ b/examples/user_guide/Network_Graphs.ipynb
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To select just nodes in 'circle15', get a list of the indices of the nodes in that circle and then select by the edge start (aka source) and end (aka target) points:"
+    "To select just nodes that are in 'circle15' set the ``selection_mode='nodes'`` overriding the default of 'edges':"
    ]
   },
   {
@@ -367,8 +367,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nodes = list(bundled.nodes.select(circle='circle15')['index'])\n",
-    "bundled.select(start=nodes, end=nodes)"
+    "bundled.select(circle='circle15', selection_mode='nodes')"
    ]
   }
  ],

--- a/examples/user_guide/Network_Graphs.ipynb
+++ b/examples/user_guide/Network_Graphs.ipynb
@@ -340,7 +340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively we can select the nodes and edges by an attribute that resides on either. In this case we will select the nodes and edges for a particular circle and then overlay just the selected part of the graph on the datashaded plot. In this way a smaller subgraph can be highlighted and the larger graph can be datashaded."
+    "Alternatively we can select the nodes and edges by an attribute that resides on either. In this case we will select the nodes and edges for a particular circle and then overlay just the selected part of the graph on the datashaded plot. Note that selections on the ``Graph`` itself will select all nodes that connect to one of the selected nodes. In this way a smaller subgraph can be highlighted and the larger graph can be datashaded."
    ]
   },
   {
@@ -350,8 +350,25 @@
    "outputs": [],
    "source": [
     "%%opts Graph (node_fill_color='white')\n",
-    "datashade(bundle_graph(fb_graph, split=False), normalization='linear', width=800, height=800) *\\\n",
+    "datashade(bundle_graph(fb_graph), normalization='linear', width=800, height=800) *\\\n",
     "bundled.select(circle='circle15')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To select just nodes in 'circle15', get a list of the indices of the nodes in that circle and then select by the edge start (aka source) and end (aka target) points:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes = list(bundled.nodes.select(circle='circle15')['index'])\n",
+    "bundled.select(start=nodes, end=nodes)"
    ]
   }
  ],

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -576,7 +576,7 @@ class Comparison(ComparisonInterface):
         cls.compare_dataset(el1, el2, msg)
         cls.compare_nodes(el1.nodes, el2.nodes, msg)
         if el1._edgepaths or el2._edgepaths:
-            cls.compare_edgepaths(el1.nodes, el2.nodes, msg)
+            cls.compare_edgepaths(el1.edgepaths, el2.edgepaths, msg)
 
     @classmethod
     def compare_nodes(cls, el1, el2, msg='Nodes'):

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -1,3 +1,5 @@
+from types import FunctionType
+
 import param
 import numpy as np
 
@@ -54,8 +56,8 @@ class layout_nodes(Operation):
         A NetworkX layout function""")
 
     def _process(self, element, key=None):
-        if self.p.layout and not (ds_layout and (isinstance(self.p.layout, ds_layout) or
-                                                 issubclass(self.p.layout, ds_layout))):
+        if self.p.layout and isinstance(self.p.layout, FunctionType):
+            import networkx as nx
             graph = nx.from_edgelist(element.array([0, 1]))
             positions = self.p.layout(graph)
             nodes = [tuple(pos)+(idx,) for idx, pos in sorted(positions.items())]

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -153,9 +153,9 @@ class Graph(Dataset, Element2D):
                     npaths += 1
                 mismatch = npaths != nedges
             if mismatch:
-                raise ValueError('Ensure that the number of edges supplied to '
-                                 'the Graph matches the number of edgepaths: '
-                                 'expected %d, found %d' % (nedges, npaths))
+                raise ValueError('Ensure that the number of edges supplied '
+                                 'to the Graph (%d) matches the number of '
+                                 'edgepaths (%d)' % (nedges, npaths))
 
 
     def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -46,6 +46,24 @@ def compute_edges(edges):
     return np.concatenate([edges, [edges[-1]+width]])
 
 
+def split_path(path):
+    """
+    Split a Path type containing a single NaN separated path into
+    multiple subpaths.
+    """
+    path = path.split()[0]
+    values = path.dimension_values(0)
+    splits = np.concatenate([[0], np.where(np.isnan(values))[0]+1, [0]])
+    subpaths = []
+    data = PandasInterface.as_dframe(path) if pd else path.array()
+    for i in range(len(splits)-1):
+        slc = slice(splits[i], splits[i+1]-1)
+        subpath = data.iloc[slc] if pd else data[slc]
+        if len(subpath):
+            subpaths.append(subpath)
+    return subpaths
+
+
 def compute_slice_bounds(slices, scs, shape):
     """
     Given a 2D selection consisting of slices/coordinates, a

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -24,7 +24,7 @@ from .element import OverlayPlot, ElementPlot
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
                     AreaPlot, VectorFieldPlot, BoxWhiskerPlot)
-from .graphs import GraphPlot
+from .graphs import GraphPlot, NodePlot
 from .path import PathPlot, PolygonPlot, ContourPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
 from .raster import RasterPlot, RGBPlot, HeatMapPlot, HSVPlot, QuadMeshPlot
@@ -85,7 +85,7 @@ associations = {Overlay: OverlayPlot,
 
                 # Graph Elements
                 Graph: GraphPlot,
-                Nodes: PointPlot,
+                Nodes: NodePlot,
                 EdgePaths: PathPlot,
 
                 # Tabular

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -11,7 +11,7 @@ except:
 
 from ...core.options import abbreviated_exception, SkipRendering
 from ...core.util import basestring, dimension_sanitizer
-from .chart import ColorbarPlot
+from .chart import ColorbarPlot, PointPlot
 from .element import CompositeElementPlot, line_properties, fill_properties, property_prefixes
 from .util import mpl_to_bokeh, bokeh_version
 
@@ -192,4 +192,13 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
         self.handles['multi_line_1_glyph'] = renderer.edge_renderer.glyph
         if 'hover' in self.handles:
             self.handles['hover'].renderers.append(renderer)
+
+
+class NodePlot(PointPlot):
+    """
+    Simple subclass of PointPlot which hides x, y position on hover.
+    """
+
+    def _hover_opts(self, element):
+        return element.dimensions()[2:], {}
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -116,7 +116,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
             end = np.array([node_indices.get(y, nan_node) for y in end], dtype=np.int32)
         path_data = dict(start=start, end=end)
         if element._edgepaths:
-            edges = element.edgepaths.split()
+            edges = element._split_edgepaths.split()
             if len(edges) == len(start):
                 path_data['xs'] = [path.dimension_values(xidx) for path in edges]
                 path_data['ys'] = [path.dimension_values(yidx) for path in edges]

--- a/tests/testgraphelement.py
+++ b/tests/testgraphelement.py
@@ -38,10 +38,15 @@ class GraphTests(ComparisonTestCase):
         with self.assertRaisesRegexp(ValueError, exception):
             graph = Graph(((self.source, self.target), self.nodes, paths.redim(x='x2')))
 
-    def test_select_by_node(self):
+    def test_select_by_node_in_edges_selection_mode(self):
         graph = Graph(((self.source, self.target),))
         selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes))[0:3]))
         self.assertEqual(graph.select(index=(1, 3)), selection) 
+
+    def test_select_by_node_in_nodes_selection_mode(self):
+        graph = Graph(((self.source, self.source+1), self.nodes))
+        selection = Graph(([(1, 2)], list(zip(*self.nodes))[1:3]))
+        self.assertEqual(graph.select(index=(1, 3), selection_mode='nodes'), selection)
 
     def test_select_by_source(self):
         graph = Graph(((self.source, self.target),))

--- a/tests/testgraphelement.py
+++ b/tests/testgraphelement.py
@@ -40,8 +40,8 @@ class GraphTests(ComparisonTestCase):
 
     def test_select_by_node(self):
         graph = Graph(((self.source, self.target),))
-        selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes))[:2]))
-        self.assertEqual(graph.select(index=(0, 2)), selection) 
+        selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes))[0:3]))
+        self.assertEqual(graph.select(index=(1, 3)), selection) 
 
     def test_select_by_source(self):
         graph = Graph(((self.source, self.target),))
@@ -52,6 +52,11 @@ class GraphTests(ComparisonTestCase):
         graph = Graph(((self.source, self.target),))
         selection = Graph(([(0,0), (1, 0)], list(zip(*self.nodes))[:2]))
         self.assertEqual(graph.select(start=(0, 2)), selection)
+
+    def test_select_by_source_and_target(self):
+        graph = Graph(((self.source, self.source+1), self.nodes))
+        selection = Graph(([(0,1)], list(zip(*self.nodes))[:2]))
+        self.assertEqual(graph.select(start=(0, 3), end=1), selection)
 
     def test_select_by_edge_data(self):
         graph = Graph(((self.target, self.source, self.edge_info),), vdims=['info'])


### PR DESCRIPTION
This PR includes a number of fixes and improvements for Graphs:

* The EdgePaths on a Graph may now be split (e.g. a separate array/dataframe for each edge) or nan separated (as is most efficient for datashading). Unlike before both are validated to have the correct number of edges.
* Applying selections and plotting with bokeh are now both allowed when nan separated data is used.
* Selection on a Graph selects all edges that connect to one of the selected nodes (and keeps both the selected nodes and the nodes that they connect to) by default. If you want to select only edges between the selected subset of nodes you can use ``selection_mode='nodes'``. This is much more useful behavior to select an important subgraph and provides more flexibility.
* Added a ``directly_connect_edges`` operation (based on datashader), which is much faster than the automatic behavior (and not split by default).
* Hide x, y location of nodes on hover