### PR TITLE
Fix bokeh version import

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -10,7 +10,7 @@ from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         PlotSize, Draw, BoundsXY, PlotReset)
 from ...streams import PositionX, PositionY, PositionXY, Bounds # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS, Comm
-from .util import convert_timestamp,bokeh_version
+from .util import convert_timestamp, bokeh_version
 
 
 class MessageCallback(object):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -10,7 +10,7 @@ from ...streams import (Stream, PointerXY, RangeXY, Selection1D, RangeX,
                         PlotSize, Draw, BoundsXY, PlotReset)
 from ...streams import PositionX, PositionY, PositionXY, Bounds # Deprecated: remove in 2.0
 from ..comms import JupyterCommJS, Comm
-from .util import convert_timestamp
+from .util import convert_timestamp,bokeh_version
 
 
 class MessageCallback(object):


### PR DESCRIPTION
fixes bokeh_version import otherwise leads to

`  line 422, in set_server_callback
   if self.on_events and bokeh_version >= '0.12.5':
NameError: name 'bokeh_version' is not defined`

atleast while serving a bokeh app. 