### PR TITLE
Fixes for empty or missing frames

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -7,7 +7,7 @@ import bokeh
 import bokeh.plotting
 from bokeh import palettes
 from bokeh.core.properties import value
-from bokeh.models import (HoverTool, Renderer, Range1d, DataRange1d,
+from bokeh.models import (HoverTool, Renderer, Range1d, DataRange1d, Title,
                           FactorRange, FuncTickFormatter, Tool, Legend)
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
 from bokeh.models.widgets import Panel, Tabs
@@ -536,8 +536,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         recursive_model_update(plot.yaxis[0], props.get('y', {}))
 
         if not self.overlaid:
-            plot.title.update(**self._title_properties(key, plot, element))
-
+            if plot.title:
+                plot.title.update(**self._title_properties(key, plot, element))
+            else:
+                plot.title = Title(**self._title_properties(key, plot, element))
         if not self.show_grid:
             plot.xgrid.grid_line_color = None
             plot.ygrid.grid_line_color = None
@@ -838,8 +840,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             self.current_frame = element
 
         renderer = self.handles.get('glyph_renderer', None)
+        glyph = self.handles.get('glyph', None)
+        visible = bool(element)
         if hasattr(renderer, 'visible'):
-            renderer.visible = bool(element)
+            renderer.visible = visible
+        if hasattr(glyph, 'visible'):
+            glyph.visible = visible
 
         if ((self.batched and not element) or element is None or (not self.dynamic and self.static) or
             (self.streaming and self.streaming.data is self.current_frame.data

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -252,6 +252,16 @@ class BokehWidget(NdWidget):
             frames = json.dumps(frames).replace('</', r'<\/')
         return frames
 
+    def get_frames(self):
+        nframes = len(self.plot)
+        if self.embed:
+            self.plot.update(nframes-1)
+            frames = OrderedDict([(idx, self._plot_figure(idx))
+                                  for idx in range(nframes)])
+        else:
+            frames = {}
+        return self.encode_frames(frames)
+
     def _plot_figure(self, idx, fig_format='json'):
         """
         Returns the figure in html format on the

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -852,7 +852,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                 frame = element.get(k, None)
                 subplot.current_frame = frame
 
-        if self.show_legend:
+        if self.show_legend and element is not None:
             self._adjust_legend(element, axis)
 
         return self._finalize_axis(key, element=element, ranges=ranges,


### PR DESCRIPTION
Fixes a number of bugs handling empty frames:

* Fixed updating title when initial frame had no title (Bokeh)
* Ensured that glyphs with a renderer, e.g. Band and Whisker, toggle visibility (bokeh)
* When embedding plot update plot to last frame to ensure all change events are recorded correctly (bokeh)
* Do not adjust legend if the current frame is empty (matplotlib) 
