### PR TITLE
Inherit parameters when casting Image to QuadMesh

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -624,8 +624,13 @@ class QuadMesh(Raster):
     vdims = param.List(default=[Dimension('z')], bounds=(1,1))
 
     def __init__(self, data, kdims=None, vdims=None, **params):
-        data = self._process_data(data)
-        Element2D.__init__(self, data, kdims=kdims, vdims=vdims, **params)
+        data, kwargs = self._process_data(data)
+        params = dict(kwargs, **params)
+        if kdims is not None:
+            params['kdims'] = kdims
+        if vdims is not None:
+            params['vdims'] = vdims
+        Element2D.__init__(self, data, **params)
         self.data = self._validate_data(self.data)
         self._grid = self.data[0].ndim == 1
 
@@ -639,15 +644,17 @@ class QuadMesh(Raster):
             x = data.dimension_values(0, expanded=False)
             y = data.dimension_values(1, expanded=False)
             zarray = data.dimension_values(2, flat=False)
+            params = util.get_param_values(data)
         else:
-            data = tuple(np.array(el) for el in data)
+            data = tuple(np.asarray(el) for el in data)
             x, y, zarray = data
+            params = {}
         ys, xs = zarray.shape
         if x.ndim == 1 and len(x) == xs:
             x = compute_edges(x)
         if y.ndim == 1 and len(y) == ys:
             y = compute_edges(y)
-        return (x, y, zarray)
+        return (x, y, zarray), params
 
 
     @property

--- a/tests/testraster.py
+++ b/tests/testraster.py
@@ -3,7 +3,7 @@ Unit tests of Raster elements
 """
 
 import numpy as np
-from holoviews.element import Raster, Image, Curve
+from holoviews.element import Raster, Image, Curve, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase
 
 class TestRaster(ComparisonTestCase):
@@ -56,3 +56,22 @@ class TestRaster(ComparisonTestCase):
         Image(None)
         Image(np.array([]))
         Image(np.zeros((0, 0)))
+
+
+
+class TestQuadMesh(ComparisonTestCase):
+
+    def setUp(self):
+        self.array1 = np.array([(0, 1, 2), (3, 4, 5)])
+
+    def test_cast_image_to_quadmesh(self):
+        img = Image(self.array1, kdims=['a', 'b'], vdims=['c'], group='A', label='B')
+        qmesh = QuadMesh(img)
+        self.assertEqual(qmesh.data[0], np.array([-0.5, -0.166667, 0.166667, 0.5]))
+        self.assertEqual(qmesh.data[1], np.array([-0.5, 0, 0.5]))
+        self.assertEqual(qmesh.data[2], self.array1[::-1])
+        self.assertEqual(qmesh.kdims, img.kdims)
+        self.assertEqual(qmesh.vdims, img.vdims)
+        self.assertEqual(qmesh.group, img.group)
+        self.assertEqual(qmesh.label, img.label)
+        


### PR DESCRIPTION
Due to an oversight the kdims, vdims, group and label aren't inherited when casting an Image to a QuadMesh.