### PR TITLE
Fixed yrotation and zrotation for mpl overlay plots.

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -771,7 +771,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
     _propagate_options = ['aspect', 'fig_size', 'xaxis', 'yaxis', 'zaxis',
                           'labelled', 'bgcolor', 'fontsize', 'invert_axes',
                           'show_frame', 'show_grid', 'logx', 'logy', 'logz',
-                          'xticks', 'yticks', 'zticks', 'xrotation', 'yrotation'
+                          'xticks', 'yticks', 'zticks', 'xrotation', 'yrotation',
                           'zrotation', 'invert_xaxis', 'invert_yaxis',
                           'invert_zaxis', 'title_format']
 


### PR DESCRIPTION
Maybe I shouldn't be trying to rotate axis labels, but I was, and I got quite confused...