### PR TITLE
Fixed empty data issues with multiinterface

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -104,6 +104,8 @@ class MultiInterface(Interface):
         """
         Tests if dimension is scalar in each subpath.
         """
+        if not dataset.data:
+            return True
         ds = cls._inner_dataset_template(dataset)
         isscalar = []
         for d in dataset.data:
@@ -117,6 +119,8 @@ class MultiInterface(Interface):
         """
         Applies selectiong on all the subpaths.
         """
+        if not self.dataset.data:
+            return []
         ds = cls._inner_dataset_template(dataset)
         data = []
         for d in dataset.data:
@@ -231,6 +235,8 @@ class MultiInterface(Interface):
         if datatype is None:
             for d in dataset.data[start: end]:
                 objs.append(dataset.clone(d, datatype=cls.subtypes))
+            return objs
+        elif not dataset.data:
             return objs
         ds = cls._inner_dataset_template(dataset)
         for d in dataset.data:

--- a/tests/testmultiinterface.py
+++ b/tests/testmultiinterface.py
@@ -60,20 +60,38 @@ class MultiInterfaceTest(ComparisonTestCase):
         mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
         self.assertEqual(len(mds), 5)
 
+    def test_multi_empty_length(self):
+        mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
+        self.assertEqual(len(mds), 0)
+
     def test_multi_array_range(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
         mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
         self.assertEqual(mds.range(0), (0, 2))
+
+    def test_multi_empty_range(self):
+        mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
+        low, high = mds.range(0)
+        self.assertFalse(np.isfinite(np.NaN))
+        self.assertFalse(np.isfinite(np.NaN))
 
     def test_multi_array_shape(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
         mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
         self.assertEqual(mds.shape, (5, 2))
 
+    def test_multi_empty_shape(self):
+        mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
+        self.assertEqual(mds.shape, (0, 2))
+
     def test_multi_array_values(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
         mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
         self.assertEqual(mds.dimension_values(0), np.array([0., 1, np.NaN, 1, 2]))
+
+    def test_multi_empty_array_values(self):
+        mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
+        self.assertEqual(mds.dimension_values(0), np.array([]))
 
     def test_multi_array_values_coordinates_nonexpanded(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
@@ -104,3 +122,13 @@ class MultiInterfaceTest(ComparisonTestCase):
         error = "Following dimensions not found in data: \['y'\]"
         with self.assertRaisesRegexp(ValueError, error):
             mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+
+    def test_multi_split(self):
+        arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
+        mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+        for arr1, arr2 in zip(mds.split(datatype='array'), arrays):
+            self.assertEqual(arr1, arr2)
+
+    def test_multi_split_empty(self):
+        mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
+        self.assertEqual(len(mds.split()), 0)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -19,7 +19,7 @@ from holoviews.core.util import pd
 from holoviews.element import (Curve, Scatter, Image, VLine, Points,
                                HeatMap, QuadMesh, Spikes, ErrorBars,
                                Scatter3D, Path, Polygons, Bars, Text,
-                               BoxWhisker, HLine, RGB, Raster)
+                               BoxWhisker, HLine, RGB, Raster, Contours)
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import Stream, PointerXY, PointerX
 from holoviews.operation import gridmatrix
@@ -872,6 +872,30 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         source = plot.handles['source']
         self.assertEqual(len(source.data['xs']), 0)
         self.assertEqual(len(source.data['ys']), 0)
+
+    def test_empty_path_plot(self):
+        path = Path([], vdims=['Intensity']).opts(plot=dict(color_index=2))
+        plot = bokeh_renderer.get_plot(path)
+        source = plot.handles['source']
+        self.assertEqual(len(source.data['xs']), 0)
+        self.assertEqual(len(source.data['ys']), 0)
+        self.assertEqual(len(source.data['Intensity']), 0)
+
+    def test_empty_contours_plot(self):
+        contours = Contours([], vdims=['Intensity'])
+        plot = bokeh_renderer.get_plot(contours)
+        source = plot.handles['source']
+        self.assertEqual(len(source.data['xs']), 0)
+        self.assertEqual(len(source.data['ys']), 0)
+        self.assertEqual(len(source.data['Intensity']), 0)
+
+    def test_empty_polygons_plot(self):
+        poly = Polygons([], vdims=['Intensity'])
+        plot = bokeh_renderer.get_plot(poly)
+        source = plot.handles['source']
+        self.assertEqual(len(source.data['xs']), 0)
+        self.assertEqual(len(source.data['ys']), 0)
+        self.assertEqual(len(source.data['Intensity']), 0)
 
     def test_side_histogram_no_cmapper(self):
         points = Points(np.random.rand(100, 2))


### PR DESCRIPTION
The MultiInterface for Paths was not handling empty data correctly in some cases. This fixes the issues and adds various data interface and plot tests.