### PR TITLE
Improved handling of DynamicMap transform methods

### DIFF
--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -186,6 +186,14 @@ class DynamicMapMethods(ComparisonTestCase):
         curve = fn(10)
         self.assertEqual(mapped[10], curve.clone(curve.data*2))
 
+    def test_deep_map_transform_element_type(self):
+        fn = lambda i: Curve(np.arange(i))
+        dmap = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])
+        dmap[10]
+        mapped = dmap.map(lambda x: Scatter(x), Curve)
+        area = mapped[11]
+        self.assertEqual(area, Scatter(fn(11)))
+
     def test_deep_map_apply_dmap_function(self):
         fn = lambda i: Curve(np.arange(i))
         dmap1 = DynamicMap(fn, kdims=[Dimension('Test', range=(10, 20))])


### PR DESCRIPTION
This PR fixes an issue when applying .map to a DynamicMap where the mapped function transforms the type of element. Previously the mapping function was applied to the DynamicMap cache first and then the function was applied to the DynamicMap clone that had the converted data. This resulted in type mismatches between what was returned by the new DynamicMap callback and what was already in the cache. By simply copying over the cache we avoid this issue and get rid of one additional superfluous level of DynamicMap nesting, resulting in a cleaner graph.