### PR TITLE
Fixed issues with Dataset conversions for stats elements

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -90,14 +90,22 @@ class DataConversion(object):
                                       "after version 1.7.")
                 groupby = kwargs.pop('mdims')
 
+        element_params = new_type.params()
+        kdim_param = element_params['kdims']
+        vdim_param = element_params['vdims']
+        if isinstance(kdim_param.bounds[1], int):
+            ndim = min([kdim_param.bounds[1], len(kdim_param.default)])
+        else:
+            ndim = None
+        nvdim = vdim_param.bounds[1] if isinstance(vdim_param.bounds[1], int) else None
         if kdims is None:
             kd_filter = groupby or []
             if not isinstance(kd_filter, list):
                 kd_filter = [groupby]
-            kdims = [kd for kd in self._element.kdims if kd not in kd_filter]
+            kdims = [kd for kd in self._element.kdims if kd not in kd_filter][:ndim]
         elif kdims and not isinstance(kdims, list): kdims = [kdims]
         if vdims is None:
-            vdims = self._element.vdims
+            vdims = [d for d in self._element.vdims if d not in kdims][:nvdim]
         if vdims and not isinstance(vdims, list): vdims = [vdims]
 
         # Checks Element type supports dimensionality

--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -24,7 +24,6 @@ class ElementConversion(DataConversion):
         return self(BoxWhisker, kdims, vdims, groupby, **kwargs)
 
     def bivariate(self, kdims=None, vdims=None, groupby=None, **kwargs):
-        from ..interface.seaborn import Bivariate
         return self(Bivariate, kdims, vdims, groupby, **kwargs)
 
     def curve(self, kdims=None, vdims=None, groupby=None, **kwargs):
@@ -34,7 +33,6 @@ class ElementConversion(DataConversion):
         return self(ErrorBars, kdims, vdims, groupby, sort=True, **kwargs)
 
     def distribution(self, dim=None, groupby=[], **kwargs):
-        from ..interface.seaborn import Distribution
         if dim is None:
             if self._element.vdims:
                 dim = self._element.vdims[0]
@@ -46,7 +44,7 @@ class ElementConversion(DataConversion):
             return reindexed.groupby(groupby, HoloMap, Distribution, **kwargs)
         else:
             element = self._element
-            params = dict(vdims=[element.get_dimension(dim)],
+            params = dict(kdims=[element.get_dimension(dim)],
                           label=element.label)
             if element.group != element.params()['group'].default:
                 params['group'] = element.group


### PR DESCRIPTION
The data conversion methods were still trying to import the elements from seaborn. Additionally the elements pose some challenges for the conversion interfaces in general so the interfaces really benefit from some additional strictness about the dimensions it tries to infer. That change only catches conditions which would otherwise have errored.