### PR TITLE
Fix issue with bokeh legends

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1101,7 +1101,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         mapper = self._get_colormapper(cdim, element, ranges, style, factors, colors)
         vbar_map['fill_color'] = {'field': cname, 'transform': mapper}
         vbar2_map['fill_color'] = {'field': cname, 'transform': mapper}
-        vbar_map['legend'] = cdim.name
+        if self.show_legend:
+            vbar_map['legend'] = cdim.name
 
         return data, mapping, style
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -7,7 +7,8 @@ import bokeh
 import bokeh.plotting
 from bokeh import palettes
 from bokeh.core.properties import value
-from bokeh.models import  HoverTool, Renderer, Range1d, DataRange1d, FactorRange, FuncTickFormatter
+from bokeh.models import  (HoverTool, Renderer, Range1d, DataRange1d,
+                           FactorRange, FuncTickFormatter, value)
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
@@ -637,7 +638,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                     self.overlay_dims.items()])
             else:
                 legend = element.label
-            properties['legend'] = legend
+            properties['legend'] = value(legend)
         return properties
 
     def _update_glyph(self, renderer, properties, mapping, glyph):

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -6,7 +6,7 @@ import numpy as np
 from bokeh.models import HoverTool, FactorRange
 
 from ...core import util
-from .element import ColorbarPlot, line_properties, fill_properties
+from .element import ColorbarPlot, LegendPlot, line_properties, fill_properties
 from .util import expand_batched_style
 
 
@@ -106,14 +106,17 @@ class PathPlot(ColorbarPlot):
         return data, elmapping, style
 
     
-class ContourPlot(PathPlot):
+class ContourPlot(LegendPlot, PathPlot):
 
     color_index = param.ClassSelector(default=0, class_=(util.basestring, int),
                                       allow_None=True, doc="""
       Index of the dimension from which the color will the drawn""")
 
+    show_legend = param.Boolean(default=False, doc="""
+        Whether to show legend for the plot.""")
+
     _color_style = 'line_color'
-    
+
     def _hover_opts(self, element):
         if self.batched:
             dims = list(self.hmap.last.kdims)+self.hmap.last.last.vdims
@@ -170,6 +173,8 @@ class ContourPlot(PathPlot):
         cmapper = self._get_colormapper(cdim, element, ranges, style, factors)
         mapping[self._color_style] = {'field': dim_name, 'transform': cmapper}
         self._get_hover_data(data, element)
+        if self.show_legend:
+            mapping['legend'] = dim_name
         return data, mapping, style
 
 


### PR DESCRIPTION
Since bokeh 0.12.7 you can specify a column in the CDS to draw the legend from. This can result in issues like this when the Element ``label`` matches the column name:

![screen shot 2017-10-09 at 6 43 41 pm](https://user-images.githubusercontent.com/1550771/31351140-dbf48f38-ad21-11e7-86e9-c00dd7dc458b.png)

Thanks to Bryan I found out that "if the legend name is also a column name you need to explicitly pass value(name)", so that's what I've done here.