### PR TITLE
Enable situate_axes in matplotlib for consistency

### DIFF
--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -22,7 +22,7 @@ class RasterPlot(ColorbarPlot):
     colorbar = param.Boolean(default=False, doc="""
         Whether to add a colorbar to the plot.""")
 
-    situate_axes = param.Boolean(default=False, doc="""
+    situate_axes = param.Boolean(default=True, doc="""
         Whether to situate the image relative to other plots. """)
 
     style_opts = ['alpha', 'cmap', 'interpolation', 'visible',


### PR DESCRIPTION
Very early on when implementing holoviews we added a ``situate_axes`` option which disables axis normalization for Raster and Image types in matplotlib. This pops up as a user question fairly frequently since it is inconsistent behavior.

Fixes: https://github.com/ioam/holoviews/issues/692