### PR TITLE
Remove all bokeh backward compatibility code

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -46,6 +46,13 @@ except ImportError:
     dd = None
 
 
+class VersionError(Exception):
+    "Raised when there is a library version mismatch."
+    def __init__(self, msg, version=None, min_version=None, **kwargs):
+        self.version = version
+        self.min_version = min_version
+        super(VersionError, self).__init__(msg, **kwargs)
+
 
 class Config(param.ParameterizedFunction):
     """

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import absolute_import
 
+from distutils.version import LooseVersion
+
 import numpy as np
+import bokeh
 from bokeh.palettes import all_palettes
 
 from ...core import (Store, Overlay, NdOverlay, Layout, AdjointLayout,
@@ -12,6 +15,12 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths)
 from ...core.options import Options, Cycle, Palette
+from ...core.util import VersionError
+
+if LooseVersion(bokeh.__version__) < '0.12.10':
+    raise VersionError("The bokeh extension requires a bokeh version >=0.12.10, "
+                       "please upgrade from bokeh %s to a more recent version."
+                       % bokeh.__version__, bokeh.__version__, '0.12.10')
 
 try:
     from ...interface import DFrame

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -198,12 +198,11 @@ options.EdgePaths = Options('plot', tools=['hover', 'tap'])
 options.GridMatrix = Options('plot', shared_xaxis=True, shared_yaxis=True,
                              xaxis=None, yaxis=None)
 
-if bokeh_version >= '0.12.5':
-    options.Overlay = Options('style', click_policy='mute')
-    options.NdOverlay = Options('style', click_policy='mute')
-    options.Curve = Options('style', muted_alpha=0.2)
-    options.Path = Options('style', muted_alpha=0.2)
-    options.Scatter = Options('style', muted_alpha=0.2)
-    options.Points = Options('style', muted_alpha=0.2)
-    options.Polygons = Options('style', muted_alpha=0.2)
+options.Overlay = Options('style', click_policy='mute')
+options.NdOverlay = Options('style', click_policy='mute')
+options.Curve = Options('style', muted_alpha=0.2)
+options.Path = Options('style', muted_alpha=0.2)
+options.Scatter = Options('style', muted_alpha=0.2)
+options.Points = Options('style', muted_alpha=0.2)
+options.Polygons = Options('style', muted_alpha=0.2)
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -8,7 +8,6 @@ from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         PlotSize, Draw, BoundsXY)
 from ...streams import PositionX, PositionY, PositionXY, Bounds # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS
-from .util import bokeh_version
 
 
 
@@ -307,7 +306,7 @@ class CustomJSCallback(MessageCallback):
         code and gathering all plotting handles and installs it on
         the requested callback handle.
         """
-        if self.on_events and bokeh_version >= '0.12.5':
+        if self.on_events:
             for event in self.on_events:
                 handle.js_on_event(event, js_callback)
         elif self.on_changes:

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -599,11 +599,11 @@ class SideSpikesPlot(SpikesPlot):
         all axis labels including ticks and ylabel. Valid options are 'left',
         'right', 'bare' 'left-bare' and 'right-bare'.""")
 
-    border = param.Integer(default=30, doc="Default borders on plot")
+    border = param.Integer(default=5, doc="Default borders on plot")
 
-    height = param.Integer(default=100, doc="Height of plot")
+    height = param.Integer(default=50, doc="Height of plot")
 
-    width = param.Integer(default=100, doc="Width of plot")
+    width = param.Integer(default=50, doc="Width of plot")
 
 
 

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -16,7 +16,7 @@ from ..util import compute_sizes, get_min_distance, dim_axis_label
 from .element import (ElementPlot, ColorbarPlot, LegendPlot, CompositeElementPlot,
                       line_properties, fill_properties)
 from .path import PathPlot, PolygonPlot
-from .util import bokeh_version, expand_batched_style, categorize_array, rgb2hex, mpl_to_bokeh
+from .util import expand_batched_style, categorize_array, rgb2hex, mpl_to_bokeh
 
 
 class PointPlot(LegendPlot, ColorbarPlot):
@@ -599,14 +599,11 @@ class SideSpikesPlot(SpikesPlot):
         all axis labels including ticks and ylabel. Valid options are 'left',
         'right', 'bare' 'left-bare' and 'right-bare'.""")
 
-    border = param.Integer(default=30 if bokeh_version < '0.12' else 5,
-                           doc="Default borders on plot")
+    border = param.Integer(default=30, doc="Default borders on plot")
 
-    height = param.Integer(default=100 if bokeh_version < '0.12' else 50,
-                           doc="Height of plot")
+    height = param.Integer(default=100, doc="Height of plot")
 
-    width = param.Integer(default=100 if bokeh_version < '0.12' else 50,
-                          doc="Width of plot")
+    width = param.Integer(default=100, doc="Width of plot")
 
 
 
@@ -694,15 +691,12 @@ class BarPlot(ColorbarPlot, LegendPlot):
         xvals = element.dimension_values(0, False)
         xvals = [x if xvals.dtype.kind in 'SU' else xdim.pprint_value(x)
                  for x in xvals]
-        if bokeh_version >= '0.12.7':
-            if gdim and not sdim:
-                gvals = element.dimension_values(gdim, False)
-                gvals = [g if gvals.dtype.kind in 'SU' else gdim.pprint_value(g) for g in gvals]
-                coords = ([(x, g) for x in xvals for g in gvals], [])
-            else:
-                coords = (xvals, [])
+        if gdim and not sdim:
+            gvals = element.dimension_values(gdim, False)
+            gvals = [g if gvals.dtype.kind in 'SU' else gdim.pprint_value(g) for g in gvals]
+            coords = ([(x, g) for x in xvals for g in gvals], [])
         else:
-            coords = ([x.replace(':', ';') for x in xvals], [])
+            coords = (xvals, [])
         if self.invert_axes: coords = coords[::-1]
         return coords
 
@@ -716,27 +710,9 @@ class BarPlot(ColorbarPlot, LegendPlot):
             element = element.last
         xlabel = dim_axis_label(element.kdims[0])
         gdim = element.get_dimension(self.group_index)
-        if bokeh_version >= '0.12.7' and gdim and gdim in element.kdims:
+        if gdim and gdim in element.kdims:
             xlabel = ', '.join([xlabel, dim_axis_label(gdim)])
         return (xlabel, dim_axis_label(element.vdims[0]), None)
-
-    def get_group(self, xvals, nshift, ngroups, width, xdim):
-        """
-        Adjust x-value positions on categorical axes to stop
-        x-axis overlapping. Currently bokeh uses a suffix
-        of the format ':%f' with a floating value to set up
-        offsets within a single category.
-
-        Needed for bokeh version <0.12.7
-        """
-        adjusted_xvals = []
-        gwidth = float(width)/ngroups
-        offset = (1.-width)/2. + gwidth/2.
-        for x in xvals:
-            adjustment = (offset+nshift/float(ngroups)*width)
-            xcat = xdim.pprint_value(x).replace(':',';')
-            adjusted_xvals.append(xcat+':%.4f' % adjustment)
-        return adjusted_xvals
 
     def get_stack(self, xvals, yvals, baselines, sign='positive'):
         """
@@ -810,12 +786,8 @@ class BarPlot(ColorbarPlot, LegendPlot):
             mapping = {'x': xdim.name, 'top': 'top',
                        'bottom': 'bottom', 'width': width}
         elif grouping == 'grouped':
-            if len(grouped) and bokeh_version < '0.12.7':
-                gwidth = width / float(len(grouped))
-            else:
-                gwidth = width
             mapping = {'x': 'xoffsets', 'top': ydim.name, 'bottom': bottom,
-                       'width': gwidth}
+                       'width': width}
         else:
             mapping = {'x': xdim.name, 'top': ydim.name, 'bottom': bottom, 'width': width}
 
@@ -845,8 +817,6 @@ class BarPlot(ColorbarPlot, LegendPlot):
             k = k[0] if isinstance(k, tuple) else k
             if group_dim:
                 gval = k if isinstance(k, basestring) else group_dim.pprint_value(k)
-                if bokeh_version < '0.12.7':
-                    gval = gval.replace(':', ';')
 
             # Apply stacking or grouping
             if grouping == 'stacked':
@@ -863,11 +833,8 @@ class BarPlot(ColorbarPlot, LegendPlot):
             elif grouping == 'grouped':
                 xs = ds.dimension_values(xdim)
                 ys = ds.dimension_values(ydim)
-                if bokeh_version >= '0.12.7':
-                    xoffsets = [(x if xs.dtype.kind in 'SU' else xdim.pprint_value(x), gval)
-                                for x in xs]
-                else:
-                    xoffsets = self.get_group(xs, i, len(grouped), width, xdim)
+                xoffsets = [(x if xs.dtype.kind in 'SU' else xdim.pprint_value(x), gval)
+                            for x in xs]
                 data['xoffsets'].append(xoffsets)
                 data[ydim.name].append(ys)
                 if hover: data[xdim.name].append(xs)
@@ -995,14 +962,9 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         if not element.kdims:
             xfactors, yfactors =  [element.label], []
         else:
-            if bokeh_version < '0.12.7':
-                factors = [', '.join([d.pprint_value(v).replace(':', ';')
-                                      for d, v in zip(element.kdims, key)])
-                           for key in element.groupby(element.kdims).data.keys()]
-            else:
-                factors = [tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
-                           for key in element.groupby(element.kdims).data.keys()]
-                factors = [f[0] if len(f) == 1 else f for f in factors]
+            factors = [tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
+                       for key in element.groupby(element.kdims).data.keys()]
+            factors = [f[0] if len(f) == 1 else f for f in factors]
             xfactors, yfactors = factors, []
         return (yfactors, xfactors) if self.invert_axes else (xfactors, yfactors)
 
@@ -1044,13 +1006,9 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         for key, g in groups.items():
             # Compute group label
             if element.kdims:
-                if bokeh_version < '0.12.7':
-                    label = ', '.join([d.pprint_value(v).replace(':', ';')
-                                       for d, v in zip(element.kdims, key)])
-                else:
-                    label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
-                    if len(label) == 1:
-                        label = label[0]
+                label = tuple(d.pprint_value(v) for d, v in zip(element.kdims, key))
+                if len(label) == 1:
+                    label = label[0]
             else:
                 label = key
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -13,7 +13,7 @@ from ...core.options import abbreviated_exception, SkipRendering
 from ...core.util import basestring, dimension_sanitizer
 from .chart import ColorbarPlot, PointPlot
 from .element import CompositeElementPlot, LegendPlot, line_properties, fill_properties, property_prefixes
-from .util import mpl_to_bokeh, bokeh_version
+from .util import mpl_to_bokeh
 
 
 class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
@@ -44,11 +44,6 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
 
     style_opts = (['edge_'+p for p in line_properties] +\
                   ['node_'+p for p in fill_properties+line_properties]+['node_size', 'cmap'])
-
-    def initialize_plot(self, ranges=None, plot=None, plots=None):
-        if bokeh_version < '0.12.7':
-            raise SkipRendering('Graph rendering requires bokeh version >=0.12.7.')
-        return super(GraphPlot, self).initialize_plot(ranges, plot, plots)
 
     def _hover_opts(self, element):
         if self.inspection_policy == 'nodes':

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -23,8 +23,7 @@ from .util import attach_periodic, compute_plot_size
 from bokeh.io.notebook import (load_notebook, publish_display_data,
                                JS_MIME_TYPE, LOAD_MIME_TYPE, EXEC_MIME_TYPE)
 from bokeh.protocol import Protocol
-from bokeh.embed import notebook_content
-from bokeh.embed.notebook import encode_utf8
+from bokeh.embed.notebook import encode_utf8, notebook_content
 
 NOTEBOOK_DIV = """
 {plot_div}

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -7,7 +7,6 @@ from ...core import Dataset
 from ...element import ItemTable
 from ..plot import GenericElementPlot
 from .plot import BokehPlot
-from .util import bokeh_version
 
 
 class TablePlot(BokehPlot, GenericElementPlot):
@@ -70,8 +69,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
 
         dims = element.dimensions()
         columns = [TableColumn(field=d.name, title=d.pprint_label) for d in dims]
-        if bokeh_version > '0.12.7':
-            style['reorderable'] = False
+        style['reorderable'] = False
         table = DataTable(source=source, columns=columns, height=self.height,
                           width=self.width, **style)
         self.handles['plot'] = table

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -13,7 +13,9 @@ except ImportError:
 
 import param
 import bokeh
-bokeh_version = LooseVersion(bokeh.__version__)
+
+bokeh_version = LooseVersion(bokeh.__version__)  # noqa
+
 from bokeh.core.enums import Palette
 from bokeh.core.json_encoder import serialize_json # noqa (API import)
 from bokeh.core.properties import value
@@ -24,10 +26,7 @@ from bokeh.models.widgets import DataTable, Tabs, Div
 from bokeh.plotting import Figure
 
 try:
-    if bokeh_version > '0.12.5':
-        from bkcharts import Chart
-    else:
-        from bokeh.charts import Chart
+    from bkcharts import Chart
 except:
     Chart = type(None) # Create stub for isinstance check
 
@@ -518,10 +517,7 @@ def categorize_array(array, dim):
     (i.e. string) values and applies escaping for colons, which bokeh
     treats as a categorical suffix.
     """
-    categories = [dim.pprint_value(x) for x in array]
-    if bokeh_version < '0.12.7':
-        categories = [cat.replace(':', ';') for cat in categories]
-    return np.array(categories)
+    return np.array([dim.pprint_value(x) for x in array])
 
 
 class periodic(object):

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -224,21 +224,23 @@ class extension(param.ParameterizedFunction):
         selected_backend = None
         for backend, imp in imports:
             try:
+                module = __import__(backend)
+            except:
+                self.warning("%s is not available, ensure %s is installed "
+                             "to activate %s extension." % (backend, backend))
+            try:
                 __import__('holoviews.plotting.%s' % imp)
                 if selected_backend is None:
                     selected_backend = backend
+            except util.VersionError as e:
+                self.warning("HoloViews %s extension could not be loaded. "
+                             "The installed %s version %s is less than "
+                             "the required version %s." %
+                             (backend, backend, e.version, e.min_version))
             except Exception as e:
-                if backend in args:
-                    args.pop(args.index(backend))
-                if backend in params:
-                    params.pop(backend)
-                if isinstance(e, ImportError):
-                    self.warning("HoloViews %s backend could not be imported, "
-                                 "ensure %s is installed." % (backend, backend))
-                else:
-                    self.warning("Holoviews %s backend could not be imported, "
-                                 "it raised the following exception: %s('%s')" %
-                                 (backend, type(e).__name__, e))
+                self.warning("Holoviews %s extension could not be imported, "
+                             "it raised the following exception: %s('%s')" %
+                             (backend, type(e).__name__, e))
             finally:
                 Store.output_settings.allowed['backend'] = list_backends()
                 Store.output_settings.allowed['fig'] = list_formats('fig', backend)


### PR DESCRIPTION
As we decided in #1949 we are going to drop compatibility with versions of bokeh older than 0.12.10 in the next release. This PR removes all code that handles backward compatibility for older versions.