### PR TITLE
Handle various error conditions in Interface constructor

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -59,8 +59,16 @@ class PandasInterface(Interface):
 
             if isinstance(data, dict) and all(c in data for c in columns):
                 data = cyODict(((d, data[d]) for d in columns))
-            elif isinstance(data, dict) and not all(d in data for d in columns):
+            elif isinstance(data, (list, dict)) and data in ([], {}):
+                data = None
+            elif (isinstance(data, dict) and not all(d in data for d in columns) and
+                  not any(isinstance(v, np.ndarray) for v in data.values())):
                 column_data = sorted(data.items())
+                k, v = column_data[0]
+                if len(util.wrap_tuple(k)) != len(kdims) or len(util.wrap_tuple(v)) != len(vdims):
+                    raise ValueError("Dictionary data not understood, should contain a column "
+                                    "per dimension or a mapping between key and value dimension "
+                                    "values.")
                 column_data = zip(*((util.wrap_tuple(k)+util.wrap_tuple(v))
                                     for k, v in column_data))
                 data = cyODict(((c, col) for c, col in zip(columns, column_data)))
@@ -72,8 +80,6 @@ class PandasInterface(Interface):
                         data = np.atleast_2d(data).T
                 else:
                     data = tuple(data[:, i] for i in range(data.shape[1]))
-            elif isinstance(data, list) and data == []:
-                data = None
 
             if isinstance(data, tuple):
                 data = [np.array(d) if not isinstance(d, np.ndarray) else d for d in data]
@@ -81,6 +87,8 @@ class PandasInterface(Interface):
                     raise ValueError('PandasInterface expects data to be of uniform shape.')
                 data = pd.DataFrame.from_items([(c, d) for c, d in
                                                 zip(columns, data)])
+            elif isinstance(data, dict) and any(c not in data for c in columns):
+                raise ValueError('PandasInterface could not find specified dimensions in the data.')
             else:
                 data = pd.DataFrame(data, columns=columns)
         return data, {'kdims':kdims, 'vdims':vdims}, {}

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -37,13 +37,15 @@ class PandasInterface(Interface):
         vdim_param = element_params['vdims']
         if util.is_dataframe(data):
             ndim = len(kdim_param.default) if kdim_param.default else None
+            nvdim = len(vdim_param.default) if vdim_param.default else None
             if kdims and vdims is None:
                 vdims = [c for c in data.columns if c not in kdims]
             elif vdims and kdims is None:
                 kdims = [c for c in data.columns if c not in vdims][:ndim]
-            elif kdims is None and (vdims is None or vdims == []):
+            elif kdims is None:
                 kdims = list(data.columns[:ndim])
-                vdims = [] if ndim is None else list(data.columns[ndim:])
+                if vdims is None:
+                    vdims = [] if None in [ndim, nvdim] else list(data.columns[ndim:ndim+nvdim])
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 raise DataError("pandas DataFrame column names used as dimensions "
                                 "must be strings not integers.", cls)

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -8,6 +8,7 @@ from itertools import product
 
 import numpy as np
 from holoviews import Dataset, HoloMap, Dimension, Image
+from holoviews.core.data.interface import DataError
 from holoviews.element.comparison import ComparisonTestCase
 
 from collections import OrderedDict
@@ -100,6 +101,14 @@ class HomogeneousColumnTypes(object):
         dataset = Dataset([], kdims=['x'], vdims=['y'])
         for d in 'xy':
             self.assertEqual(dataset.dimension_values(d), np.array([]))
+
+    def test_dataset_dict_dim_not_found_raises_on_array(self):
+        with self.assertRaises(ValueError):
+            dataset = Dataset({'x': np.zeros(5)}, kdims=['Test'], vdims=[])
+
+    def test_dataset_dict_dim_not_found_raises_on_scalar(self):
+        with self.assertRaises(ValueError):
+            dataset = Dataset({'x': 1}, kdims=['Test'], vdims=[])
 
     # Properties and information
 


### PR DESCRIPTION
Handles some cases in the interfaces that would previously work even though they really shouldn't, includes:

```
Dataset({'x': np.zeros(5)}, kdims=['Test'], vdims=[])

Dataset({'x': 1}, kdims=['Test'], vdims=[])
```

Also handles elements which really only have one dimension, e.g. ``Distribution`` when passing in pandas dataframe with more than 2 dimensions.

```
Distribution(pd.DataFrame({'x': np.zeros(5), 'y': np.zeros(5), 'z': np.zeros(5)})
```

Once this is merged I'm going to make an issue about eventually dropping the dictionary mapping format that has clung on since ``NdElement``, examples include ``{0: 1}, {('A', 'B'): 1}, {('A', 'B'): (1, 2)}``, here both keys and values represent dimension values. It's terrible to validate and just not a great format. The only time it's semi-useful is for specifying HeatMaps.