### PR TITLE
Improved streaming updates on overlaid plots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -139,9 +139,12 @@ class BokehPlot(DimensionedPlot):
         """
         Update datasource with data for a new frame.
         """
-        if self.streaming and self.streaming.data is self.current_frame.data and self._stream_data:
-            data = {k: v[-self.streaming._chunk_length:] for k, v in data.items()}
-            source.stream(data, self.streaming.length)
+        if (self.streaming and self.streaming[0].data is self.current_frame.data
+            and self._stream_data):
+            stream = self.streaming[0]
+            if stream._triggering:
+                data = {k: v[-stream._chunk_length:] for k, v in data.items()}
+                source.stream(data, stream.length)
         else:
             source.data.update(data)
 

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -32,8 +32,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
         element_ids = self.hmap.traverse(lambda x: id(x), [Dataset, ItemTable])
         self.static = len(set(element_ids)) == 1 and len(self.keys) == len(self.hmap)
         self.callbacks = [] # Callback support on tables not implemented
-        dfstream = [s for s in self.streams if isinstance(s, Buffer)]
-        self.streaming = dfstream[0] if any(dfstream) else None
+        self.streaming = [s for s in self.streams if isinstance(s, Buffer)]
 
 
     def _execute_hooks(self, element):
@@ -98,8 +97,8 @@ class TablePlot(BokehPlot, GenericElementPlot):
         self.handles['previous_id'] = current_id
         self.static_source = (self.dynamic and (current_id == previous_id))
         if (element is None or (not self.dynamic and self.static) or
-            (self.streaming and self.streaming.data is self.current_frame.data
-             and not self.streaming._triggering) or self.static_source):
+            (self.streaming and self.streaming[0].data is self.current_frame.data
+             and not self.streaming[0]._triggering) or self.static_source):
             return
         source = self.handles['source']
         style = self.lookup_options(element, 'style')[self.cyclic_index]


### PR DESCRIPTION
Previously the stream handling code in the bokeh backend was not correctly handling a condition where multiple subplots were attached to different streaming sources. In those cases it would fall back to sending a full update of the data for some subplots. It now appropriately skips updates to a streaming plot when it isn't being triggered.

Additionally it now forces the ranges to be updated in streaming mode, which previously caused issues when running a plot reset.