### PR TITLE
Ensure histogram operation does not raise deprecation warning

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -555,7 +555,7 @@ class histogram(Operation):
         if view.group != view.__class__.__name__:
             params['group'] = view.group
 
-        return Histogram(hist, edges, kdims=[view.get_dimension(selected_dim)],
+        return Histogram((hist, edges), kdims=[view.get_dimension(selected_dim)],
                          label=view.label, **params)
 
 


### PR DESCRIPTION
In a recent PR I added a deprecation warning when constructing a Histogram with two separate arguments for edges and values but overlooked the fact that the histogram operation still does this.