### PR TITLE
Improvements for ndloc and sampling

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -194,6 +194,44 @@ class XArrayInterface(GridInterface):
 
 
     @classmethod
+    def ndloc(cls, dataset, indices):
+        kdims = [d.name for d in dataset.kdims[::-1]]
+        adjusted_indices = []
+        for kd, ind in zip(kdims, indices):
+            coords = cls.coords(dataset, kd, False)
+            ncoords = len(coords)
+            if np.all(coords[1:] < coords[:-1]):
+                if np.isscalar(ind):
+                    ind = ncoords-ind-1 
+                elif isinstance(ind, slice):
+                    start = None if ind.stop is None else ncoords-ind.stop
+                    stop = None if ind.start is None else ncoords-ind.start
+                    ind = slice(start, stop, ind.step)
+                elif isinstance(ind, np.ndarray) and ind.dtype.kind == 'b':
+                    ind = ind[::-1]
+                elif isinstance(ind, (np.ndarray, list)):
+                    ind = [ncoords-i-1 for i in ind]
+            if isinstance(ind, list):
+                ind = np.array(ind)
+            if isinstance(ind, np.ndarray) and ind.dtype.kind == 'b':
+                ind = np.where(ind)[0]
+            adjusted_indices.append(ind)
+
+        isel = dict(zip(kdims, adjusted_indices))
+        all_scalar = all(map(np.isscalar, indices))
+        if all_scalar and len(dataset.vdims) == 1:
+            return dataset.data[dataset.vdims[0].name].isel(**isel).values.item()
+
+        # Detect if the indexing is selecting samples or slicing the array
+        sampled = (all(isinstance(ind, np.ndarray) and ind.dtype.kind != 'b'
+                       for ind in adjusted_indices) and len(indices) == len(kdims))
+        if sampled:
+            return dataset.data.isel_points(**isel).to_dataframe().reset_index()
+        else:
+            return dataset.data.isel(**isel)
+
+
+    @classmethod
     def concat(cls, dataset_objs):
         #cast_objs = cls.cast(dataset_objs)
         # Reimplement concat to automatically add dimensions

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -361,6 +361,14 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         xs, ys = zip(*samples)
         yidx, xidx = self.sheet2matrixidx(np.array(xs), np.array(ys))
         yidx = shape[0]-yidx-1
+
+        # Detect out-of-bounds indices
+        out_of_bounds= (yidx<0) | (xidx<0) | (yidx>=shape[0]) | (xidx>=shape[1])
+        if out_of_bounds.any():
+            coords = [samples[idx] for idx in np.where(out_of_bounds)[0]]
+            raise IndexError('Coordinate(s) %s out of bounds for %s with bounds %s' %
+                             (coords, type(self).__name__, self.bounds.lbrt()))
+
         data = self.interface.ndloc(self, (yidx, xidx))
         return self.clone(data, new_type=Table, datatype=['dataframe', 'dict'])
 

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -918,6 +918,24 @@ class GridTests(object):
         ds = Dataset((xs, ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
         self.assertEqual(ds.ndloc[0,0], arr[0, 0])
 
+    def test_dataset_ndloc_index_inverted_x(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[0,0], arr[0, 9])
+
+    def test_dataset_ndloc_index_inverted_y(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs, ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[0,0], arr[4, 0])
+
+    def test_dataset_ndloc_index_inverted_xy(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[0,0], arr[4, 9])
+
     def test_dataset_ndloc_index2(self):
         xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
         arr = np.arange(10)*np.arange(5)[np.newaxis].T
@@ -932,11 +950,59 @@ class GridTests(object):
                          datatype=[self.datatype])
         self.assertEqual(ds.ndloc[1:, 2:5], sliced)
 
+    def test_dataset_ndloc_slice_inverted_x(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        sliced = Dataset((xs[::-1][5:8], ys[1:], arr[1:, 5:8]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[1:, 2:5], sliced)
+
+    def test_dataset_ndloc_slice_inverted_y(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs, ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        sliced = Dataset((xs[2:5], ys[::-1][:-1], arr[:-1, 2:5]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[1:, 2:5], sliced)
+
+    def test_dataset_ndloc_slice_inverted_xy(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype])
+        sliced = Dataset((xs[::-1][5:8], ys[::-1][:-1], arr[:-1, 5:8]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=[self.datatype])
+        self.assertEqual(ds.ndloc[1:, 2:5], sliced)
+
     def test_dataset_ndloc_lists(self):
         xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
         arr = np.arange(10)*np.arange(5)[np.newaxis].T
         ds = Dataset((xs, ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype, 'dictionary'])
         sliced = Dataset((xs[[1, 2, 3]], ys[[0, 1, 2]], arr[[0, 1, 2], [1, 2, 3]]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=['dictionary'])
+        self.assertEqual(ds.ndloc[[0, 1, 2], [1, 2, 3]], sliced)
+
+    def test_dataset_ndloc_lists_invert_x(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys, arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype, 'dictionary'])
+        sliced = Dataset((xs[::-1][[8, 7, 6]], ys[[0, 1, 2]], arr[[0, 1, 2], [8, 7, 6]]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=['dictionary'])
+        self.assertEqual(ds.ndloc[[0, 1, 2], [1, 2, 3]], sliced)
+
+    def test_dataset_ndloc_lists_invert_y(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs, ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype, 'dictionary'])
+        sliced = Dataset((xs[[1, 2, 3]], ys[::-1][[4, 3, 2]], arr[[4, 3, 2], [1, 2, 3]]), kdims=['x', 'y'], vdims=['z'],
+                         datatype=['dictionary'])
+        self.assertEqual(ds.ndloc[[0, 1, 2], [1, 2, 3]], sliced)
+
+    def test_dataset_ndloc_lists_invert_xy(self):
+        xs, ys = np.linspace(0.12, 0.81, 10), np.linspace(0.12, 0.391, 5)
+        arr = np.arange(10)*np.arange(5)[np.newaxis].T
+        ds = Dataset((xs[::-1], ys[::-1], arr), kdims=['x', 'y'], vdims=['z'], datatype=[self.datatype, 'dictionary'])
+        sliced = Dataset((xs[::-1][[8, 7, 6]], ys[::-1][[4, 3, 2]], arr[[4, 3, 2], [8, 7, 6]]), kdims=['x', 'y'], vdims=['z'],
                          datatype=['dictionary'])
         self.assertEqual(ds.ndloc[[0, 1, 2], [1, 2, 3]], sliced)
 


### PR DESCRIPTION
A while ago we added ``ndloc`` as a means to provide array like integer indexing for gridded Datasets. This has worked out well overall and this PR simply builds on top of that. In particular this PR adds an out-of-bounds IndexError when sampling outside the Image bounds. Secondly it adds an xarray ndloc implementation, which should be more efficient than the generic implementation that we currently have, ensure that the datatype doesn't change when sampling and selecting and also ensure that any xarray variables that are not referenced by HoloViews aren't dropped after a slicing operation. Also added a number of additional unit tests ensuring that the implementations behave identically.