### PR TITLE
Avoid seaborn API import warning

### DIFF
--- a/holoviews/plotting/mpl/seaborn.py
+++ b/holoviews/plotting/mpl/seaborn.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import matplotlib.pyplot as plt
 
 try:
-    import seaborn.apionly as sns
+    import seaborn as sns
 except:
     sns = None
 


### PR DESCRIPTION
Since seaborn 0.8.0 the apionly import is the default and trying to ``import seaborn.apionly as sns`` raises a deprecation warning.