### PR TITLE
Add Chord element

### DIFF
--- a/examples/gallery/demos/bokeh/route_chord.ipynb
+++ b/examples/gallery/demos/bokeh/route_chord.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most examples work across multiple plotting backends equivalent, this example is also available for:\n",
+    "Most examples work across multiple plotting backends. This example is also available for:\n",
     "\n",
     "* [Matplotlib - route_chord](../matplotlib/route_chord.ipynb)"
    ]

--- a/examples/gallery/demos/bokeh/route_chord.ipynb
+++ b/examples/gallery/demos/bokeh/route_chord.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends equivalent, this example is also available for:\n",
+    "\n",
+    "* [Matplotlib - route_chord](../matplotlib/route_chord.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "from bokeh.sampledata.airport_routes import routes, airports\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Count the routes between Airports\n",
+    "route_counts = routes.groupby(['SourceID', 'DestinationID']).Stops.count().reset_index()\n",
+    "nodes = hv.Dataset(airports, 'AirportID', 'City')\n",
+    "chord = hv.Chord((route_counts, nodes), ['SourceID', 'DestinationID'], ['Stops'])\n",
+    "\n",
+    "# Select the 20 busiest airports\n",
+    "busiest = list(routes.groupby('SourceID').count().sort_values('Stops').iloc[-20:].index.values)\n",
+    "busiest_airports = chord.select(AirportID=busiest, selection_mode='nodes')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Chord [edge_color_index='SourceID' label_index='City' color_index='AirportID' width=800 height=800]\n",
+    "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
+    "busiest_airports"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/gallery/demos/matplotlib/route_chord.ipynb
+++ b/examples/gallery/demos/matplotlib/route_chord.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends equivalent, this example is also available for:\n",
+    "\n",
+    "* [Bokeh - route_chord](../bokeh/route_chord.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "from bokeh.sampledata.airport_routes import routes, airports\n",
+    "\n",
+    "hv.extension('matplotlib')\n",
+    "%output fig='svg' size=300"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Count the routes between Airports\n",
+    "route_counts = routes.groupby(['SourceID', 'DestinationID']).Stops.count().reset_index()\n",
+    "nodes = hv.Dataset(airports, 'AirportID', 'City')\n",
+    "chord = hv.Chord((route_counts, nodes), ['SourceID', 'DestinationID'], ['Stops'])\n",
+    "\n",
+    "# Select the 20 busiest airports\n",
+    "busiest = list(routes.groupby('SourceID').count().sort_values('Stops').iloc[-20:].index.values)\n",
+    "busiest_airports = chord.select(AirportID=busiest, selection_mode='nodes')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Chord [edge_color_index='SourceID' label_index='City' color_index='AirportID' width=800 height=800]\n",
+    "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
+    "busiest_airports"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/gallery/demos/matplotlib/route_chord.ipynb
+++ b/examples/gallery/demos/matplotlib/route_chord.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most examples work across multiple plotting backends equivalent, this example is also available for:\n",
+    "Most examples work across multiple plotting backends. This example is also available for:\n",
     "\n",
     "* [Bokeh - route_chord](../bokeh/route_chord.ipynb)"
    ]

--- a/examples/reference/elements/bokeh/Chord.ipynb
+++ b/examples/reference/elements/bokeh/Chord.ipynb
@@ -48,7 +48,22 @@
    "outputs": [],
    "source": [
     "links = pd.DataFrame(data['links'])\n",
-    "print(links.head(3))\n",
+    "print(links.head(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the simplest case we can construct the ``Chord`` by passing it just the edges"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hv.Chord(links)"
    ]
   },
@@ -58,7 +73,24 @@
    "source": [
     "The plot automatically adds hover and tap support, letting us reveal the connections of each node.\n",
     "\n",
-    "By adding additional columns of data we can increase the information shown when hovering. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+    "To add node labels and other information we can construct a ``Dataset`` with a key dimension of node indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes = hv.Dataset(pd.DataFrame(data['nodes']), 'index')\n",
+    "nodes.data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by."
    ]
   },
   {
@@ -69,28 +101,14 @@
    "source": [
     "%%opts Chord [label_index='name' color_index='index' edge_color_index='source'] \n",
     "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
-    "nodes = hv.Dataset(pd.DataFrame(data['nodes']).reset_index(), 'index')\n",
     "hv.Chord((links, nodes)).select(value=(5, None))"
    ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/Chord.ipynb
+++ b/examples/reference/elements/bokeh/Chord.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
+    "<dl class=\"dl-horizontal\">\n",
+    "  <dt>Title</dt> <dd> Graph Element</dd>\n",
+    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
+    "  <dt>Backends</dt> \n",
+    "    <dd><a href='./Chord.ipynb'>Bokeh</a></dd>\n",
+    "    <dd><a href='../matplotlib/Chord.ipynb'>Matplotlib</a></dd>\n",
+    "</dl>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "from bokeh.sampledata.les_mis import data\n",
+    "\n",
+    "hv.extension('bokeh')\n",
+    "%output size=200"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``Chord`` element allows representating the inter-relationships between data in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
+    "\n",
+    "If the weight values are integers they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
+    "\n",
+    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor. The most basic constructor accepts a columnar dataset of the source and target nodes an an optional value. Here we supply a dataframe containing the number of dialogues between characters of the Les Misérables musical. The data contains ``source`` and ``target`` node indices and an associated ``value`` column:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "links = pd.DataFrame(data['links'])\n",
+    "print(links.head(3))\n",
+    "hv.Chord(links)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot automatically adds hover and tap support letting us reveal the connections of each node.\n",
+    "\n",
+    "By adding additional nodes data we can add additional data for each node. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Chord [label_index='name' color_index='index' edge_color_index='source'] \n",
+    "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
+    "nodes = hv.Dataset(pd.DataFrame(data['nodes']).reset_index(), 'index')\n",
+    "hv.Chord((links, nodes)).select(value=(5, None))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/reference/elements/bokeh/Chord.ipynb
+++ b/examples/reference/elements/bokeh/Chord.ipynb
@@ -34,11 +34,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Chord`` element allows representating the inter-relationships between data in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
+    "The ``Chord`` element allows representing the inter-relationships between data points in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
     "\n",
-    "If the weight values are integers they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
+    "If the weight values are integers, they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
     "\n",
-    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor. The most basic constructor accepts a columnar dataset of the source and target nodes an an optional value. Here we supply a dataframe containing the number of dialogues between characters of the Les Misérables musical. The data contains ``source`` and ``target`` node indices and an associated ``value`` column:"
+    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor. The most basic constructor accepts a columnar dataset of the source and target nodes and an optional value. Here we supply a dataframe containing the number of dialogues between characters of the *Les Misérables* musical. The data contains ``source`` and ``target`` node indices and an associated ``value`` column:"
    ]
   },
   {
@@ -56,9 +56,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot automatically adds hover and tap support letting us reveal the connections of each node.\n",
+    "The plot automatically adds hover and tap support, letting us reveal the connections of each node.\n",
     "\n",
-    "By adding additional nodes data we can add additional data for each node. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+    "By adding additional columns of data we can increase the information shown when hovering. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/Chord.ipynb
+++ b/examples/reference/elements/matplotlib/Chord.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
+    "<dl class=\"dl-horizontal\">\n",
+    "  <dt>Title</dt> <dd> Graph Element</dd>\n",
+    "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
+    "  <dt>Backends</dt> \n",
+    "    <dd><a href='./Chord.ipynb'>Matplotlib</a></dd>\n",
+    "    <dd><a href='../bokeh/Chord.ipynb'>Bokeh</a></dd>\n",
+    "</dl>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import holoviews as hv\n",
+    "from bokeh.sampledata.les_mis import data\n",
+    "\n",
+    "hv.extension('matplotlib')\n",
+    "%output size=200 fig='svg'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ``Chord`` element allows representating the inter-relationships between data in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
+    "\n",
+    "If the weight values are integers they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
+    "\n",
+    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "links = pd.DataFrame(data['links'])\n",
+    "hv.Chord(links)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The plot automatically adds hover and tap support letting us reveal the connections of each node.\n",
+    "\n",
+    "By adding additional nodes data we can add additional data for each node. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Chord [label_index='name' color_index='index' edge_color_index='source'] \n",
+    "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
+    "nodes = hv.Dataset(pd.DataFrame(data['nodes']).reset_index(), 'index')\n",
+    "hv.Chord((links, nodes)).select(value=(5, None))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/reference/elements/matplotlib/Chord.ipynb
+++ b/examples/reference/elements/matplotlib/Chord.ipynb
@@ -38,7 +38,7 @@
     "\n",
     "If the weight values are integers, they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
     "\n",
-    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor."
+    "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor. The most basic constructor accepts a columnar dataset of the source and target nodes and an optional value. Here we supply a dataframe containing the number of dialogues between characters of the *Les Misérables* musical. The data contains ``source`` and ``target`` node indices and an associated ``value`` column:"
    ]
   },
   {
@@ -48,6 +48,22 @@
    "outputs": [],
    "source": [
     "links = pd.DataFrame(data['links'])\n",
+    "print(links.head(3))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the simplest case we can construct the ``Chord`` by passing it just the edges:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hv.Chord(links)"
    ]
   },
@@ -55,9 +71,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot automatically adds hover and tap support, letting us reveal the connections of each node.\n",
-    "\n",
-    "By adding additional columns of data, we can increase the information shown when hovering. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+    "To add node labels and other information we can construct a ``Dataset`` with a key dimension of node indices."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nodes = hv.Dataset(pd.DataFrame(data['nodes']), 'index')\n",
+    "nodes.data.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
    ]
   },
   {
@@ -68,28 +99,14 @@
    "source": [
     "%%opts Chord [label_index='name' color_index='index' edge_color_index='source'] \n",
     "%%opts Chord (cmap='Category20' edge_cmap='Category20')\n",
-    "nodes = hv.Dataset(pd.DataFrame(data['nodes']).reset_index(), 'index')\n",
     "hv.Chord((links, nodes)).select(value=(5, None))"
    ]
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/matplotlib/Chord.ipynb
+++ b/examples/reference/elements/matplotlib/Chord.ipynb
@@ -34,9 +34,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Chord`` element allows representating the inter-relationships between data in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
+    "The ``Chord`` element allows representing the inter-relationships between data points in a graph. The nodes are arranged radially around a circle with the relationships between the data points drawn as arcs (or chords) connecting the nodes. The number of chords is scaled by a weight declared as a value dimension on the ``Chord`` element.\n",
     "\n",
-    "If the weight values are integers they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
+    "If the weight values are integers, they define the number of chords to be drawn between the source and target nodes directly. If the weights are floating point values, they are normalized to a default of 500 chords, which are divided up among the edges. Any non-zero weight will be assigned at least one chord.\n",
     "\n",
     "The ``Chord`` element is a type of ``Graph`` element and shares the same constructor."
    ]
@@ -55,9 +55,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The plot automatically adds hover and tap support letting us reveal the connections of each node.\n",
+    "The plot automatically adds hover and tap support, letting us reveal the connections of each node.\n",
     "\n",
-    "By adding additional nodes data we can add additional data for each node. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
+    "By adding additional columns of data, we can increase the information shown when hovering. Additionally we can now color the nodes and edges by their index and add some labels. The ``label_index``, ``color_index`` and ``edge_color_index`` allow specifying columns to color by. "
    ]
   },
   {

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -613,14 +613,21 @@ class layout_chords(Operation):
             src_area, tgt_area = all_areas[src_idx[i]], all_areas[tgt_idx[i]]
             subpaths = []
             for _ in range(int(values[i])):
+                if not src_area or not tgt_area:
+                    continue
                 x0, y0 = src_area.pop()
+                if not tgt_area:
+                    continue
                 x1, y1 = tgt_area.pop()
                 b = quadratic_bezier((x0, y0), (x1, y1), (x0/2., y0/2.),
                                      (x1/2., y1/2.), steps=self.p.chord_samples)
                 subpaths.append(b)
                 subpaths.append(empty)
+            subpaths = [p for p in subpaths[:-1] if len(p)]
             if subpaths:
-                paths.append(np.concatenate(subpaths[:-1]))
+                paths.append(np.concatenate(subpaths))
+            else:
+                paths.append(np.array([]))
 
         # Construct Chord element from components
         if nodes_el:

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -654,7 +654,7 @@ class Chord(Graph):
     their weight.
     """
 
-    group = param.String(default='Chord')
+    group = param.String(default='Chord', constant=True)
 
     def __init__(self, data, kdims=None, vdims=None, compute=True, **params):
         if isinstance(data, tuple):

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -587,10 +587,6 @@ class layout_chords(Operation):
         points[1:] = areas_in_radians
         points = points.cumsum()
 
-        # Compute edge points
-        xs = np.cos(points)
-        ys = np.sin(points)
-
         # Compute mid-points for node positions
         midpoints = np.convolve(points, [0.5, 0.5], mode='valid')
         mxs = np.cos(midpoints)
@@ -677,7 +673,6 @@ class Chord(Graph):
                     nodes = Dataset(nodes)
                     nodes = nodes.clone(kdims=nodes.kdims[0],
                                         vdims=nodes.kdims[1:])
-        node_info = nodes
         super(Graph, self).__init__(edges, kdims=kdims, vdims=vdims, **params)
         if compute:
             self._nodes = nodes

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -235,6 +235,23 @@ def circular_layout(nodes):
     return (x, y, nodes)
 
 
+def quadratic_bezier(start, end, c0=(0, 0), c1=(0, 0), steps=50):
+    """
+    Compute quadratic bezier spline given start and end coordinate and
+    two control points.
+    """
+    steps = np.linspace(0, 1, steps)
+    sx, sy = start
+    ex, ey = end
+    cx0, cy0 = c0
+    cx1, cy1 = c1
+    xs = ((1-steps)**3*sx + 3*((1-steps)**2)*steps*cx0 +
+          3*(1-steps)*steps**2*cx1 + steps**3*ex)
+    ys = ((1-steps)**3*sy + 3*((1-steps)**2)*steps*cy0 +
+          3*(1-steps)*steps**2*cy1 + steps**3*ey)
+    return np.column_stack([xs, ys])
+
+
 def connect_edges_pd(graph):
     """
     Given a Graph element containing abstract edges compute edge

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -14,7 +14,7 @@ from ...element import (Curve, Points, Scatter, Image, Raster, Path,
                         ErrorBars, Text, HLine, VLine, Spline, Spikes,
                         Table, ItemTable, Area, HSV, QuadMesh, VectorField,
                         Graph, Nodes, EdgePaths, Distribution, Bivariate,
-                        TriMesh, Violin)
+                        TriMesh, Violin, Chord)
 from ...core.options import Options, Cycle, Palette
 from ...core.util import VersionError
 
@@ -34,7 +34,7 @@ from .element import OverlayPlot, ElementPlot
 from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
                     AreaPlot, VectorFieldPlot)
-from .graphs import GraphPlot, NodePlot, TriMeshPlot
+from .graphs import GraphPlot, NodePlot, TriMeshPlot, ChordPlot
 from .path import PathPlot, PolygonPlot, ContourPlot
 from .plot import GridPlot, LayoutPlot, AdjointLayoutPlot
 from .raster import RasterPlot, RGBPlot, HeatMapPlot, HSVPlot, QuadMeshPlot
@@ -95,6 +95,7 @@ associations = {Overlay: OverlayPlot,
 
                 # Graph Elements
                 Graph: GraphPlot,
+                Chord: ChordPlot,
                 Nodes: NodePlot,
                 EdgePaths: PathPlot,
                 TriMesh: TriMeshPlot,
@@ -210,6 +211,22 @@ options.TriMesh = Options('style', node_size=5, node_line_color='black',
                           node_nonselection_alpha=0.2,
                           edge_line_width=1)
 options.TriMesh = Options('plot', tools=[])
+options.Chord = Options('style', node_size=15, node_fill_color=Cycle(),
+                        node_line_color='black',
+                        node_selection_fill_color='limegreen',
+                        node_nonselection_fill_color=Cycle(),
+                        node_hover_line_color='black',
+                        node_nonselection_line_color='black',
+                        node_selection_line_color='black',
+                        node_hover_fill_color='limegreen',
+                        node_nonselection_alpha=0.2,
+                        edge_nonselection_alpha=0.1,
+                        edge_line_color='black', edge_line_width=1,
+                        edge_nonselection_line_color='black',
+                        edge_hover_line_color='limegreen',
+                        edge_selection_line_color='limegreen',
+                        label_text_font_size='8pt')
+options.Chord = Options('plot', xaxis=None, yaxis=None)
 options.Nodes = Options('style', line_color='black', color=Cycle(),
                         size=20, nonselection_fill_color=Cycle(),
                         selection_fill_color='limegreen',

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -7,7 +7,8 @@ from bokeh.models import (StaticLayoutProvider, NodesAndLinkedEdges,
                           EdgesAndLinkedNodes, Patches, Bezier)
 
 from ...core.data import Dataset
-from ...core.util import basestring, dimension_sanitizer, unique_array, max_range
+from ...core.util import (basestring, dimension_sanitizer, unique_array,
+                          max_range)
 from ...core.options import Cycle
 from .chart import ColorbarPlot, PointPlot
 from .element import (CompositeElementPlot, LegendPlot, line_properties,
@@ -117,7 +118,6 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                 factors = (str(f) for f in factors)
             factors = list(factors)
             colors = process_cmap(cycle or cmap, len(factors))
-
         if field not in edge_data:
             edge_data[field] = cvals
         edge_style = dict(style, cmap=cmap)

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -348,12 +348,14 @@ class ChordPlot(GraphPlot):
                              "expected one of %s, got %s." %
                              (dims, self.label_index))
             return data, mapping, style
+
+        nodes = element.nodes
         if element.vdims:
-            edges = Dataset(element)[element[element.vdims[0].name]>0]
-            nodes = list(np.unique([edges.dimension_values(i) for i in range(2)]))
-            nodes = element.nodes.select(**{element.nodes.kdims[2].name: nodes})
-        else:
-            nodes = element
+            values = element.dimension_values(element.vdims[0])
+            if values.dtype.kind in 'if':
+                edges = Dataset(element)[values>0]
+                nodes = list(np.unique([edges.dimension_values(i) for i in range(2)]))
+                nodes = element.nodes.select(**{element.nodes.kdims[2].name: nodes})
         xs, ys = (nodes.dimension_values(i)*offset for i in range(2))
         labels = [lidx.pprint_value(v) for v in nodes.dimension_values(lidx)]
         angles = np.arctan2(ys, xs)

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -158,6 +158,7 @@ Store.register({Curve: CurvePlot,
                 # Graph Elements
                 Graph: GraphPlot,
                 TriMesh: TriMeshPlot,
+                Chord: ChordPlot,
                 Nodes: PointPlot,
                 EdgePaths: PathPlot,
 
@@ -277,6 +278,9 @@ options.Graph = Options('style', node_edgecolors='black', node_facecolors=Cycle(
                         edge_color='black', node_size=15)
 options.TriMesh = Options('style', node_edgecolors='black', node_facecolors='white',
                           edge_color='black', node_size=5, edge_linewidth=1)
+options.Chord = Options('style', node_edgecolors='black', node_facecolors=Cycle(),
+                        edge_color='black', node_size=10, edge_linewidth=0.5)
+options.Chord = Options('plot', xaxis=None, yaxis=None)
 options.Nodes = Options('style', edgecolors='black', facecolors=Cycle(),
                         marker='o', s=20**2)
 options.EdgePaths = Options('style', color='black')

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -270,9 +270,46 @@ class ChordPlot(GraphPlot):
         artists.update(super(ChordPlot, self).init_artists(ax, plot_args, plot_kwargs))
         if 'text' in plot_args:
             fontsize = plot_kwargs.get('text_font_size', 8)
+            labels = []
             for (x, y, l, a) in zip(*plot_args['text']):
-                ax.annotate(l, xy=(x, y), xycoords='data', rotation=a,
-                            horizontalalignment='left', fontsize=fontsize,
-                            verticalalignment='center', rotation_mode='anchor')
-
+                label = ax.annotate(l, xy=(x, y), xycoords='data', rotation=a,
+                                    horizontalalignment='left', fontsize=fontsize,
+                                    verticalalignment='center', rotation_mode='anchor')
+                labels.append(label)
+            artists['labels'] = labels
         return artists
+
+    def _update_arcs(self, element, data, style):
+        edges = self.handles['arcs']
+        paths = data['arcs']
+        edges.set_paths(paths)
+        edges.set_visible(style.get('visible', True))
+
+
+    def _update_labels(self, ax, element, data, style):
+        labels = self.handles.get('labels', [])
+        for label in labels:
+            try:
+                label.remove()
+            except:
+                pass
+        if 'text' not in data:
+            self.handles['labels'] = []
+            return
+        labels = []
+        fontsize = style.get('text_font_size', 8)
+        for (x, y, l, a) in zip(*data['text']):
+            label = ax.annotate(l, xy=(x, y), xycoords='data', rotation=a,
+                                horizontalalignment='left', fontsize=fontsize,
+                                verticalalignment='center', rotation_mode='anchor')
+            labels.append(label)
+        self.handles['labels'] = labels
+
+
+    def update_handles(self, key, axis, element, ranges, style):
+        data, style, axis_kwargs = self.get_data(element, ranges, style)
+        self._update_nodes(element, data, style)
+        self._update_edges(element, data, style)
+        self._update_arcs(element, data, style)
+        self._update_labels(axis, element, data, style)
+        return axis_kwargs

--- a/holoviews/plotting/mpl/graphs.py
+++ b/holoviews/plotting/mpl/graphs.py
@@ -239,12 +239,13 @@ class ChordPlot(GraphPlot):
                              "expected one of %s, got %s." %
                              (dims, self.label_index))
             return data, style, plot_kwargs
+        nodes = element.nodes
         if element.vdims:
-            edges = Dataset(element)[element[element.vdims[0].name]>0]
-            nodes = list(np.unique([edges.dimension_values(i) for i in range(2)]))
-            nodes = element.nodes.select(**{element.nodes.kdims[2].name: nodes})
-        else:
-            nodes = element
+            values = element.dimension_values(element.vdims[0])
+            if values.dtype.kind in 'if':
+                edges = Dataset(element)[values>0]
+                nodes = list(np.unique([edges.dimension_values(i) for i in range(2)]))
+                nodes = element.nodes.select(**{element.nodes.kdims[2].name: nodes})
         offset = style.get('label_offset', 1.05)
         xs, ys = (nodes.dimension_values(i)*offset for i in range(2))
         labels = [lidx.pprint_value(v) for v in nodes.dimension_values(lidx)]

--- a/tests/element/testgraphelement.py
+++ b/tests/element/testgraphelement.py
@@ -8,7 +8,7 @@ from holoviews.core.data import Dataset
 from holoviews.core import util
 from holoviews.element.chart import Points
 from holoviews.element.graphs import (
-    Graph, Nodes, TriMesh, circular_layout, connect_edges,
+    Graph, Nodes, TriMesh, Chord, circular_layout, connect_edges,
     connect_edges_pd)
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -127,6 +127,34 @@ class GraphTests(ComparisonTestCase):
         redimmed = graph.redim(x='x2', y='y2')
         self.assertEqual(redimmed.nodes, graph.nodes.redim(x='x2', y='y2'))
         self.assertEqual(redimmed.edgepaths, graph.edgepaths.redim(x='x2', y='y2'))
+
+
+
+class ChordTests(ComparisonTestCase):
+
+    def setUp(self):
+        self.simplices = [(0, 1, 2), (1, 2, 3), (2, 3, 4)]
+
+    def test_chord_constructor_no_vdims(self):
+        chord = Chord(self.simplices)
+        nodes = np.array([[0.8660254037844387, 0.49999999999999994, 0],
+                          [-0.4999999999999998, 0.8660254037844388, 1],
+                          [-0.5000000000000004, -0.8660254037844384, 2],
+                          [0.8660254037844379, -0.5000000000000012, 3]])
+        self.assertEqual(chord.nodes, Nodes(nodes))
+        self.assertEqual(chord.array(), np.array([s[:2] for s in self.simplices]))
+
+    def test_chord_constructor_with_vdims(self):
+        chord = Chord(self.simplices, vdims=['z'])
+        nodes = np.array(
+            [[0.9396926207859084, 0.3420201433256687, 0],
+             [6.123233995736766e-17, 1.0, 1],
+             [-0.8660254037844388, -0.4999999999999998, 2],
+             [0.7660444431189779, -0.6427876096865396, 3]]
+        )
+        self.assertEqual(chord.nodes, Nodes(nodes))
+        self.assertEqual(chord.array(), np.array(self.simplices))
+
 
 
 class TriMeshTests(ComparisonTestCase):

--- a/tests/plotting/bokeh/testgraphplot.py
+++ b/tests/plotting/bokeh/testgraphplot.py
@@ -4,9 +4,7 @@ from unittest import SkipTest
 
 import numpy as np
 from holoviews.core.data import Dataset
-from holoviews.core.options import Store
 from holoviews.element import Graph, TriMesh, Chord, circular_layout
-from holoviews.element.comparison import ComparisonTestCase
 
 try:
     from bokeh.models import (NodesAndLinkedEdges, EdgesAndLinkedNodes, Patches)

--- a/tests/plotting/bokeh/testgraphplot.py
+++ b/tests/plotting/bokeh/testgraphplot.py
@@ -5,25 +5,22 @@ from unittest import SkipTest
 import numpy as np
 from holoviews.core.data import Dataset
 from holoviews.core.options import Store
-from holoviews.element import Graph, TriMesh, circular_layout
+from holoviews.element import Graph, TriMesh, Chord, circular_layout
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
-    bokeh_renderer = Store.renderers['bokeh']
     from bokeh.models import (NodesAndLinkedEdges, EdgesAndLinkedNodes, Patches)
     from bokeh.models.mappers import CategoricalColorMapper, LinearColorMapper
-except :
-    bokeh_renderer = None
+except:
+    pass
+
+from .testplot import TestBokehPlot, bokeh_renderer
 
 
-class BokehGraphPlotTests(ComparisonTestCase):
-    
+class TestBokehGraphPlot(TestBokehPlot):
+
     def setUp(self):
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
-        self.default_comm = bokeh_renderer.comms['default']
+        super(TestBokehGraphPlot, self).setUp()
 
         N = 8
         self.nodes = circular_layout(np.arange(N, dtype=np.int32))
@@ -37,10 +34,6 @@ class BokehGraphPlotTests(ComparisonTestCase):
         self.graph3 = Graph(((self.source, self.target), self.node_info2))
         self.graph4 = Graph(((self.source, self.target, self.weights),), vdims='Weight')
 
-    def tearDown(self):
-        Store.current_backend = self.previous_backend
-        bokeh_renderer.comms['default'] = self.default_comm
-        
     def test_plot_simple_graph(self):
         plot = bokeh_renderer.get_plot(self.graph)
         node_source = plot.handles['scatter_1_source']
@@ -168,23 +161,15 @@ class BokehGraphPlotTests(ComparisonTestCase):
         self.assertEqual(glyph.line_color, {'field': 'Weight', 'transform': cmapper})
 
 
-class TestBokehTriMeshPlots(ComparisonTestCase):
+class TestBokehTriMeshPlot(TestBokehPlot):
 
     def setUp(self):
-        if not bokeh_renderer:
-            raise SkipTest("Bokeh required to test plot instantiation")
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'bokeh'
-        self.default_comm = bokeh_renderer.comms['default']
+        super(TestBokehTriMeshPlot, self).setUp()
 
         self.nodes = [(0, 0, 0), (0.5, 1, 1), (1., 0, 2), (1.5, 1, 3)]
         self.simplices = [(0, 1, 2, 0), (1, 2, 3, 1)]
         self.trimesh = TriMesh((self.simplices, self.nodes))
         self.trimesh_weighted = TriMesh((self.simplices, self.nodes), vdims='weight')
-
-    def tearDown(self):
-        Store.current_backend = self.previous_backend
-        bokeh_renderer.comms['default'] = self.default_comm
 
     def test_plot_simple_trimesh(self):
         plot = bokeh_renderer.get_plot(self.trimesh)
@@ -234,3 +219,47 @@ class TestBokehTriMeshPlots(ComparisonTestCase):
         self.assertEqual(cmapper.high, 1)
         self.assertEqual(edge_source.data['weight'], np.array([0, 1]))
         self.assertEqual(glyph.line_color, {'field': 'weight', 'transform': cmapper})
+
+
+class TestBokehChordPlot(TestBokehPlot):
+
+    def setUp(self):
+        super(TestBokehChordPlot, self).setUp()
+        self.edges = [(0, 1, 1), (0, 2, 2), (1, 2, 3)]
+        self.nodes = Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
+        self.chord = Chord((self.edges, self.nodes))
+
+    def test_chord_nodes_label_text(self):
+        g = self.chord.opts(plot=dict(label_index='Label'))
+        plot = bokeh_renderer.get_plot(g)
+        source = plot.handles['text_1_source']
+        self.assertEqual(source.data['text'], ['A', 'B', 'C'])
+
+    def test_chord_nodes_categorically_colormapped(self):
+        g = self.chord.opts(plot=dict(color_index='Label', label_index='Label'),
+                            style=dict(cmap=['#FFFFFF', '#888888', '#000000']))
+        plot = bokeh_renderer.get_plot(g)
+        cmapper = plot.handles['color_mapper']
+        source = plot.handles['scatter_1_source']
+        arc_source = plot.handles['multi_line_2_source']
+        glyph = plot.handles['scatter_1_glyph']
+        self.assertIsInstance(cmapper, CategoricalColorMapper)
+        self.assertEqual(cmapper.factors, ['A', 'B', 'C'])
+        self.assertEqual(cmapper.palette, ['#FFFFFF', '#888888', '#000000'])
+        self.assertEqual(source.data['Label'], np.array(['A', 'B', 'C']))
+        self.assertEqual(arc_source.data['Label'], np.array(['A', 'B', 'C']))
+        self.assertEqual(glyph.fill_color, {'field': 'Label', 'transform': cmapper})
+
+    def test_chord_edges_categorically_colormapped(self):
+        g = self.chord.opts(plot=dict(edge_color_index='start'),
+                            style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        plot = bokeh_renderer.get_plot(g)
+        cmapper = plot.handles['edge_colormapper']
+        edge_source = plot.handles['multi_line_1_source']
+        glyph = plot.handles['multi_line_1_glyph']
+        self.assertIsInstance(cmapper, CategoricalColorMapper)
+        self.assertEqual(cmapper.palette, ['#FFFFFF', '#000000', '#FFFFFF'])
+        self.assertEqual(cmapper.factors, ['0', '1', '2'])
+        self.assertEqual(edge_source.data['start_str'], ['0', '0', '1'])
+        self.assertEqual(glyph.line_color, {'field': 'start_str', 'transform': cmapper})
+

--- a/tests/plotting/matplotlib/testgraphplot.py
+++ b/tests/plotting/matplotlib/testgraphplot.py
@@ -5,29 +5,24 @@ from unittest import SkipTest
 import numpy as np
 from holoviews.core.data import Dataset
 from holoviews.core.options import Store, Cycle
-from holoviews.element import Graph, TriMesh, circular_layout
+from holoviews.element import Graph, TriMesh, Chord, circular_layout
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.plotting import comms
 
 # Standardize backend due to random inconsistencies
 try:
-    from matplotlib import pyplot
-    pyplot.switch_backend('agg')
+    from holoviews.plotting.mpl import OverlayPlot
     from matplotlib.collections import LineCollection, PolyCollection
-    mpl_renderer = Store.renderers['matplotlib']
 except:
-    mpl_renderer = None
+    pass
+
+from .testplot import TestMPLPlot, mpl_renderer
 
 
-class MplGraphPlotTests(ComparisonTestCase):
+class TestMplGraphPlot(TestMPLPlot):
 
     def setUp(self):
-        if not mpl_renderer:
-            raise SkipTest('Matplotlib tests require matplotlib to be available')
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'matplotlib'
-        self.default_comm = mpl_renderer.comms['default']
-        mpl_renderer.comms['default'] = (comms.Comm, '')
+        super(TestMplGraphPlot, self).setUp()
 
         N = 8
         self.nodes = circular_layout(np.arange(N, dtype=np.int32))
@@ -40,11 +35,6 @@ class MplGraphPlotTests(ComparisonTestCase):
         self.graph2 = Graph(((self.source, self.target), self.node_info))
         self.graph3 = Graph(((self.source, self.target), self.node_info2))
         self.graph4 = Graph(((self.source, self.target, self.weights),), vdims='Weight')
-
-
-    def tearDown(self):
-        mpl_renderer.comms['default'] = self.default_comm
-        Store.current_backend = self.previous_backend
 
     def test_plot_simple_graph(self):
         plot = mpl_renderer.get_plot(self.graph)
@@ -100,24 +90,15 @@ class MplGraphPlotTests(ComparisonTestCase):
 
 
 
-class TestMplTriMeshPlots(ComparisonTestCase):
+class TestMplTriMeshPlot(TestMPLPlot):
 
     def setUp(self):
-        if not mpl_renderer:
-            raise SkipTest('Matplotlib tests require matplotlib to be available')
-        self.previous_backend = Store.current_backend
-        Store.current_backend = 'matplotlib'
-        self.default_comm = mpl_renderer.comms['default']
-        mpl_renderer.comms['default'] = (comms.Comm, '')
+        super(TestMplTriMeshPlot, self).setUp()
 
         self.nodes = [(0, 0, 0), (0.5, 1, 1), (1., 0, 2), (1.5, 1, 3)]
         self.simplices = [(0, 1, 2, 0), (1, 2, 3, 1)]
         self.trimesh = TriMesh((self.simplices, self.nodes))
         self.trimesh_weighted = TriMesh((self.simplices, self.nodes), vdims='weight')
-
-    def tearDown(self):
-        mpl_renderer.comms['default'] = self.default_comm
-        Store.current_backend = self.previous_backend
 
     def test_plot_simple_trimesh(self):
         plot = mpl_renderer.get_plot(self.trimesh)
@@ -163,3 +144,39 @@ class TestMplTriMeshPlots(ComparisonTestCase):
                            [0.215686, 0.494118, 0.721569, 1.]])
         self.assertEqual(edges.get_facecolors(), colors)
 
+
+class TestMplChordPlot(TestMPLPlot):
+
+    def setUp(self):
+        super(TestMplChordPlot, self).setUp()
+        self.edges = [(0, 1, 1), (0, 2, 2), (1, 2, 3)]
+        self.nodes = Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
+        self.chord = Chord((self.edges, self.nodes))
+
+    def test_chord_nodes_label_text(self):
+        g = self.chord.opts(plot=dict(label_index='Label'))
+        plot = mpl_renderer.get_plot(g)
+        labels = plot.handles['labels']
+        self.assertEqual([l.get_text() for l in labels], ['A', 'B', 'C'])
+
+    def test_chord_nodes_categorically_colormapped(self):
+        g = self.chord.opts(plot=dict(color_index='Label'),
+                            style=dict(cmap=['#FFFFFF', '#CCCCCC', '#000000']))
+        plot = mpl_renderer.get_plot(g)
+        arcs = plot.handles['arcs']
+        nodes = plot.handles['nodes']
+        colors = np.array([[ 1.,   1.,   1.,   1. ],
+                           [ 0.8,  0.8,  0.8,  1. ],
+                           [ 0.,   0.,   0.,   1. ]])
+        self.assertEqual(arcs.get_colors(), colors)
+        self.assertEqual(nodes.get_facecolors(), colors)
+
+    def test_chord_edges_categorically_colormapped(self):
+        g = self.chord.opts(plot=dict(edge_color_index='start'),
+                            style=dict(edge_cmap=['#FFFFFF', '#000000']))
+        plot = mpl_renderer.get_plot(g)
+        edges = plot.handles['edges']
+        colors = np.array([[ 1., 1., 1., 1. ],
+                           [ 1., 1., 1., 1. ],
+                           [ 0., 0., 0., 1. ]])
+        self.assertEqual(edges.get_edgecolors(), colors)

--- a/tests/plotting/matplotlib/testgraphplot.py
+++ b/tests/plotting/matplotlib/testgraphplot.py
@@ -1,17 +1,12 @@
 from __future__ import absolute_import
 
-from unittest import SkipTest
-
 import numpy as np
 from holoviews.core.data import Dataset
-from holoviews.core.options import Store, Cycle
+from holoviews.core.options import Cycle
 from holoviews.element import Graph, TriMesh, Chord, circular_layout
-from holoviews.element.comparison import ComparisonTestCase
-from holoviews.plotting import comms
 
 # Standardize backend due to random inconsistencies
 try:
-    from holoviews.plotting.mpl import OverlayPlot
     from matplotlib.collections import LineCollection, PolyCollection
 except:
     pass


### PR DESCRIPTION
As outlined in https://github.com/ioam/holoviews/issues/2137 this PR adds support for a ``Chord`` element. So far this is just a WIP, but basically this just extends the existing ``Graph`` element to lay things out in a circle and draw bezier splines between the nodes. The next step will be to allow scaling the line thickness by a value in a separate PR, which will allow scaling the chords representing the edges between nodes and then start drawing the bands around the circle.

Progress for what is supported can be tracked in: https://anaconda.org/philippjfr/chord/notebook