### PR TITLE
Bokeh optimizations

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -30,9 +30,9 @@ class TextPlot(ElementPlot):
             props['text_color'] = props.pop('color')
         return props
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         mapping = dict(x='x', y='y', text='text')
-        if empty:
+        if self.static_source:
             return dict(x=[], y=[], text=[]), mapping
         if self.invert_axes:
             data = dict(x=[element.y], y=[element.x])
@@ -43,10 +43,10 @@ class TextPlot(ElementPlot):
         return (data, mapping)
 
 
-    def get_batched_data(self, element, ranges=None, empty=False):
+    def get_batched_data(self, element, ranges=None):
         data = defaultdict(list)
         for key, el in element.data.items():
-            eldata, elmapping = self.get_data(el, ranges, empty)
+            eldata, elmapping = self.get_data(el, ranges)
             for k, eld in eldata.items():
                 data[k].extend(eld)
         return data, elmapping
@@ -65,7 +65,7 @@ class LineAnnotationPlot(ElementPlot):
 
     _plot_methods = dict(single='Span')
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         data, mapping = {}, {}
         dim = 'width' if isinstance(element, HLine) else 'height'
         if self.invert_axes:
@@ -99,7 +99,7 @@ class SplinePlot(ElementPlot):
     style_opts = line_properties
     _plot_methods = dict(single='bezier')
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         data_attrs = ['x0', 'y0', 'cx0', 'cy0', 'cx1', 'cy1', 'x1', 'y1',]
         verts = np.array(element.data[0])
         inds = np.where(np.array(element.data[1])==1)[0]
@@ -130,7 +130,7 @@ class ArrowPlot(CompositeElementPlot):
 
     _plot_methods = dict(single='text')
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         plot = self.state
         label_mapping = dict(x='x', y='y', text='text')
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -951,6 +951,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         current_frames = [el for f in self.traverse(lambda x: x.current_frame)
                           for el in (f.traverse(lambda x: x, [Element])
                                      if f else [])]
+        current_frames = util.unique_iterator(current_frames)
         return any(self.lookup_options(frame, 'norm').options.get('framewise')
                    for frame in current_frames)
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -84,7 +84,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
         xlabel, ylabel = [kd.pprint_label for kd in element.nodes.kdims[:2]]
         return xlabel, ylabel, None
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         style = self.style[self.cyclic_index]
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
 
@@ -115,7 +115,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
             start = np.array([node_indices.get(x, nan_node) for x in start], dtype=np.int32)
             end = np.array([node_indices.get(y, nan_node) for y in end], dtype=np.int32)
         path_data = dict(start=start, end=end)
-        if element._edgepaths:
+        if element._edgepaths and not self.static_source:
             edges = element._split_edgepaths.split()
             if len(edges) == len(start):
                 path_data['xs'] = [path.dimension_values(xidx) for path in edges]
@@ -150,7 +150,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
 
     def _init_glyphs(self, plot, element, ranges, source):
         # Get data and initialize data source
-        data, mapping = self.get_data(element, ranges, False)
+        data, mapping = self.get_data(element, ranges)
         self.handles['previous_id'] = element._plot_id
         properties = {}
         mappings = {}

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -87,13 +87,14 @@ class PathPlot(ElementPlot):
                 data[k].extend(eld)
 
             # Apply static styles
-            nvals = len(list(eldata.values())[0])
-            style = styles[zorder]
-            sdata, smapping = expand_batched_style(style, self._batched_style_opts,
-                                                   elmapping, nvals)
-            elmapping.update({k: v for k, v in smapping.items() if k not in elmapping})
-            for k, v in sdata.items():
-                data[k].extend(list(v))
+            if eldata:
+                nvals = len(list(eldata.values())[0])
+                style = styles[zorder]
+                sdata, smapping = expand_batched_style(style, self._batched_style_opts,
+                                                       elmapping, nvals)
+                elmapping.update({k: v for k, v in smapping.items() if k not in elmapping})
+                for k, v in sdata.items():
+                    data[k].extend(list(v))
 
         return data, elmapping
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -94,7 +94,7 @@ class BokehPlot(DimensionedPlot):
         self.root = None
 
 
-    def get_data(self, element, ranges=None, empty=False):
+    def get_data(self, element, ranges=None):
         """
         Returns the data from an element in the appropriate format for
         initializing or updating a ColumnDataSource and a dictionary


### PR DESCRIPTION
This PR is meant to provide various optimizations for the bokeh backend. In particular we have the static data optimization in the bokeh backend preventing the data source from being updated and sent to the frontend. However since styling options may still change, the get_data method still has to be executed to modify color mappers and other style-data mappings. However certain data columns are guaranteed to never change and therefore can be skipped. This can provide significant improvements particularly for large paths, and geoviews geometries.