### PR TITLE
Add axis handles to OverlayPlot

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1364,6 +1364,12 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             self._process_legend()
         self.drawn = True
 
+        if 'plot' in self.handles and not self.tabs:
+            plot = self.handles['plot']
+            self.handles['xaxis'] = plot.xaxis[0]
+            self.handles['yaxis'] = plot.yaxis[0]
+            self.handles['x_range'] = plot.x_range
+            self.handles['y_range'] = plot.y_range
         for cb in self.callbacks:
             cb.initialize()
 


### PR DESCRIPTION
The bokeh callbacks sometimes inspect the handles to determine whether to transform the data in some way, e.g. to convert datetimes. On an OverlayPlot this currently does not work because the axis is not defined in the handles.