### PR TITLE
Disable deep hashing if memoization is off

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -460,7 +460,7 @@ class Callable(param.Parameterized):
         self._is_overlay = False
         self.args = None
         self.kwargs = None
-        self._memoize = self.memoize
+        self._stream_memoization = self.memoize
 
     @property
     def argspec(self):
@@ -495,7 +495,7 @@ class Callable(param.Parameterized):
         for stream in [s for i in inputs for s in get_nested_streams(i)]:
             if stream not in streams: streams.append(stream)
 
-        memoize = self._memoize and not any(s.transient and s._triggering for s in streams)
+        memoize = self._stream_memoization and not any(s.transient and s._triggering for s in streams)
         values = tuple(tuple(sorted(s.hashkey.items())) for s in streams)
         key = args + tuple(sorted(kwarg_hash)) + values
 
@@ -593,14 +593,14 @@ def dynamicmap_memoization(callable_obj, streams):
     DynamicMap). Memoization is disabled if any of the streams require
     it it and are currently in a triggered state.
     """
-    memoization_state = bool(callable_obj._memoize)
-    callable_obj._memoize &= not any(s.transient and s._triggering for s in streams)
+    memoization_state = bool(callable_obj._stream_memoization)
+    callable_obj._stream_memoization &= not any(s.transient and s._triggering for s in streams)
     try:
         yield
     except:
         raise
     finally:
-        callable_obj._memoize = memoization_state
+        callable_obj._stream_memoization = memoization_state
 
 
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -839,7 +839,7 @@ class DynamicMap(HoloMap):
         # Additional validation needed to ensure kwargs don't clash
         kdims = [kdim.name for kdim in self.kdims]
         kwarg_items = [s.contents.items() for s in self.streams]
-        hash_items = [s.hashkey.items() for s in self.streams]
+        hash_items = tuple(tuple(sorted(s.hashkey.items())) for s in self.streams)
         flattened = [(k,v) for kws in kwarg_items for (k,v) in kws
                      if k not in kdims]
 

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -495,7 +495,7 @@ class Callable(param.Parameterized):
             if stream not in streams: streams.append(stream)
 
         memoize = self._memoize and not any(s.transient and s._triggering for s in streams)
-        values = tuple(tuple(sorted(s.contents.items())) for s in streams)
+        values = tuple(tuple(sorted(s.hashkey.items())) for s in streams)
         key = args + tuple(sorted(kwargs.items())) + values
 
         hashed_key = util.deephash(key) if self.memoize else None

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -101,7 +101,7 @@ class HashableJSON(json.JSONEncoder):
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         if pd and isinstance(obj, (pd.Series, pd.DataFrame)):
-            return repr(sorted(list(obj.to_dict().items())))
+            return obj.to_csv().encode('utf-8')
         elif isinstance(obj, self.string_hashable):
             return str(obj)
         elif isinstance(obj, self.repr_hashable):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -4,6 +4,8 @@ generate and respond to events, originating either in Python on the
 server-side or in Javascript in the Jupyter notebook (client-side).
 """
 
+import uuid
+
 import param
 import numpy as np
 from numbers import Number
@@ -361,6 +363,33 @@ class Counter(Stream):
         return {'counter': self.counter + 1}
 
 
+class StreamData(Stream):
+    """
+    A Stream used to pipe arbitrary data to a callback.
+    Unlike other streams memoization can be disabled for a
+    StreamData stream (and is disabled by default).
+    """
+
+    data = param.Parameter(default=None)
+
+    def __init__(self, memoize=False, **params):
+        super(StreamData, self).__init__(**params)
+        self._memoize = memoize
+
+    def send(self, data):
+        """
+        A convenience method to send an event with data without
+        supplying a keyword.
+        """
+        self.event(data=data)
+
+    @property
+    def hashkey(self):
+        if self._memoize:
+            return self.contents
+        return {'hash': uuid.uuid4().hex}
+
+
 class LinkedStream(Stream):
     """
     A LinkedStream indicates is automatically linked to plot interactions
@@ -413,11 +442,11 @@ class PointerXY(LinkedStream):
     the plot bounds, the position values are set to None.
     """
 
-    x = param.ClassSelector(class_=(Number, util.basestring), default=None,
+    x = param.ClassSelector(class_=(Number, util.basestring, tuple), default=None,
                             constant=True, doc="""
            Pointer position along the x-axis in data coordinates""")
 
-    y = param.ClassSelector(class_=(Number, util.basestring), default=None,
+    y = param.ClassSelector(class_=(Number, util.basestring, tuple), default=None,
                             constant=True, doc="""
            Pointer position along the y-axis in data coordinates""")
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -296,6 +296,15 @@ class Stream(param.Parameterized):
         return {self._rename.get(k,k):v for (k,v) in filtered.items()
                 if (self._rename.get(k,True) is not None)}
 
+    @property
+    def hashkey(self):
+        """
+        The object the memoization hash is computed from. By default
+        returns the stream contents but can be overridden to provide
+        a custom hash key.
+        """
+        return self.contents
+
 
     def _set_stream_parameters(self, **kwargs):
         """

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -370,7 +370,8 @@ class StreamData(Stream):
     StreamData stream (and is disabled by default).
     """
 
-    data = param.Parameter(default=None)
+    data = param.Parameter(default=None, constant=True, doc="""
+        Arbitrary data being streamed to a DynamicMap callback.""")
 
     def __init__(self, memoize=False, **params):
         super(StreamData, self).__init__(**params)


### PR DESCRIPTION
Currently ``Callable`` runs deep hashing on the stream values whether or not memoization is enabled. This PR simply disables it when memoization is off, which has no effect but can be more efficient.