### PR TITLE
Handle Bars with log axes

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -670,8 +670,10 @@ class BarPlot(ColorbarPlot, LegendPlot):
         # Set y-baseline
         if y0 < 0:
             y1 = max([y1, 0])
+        elif self.logy:
+            y0 = (ydim.range[0] or (10**(np.log10(y1)-2)) if y1 else 0.01)
         else:
-            y0 = None if self.logy else 0
+            y0 = 0
 
         # Ensure x-axis is picked up as categorical
         x0 = xdim.pprint_value(extents[0])
@@ -801,6 +803,11 @@ class BarPlot(ColorbarPlot, LegendPlot):
                                       container_type=OrderedDict,
                                       datatype=['dataframe', 'dictionary'])
 
+        y0, y1 = ranges.get(ydim.name, (None, None))
+        if self.logy:
+            bottom = (ydim.range[0] or (10**(np.log10(y1)-2)) if y1 else 0.01)
+        else:
+            bottom = 0
         # Map attributes to data
         if grouping == 'stacked':
             mapping = {'x': xdim.name, 'top': 'top',
@@ -810,10 +817,10 @@ class BarPlot(ColorbarPlot, LegendPlot):
                 gwidth = width / float(len(grouped))
             else:
                 gwidth = width
-            mapping = {'x': 'xoffsets', 'top': ydim.name, 'bottom': 0,
+            mapping = {'x': 'xoffsets', 'top': ydim.name, 'bottom': bottom,
                        'width': gwidth}
         else:
-            mapping = {'x': xdim.name, 'top': ydim.name, 'bottom': 0, 'width': width}
+            mapping = {'x': xdim.name, 'top': ydim.name, 'bottom': bottom, 'width': width}
 
         # Get colors
         cdim = color_dim or group_dim
@@ -836,7 +843,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
 
         # Iterate over stacks and groups and accumulate data
         data = defaultdict(list)
-        baselines = defaultdict(lambda: {'positive': 0, 'negative': 0})
+        baselines = defaultdict(lambda: {'positive': bottom, 'negative': 0})
         for i, (k, ds) in enumerate(grouped.items()):
             k = k[0] if isinstance(k, tuple) else k
             if group_dim:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -582,8 +582,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if shared:
                 shared = (axis_range.start, axis_range.end)
                 low, high = util.max_range([(low, high), shared])
-            if log and low <= 0:
-                low = 0.01 if high < 0.01 else 10**(np.log10(high)-1)
+            if log and (low is None or low <= 0):
+                low = 0.01 if high < 0.01 else 10**(np.log10(high)-2)
                 self.warning("Logarithmic axis range encountered value less than or equal to zero, "
                              "please supply explicit lower-bound to override default of %.3f." % low)
             if low is not None and (isinstance(low, util.datetime_types)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -953,6 +953,32 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(source.data['top'], np.array([0, 1, 2]))
         self.assertEqual(source.data['bottom'], np.array([-1, 0, 0]))
 
+    def test_bars_logy(self):
+        bars = Bars([('A', 1), ('B', 2), ('C', 3)],
+                    kdims=['Index'], vdims=['Value'])
+        plot = bokeh_renderer.get_plot(bars.opts(plot=dict(logy=True)))
+        source = plot.handles['source']
+        glyph = plot.handles['glyph']
+        y_range = plot.handles['y_range']
+        self.assertEqual(list(source.data['Index']), ['A', 'B', 'C'])
+        self.assertEqual(source.data['Value'], np.array([1, 2, 3]))
+        self.assertEqual(glyph.bottom, 10**(np.log10(3)-2))
+        self.assertEqual(y_range.start, 10**(np.log10(3)-2))
+        self.assertEqual(y_range.end, 3.)
+
+    def test_bars_logy_explicit_range(self):
+        bars = Bars([('A', 1), ('B', 2), ('C', 3)],
+                    kdims=['Index'], vdims=['Value']).redim.range(Value=(0.001, 3))
+        plot = bokeh_renderer.get_plot(bars.opts(plot=dict(logy=True)))
+        source = plot.handles['source']
+        glyph = plot.handles['glyph']
+        y_range = plot.handles['y_range']
+        self.assertEqual(list(source.data['Index']), ['A', 'B', 'C'])
+        self.assertEqual(source.data['Value'], np.array([1, 2, 3]))
+        self.assertEqual(glyph.bottom, 0.001)
+        self.assertEqual(y_range.start, 0.001)
+        self.assertEqual(y_range.end, 3.)
+
     def test_points_no_single_item_legend(self):
         points = Points([('A', 1), ('B', 2)], label='A')
         plot = bokeh_renderer.get_plot(points)


### PR DESCRIPTION
Handling logarithmic bar plots is a special case because Bars usually start at zero, which bokeh does not allow. This PR uses the same code that we usually use to display logarithmic plots in bokeh, which will provide a warning that it automatically computed a logy lower bound and the user should override it. 

Fixes: https://github.com/ioam/holoviews/issues/1780