### PR TITLE
Bokeh plotting fixes

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -949,7 +949,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         Extents are set to '' and None because x-axis is categorical and
         y-axis auto-ranges.
         """
-        yrange = element.range(element.vdims[0], data_range=False)
+        yrange = ranges.get(element.vdims[0].name, (np.NaN, np.NaN))
         return ('', yrange[0], '', yrange[1])
 
     def _get_axis_labels(self, *args, **kwargs):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import numpy as np
 import param
 from bokeh.models import (DataRange1d, CategoricalColorMapper, CustomJS,
-                          HoverTool, FactorRange, Whisker, Band)
+                          HoverTool, FactorRange, Whisker, Band, Range1d)
 from bokeh.models.tools import BoxSelectTool
 
 from ...core import Dataset, OrderedDict
@@ -638,7 +638,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
     _plot_methods = dict(single=('vbar', 'hbar'))
 
     # Declare that y-range should auto-range if not bounded
-    _y_range_type = DataRange1d
+    _y_range_type = Range1d
 
     def get_extents(self, element, ranges):
         """
@@ -932,7 +932,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
     _x_range_type = FactorRange
 
     # Declare that y-range should auto-range if not bounded
-    _y_range_type = DataRange1d
+    _y_range_type = Range1d
 
     # Map each glyph to a style group
     _style_groups = {'rect': 'whisker', 'segment': 'whisker',

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -974,10 +974,10 @@ class CompositeElementPlot(ElementPlot):
         data, mapping, style = self.get_data(element, ranges, style)
 
         for key in sorted(dict(mapping, **data)):
-            gdata = data[key]
+            gdata = data.get(key)
             source = self.handles[key+'_source']
             glyph = self.handles.get(key+'_glyph')
-            if not self.static_source:
+            if not self.static_source and gdata is not None:
                 self._update_datasource(source, gdata)
 
             if glyph:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -919,10 +919,16 @@ class CompositeElementPlot(ElementPlot):
         style = self.style[self.cyclic_index]
         data, mapping, style = self.get_data(element, ranges, style)
 
+        source_cache = {}
         current_id = element._plot_id
         self.handles['previous_id'] = current_id
         for key in dict(mapping, **data):
-            source = self._init_datasource(data.get(key, {}))
+            ds_data = data.get(key, {})
+            if id(ds_data) in source_cache:
+                source = source_cache[id(ds_data)]
+            else:
+                source = self._init_datasource(ds_data)
+                source_cache[id(ds_data)] = source
             self.handles[key+'_source'] = source
             properties = self._glyph_properties(plot, element, source, ranges, style)
             properties = self._process_properties(key, properties)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -559,8 +559,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if any(isinstance(ax_range, FactorRange) for ax_range in [x_range, y_range]):
             xfactors, yfactors = self._get_factors(element)
         framewise = self.framewise
-        xupdate = (not self.model_changed(x_range) and framewise or self.streaming or xfactors is not None)
-        yupdate = (not self.model_changed(y_range) and framewise or self.streaming or yfactors is not None)
+        xupdate = ((not self.model_changed(x_range) and (framewise or self.streaming))
+                   or xfactors is not None)
+        yupdate = ((not self.model_changed(y_range) and (framewise or self.streaming))
+                   or yfactors is not None)
         if not self.drawn or xupdate:
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis, self._shared['x'], self.logx)
         if not self.drawn or yupdate:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -559,9 +559,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if any(isinstance(ax_range, FactorRange) for ax_range in [x_range, y_range]):
             xfactors, yfactors = self._get_factors(element)
         framewise = self.framewise
-        if not self.drawn or (not self.model_changed(x_range) and framewise or self.streaming) or xfactors:
+        xupdate = (not self.model_changed(x_range) and framewise or self.streaming or xfactors is not None)
+        yupdate = (not self.model_changed(y_range) and framewise or self.streaming or yfactors is not None)
+        if not self.drawn or xupdate:
             self._update_range(x_range, l, r, xfactors, self.invert_xaxis, self._shared['x'], self.logx)
-        if not self.drawn or (not self.model_changed(y_range) and framewise or self.streaming) or yfactors:
+        if not self.drawn or yupdate:
             self._update_range(y_range, b, t, yfactors, self.invert_yaxis, self._shared['y'], self.logy)
 
 


### PR DESCRIPTION
A number of smaller fixes/enhancements for bokeh plots:

* CompositeElementPlot now allows drawing multiple glyphs from the same datasource
* CompositeElementPlot no longer errors when a plot doesn't return data for a particular glyph (fixes http://holoviews.org/gallery/demos/bokeh/dropdown_economic.html)
* BoxWhisker and BarPlot use regular Range1d models not DataRange1d, which has changed behavior in 0.12.11dev and no longer updates as one would expect (also DataRange1d is not actually required anymore)