### PR TITLE
Handle zero-sized array reductions

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -111,12 +111,17 @@ class ResamplingOperation(Operation):
                     x0, x1 = self.p.x_range
                     ex0, ex1 = element.range(x)
                     x_range = max([x0, ex0]), min([x1, ex1])
+                if x_range[0] == x_range[1]:
+                    x_range = (x_range[0]-0.5, x_range[0]+0.5)
+                    
                 if self.p.expand or not self.p.y_range:
                     y_range = self.p.y_range or element.range(y)
                 else:
                     y0, y1 = self.p.y_range
                     ey0, ey1 = element.range(y)
                     y_range = max([y0, ey0]), min([y1, ey1])
+                if y_range[0] == y_range[1]:
+                    y_range = (y_range[0]-0.5, y_range[0]+0.5)
             width, height = self.p.width, self.p.height
         (xstart, xend), (ystart, yend) = x_range, y_range
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -120,10 +120,20 @@ class ResamplingOperation(Operation):
                     y0, y1 = self.p.y_range
                     ey0, ey1 = element.range(y)
                     y_range = max([y0, ey0]), min([y1, ey1])
-                if y_range[0] == y_range[1]:
-                    y_range = (y_range[0]-0.5, y_range[0]+0.5)
             width, height = self.p.width, self.p.height
         (xstart, xend), (ystart, yend) = x_range, y_range
+
+        if not np.isfinite(xstart) and not np.isfinite(xend):
+            xstart, xend = 0, 1
+        elif xstart == xend:
+            xstart, xend = (xstart-0.5, xend+0.5)
+        x_range = (xstart, xend)
+
+        if not np.isfinite(ystart) and not np.isfinite(yend):
+            ystart, yend = 0, 1
+        elif ystart == yend:
+            ystart, yend = (ystart-0.5, yend+0.5)
+        y_range = (ystart, yend)
 
         # Compute highest allowed sampling density
         xspan = xend - xstart
@@ -135,6 +145,7 @@ class ResamplingOperation(Operation):
         xunit, yunit = float(xspan)/width, float(yspan)/height
         xs, ys = (np.linspace(xstart+xunit/2., xend-xunit/2., width),
                   np.linspace(ystart+yunit/2., yend-yunit/2., height))
+
         return (x_range, y_range), (xs, ys), (width, height)
 
 

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -520,8 +520,11 @@ class histogram(Operation):
                 weights = weights[mask]
         else:
             weights = None
-        hist_range = find_minmax((np.nanmin(data), np.nanmax(data)), (0, -float('inf')))\
-            if self.p.bin_range is None else self.p.bin_range
+        try:
+            hist_range = find_minmax((np.nanmin(data), np.nanmax(data)), (0, -float('inf')))\
+                         if self.p.bin_range is None else self.p.bin_range
+        except ValueError:
+            hist_range = (0, 1)
 
         # Avoids range issues including zero bin range and empty bins
         if hist_range == (0, 0):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -681,7 +681,10 @@ class ColorbarPlot(ElementPlot):
         # Check whether the colorbar should indicate clipping
         values = np.asarray(element.dimension_values(vdim))
         if values.dtype.kind not in 'OSUM':
-            el_min, el_max = np.nanmin(values), np.nanmax(values)
+            try:
+                el_min, el_max = np.nanmin(values), np.nanmax(values)
+            except ValueError:
+                el_min, el_max = -np.inf, np.inf
         else:
             el_min, el_max = -np.inf, np.inf
         vmin = -np.inf if opts['vmin'] is None else opts['vmin']


### PR DESCRIPTION
When applying the histogram and datashader operations to an empty array it currently errors due to zero-sized array reductions and zero-range errors. This PR ensures that both operations default to a 0-1 range in that case and also handles colormapping issues in matplotlib for empty arrays. 

Fixes: https://github.com/ioam/holoviews/issues/1506 and https://github.com/ioam/holoviews/issues/1522