### PR TITLE
Added DataError for irrecoverable data interface initialization errors

### DIFF
--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -5,7 +5,7 @@ except ImportError:
 
 import numpy as np
 
-from .interface import Interface
+from .interface import Interface, DataError
 from ..dimension import Dimension
 from ..element import Element
 from ..ndmapping import NdMapping, item_check
@@ -75,8 +75,8 @@ class ArrayInterface(Interface):
         ndims = len(dataset.dimensions())
         ncols = dataset.data.shape[1] if dataset.data.ndim > 1 else 1
         if ncols < ndims:
-            raise ValueError("Supplied data does not match specified "
-                             "dimensions, expected at least %s columns." % ndims)
+            raise DataError("Supplied data does not match specified "
+                            "dimensions, expected at least %s columns." % ndims)
 
 
     @classmethod

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -76,7 +76,7 @@ class ArrayInterface(Interface):
         ncols = dataset.data.shape[1] if dataset.data.ndim > 1 else 1
         if ncols < ndims:
             raise DataError("Supplied data does not match specified "
-                            "dimensions, expected at least %s columns." % ndims)
+                            "dimensions, expected at least %s columns." % ndims, cls)
 
 
     @classmethod

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -104,10 +104,14 @@ class DictInterface(Interface):
         dimensions = dataset.dimensions(label='name')
         not_found = [d for d in dimensions if d not in dataset.data]
         if not_found:
-            raise DataError('Following dimensions not found in data: %s' % not_found)
-        lengths = [len(dataset.data[dim]) for dim in dimensions if not np.isscalar(dataset.data[dim])]
-        if len({l for l in lengths if l > 1}) > 1:
-            raise DataError('Length of columns do not match')
+            raise DataError('Following columns specified as dimensions '
+                            'but not found in data: %s' % not_found, cls)
+        lengths = [(dim, 1 if np.isscalar(dataset.data[dim]) else len(dataset.data[dim]))
+                   for dim in dimensions]
+        if len({l for d, l in lengths if l > 1}) > 1:
+            lengths = ', '.join(['%s: %d' % l for l in sorted(lengths)])
+            raise DataError('Length of columns must be equal or scalar, '
+                            'columns have lengths: %s' % lengths, cls)
 
 
     @classmethod

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -8,7 +8,7 @@ except ImportError:
 
 import numpy as np
 
-from .interface import Interface
+from .interface import Interface, DataError
 from ..dimension import Dimension
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
@@ -104,10 +104,10 @@ class DictInterface(Interface):
         dimensions = dataset.dimensions(label='name')
         not_found = [d for d in dimensions if d not in dataset.data]
         if not_found:
-            raise ValueError('Following dimensions not found in data: %s' % not_found)
+            raise DataError('Following dimensions not found in data: %s' % not_found)
         lengths = [len(dataset.data[dim]) for dim in dimensions if not np.isscalar(dataset.data[dim])]
         if len({l for l in lengths if l > 1}) > 1:
-            raise ValueError('Length of columns do not match')
+            raise DataError('Length of columns do not match')
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -77,7 +77,7 @@ class GridInterface(DictInterface):
             if shape != expected[::-1] and not (not expected and shape == (1,)):
                 raise DataError('Key dimension values and value array %s '
                                 'shapes do not match. Expected shape %s, '
-                                'actual shape: %s' % (vdim, expected[::-1], shape))
+                                'actual shape: %s' % (vdim, expected[::-1], shape), cls)
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -74,10 +74,11 @@ class GridInterface(DictInterface):
         expected = tuple([len(data[kd]) for kd in kdim_names])
         for vdim in vdim_names:
             shape = data[vdim].shape
+            error = DataError if len(shape) > 1 else ValueError
             if shape != expected[::-1] and not (not expected and shape == (1,)):
-                raise DataError('Key dimension values and value array %s '
-                                'shapes do not match. Expected shape %s, '
-                                'actual shape: %s' % (vdim, expected[::-1], shape), cls)
+                raise error('Key dimension values and value array %s '
+                            'shapes do not match. Expected shape %s, '
+                            'actual shape: %s' % (vdim, expected[::-1], shape), cls)
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -8,7 +8,7 @@ except ImportError:
 import numpy as np
 
 from .dictionary import DictInterface
-from .interface import Interface
+from .interface import Interface, DataError
 from ..dimension import Dimension
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
@@ -75,9 +75,9 @@ class GridInterface(DictInterface):
         for vdim in vdim_names:
             shape = data[vdim].shape
             if shape != expected[::-1] and not (not expected and shape == (1,)):
-                raise ValueError('Key dimension values and value array %s '
-                                 'shape do not match. Expected shape %s, '
-                                 'actual shape: %s' % (vdim, expected[::-1], shape))
+                raise DataError('Key dimension values and value array %s '
+                                'shapes do not match. Expected shape %s, '
+                                'actual shape: %s' % (vdim, expected[::-1], shape))
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -9,6 +9,11 @@ from .. import util
 class DataError(ValueError):
     "DataError is raised when the data cannot be interpreted"
 
+    def __init__(self, msg, interface=None):
+        if interface is not None:
+            msg = '\n\n'.join([msg, interface.error()])
+        super(DataError, self).__init__(msg)
+
 
 class iloc(object):
     """
@@ -126,6 +131,24 @@ class Interface(param.Parameterized):
 
 
     @classmethod
+    def error(cls):
+        info = dict(interface=cls.__name__)
+        url = "http://holoviews.org/user_guide/%s_Datasets.html"
+        if cls.multi:
+            datatype = 'a list of tabular'
+            info['url'] = url % 'Tabular'
+        else:
+            if cls.gridded:
+                datatype = 'gridded'
+            else:
+                datatype = 'tabular'
+            info['url'] = url % datatype.capitalize()
+        info['datatype'] = datatype
+        return ("{interface} expects {datatype} data, for more information "
+                "on supported datatypes see {url}".format(**info))
+
+
+    @classmethod
     def initialize(cls, eltype, data, kdims, vdims, datatype=None):
         # Process params and dimensions
         if isinstance(data, Element):
@@ -184,7 +207,7 @@ class Interface(param.Parameterized):
         if not_found:
             raise DataError("Supplied data does not contain specified "
                             "dimensions, the following dimensions were "
-                            "not found: %s" % repr(not_found))
+                            "not found: %s" % repr(not_found), cls)
 
 
     @classmethod

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -6,6 +6,10 @@ from ..ndmapping import OrderedDict
 from .. import util
 
 
+class DataError(ValueError):
+    "DataError is raised when the data cannot be interpreted"
+
+
 class iloc(object):
     """
     iloc is small wrapper object that allows row, column based
@@ -162,6 +166,8 @@ class Interface(param.Parameterized):
             try:
                 (data, dims, extra_kws) = interface.init(eltype, data, kdims, vdims)
                 break
+            except DataError:
+                raise
             except Exception:
                 pass
         else:
@@ -176,9 +182,9 @@ class Interface(param.Parameterized):
         not_found = [d for d in dataset.dimensions(label='name')
                      if d not in dataset.data]
         if not_found:
-            raise ValueError("Supplied data does not contain specified "
-                             "dimensions, the following dimensions were "
-                             "not found: %s" % repr(not_found))
+            raise DataError("Supplied data does not contain specified "
+                            "dimensions, the following dimensions were "
+                            "not found: %s" % repr(not_found))
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -8,7 +8,7 @@ from iris.util import guess_coord_axis
 
 import numpy as np
 
-from .interface import Interface
+from .interface import Interface, DataError
 from .grid import GridInterface
 from ..dimension import Dimension
 from ..element import Element
@@ -129,7 +129,7 @@ class CubeInterface(GridInterface):
     @classmethod
     def validate(cls, dataset):
         if len(dataset.vdims) > 1:
-            raise ValueError("Iris cubes do not support more than one value dimension")
+            raise DataError("Iris cubes do not support more than one value dimension")
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -129,7 +129,7 @@ class CubeInterface(GridInterface):
     @classmethod
     def validate(cls, dataset):
         if len(dataset.vdims) > 1:
-            raise DataError("Iris cubes do not support more than one value dimension")
+            raise DataError("Iris cubes do not support more than one value dimension", cls)
 
 
     @classmethod

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from ..util import max_range
-from .interface import Interface
+from .interface import Interface, DataError
+
 
 class MultiInterface(Interface):
     """
@@ -40,11 +41,11 @@ class MultiInterface(Interface):
                                                          datatype=cls.subtypes)
             if prev_interface:
                 if prev_interface != interface:
-                    raise ValueError('MultiInterface subpaths must all have matching datatype.')
+                    raise DataError('MultiInterface subpaths must all have matching datatype.', cls)
                 if dims['kdims'] != prev_dims['kdims']:
-                    raise ValueError('MultiInterface subpaths must all have matching kdims.')
+                    raise DataError('MultiInterface subpaths must all have matching kdims.', cls)
                 if dims['vdims'] != prev_dims['vdims']:
-                    raise ValueError('MultiInterface subpaths must all have matching vdims.')
+                    raise DataError('MultiInterface subpaths must all have matching vdims.', cls)
             new_data.append(d)
             prev_interface, prev_dims = interface, dims
         return new_data, dims, {}

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -10,7 +10,7 @@ except ImportError:
 import numpy as np
 import pandas as pd
 
-from .interface import Interface
+from .interface import Interface, DataError
 from ..dimension import Dimension
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
@@ -44,6 +44,9 @@ class PandasInterface(Interface):
             elif kdims is None and vdims is None:
                 kdims = list(data.columns[:ndim])
                 vdims = [] if ndim is None else list(data.columns[ndim:])
+            if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
+                raise DataError("pandas DataFrame column names used as dimensions "
+                                "must be strings not integers.")
         else:
             # Check if data is of non-numeric type
             # Then use defined data type
@@ -92,9 +95,9 @@ class PandasInterface(Interface):
         not_found = [d for d in dataset.dimensions(label='name')
                      if d not in dataset.data.columns]
         if not_found:
-            raise ValueError("Supplied data does not contain specified "
-                             "dimensions, the following dimensions were "
-                             "not found: %s" % repr(not_found))
+            raise DataError("Supplied data does not contain specified "
+                            "dimensions, the following dimensions were "
+                            "not found: %s" % repr(not_found))
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -46,7 +46,7 @@ class PandasInterface(Interface):
                 vdims = [] if ndim is None else list(data.columns[ndim:])
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 raise DataError("pandas DataFrame column names used as dimensions "
-                                "must be strings not integers.")
+                                "must be strings not integers.", cls)
         else:
             # Check if data is of non-numeric type
             # Then use defined data type
@@ -97,7 +97,7 @@ class PandasInterface(Interface):
         if not_found:
             raise DataError("Supplied data does not contain specified "
                             "dimensions, the following dimensions were "
-                            "not found: %s" % repr(not_found))
+                            "not found: %s" % repr(not_found), cls)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -16,7 +16,7 @@ from ..dimension import Dimension
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..element import Element
 from .grid import GridInterface
-from .interface import Interface
+from .interface import Interface, DataError
 
 
 class XArrayInterface(GridInterface):
@@ -44,6 +44,9 @@ class XArrayInterface(GridInterface):
         vdim_param = element_params['vdims']
 
         if isinstance (data, xr.DataArray):
+            if data.name is None:
+                raise DataError("xarray DataArray must define a name to "
+                                "be wrapped by a HoloViews %s" % eltype.__name__)
             if data.name:
                 vdim = Dimension(data.name)
             elif vdims:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -51,7 +51,7 @@ class XArrayInterface(GridInterface):
             elif len(vdim_param.default) == 1:
                 vdim = vdim_param.default[0]
             else:
-                raise DataError("If xarray DataArray does not define a name"
+                raise DataError("If xarray DataArray does not define a name "
                                 "an explicit vdim must be supplied.", cls)
             vdims = [vdim]
             if not kdims:
@@ -91,8 +91,13 @@ class XArrayInterface(GridInterface):
                 kdims = [name for name in data.indexes.keys()
                          if isinstance(data[name].data, np.ndarray)]
 
+        not_found = [d for d in kdims if d.name not in data.coords]
         if not isinstance(data, xr.Dataset):
             raise TypeError('Data must be be an xarray Dataset type.')
+        elif not_found:
+            raise DataError("xarray Dataset must define coordinates "
+                            "for all defined kdims, %s coordinates not found."
+                            % not_found, cls)
         return data, {'kdims': kdims, 'vdims': vdims}, {}
 
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -45,8 +45,8 @@ class XArrayInterface(GridInterface):
 
         if isinstance (data, xr.DataArray):
             if data.name is None:
-                raise DataError("xarray DataArray must define a name to "
-                                "be wrapped by a HoloViews %s" % eltype.__name__)
+                raise DataError("xarray DataArray must define a name."
+                                % eltype.__name__, cls)
             if data.name:
                 vdim = Dimension(data.name)
             elif vdims:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -44,15 +44,15 @@ class XArrayInterface(GridInterface):
         vdim_param = element_params['vdims']
 
         if isinstance (data, xr.DataArray):
-            if data.name is None:
-                raise DataError("xarray DataArray must define a name."
-                                % eltype.__name__, cls)
             if data.name:
                 vdim = Dimension(data.name)
             elif vdims:
                 vdim = vdims[0]
             elif len(vdim_param.default) == 1:
                 vdim = vdim_param.default[0]
+            else:
+                raise DataError("If xarray DataArray does not define a name"
+                                "an explicit vdim must be supplied.", cls)
             vdims = [vdim]
             if not kdims:
                 kdims = [Dimension(d) for d in data.dims[::-1]]

--- a/tests/testmultiinterface.py
+++ b/tests/testmultiinterface.py
@@ -6,6 +6,7 @@ from unittest import SkipTest
 
 import numpy as np
 from holoviews import Dataset
+from holoviews.core.data.interface import DataError
 from holoviews.element import Path
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -112,15 +113,13 @@ class MultiInterfaceTest(ComparisonTestCase):
     def test_multi_mixed_interface_raises(self):
         arrays = [np.random.rand(10, 2) if j else {'x': range(10), 'y': range(10)}
                   for i in range(2) for j in range(2)]
-        error = "None of the available storage backends were able to support the supplied data format."
-        with self.assertRaisesRegexp(ValueError, error):
+        with self.assertRaises(DataError):
             mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
 
     def test_multi_mixed_dims_raises(self):
         arrays = [{'x': range(10), 'y' if j else 'z': range(10)}
                   for i in range(2) for j in range(2)]
-        error = "Following dimensions not found in data: \['y'\]"
-        with self.assertRaisesRegexp(ValueError, error):
+        with self.assertRaises(DataError):
             mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular'])
 
     def test_multi_split(self):


### PR DESCRIPTION
We really need to do something about Interface data errors, particularly those that can provide clear and unambiguous exception message when the data is definitely incorrectly defined. In this PR I introduce a ``DataError``, which prevents the Interface from trying to fall back to other data types and therefore allows raising a proper exception message. This approach is much simpler than what I outlined in https://github.com/ioam/holoviews/issues/1986 and makes the process of raising specific exceptions quite simple.

Addresses:

https://github.com/ioam/holoviews/issues/1762
https://github.com/ioam/holoviews/issues/1867