### PR TITLE
Image grid fixes

### DIFF
--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -7,7 +7,7 @@ from ..ndmapping import  NdMapping, item_check
 from ..sheetcoords import Slice
 from .. import util
 from .grid import GridInterface
-from .interface import Interface
+from .interface import Interface, DataError
 
 
 class ImageInterface(GridInterface):
@@ -45,6 +45,15 @@ class ImageInterface(GridInterface):
                 data = data[:, ::-1]
             if inverty:
                 data = data[::-1, :]
+
+            expected = (len(ys), len(xs))
+            shape = data.shape[:2]
+            error = DataError if len(shape) > 1 else ValueError
+            if shape != expected and not (not expected and shape == (1,)):
+                raise error('Key dimension values and value array %s '
+                            'shapes do not match. Expected shape %s, '
+                            'actual shape: %s' % (vdim, expected, shape), cls)
+
         if not isinstance(data, np.ndarray) or data.ndim not in [2, 3]:
             raise ValueError('ImageInterface expects a 2D array.')
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -439,6 +439,8 @@ class regrid(ResamplingOperation):
                 xarr = element.data[vd.name]
                 if 'datetime' in (xtype, ytype):
                     xarr = xarr.copy()
+                if dims != xarr.dims:
+                    xarr = xarr.transpose(*dims)
             else:
                 arr = element.dimension_values(vd, flat=False)
                 xarr = xr.DataArray(arr, coords=coord_dict, dims=dims)

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -93,7 +93,15 @@ class DatashaderRegridTests(ComparisonTestCase):
         regridded = regrid(img, width=2, height=2, dynamic=False)
         expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         self.assertEqual(regridded, expected)
-    
+
+    def test_regrid_mean_xarray_transposed(self):
+        img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T),
+                    datatype=['xarray'])
+        img.data = img.data.T
+        regridded = regrid(img, width=2, height=2, dynamic=False)
+        expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
+        self.assertEqual(regridded, expected)
+
     def test_regrid_rgb_mean(self):
         arr = (np.arange(10) * np.arange(5)[np.newaxis].T).astype('f')
         rgb = RGB((range(10), range(5), arr, arr*2, arr*2))

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -6,6 +6,7 @@ import numpy as np
 from holoviews import Dimension, Image, Curve, RGB, HSV, Dataset, Table
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.core.util import date_range
+from holoviews.core.data.interface import DataError
 
 from .testdataset import DatatypeContext
 
@@ -23,9 +24,22 @@ class ImageInterfaceTest(ComparisonTestCase):
     def init_data(self):
         self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
         self.image = Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
-
+        
     def tearDown(self):
         self.eltype.datatype = self.restore_datatype
+
+    def test_init_data_tuple(self):
+        xs = np.arange(5)
+        ys = np.arange(10)
+        array = xs * ys[:, np.newaxis]
+        image = Image((xs, ys, array))
+
+    def test_init_data_tuple_error(self):
+        xs = np.arange(5)
+        ys = np.arange(10)
+        array = xs * ys[:, np.newaxis]
+        with self.assertRaises(DataError):
+            Image((ys, xs, array))
 
     def test_init_data_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())


### PR DESCRIPTION
Fixes for https://github.com/ioam/holoviews/issues/2094, the ImageInterface was not validating that the Image coordinates matched the array shape and the regrid operation was not ensuring the array had the correct orientation before regridding.