### PR TITLE
Fixed bug when raising Dimension error

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -324,7 +324,7 @@ class Dimension(param.Parameterized):
         if isinstance(spec, tuple):
             if not all(isinstance(s, basestring) for s in spec) or len(spec) != 2:
                 raise ValueError("Dimensions specified as a tuple must be a tuple "
-                                 "consisting of the name and label not: %s" % spec) 
+                                 "consisting of the name and label not: %s" % str(spec)) 
             name, label = spec
             all_params['name'] = name
             all_params['label'] = label


### PR DESCRIPTION
This error in Dimension previously raised errors about not all string arguments being converted because ``spec`` could be a tuple, to fix it I've simply cast the variable to a string.