### PR TITLE
Ensure Renderer.html works with comms msg_handler

### DIFF
--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -276,6 +276,8 @@ class Renderer(Exporter):
         html = tag.format(src=src, mime_type=mime_type, css=css)
         if comm and plot.comm is not None:
             comm, msg_handler = self.comms[self.mode]
+            if msg_handler is None:
+                return html
             msg_handler = msg_handler.format(comm_id=plot.comm.id)
             return comm.template.format(init_frame=html,
                                         msg_handler=msg_handler,


### PR DESCRIPTION
The ``Renderer.html`` method tries to add a ``msg_handler`` to dynamic plots. In some cases none is provided in which case it shouldn't error, this skips adding the ``msg_handler`` when none is provided. Fixes #1735 and #1897.