### PR TITLE
Add support for passing list as cmap in mpl

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -694,7 +694,13 @@ class ColorbarPlot(ElementPlot):
             self._cbar_extend = 'max'
 
         # Define special out-of-range colors on colormap
-        cmap = copy.copy(plt.cm.get_cmap(opts.get('cmap')))
+        cmap = opts.get('cmap')
+        if isinstance(cmap, list):
+            cmap = mpl_colors.ListedColormap(cmap)
+        elif isinstance(cmap, util.basestring):
+            cmap = copy.copy(plt.cm.get_cmap(cmap))
+        else:
+            cmap = copy.copy(cmap)
         colors = {}
         for k, val in self.clipping_colors.items():
             if isinstance(val, tuple):

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -30,6 +30,7 @@ from holoviews.plotting.util import rgb2hex
 try:
     from matplotlib import pyplot
     pyplot.switch_backend('agg')
+    from matplotlib.colors import ListedColormap
     from holoviews.plotting.mpl import OverlayPlot
     mpl_renderer = Store.renderers['matplotlib']
 except:
@@ -339,14 +340,21 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         self.assertEqual(artist.get_array().data, arr.T[:, ::-1].flatten())
 
     def test_heatmap_invert_axes(self):
-        arr = np.array([[0, 1, 2], [3, 4,  5]])
+        arr = np.array([[0, 1, 2], [3, 4, 5]])
         hm = HeatMap(Image(arr)).opts(plot=dict(invert_axes=True))
         plot = mpl_renderer.get_plot(hm)
         artist = plot.handles['artist']
         self.assertEqual(artist.get_array().data, arr.T[::-1, ::-1])
         self.assertEqual(artist.get_extent(), (0, 2, 0, 3))
 
-
+    def test_image_listed_cmap(self):
+        colors = ['#ffffff','#000000']
+        img = Image(np.array([[0, 1, 2], [3, 4, 5]])).opts(style=dict(cmap=colors))
+        plot = mpl_renderer.get_plot(img)
+        artist = plot.handles['artist']
+        cmap = artist.get_cmap()
+        self.assertIsInstance(cmap, ListedColormap)
+        self.assertEqual(cmap.colors, colors)
 
 
 class TestBokehPlotInstantiation(ComparisonTestCase):


### PR DESCRIPTION
As the title says this allows passing a list of colors as a cmap for mpl matching the bokeh behavior and addressing https://github.com/ioam/holoviews/issues/1885.