### PR TITLE
Fix static source optimization on Graph Element

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -166,6 +166,7 @@ class Graph(Dataset, Element2D):
             data = (self.data, self.nodes)
             if self._edgepaths:
                 data = data + (self.edgepaths,)
+            overrides['plot_id'] = self._plot_id
         elif not isinstance(data, tuple):
             data = (data, self.nodes)
             if self._edgepaths:

--- a/tests/testgraphelement.py
+++ b/tests/testgraphelement.py
@@ -38,6 +38,9 @@ class GraphTests(ComparisonTestCase):
         with self.assertRaisesRegexp(ValueError, exception):
             graph = Graph(((self.source, self.target), self.nodes, paths.redim(x='x2')))
 
+    def test_graph_clone_static_plot_id(self):
+        self.assertEqual(self.graph.clone()._plot_id, self.graph._plot_id)
+
     def test_select_by_node_in_edges_selection_mode(self):
         graph = Graph(((self.source, self.target),))
         selection = Graph(([(1, 0), (2, 0)], list(zip(*self.nodes))[0:3]))


### PR DESCRIPTION
The Graph.clone method was not retaining the ``_plot_id`` which is what the static source optimization uses resulting in data being sent unnecessarily.