### PR TITLE
Enable compute_edges with unequally spaced data

### DIFF
--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -29,20 +29,16 @@ except:
 
 def compute_edges(edges):
     """
-    Computes edges from a number of bin centers,
-    throwing an exception if the edges are not
-    evenly spaced.
+    Computes edges as midpoints of the bin centers.
+    The first and last boundaries are equidistant from the first and last
+    midpoints respectively.
     """
     edges = np.asarray(edges)
     if edges.dtype.kind == 'i':
         edges = edges.astype('f')
-    widths = np.diff(edges)
-    if np.allclose(widths, widths[0]):
-        width = widths[0]
-    else:
-        raise ValueError('Centered bins have to be of equal width.')
-    edges -= width/2.
-    return np.concatenate([edges, [edges[-1]+width]])
+    midpoints = (edges[:-1] + edges[1:])/2.0
+    boundaries = (2*edges[0] - midpoints[0], 2*edges[-1] - midpoints[-1])
+    return np.concatenate([boundaries[:1], midpoints, boundaries[-1:]])
 
 
 def split_path(path):

--- a/tests/testelementutils.py
+++ b/tests/testelementutils.py
@@ -22,5 +22,5 @@ class TestComputeEdges(ComparisonTestCase):
                          np.array([0.25, 0.75, 1.25, 1.75]))
 
     def test_uneven_edges(self):
-        with self.assertRaisesRegexp(ValueError, "Centered bins"):
-            compute_edges(self.array3)
+        self.assertEqual(compute_edges(self.array3),
+                         np.array([0.5, 1.5, 3.0, 5.0]))


### PR DESCRIPTION
This is a simple modification that allows one to use `QuadMesh` etc. with unevenly spaced points without having to explicitly provide the bin boundaries.  This simply uses the midpoints as bin boundaries and sets the endpoints as the midpoints of the outer cells.  This thus maintains the previous behaviour when equally-spaced points are provided, and now simply allows for unevenly spaced points.  (See also issue #1869.)