### PR TITLE
Ensure all clone methods correctly retain id

### DIFF
--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -763,7 +763,7 @@ class UniformNdMapping(NdMapping):
             settings = {k: v for k, v in settings.items()
                       if k in new_params}
         settings = dict(settings, **overrides)
-        if 'id' not in settings:
+        if 'id' not in settings and new_type in [type(self), None]:
             settings['id'] = self.id
 
         if data is None and shared_data:

--- a/holoviews/element/annotation.py
+++ b/holoviews/element/annotation.py
@@ -66,6 +66,8 @@ class Annotation(Element2D):
         pos_args = getattr(self, '_' + type(self).__name__ + '__pos_params', [])
         settings = {k: v for k, v in dict(self.get_param_values(), **overrides).items()
                     if k not in pos_args[:len(args)]}
+        if 'id' not in settings:
+            settings['id'] = self.id
         return self.__class__(*args, **settings)
 
 

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -200,6 +200,8 @@ class BaseShape(Path):
         containing the specified args and kwargs.
         """
         settings = dict(self.get_param_values(), **overrides)
+        if 'id' not in settings:
+            settings['id'] = self.id
         if not args:
             settings['plot_id'] = self._plot_id
 


### PR DESCRIPTION
Certain clone methods on Annotations, BaseShape and UniformNdMapping were not passing the ``id`` along resulting in styles getting dropped when different operations were applied to these objects. One issue that's caused by this is https://github.com/ioam/holoviews/issues/1904, but there may be others I missed.