### PR TITLE
Fixed bug in bokeh Graphs when plotting string index

### DIFF
--- a/tests/testbokehgraphs.py
+++ b/tests/testbokehgraphs.py
@@ -73,7 +73,7 @@ class BokehGraphPlotTests(ComparisonTestCase):
         renderer = plot.handles['glyph_renderer']
         hover = plot.handles['hover']
         self.assertIsInstance(renderer.inspection_policy, NodesAndLinkedEdges)
-        self.assertEqual(hover.tooltips, [('index', '@{index}')])
+        self.assertEqual(hover.tooltips, [('index', '@{index_hover}')])
         self.assertIn(renderer, hover.renderers)
 
     def test_graph_inspection_policy_edges(self):


### PR DESCRIPTION
When the hover tool was enabled and the node indices were not integers Graph nodes would in some cases disappear.