### PR TITLE
Ensure that key dimensions are hashed correctly

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -487,7 +487,7 @@ class Callable(param.Parameterized):
 
     def __call__(self, *args, **kwargs):
         # Nothing to do for callbacks that accept no arguments
-        kwarg_hash = kwargs.pop('memoization_hash', [])
+        kwarg_hash = kwargs.pop('memoization_hash', ())
         (self.args, self.kwargs) = (args, kwargs)
         if not args and not kwargs: return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
@@ -497,7 +497,7 @@ class Callable(param.Parameterized):
 
         memoize = self._stream_memoization and not any(s.transient and s._triggering for s in streams)
         values = tuple(tuple(sorted(s.hashkey.items())) for s in streams)
-        key = args + tuple(sorted(kwarg_hash)) + values
+        key = args + kwarg_hash + values
 
         hashed_key = util.deephash(key) if self.memoize else None
         if hashed_key is not None and memoize and hashed_key in self._memoized:
@@ -839,7 +839,7 @@ class DynamicMap(HoloMap):
         # Additional validation needed to ensure kwargs don't clash
         kdims = [kdim.name for kdim in self.kdims]
         kwarg_items = [s.contents.items() for s in self.streams]
-        hash_items = tuple(tuple(sorted(s.hashkey.items())) for s in self.streams)
+        hash_items = tuple(tuple(sorted(s.hashkey.items())) for s in self.streams)+args
         flattened = [(k,v) for kws in kwarg_items for (k,v) in kws
                      if k not in kdims]
 

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -429,6 +429,22 @@ class DynamicTestOverlay(ComparisonTestCase):
 
 class DynamicCallableMemoize(ComparisonTestCase):
 
+    def test_dynamic_keydim_not_memoize(self):
+        dmap = DynamicMap(lambda x: Curve([(0, x)]), kdims=['x'])
+        self.assertEqual(dmap[0], Curve([(0, 0)]))
+        self.assertEqual(dmap[1], Curve([(0, 1)]))
+
+    def test_dynamic_keydim_memoize(self):
+        dmap = DynamicMap(lambda x: Curve([(0, x)]), kdims=['x'])
+        self.assertIs(dmap[0], dmap[0])
+
+    def test_dynamic_keydim_memoize_disable(self):
+        dmap = DynamicMap(Callable(lambda x: Curve([(0, x)]), memoize=False), kdims=['x'])
+        first = dmap[0]
+        del dmap.data[(0,)]
+        second = dmap[0]
+        self.assertIsNot(first, second)
+        
     def test_dynamic_callable_memoize(self):
         # Always memoized only one of each held
         def history_callback(x, history=deque(maxlen=10)):


### PR DESCRIPTION
In an earlier PR I accidentally dropped the DynamicMap key dimensions values from the memoization hash, which meant it never updated. Somehow this wasn't caught at all so I've added some unit tests.