### PR TITLE
Notebook flake fixes

### DIFF
--- a/doc/Tutorials/Containers.ipynb
+++ b/doc/Tutorials/Containers.ipynb
@@ -210,7 +210,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "from holoviews import Curve, ItemTable, Empty\n",
     "sine_points = [(0.1*i, np.sin(0.1*i)) for i in range(100)]\n",
     "cosine_points = [(0.1*i, np.cos(0.1*i)) for i in range(100)]\n",
     "(hv.ItemTable([('A',1),('B',2)]) + hv.Curve(sine_points) + hv.Empty() + hv.Curve(cosine_points)).cols(2)"
@@ -487,7 +486,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from holoviews import NdLayout\n",
     "hv.NdLayout(matrices, kdims=['phase', 'frequency'])[0:1.6, 0:2].cols(3)"
    ]
   },

--- a/doc/Tutorials/Exploring_Data.ipynb
+++ b/doc/Tutorials/Exploring_Data.ipynb
@@ -38,11 +38,7 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import datetime as dt\n",
     "\n",
-    "from itertools import product\n",
-    "\n",
-    "from matplotlib import pyplot as plt\n",
     "import matplotlib.dates as md\n",
     "\n",
     "\n",

--- a/doc/Tutorials/Exporting.ipynb
+++ b/doc/Tutorials/Exporting.ipynb
@@ -25,7 +25,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews.operation import contours\n",
     "hv.notebook_extension()"

--- a/doc/Tutorials/Linked_Streams.ipynb
+++ b/doc/Tutorials/Linked_Streams.ipynb
@@ -116,7 +116,7 @@
    "outputs": [],
    "source": [
     "pointer_dmap = hv.DynamicMap(lambda x, y: hv.Points([(x, y)]), streams=[pointer])\n",
-    "print pointer.source is pointer_dmap"
+    "print(pointer.source is pointer_dmap)"
    ]
   },
   {

--- a/doc/Tutorials/Pandas_Seaborn.ipynb
+++ b/doc/Tutorials/Pandas_Seaborn.ipynb
@@ -18,7 +18,6 @@
     "import itertools\n",
     "\n",
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import seaborn as sb\n",
     "import holoviews as hv\n",
     "\n",

--- a/doc/Tutorials/Streams.ipynb
+++ b/doc/Tutorials/Streams.ipynb
@@ -8,7 +8,6 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "import numpy as np\n",
     "hv.notebook_extension()"
    ]
   },


### PR DESCRIPTION
I'm testing a notebook linting tool. These are the issues it found in the `doc/` directory, running it with python3.

It's not clear to me that everything it's found is correct, e.g.

* Is there a notebook about pandas that doesn't use pandas? Or is it because you need to import pandas to get features of the pandas backend?
* Do notebooks work in python 2 and python 3 with both the print statement and function? One notebook had both in.
* Are some things in notebooks deliberately imported and unused?

This is what I ran:
```
pip install pytest-nbsmoke
pytest --tb=short --nbsmoke-lint doc/
```

`--tb=short` is necessary because currently the combined pytest/nbconvert output is huge, unfortunately.

If I run nbsmoke on `examples/`, I get a lot more to fix. But first I wanted to see how you feel about these changes...