### PR TITLE
Fixed pandas dimension ingestion

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -36,8 +36,8 @@ class PandasInterface(Interface):
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
         if util.is_dataframe(data):
-            ndim = len(kdim_param.default) if kdim_param.default else None
-            nvdim = len(vdim_param.default) if vdim_param.default else None
+            ndim = len(kdim_param.default) if kdim_param.default else 0
+            nvdim = vdim_param.bounds[1] if isinstance(vdim_param.bounds[1], int) else None
             if kdims and vdims is None:
                 vdims = [c for c in data.columns if c not in kdims]
             elif vdims and kdims is None:
@@ -45,7 +45,9 @@ class PandasInterface(Interface):
             elif kdims is None:
                 kdims = list(data.columns[:ndim])
                 if vdims is None:
-                    vdims = [] if None in [ndim, nvdim] else list(data.columns[ndim:ndim+nvdim])
+                    vdims = list(data.columns[ndim:((ndim+nvdim) if nvdim else None)])
+            elif kdims == [] and vdims is None:
+                vdims = list(data.columns[:nvdim if nvdim else None])
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 raise DataError("pandas DataFrame column names used as dimensions "
                                 "must be strings not integers.", cls)

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -9,6 +9,7 @@ from itertools import product
 import numpy as np
 from holoviews import Dataset, HoloMap, Dimension, Image
 from holoviews.core.data.interface import DataError
+from holoviews.element import Distribution, Points
 from holoviews.element.comparison import ComparisonTestCase
 
 from collections import OrderedDict
@@ -862,6 +863,53 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         self.data_instance_type = pd.DataFrame
         self.init_column_data()
 
+    def test_dataset_extract_vdims(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Dataset(df, kdims=['x'])
+        self.assertEqual(ds.vdims, [Dimension('y'), Dimension('z')])
+
+    def test_dataset_extract_kdims(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Distribution(df)
+        self.assertEqual(ds.kdims, [Dimension('x')])
+
+    def test_dataset_extract_kdims_and_vdims(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Points(df)
+        self.assertEqual(ds.kdims, [Dimension('x'), Dimension('y')])
+        self.assertEqual(ds.vdims, [Dimension('z')])
+
+    def test_dataset_extract_kdims_with_vdims_defined(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Points(df, vdims=['x'])
+        self.assertEqual(ds.kdims, [Dimension('y'), Dimension('z')])
+        self.assertEqual(ds.vdims, [Dimension('x')])
+
+    def test_dataset_extract_kdims_declare_no_vdims(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Points(df, vdims=[])
+        self.assertEqual(ds.kdims, [Dimension('x'), Dimension('y')])
+        self.assertEqual(ds.vdims, [])
+
+    def test_dataset_extract_kdims_declare_no_vdims(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Dataset(df, kdims=[])
+        self.assertEqual(ds.kdims, [])
+        self.assertEqual(ds.vdims, [Dimension('x'), Dimension('y'), Dimension('z')])
+        
+    def test_dataset_extract_vdims_with_kdims_defined(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Points(df, kdims=['x', 'z'])
+        self.assertEqual(ds.kdims, [Dimension('x'), Dimension('z')])
+        self.assertEqual(ds.vdims, [Dimension('y')])
+
     def test_multi_dimension_groupby(self):
         x, y, z = list('AB'*10), np.arange(20)%3, np.arange(20)
         ds = Dataset((x, y, z), kdims=['x', 'y'], vdims=['z'],  datatype=[self.datatype])
@@ -869,6 +917,7 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         grouped = ds.groupby(['x', 'y'])
         self.assertEqual(grouped.keys(), keys)
         group = Dataset({'z': [5, 11, 17]}, vdims=['z'])
+        print(grouped.last.kdims, grouped.last.vdims)
         self.assertEqual(grouped.last, group)
 
     def test_dataset_simple_dict_sorted(self):


### PR DESCRIPTION
The changes I made to how the pandas interface ingests dimensions weren't quite correct so this restores the old behavior while also fixing an issue with too many dimensions being extracted as vdims.

This time I also added a bunch of tests to ensure it's actually working properly.