### PR TITLE
Allow setting explicit BoxWhisker range

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -938,7 +938,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         Extents are set to '' and None because x-axis is categorical and
         y-axis auto-ranges.
         """
-        return ('', None, '', None)
+        yrange = element.range(element.vdims[0], data_range=False)
+        return ('', yrange[0], '', yrange[1])
 
     def _get_axis_labels(self, *args, **kwargs):
         """


### PR DESCRIPTION
Currently there is no way to set the BoxWhisker range at all. While it makes sense that it auto-ranges by default it should respect explicitly set ranges. Partially addresses https://github.com/ioam/holoviews/issues/1937.