### PR TITLE
Ensure HeatMap correctly constructs from pandas

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -48,7 +48,8 @@ class PandasInterface(Interface):
             elif kdims is None:
                 kdims = list(data.columns[:ndim])
                 if vdims is None:
-                    vdims = list(data.columns[ndim:((ndim+nvdim) if nvdim else None)])
+                    vdims = [d for d in data.columns[ndim:((ndim+nvdim) if nvdim else None)]
+                             if d not in kdims]
             elif kdims == [] and vdims is None:
                 vdims = list(data.columns[:nvdim if nvdim else None])
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -16,6 +16,7 @@ import numpy as np
 import param
 from ..core import Dimension, Element2D, Dataset
 from ..core.data import MultiInterface, ArrayInterface
+from ..core.util import disable_constant
 
 
 class Path(Dataset, Element2D):
@@ -148,8 +149,9 @@ class Contours(Path):
             params['vdims'] = vdims
         super(Contours, self).__init__(data, kdims=kdims, **params)
         if params.get('level') is not None:
-            self.vdims = [d if isinstance(d, Dimension) else Dimension(d)
-                          for d in vdims]
+            with disable_constant(self):
+                self.vdims = [d if isinstance(d, Dimension) else Dimension(d)
+                              for d in vdims]
         else:
             all_scalar = all(self.interface.isscalar(self, vdim) for vdim in self.vdims)
             if not all_scalar:

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -36,7 +36,7 @@ class Path(Dataset, Element2D):
     """
 
     kdims = param.List(default=[Dimension('x'), Dimension('y')],
-                       constant=True, bounds=(2, None), doc="""
+                       constant=True, bounds=(2, 2), doc="""
         The label of the x- and y-dimension of the Image in form
         of a string or dimension object.""")
 
@@ -128,7 +128,7 @@ class Contours(Path):
     level = param.Number(default=None, doc="""
         Optional level associated with the set of Contours.""")
 
-    vdims = param.List(default=[], doc="""
+    vdims = param.List(default=[], constant=True, doc="""
         Contours optionally accept a value dimension, corresponding
         to the supplied values.""")
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -615,7 +615,8 @@ class QuadMesh(Raster):
 
     group = param.String(default="QuadMesh", constant=True)
 
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
+    kdims = param.List(default=[Dimension('x'), Dimension('y')],
+                       bounds=(2, 2), constant=True)
 
     vdims = param.List(default=[Dimension('z')], bounds=(1,1))
 
@@ -777,9 +778,10 @@ class HeatMap(Dataset, Element2D):
 
     group = param.String(default='HeatMap', constant=True)
 
-    kdims = param.List(default=[Dimension('x'), Dimension('y')])
+    kdims = param.List(default=[Dimension('x'), Dimension('y')],
+                       bounds=(2, 2), constant=True)
 
-    vdims = param.List(default=[Dimension('z')])
+    vdims = param.List(default=[Dimension('z')], constant=True)
 
     def __init__(self, data, kdims=None, vdims=None, **params):
         super(HeatMap, self).__init__(data, kdims=kdims, vdims=vdims, **params)

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -869,6 +869,13 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         ds = Dataset(df, kdims=['x'])
         self.assertEqual(ds.vdims, [Dimension('y'), Dimension('z')])
 
+    def test_dataset_extract_kdims_and_vdims_no_bounds(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Dataset(df)
+        self.assertEqual(ds.kdims, [Dimension('x'), Dimension('y'), Dimension('z')])
+        self.assertEqual(ds.vdims, [])
+
     def test_dataset_extract_kdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])

--- a/tests/testmultiinterface.py
+++ b/tests/testmultiinterface.py
@@ -101,7 +101,7 @@ class MultiInterfaceTest(ComparisonTestCase):
 
     def test_multi_array_values_coordinates_nonexpanded_constant_kdim(self):
         arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2), np.ones(2)*i]) for i in range(2)]
-        mds = Path(arrays, kdims=['x', 'y', 'z'], datatype=['multitabular'])
+        mds = Path(arrays, kdims=['x', 'y'], vdims=['z'], datatype=['multitabular'])
         self.assertEqual(mds.dimension_values(2, expanded=False), np.array([0, 1]))
 
     def test_multi_array_redim(self):


### PR DESCRIPTION
Since ``HeatMap`` didn't define a dimension bounds the ``PandasInterface`` was incorrectly handling the kdims and vdims. So I've defined the ``bounds`` on the kdims and ensured the PandasInterface correctly infers dimensions for an Element that doesn't define the kdims bounds.