### PR TITLE
Fixed bug in MultiPath nonzero

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -184,7 +184,7 @@ class MultiInterface(Interface):
 
     @classmethod
     def nonzero(cls, dataset):
-        return bool(cls.length(dataset))
+        return bool(dataset.data)
 
     @classmethod
     def redim(cls, dataset, dimensions):


### PR DESCRIPTION
In certain cases a bug can arise where param (incorrectly) checks ``if not obj`` on a ``Dataset`` while it is being constructed. This is usually not a problem because that checks the length and the length can usually be checked before the parameters are set. In the case of the MultiInterface this is not true because it has to construct sub-elements to check the length. This PR just checks the length of the interface ``.data``, which works fine and doesn't require constructing sub-elements. Separately I'll submit a change to param so it no longer tries too check whether the object evaluates to True.