### PR TITLE
Made HLine.dimension_values API consistent

### DIFF
--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -105,7 +105,7 @@ class HLine(Annotation):
     def __init__(self, y, **params):
         super(HLine, self).__init__(y, y=y, **params)
 
-    def dimension_values(self, dimension):
+    def dimension_values(self, dimension, expanded=True, flat=True):
         index = self.get_dimension_index(dimension)
         if index == 0:
             return np.array([])


### PR DESCRIPTION
The ``HLine.dimension_values`` method does not support the canonical arguments breaking under certain conditions. Fixes https://github.com/ioam/holoviews/issues/1828.