### PR TITLE
Fixed shared_axis bug when plotting GridMatrix with Histogram

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -382,10 +382,6 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             if not self.shared_yaxis:
                 kwargs['yaxis'] = None
 
-            if isinstance(layout, GridMatrix):
-                if view.traverse(lambda x: x, [Histogram]):
-                    kwargs['shared_axes'] = False
-
             # Create subplot
             plotting_class = Store.registry[self.renderer.backend].get(vtype, None)
             if plotting_class is None:


### PR DESCRIPTION
This code was leftover from when Histogram's all had the same y-axis label and it was more convenient to ensure they were not linked when in GridMatrix. Fixes https://github.com/ioam/holoviews/issues/2131