### PR TITLE
Fixed Area.stack when passing in an NdOverlay

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -390,9 +390,11 @@ class Area(Curve):
         their baselines. To stack a HoloMap or DynamicMap use the map
         method.
         """
-        baseline = np.zeros(len(areas.get(0)))
+        if not len(areas):
+            return stacked
+        baseline = np.zeros(len(areas.values()[0]))
         stacked = areas.clone(shared_data=False)
-        vdims = [areas.get(0).vdims[0], 'Baseline']
+        vdims = [areas.values()[0].vdims[0], 'Baseline']
         for k, area in areas.items():
             x, y = (area.dimension_values(i) for i in range(2))
             stacked[k] = area.clone((x, y+baseline, baseline), vdims=vdims,


### PR DESCRIPTION
The Area.stack classmethod provides an easy way to stack an Overlay of Areas, but currently it does not work with NdOverlays. This is an easy fix to address this issue.