### PR TITLE
Added CSS class to logo block

### DIFF
--- a/holoviews/ipython/load_notebook.html
+++ b/holoviews/ipython/load_notebook.html
@@ -3,7 +3,7 @@
 {{ widgetcss }}
 
 {% if logo %}
-<div>
+<div class="logo-block">
 <img src='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz
 AAAB+wAAAfsBxc2miwAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAA6zSURB
 VHic7ZtpeFRVmsf/5966taWqUlUJ2UioBBJiIBAwCZtog9IOgjqACsogKtqirT2ttt069nQ/zDzt


### PR DESCRIPTION
Adds a CSS class to the logo in the extension so it can be styled separately in the doc build.