### PR TITLE
Add display_options parameter to bokeh widgets

### DIFF
--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -25,6 +25,9 @@ class BokehServerWidgets(param.Parameterized):
     and dropdown widgets letting you select non-numeric values.
     """
 
+    display_options = param.Dict(default={}, doc="""
+        Additional options controlling display options of the widgets.""")
+
     editable = param.Boolean(default=False, doc="""
         Whether the slider text fields should be editable. Disabled
         by default for a more compact widget layout.""")


### PR DESCRIPTION
This simply makes the API of bokeh widgets consistent, ensuring that they do not raise a warning when display_options are passed. The only actual display_option being passed is the ``fps``, which does not apply to these widgets since they do not have a "play" feature.

Fixes #1660 