### PR TITLE
Refactored bokeh plotting API

### DIFF
--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -84,8 +84,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
         xlabel, ylabel = [kd.pprint_label for kd in element.nodes.kdims[:2]]
         return xlabel, ylabel, None
 
-    def get_data(self, element, ranges=None):
-        style = self.style[self.cyclic_index]
+    def get_data(self, element, ranges, style):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
 
         # Get node data
@@ -135,7 +134,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
 
         data = {'scatter_1': point_data, 'multi_line_1': path_data, 'layout': layout}
         mapping = {'scatter_1': point_mapping, 'multi_line_1': {}}
-        return data, mapping
+        return data, mapping, style
 
 
     def _update_datasource(self, source, data):
@@ -150,14 +149,15 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot):
 
     def _init_glyphs(self, plot, element, ranges, source):
         # Get data and initialize data source
-        data, mapping = self.get_data(element, ranges)
+        style = self.style[self.cyclic_index]
+        data, mapping, style = self.get_data(element, ranges, style)
         self.handles['previous_id'] = element._plot_id
         properties = {}
         mappings = {}
         for key in mapping:
             source = self._init_datasource(data.get(key, {}))
             self.handles[key+'_source'] = source
-            glyph_props = self._glyph_properties(plot, element, source, ranges)
+            glyph_props = self._glyph_properties(plot, element, source, ranges, style)
             properties.update(glyph_props)
             mappings.update(mapping.get(key, {}))
         properties = {p: v for p, v in properties.items() if p not in ('legend', 'source')}

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -94,7 +94,7 @@ class BokehPlot(DimensionedPlot):
         self.root = None
 
 
-    def get_data(self, element, ranges=None):
+    def get_data(self, element, ranges, style):
         """
         Returns the data from an element in the appropriate format for
         initializing or updating a ColumnDataSource and a dictionary


### PR DESCRIPTION
This PR represents a major cleanup of the (internal) bokeh plotting API to make it more consistent with matplotlib and simplify some things. Basically it adds the dictionary of style options to the bokeh ``ElementPlot.get_data`` method signature and return types. This means that at least the input signature of these methods now matches matplotlib. It's also in many cases much cleaner because a) most ElementPlots need the style as input and b) many also modify the style depending on the element data or parameters, which currently requires subclassing a completely different method. This will make it easier to write a guide on extending HoloViews with new plots and also simplify the process itself.

Concretely the motivation here was to make it easier for me to write some of the statistical plot classes.

This does represent a major change and will force me to pin the latest version of holoviews in the new geoviews release, however in another recent change I already removed the ``empty`` keyword from the signature so that was already necessary.