### PR TITLE
Changed datashader default colormap to fit HV defaults

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -497,10 +497,13 @@ class shade(Operation):
     Iterable or a Callable.
     """
 
-    cmap = param.ClassSelector(default=["deepskyblue","black"], class_=(Iterable, Callable, dict), doc="""
-        Iterable or callable which returns colors as hex colors, to
-        be used for the colormap of single-layer datashader output. 
-        Callable type must allow mapping colors between 0 and 1.""")
+    cmap = param.ClassSelector(class_=(Iterable, Callable, dict), doc="""
+        Iterable or callable which returns colors as hex colors
+        or web color names (as defined by datashader), to be used
+        for the colormap of single-layer datashader output. 
+        Callable type must allow mapping colors between 0 and 1.
+        The default value of None reverts to Datashader's default
+        colormap.""")
 
     color_key = param.ClassSelector(class_=(Iterable, Callable, dict), doc="""
         Iterable or callable which returns colors as hex colors, to

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -497,7 +497,7 @@ class shade(Operation):
     Iterable or a Callable.
     """
 
-    cmap = param.ClassSelector(default=fire, class_=(Iterable, Callable, dict), doc="""
+    cmap = param.ClassSelector(default=["deepskyblue","black"], class_=(Iterable, Callable, dict), doc="""
         Iterable or callable which returns colors as hex colors, to
         be used for the colormap of single-layer datashader output. 
         Callable type must allow mapping colors between 0 and 1.""")


### PR DESCRIPTION
Currently, ``holoviews.operation.datashade.shade()`` and  ``holoviews.operation.datashade.datashade()`` use a default colormap of ``fire``, originally chosen to match the default Image colormap in HoloViews.  This made sense at first, because datashader produces images.  However, a datashader plot is rarely a dense image covering every pixel; instead it tends to have many transparent pixels, and is thus much more like a line or points plot in HoloViews.  When using ``datashade()`` on an ``hv.Points()``, etc. object using the HV/Jupyter/browser default white page background, a fire colormap is inappropriate, because the highest value maps to the page color.  This resulted in bits of datashader plots disappearing, which appeared to be a bug in datashader but was simply the result of using a colormap ending in white on a white page.  These bits sometimes disappear in the initial rendering, if there happen to be isolated pixels at the highest strength, or more often when zooming in far enough that a single color becomes visible, at which point the entire plot disappears.

This PR selects a colormap designed to be thematically compatible with the HV default blue color for lines and points:

![image](https://user-images.githubusercontent.com/1695496/32353231-906461fe-bff2-11e7-986b-927ed7ae076d.png)
