### PR TITLE
Various fixes and cleanup of bokeh BarsPlot

### DIFF
--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -985,7 +985,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         source = plot.handles['source']
         self.assertEqual([tuple(x) for x in source.data['xoffsets']],
                          [('A', '0'), ('B', '0'), ('A', '1')])
-        self.assertEqual(list(source.data['Category']), ['0', '0', '1'])
+        self.assertEqual(list(source.data['Category']), [0, 0, 1])
         self.assertEqual(source.data['Value'], np.array([1, 2, -1]))
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.factors, [('A', '0'), ('A', '1'), ('B', '0'), ('B', '1')])
@@ -995,7 +995,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                     kdims=['Index', 'Category'], vdims=['Value'])
         plot = bokeh_renderer.get_plot(bars.opts(plot=dict(stack_index=1)))
         source = plot.handles['source']
-        self.assertEqual(list(source.data['Category']), ['1', '0', '0'])
+        self.assertEqual(list(source.data['Category']), [1, 0, 0])
         self.assertEqual(list(source.data['Index']), ['A', 'A', 'B'])
         self.assertEqual(source.data['top'], np.array([0, 1, 2]))
         self.assertEqual(source.data['bottom'], np.array([-1, 0, 0]))


### PR DESCRIPTION
The BarsPlot has gone through a lot of iteration due to fundamental changes to the way categoricals are handled in Bokeh. As a long term goal I think it should be rewritten again but for the time being this PR addresses several issues:

* Negative values are stacked correctly
* Stacked bars are colored correctly and stay in their original order
* Avoid warnings that the ColumnDataSource columns are not of matching lengths