### PR TITLE
Add support for datetime axis on Image

### DIFF
--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -8,6 +8,7 @@ File originally part of the Topographica project.
 ### translated, etc. easily.
 ###
 import param
+import numpy as np
 from param.parameterized import get_occupied_slots
 
 
@@ -90,7 +91,8 @@ class BoundingBox(BoundingRegion):
         will display the bounds.
         """
         l, b, r, t = self._aarect.lbrt()
-        if r == -l and t == -b and r == t:
+        if (not isinstance(r, np.datetime64) and r == -l and
+            not isinstance(b, np.datetime64) and t == -b and r == t):
             return 'BoundingBox(radius=%s)' % (r)
         else:
             return 'BoundingBox(points=((%s,%s),(%s,%s)))' % (l, b, r, t)

--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -10,6 +10,7 @@ File originally part of the Topographica project.
 import param
 import numpy as np
 from param.parameterized import get_occupied_slots
+from .util import datetime_types
 
 
 class BoundingRegion(object):
@@ -91,8 +92,8 @@ class BoundingBox(BoundingRegion):
         will display the bounds.
         """
         l, b, r, t = self._aarect.lbrt()
-        if (not isinstance(r, np.datetime64) and r == -l and
-            not isinstance(b, np.datetime64) and t == -b and r == t):
+        if (not isinstance(r, datetime_types) and r == -l and
+            not isinstance(b, datetime_types) and t == -b and r == t):
             return 'BoundingBox(radius=%s)' % (r)
         else:
             return 'BoundingBox(points=((%s,%s),(%s,%s)))' % (l, b, r, t)

--- a/holoviews/core/boundingregion.py
+++ b/holoviews/core/boundingregion.py
@@ -8,7 +8,6 @@ File originally part of the Topographica project.
 ### translated, etc. easily.
 ###
 import param
-import numpy as np
 from param.parameterized import get_occupied_slots
 from .util import datetime_types
 

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -109,7 +109,7 @@ class ImageInterface(GridInterface):
                 density = obj.xdensity
             halfd = (1./density)/2.
             if isinstance(low, util.datetime_types):
-                halfd = np.timedelta64(int(halfd), obj._time_unit)
+                halfd = np.timedelta64(int(round(halfd)), obj._time_unit)
             drange = (low+halfd, high-halfd)
         elif 1 < dim_idx < len(obj.vdims) + 2:
             dim_idx -= 2

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -104,12 +104,12 @@ class ImageInterface(GridInterface):
             if dim_idx:
                 halfd = (1./obj.ydensity)/2.
                 if isinstance(b, np.datetime64):
-                    halfd = np.timedelta(halfd, obj._time_unit)
+                    halfd = np.timedelta64(int(halfd), obj._time_unit)
                 drange = (b+halfd, t-halfd)
             else:
                 halfd = (1./obj.xdensity)/2.
                 if isinstance(l, np.datetime64):
-                    halfd = np.timedelta(halfd, obj._time_unit)
+                    halfd = np.timedelta64(int(halfd), obj._time_unit)
                 drange = (l+halfd, r-halfd)
         elif 1 < dim_idx < len(obj.vdims) + 2:
             dim_idx -= 2
@@ -129,13 +129,13 @@ class ImageInterface(GridInterface):
         if dim_idx in [0, 1]:
             l, b, r, t = dataset.bounds.lbrt()
             dim2, dim1 = dataset.data.shape[:2]
-            xstep = (1./dataset.xdensity)
+            xstep = (1./util.compute_density(l, r, dim1, dataset._time_unit))
             if isinstance(l, np.datetime64):
                 xstep = np.timedelta64(int(xstep), dataset._time_unit)
                 xlin = l+np.arange(dim1)*xstep
             else:
                 xlin = np.linspace(l+(xstep/2.), r-(xstep/2.), dim1)
-            ystep = 1./dataset.ydensity
+            ystep = (1./util.compute_density(b, t, dim2, dataset._time_unit))
             if isinstance(b, np.datetime64):
                 ystep = np.timedelta64(int(ystep), dataset._time_unit)
                 ylin = b+np.arange(dim2)*ystep

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -34,8 +34,8 @@ class ImageInterface(GridInterface):
             data = dict(zip(dimensions, data))
         if isinstance(data, dict):
             xs, ys = np.asarray(data[kdims[0].name]), np.asarray(data[kdims[1].name])
-            l, r, xdensity, invertx = util.bound_range(xs, None)
-            b, t, ydensity, inverty = util.bound_range(ys, None)
+            l, r, xdensity, invertx = util.bound_range(xs, None, eltype._time_unit)
+            b, t, ydensity, inverty = util.bound_range(ys, None, eltype._time_unit)
             kwargs['bounds'] = BoundingBox(points=((l, b), (r, t)))
             if len(vdims) == 1:
                 data = np.flipud(np.asarray(data[vdims[0].name]))

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -77,6 +77,7 @@ outside of the actual matrix.
 
 import numpy as np
 from .boundingregion import BoundingBox
+from .util import datetime_types
 
 
 # Note about the 'bounds-master' approach we have adopted
@@ -221,12 +222,12 @@ class SheetCoordinateSystem(object):
         # to be flipped, because the points are moving down in the
         # sheet as the y index increases in the matrix.
         xdensity = 1./self.__xdensity
-        if isinstance(x, np.datetime64):
+        if isinstance(x, datetime_types):
             xdensity = np.timedelta64(int(xdensity), self._time_unit)
         float_col = (x-self.lbrt[0]) / xdensity
 
         ydensity = 1./self.__ydensity
-        if isinstance(y, np.datetime64):
+        if isinstance(y, datetime_types):
             ydensity = np.timedelta64(int(ydensity), self._time_unit)
         float_row = (self.lbrt[3]-y) / ydensity
 
@@ -267,11 +268,11 @@ class SheetCoordinateSystem(object):
         Inverse of sheet2matrix().
         """
         xoffset = float_col*self.__xstep
-        if isinstance(self.lbrt[0], np.datetime64):
+        if isinstance(self.lbrt[0], datetime_types):
             xoffset = np.timedelta64(int(xoffset), self._time_unit)
-        x = xoffset + self.lbrt[0]
+        x = self.lbrt[0] + xoffset
         yoffset = float_row*self.__ystep
-        if isinstance(self.lbrt[3], np.datetime64):
+        if isinstance(self.lbrt[3], datetime_types):
             yoffset = np.timedelta64(int(yoffset), self._time_unit)
         y = self.lbrt[3] - yoffset
         return x, y
@@ -293,9 +294,9 @@ class SheetCoordinateSystem(object):
         x,y = self.matrix2sheet((row+0.5), (col+0.5))
 
         # Rounding allows easier comparison with user specified values
-        if not isinstance(x, np.datetime64):
+        if not isinstance(x, datetime_types):
             x = np.around(x,10)
-        if not isinstance(y, np.datetime64):
+        if not isinstance(y, datetime_types):
             y = np.around(y,10)
         return x, y
 

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -223,14 +223,14 @@ class SheetCoordinateSystem(object):
         # sheet as the y index increases in the matrix.
         xdensity = self.__xdensity
         if isinstance(x, datetime_types):
-            xdensity = np.timedelta64(int(1./xdensity), self._time_unit)
+            xdensity = np.timedelta64(int(round(1./xdensity)), self._time_unit)
             float_col = (x-self.lbrt[0]) / xdensity
         else:
             float_col = (x-self.lbrt[0]) * xdensity
 
         ydensity = self.__ydensity
         if isinstance(y, datetime_types):
-            ydensity = np.timedelta64(int(1./ydensity), self._time_unit)
+            ydensity = np.timedelta64(int(round(1./ydensity)), self._time_unit)
             float_row = (self.lbrt[3]-y) / ydensity
         else:
             float_row = (self.lbrt[3]-y) * ydensity
@@ -273,11 +273,11 @@ class SheetCoordinateSystem(object):
         """
         xoffset = float_col*self.__xstep
         if isinstance(self.lbrt[0], datetime_types):
-            xoffset = np.timedelta64(int(xoffset), self._time_unit)
+            xoffset = np.timedelta64(int(round(xoffset)), self._time_unit)
         x = self.lbrt[0] + xoffset
         yoffset = float_row*self.__ystep
         if isinstance(self.lbrt[3], datetime_types):
-            yoffset = np.timedelta64(int(yoffset), self._time_unit)
+            yoffset = np.timedelta64(int(round(yoffset)), self._time_unit)
         y = self.lbrt[3] - yoffset
         return x, y
 

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -137,6 +137,8 @@ class SheetCoordinateSystem(object):
 
     shape = property(__get_shape)
 
+    # Determines the unit of time densities are defined relative to
+    # when one or both axes are datetime types
     _time_unit = 'us'
 
     def __init__(self,bounds,xdensity,ydensity=None):

--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -221,15 +221,19 @@ class SheetCoordinateSystem(object):
         # then scale to the size of the matrix. The y coordinate needs
         # to be flipped, because the points are moving down in the
         # sheet as the y index increases in the matrix.
-        xdensity = 1./self.__xdensity
+        xdensity = self.__xdensity
         if isinstance(x, datetime_types):
-            xdensity = np.timedelta64(int(xdensity), self._time_unit)
-        float_col = (x-self.lbrt[0]) / xdensity
+            xdensity = np.timedelta64(int(1./xdensity), self._time_unit)
+            float_col = (x-self.lbrt[0]) / xdensity
+        else:
+            float_col = (x-self.lbrt[0]) * xdensity
 
-        ydensity = 1./self.__ydensity
+        ydensity = self.__ydensity
         if isinstance(y, datetime_types):
-            ydensity = np.timedelta64(int(ydensity), self._time_unit)
-        float_row = (self.lbrt[3]-y) / ydensity
+            ydensity = np.timedelta64(int(1./ydensity), self._time_unit)
+            float_row = (self.lbrt[3]-y) / ydensity
+        else:
+            float_row = (self.lbrt[3]-y) * ydensity
 
         return float_row, float_col
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1518,7 +1518,7 @@ def bound_range(vals, density, time_unit='us'):
         raise ValueError('Could not determine Image density, ensure it has a non-zero range.')
     halfd = 0.5/density
     if isinstance(low, datetime_types):
-        halfd = np.timedelta64(round(halfd), time_unit)
+        halfd = np.timedelta64(int(round(halfd)), time_unit)
     return low-halfd, high+halfd, density, invert
 
 
@@ -1533,7 +1533,7 @@ def compute_density(start, end, length, time_unit='us'):
     diff = end-start
     if isinstance(diff, timedelta_types):
         if isinstance(diff, np.timedelta64):
-            diff = np.timedelta64(diff, 'us').tolist()
+            diff = np.timedelta64(diff, time_unit).tolist()
         tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
         return (length/(diff.total_seconds()*tscale))
     else:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1516,3 +1516,14 @@ def bound_range(vals, density):
         raise ValueError('Could not determine Image density, ensure it has a non-zero range.')
     halfd = 0.5/density
     return low-halfd, high+halfd, density, invert
+
+
+def compute_density(start, end, length, time_unit='us'):
+    if isinstance(start, int): start = float(start)
+    if isinstance(end, int): end = float(end)
+    diff = end-start
+    if isinstance(diff, np.timedelta64):
+        tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
+        return (length/(diff.tolist().total_seconds()*tscale))
+    else:
+        return length/diff

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1518,7 +1518,7 @@ def bound_range(vals, density, time_unit='us'):
         raise ValueError('Could not determine Image density, ensure it has a non-zero range.')
     halfd = 0.5/density
     if isinstance(low, datetime_types):
-        halfd = np.timedelta64(int(halfd), time_unit)
+        halfd = np.timedelta64(round(halfd), time_unit)
     return low-halfd, high+halfd, density, invert
 
 
@@ -1548,7 +1548,7 @@ def date_range(start, end, length, time_unit='us'):
     step = (1./compute_density(start, end, length, time_unit))
     if pd and isinstance(start, pd.Timestamp):
         start = start.to_datetime64()
-    step = np.timedelta64(int(step), time_unit)
+    step = np.timedelta64(int(round(step)), time_unit)
     return start+step/2.+np.arange(length)*step
 
 
@@ -1562,5 +1562,7 @@ def dt_to_int(value, time_unit='us'):
     elif isinstance(value, np.datetime64):
         value = value.tolist()
     if isinstance(value, int):
-        return value * 10e-4
+        # Handle special case of nanosecond precision which cannot be
+        # represented by python datetime
+        return value * 10**-(np.log10(tscale)-3)
     return int(value.timestamp()) * tscale

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1565,4 +1565,9 @@ def dt_to_int(value, time_unit='us'):
         # Handle special case of nanosecond precision which cannot be
         # represented by python datetime
         return value * 10**-(np.log10(tscale)-3)
-    return int(value.timestamp()) * tscale
+    try:
+        # Handle python3
+        return int(value.timestamp() * tscale)
+    except:
+        # Handle python2
+        return (time.mktime(value.timetuple()) + value.microsecond / 1e6) * tscale

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -8,10 +8,10 @@ from ..core.data import ImageInterface
 from ..core import Dimension, Element2D, Overlay, Dataset
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
-from ..core.util import max_range, dimension_range
+from ..core.util import max_range, dimension_range, compute_density
 from .chart import Curve
 from .tabular import Table
-from .util import compute_edges, compute_slice_bounds, categorical_aggregate2d, compute_density
+from .util import compute_edges, compute_slice_bounds, categorical_aggregate2d
 
 
 class Raster(Element2D):
@@ -423,6 +423,8 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
                 return (b, t) if idx else (l, r)
             density = self.ydensity if idx else self.xdensity
             halfd = (1./density)/2.
+            if isinstance(low, np.datetime64):
+                halfd = np.timedelta64(int(halfd), self._time_unit)
             return (low-halfd, high+halfd)
         else:
             return super(Image, self).range(dim, data_range)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -236,9 +236,9 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         dim2, dim1 = self.interface.shape(self, gridded=True)[:2]
         if bounds is None:
             xvals = self.dimension_values(0, False)
-            l, r, xdensity, _ = util.bound_range(xvals, xdensity)
+            l, r, xdensity, _ = util.bound_range(xvals, xdensity, self._time_unit)
             yvals = self.dimension_values(1, False)
-            b, t, ydensity, _ = util.bound_range(yvals, ydensity)
+            b, t, ydensity, _ = util.bound_range(yvals, ydensity, self._time_unit)
             bounds = BoundingBox(points=((l, b), (r, t)))
         elif np.isscalar(bounds):
             bounds = BoundingBox(radius=bounds)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -424,7 +424,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
             density = self.ydensity if idx else self.xdensity
             halfd = (1./density)/2.
             if isinstance(low, datetime_types):
-                halfd = np.timedelta64(int(halfd), self._time_unit)
+                halfd = np.timedelta64(int(round(halfd)), self._time_unit)
             return (low-halfd, high+halfd)
         else:
             return super(Image, self).range(dim, data_range)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -8,7 +8,7 @@ from ..core.data import ImageInterface
 from ..core import Dimension, Element2D, Overlay, Dataset
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
-from ..core.util import max_range, dimension_range, compute_density
+from ..core.util import max_range, dimension_range, compute_density, datetime_types
 from .chart import Curve
 from .tabular import Table
 from .util import compute_edges, compute_slice_bounds, categorical_aggregate2d
@@ -423,7 +423,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
                 return (b, t) if idx else (l, r)
             density = self.ydensity if idx else self.xdensity
             halfd = (1./density)/2.
-            if isinstance(low, np.datetime64):
+            if isinstance(low, datetime_types):
                 halfd = np.timedelta64(int(halfd), self._time_unit)
             return (low-halfd, high+halfd)
         else:

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -76,9 +76,9 @@ def compute_slice_bounds(slices, scs, shape):
     xunit = (1./xdensity)
     yunit = (1./ydensity)
     if isinstance(l, datetime_types):
-        xunit = np.timedelta64(int(xunit), scs._time_unit)
+        xunit = np.timedelta64(int(round(xunit)), scs._time_unit)
     if isinstance(b, datetime_types):
-        yunit = np.timedelta64(int(yunit), scs._time_unit)
+        yunit = np.timedelta64(int(round(yunit)), scs._time_unit)
     if isinstance(xidx, slice):
         l = l if xidx.start is None else max(l, xidx.start)
         r = r if xidx.stop is None else min(r, xidx.stop)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -27,6 +27,16 @@ except:
     xr = None
 
 
+def compute_density(start, end, length, time_unit='us'):
+    if isinstance(start, int): start = float(start)
+    if isinstance(end, int): end = float(end)
+    diff = end-start
+    if isinstance(diff, np.timedelta64):
+        tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
+        return (length/(diff.tolist().total_seconds()*tscale))
+    else:
+        return length/diff
+
 
 def compute_edges(edges):
     """
@@ -76,6 +86,10 @@ def compute_slice_bounds(slices, scs, shape):
     xdensity, ydensity = scs.xdensity, scs.ydensity
     xunit = (1./xdensity)
     yunit = (1./ydensity)
+    if isinstance(l, np.datetime64):
+        xunit = np.timedelta64(int(xunit), scs._time_unit)
+    if isinstance(b, np.datetime64):
+        yunit = np.timedelta64(int(yunit), scs._time_unit)
     if isinstance(xidx, slice):
         l = l if xidx.start is None else max(l, xidx.start)
         r = r if xidx.stop is None else min(r, xidx.stop)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -8,7 +8,7 @@ from ..core.boundingregion import BoundingBox
 from ..core.operation import Operation
 from ..core.sheetcoords import Slice
 from ..core.util import (is_nan, sort_topologically, one_to_one,
-                         cartesian_product, is_cyclic)
+                         cartesian_product, is_cyclic, datetime_types)
 
 try:
     import pandas as pd
@@ -75,9 +75,9 @@ def compute_slice_bounds(slices, scs, shape):
     xdensity, ydensity = scs.xdensity, scs.ydensity
     xunit = (1./xdensity)
     yunit = (1./ydensity)
-    if isinstance(l, np.datetime64):
+    if isinstance(l, datetime_types):
         xunit = np.timedelta64(int(xunit), scs._time_unit)
-    if isinstance(b, np.datetime64):
+    if isinstance(b, datetime_types):
         yunit = np.timedelta64(int(yunit), scs._time_unit)
     if isinstance(xidx, slice):
         l = l if xidx.start is None else max(l, xidx.start)

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -27,17 +27,6 @@ except:
     xr = None
 
 
-def compute_density(start, end, length, time_unit='us'):
-    if isinstance(start, int): start = float(start)
-    if isinstance(end, int): end = float(end)
-    diff = end-start
-    if isinstance(diff, np.timedelta64):
-        tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
-        return (length/(diff.tolist().total_seconds()*tscale))
-    else:
-        return length/diff
-
-
 def compute_edges(edges):
     """
     Computes edges from a number of bin centers,

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -10,7 +10,7 @@ from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         PlotSize, Draw, BoundsXY)
 from ...streams import PositionX, PositionY, PositionXY, Bounds # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS
-
+from .util import convert_timestamp
 
 
 class MessageCallback(object):
@@ -549,9 +549,9 @@ class PointerXYCallback(Callback):
         xaxis = self.plot.handles.get('xaxis')
         yaxis = self.plot.handles.get('yaxis')
         if 'x' in msg and isinstance(xaxis, DatetimeAxis):
-            msg['x'] = dt.datetime.fromtimestamp(msg['x']/1000.)
+            msg['x'] = convert_timestamp(msg['x'])
         if 'y' in msg and isinstance(yaxis, DatetimeAxis):
-            msg['y'] = dt.datetime.fromtimestamp(msg['y']/1000.)
+            msg['y'] = convert_timestamp(msg['y'])
         return msg
 
 
@@ -665,16 +665,16 @@ class RangeXYCallback(Callback):
         if 'x0' in msg and 'x1' in msg:
             x0, x1 = msg['x0'], msg['x1']
             if isinstance(self.plot.handles['xaxis'], DatetimeAxis):
-                x0 = dt.datetime.fromtimestamp(x0/1000.)
-                x1 = dt.datetime.fromtimestamp(x1/1000.)
+                x0 = convert_timestamp(x0)
+                x1 = convert_timestamp(x1)
             if self.plot.invert_xaxis:
                 x0, x1 = x1, x0
             data['x_range'] = (x0, x1)
         if 'y0' in msg and 'y1' in msg:
             y0, y1 = msg['y0'], msg['y1']
             if isinstance(self.plot.handles['yaxis'], DatetimeAxis):
-                y0 = dt.datetime.fromtimestamp(y0/1000.)
-                y1 = dt.datetime.fromtimestamp(y1/1000.)
+                y0 = convert_timestamp(y0)
+                y1 = convert_timestamp(y1)
             if self.plot.invert_yaxis:
                 y0, y1 = y1, y0
             data['y_range'] = (y0, y1)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -50,6 +50,13 @@ markers = {'s': {'marker': 'square'},
            '4': {'marker': 'triangle', 'angle': np.pi/2}}
 
 
+def convert_timestamp(timestamp):
+    """
+    Converts bokehJS timestamp to datetime64.
+    """
+    return np.datetime64(dt.datetime.fromtimestamp(timestamp/1000.))
+
+
 def rgba_tuple(rgba):
     """
     Ensures RGB(A) tuples in the range 0-1 are scaled to 0-255.

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -516,10 +516,10 @@ class RangeXY(LinkedStream):
     Axis ranges along x- and y-axis in data coordinates.
     """
 
-    x_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
+    x_range = param.Tuple(default=None, length=2, constant=True, doc="""
       Range of the x-axis of a plot in data coordinates""")
 
-    y_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
+    y_range = param.Tuple(default=None, length=2, constant=True, doc="""
       Range of the y-axis of a plot in data coordinates""")
 
 
@@ -528,7 +528,7 @@ class RangeX(LinkedStream):
     Axis range along x-axis in data coordinates.
     """
 
-    x_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
+    x_range = param.Tuple(default=None, length=2, constant=True, doc="""
       Range of the x-axis of a plot in data coordinates""")
 
 
@@ -537,7 +537,7 @@ class RangeY(LinkedStream):
     Axis range along y-axis in data coordinates.
     """
 
-    y_range = param.NumericTuple(default=None, length=2, constant=True, doc="""
+    y_range = param.Tuple(default=None, length=2, constant=True, doc="""
       Range of the y-axis of a plot in data coordinates""")
 
 

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -1557,3 +1557,16 @@ class RasterDatasetTest(GridTests, ComparisonTestCase):
 
     def tearDown(self):
         Dataset.datatype = self.restore_datatype
+
+    def test_canonical_vdim(self):
+        x = np.array([ 0.  ,  0.75,  1.5 ])
+        y = np.array([ 1.5 ,  0.75,  0.  ])
+        z = np.array([[ 0.06925999,  0.05800389,  0.05620127],
+                      [ 0.06240918,  0.05800931,  0.04969735],
+                      [ 0.05376789,  0.04669417,  0.03880118]])
+        dataset = Image((x, y, z), kdims=['x', 'y'], vdims=['z'])
+        canonical = np.array([[ 0.05376789,  0.04669417,  0.03880118],
+                              [ 0.06240918,  0.05800931,  0.04969735],
+                              [ 0.06925999,  0.05800389,  0.05620127]])
+        self.assertEqual(dataset.dimension_values('z', flat=False),
+                         canonical)


### PR DESCRIPTION
Adds support for datetime axes on Image, SheetCoordinateSystem, BoundingBox and Slice. The basics are all working including instantiation of an Image with datetime bounds and slicing and indexing. Will make it possible to generate datashaded images with datetime axes.

<img width="903" alt="screen shot 2017-10-26 at 4 27 42 am" src="https://user-images.githubusercontent.com/1550771/32033716-0b9c0a18-ba06-11e7-8b30-2029bf6ff8e3.png">
