### PR TITLE
Removed width/height style opts from TabularPlot

### DIFF
--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -16,7 +16,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
     width = param.Number(default=400)
 
     style_opts = ['row_headers', 'selectable', 'editable',
-                  'sortable', 'fit_columns', 'width', 'height']
+                  'sortable', 'fit_columns']
 
     finalize_hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing a column.


### PR DESCRIPTION
For some reason width and height style options were defined on bokeh TabularPlot leading to confusion and errors like in this issue: https://github.com/ioam/holoviews/issues/1583