### PR TITLE
Handling pandas Series and single column DataFrames

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -110,7 +110,7 @@ class DictInterface(Interface):
 
     @classmethod
     def validate(cls, dataset, vdims=True):
-        dim_types = 'key' if vdims else 'all'
+        dim_types = 'all' if vdims else 'key'
         dimensions = dataset.dimensions(dim_types, label='name')
         not_found = [d for d in dimensions if d not in dataset.data]
         if not_found:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -56,6 +56,16 @@ class PandasInterface(Interface):
                              if d not in kdims]
             elif kdims == [] and vdims is None:
                 vdims = list(data.columns[:nvdim if nvdim else None])
+
+            # Handle reset of index if kdims reference index by name
+            for kd in kdims:
+                if isinstance(kd, Dimension): kd = kd.name
+                if kd in data.columns:
+                    continue
+                if any(kd == ('index' if name is None else name)
+                       for name in data.index.names):
+                    data = data.reset_index()
+                    break
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 raise DataError("pandas DataFrame column names used as dimensions "
                                 "must be strings not integers.", cls)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -35,7 +35,11 @@ class PandasInterface(Interface):
         element_params = eltype.params()
         kdim_param = element_params['kdims']
         vdim_param = element_params['vdims']
+        if util.is_series(data):
+            data = data.to_frame()
         if util.is_dataframe(data):
+            if eltype._auto_indexable_1d and len(data.columns) == 1:
+                data = data.reset_index()
             if isinstance(kdim_param.bounds[1], int):
                 ndim = min([kdim_param.bounds[1], len(kdim_param.default)])
             else:
@@ -108,7 +112,7 @@ class PandasInterface(Interface):
 
     @classmethod
     def validate(cls, dataset, vdims=True):
-        dim_types = 'all' if vdims else 'key' 
+        dim_types = 'all' if vdims else 'key'
         dimensions = dataset.dimensions(dim_types, label='name')
         not_found = [d for d in dimensions if d not in dataset.data.columns]
         if not_found:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1134,10 +1134,18 @@ def find_file(folder, filename):
 
 def is_dataframe(data):
     """
-    Checks whether the supplied data is DataFrame type.
+    Checks whether the supplied data is of DataFrame type.
     """
     return((pd is not None and isinstance(data, pd.DataFrame)) or
           (dd is not None and isinstance(data, dd.DataFrame)))
+
+
+def is_series(data):
+    """
+    Checks whether the supplied data is of Series type.
+    """
+    return((pd is not None and isinstance(data, pd.Series)) or
+          (dd is not None and isinstance(data, dd.Series)))
 
 
 def get_param_values(data):

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -863,6 +863,14 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         self.data_instance_type = pd.DataFrame
         self.init_column_data()
 
+    def test_dataset_series_construct(self):
+        ds = Dataset(pd.Series([1, 2, 3], name='A'))
+        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), ['index', 'A']))
+
+    def test_dataset_single_column_construct(self):
+        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A']))
+        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), ['index', 'A']))
+
     def test_dataset_extract_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])

--- a/tests/testdataset.py
+++ b/tests/testdataset.py
@@ -877,6 +877,13 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         ds = Dataset(df, kdims=['x'])
         self.assertEqual(ds.vdims, [Dimension('y'), Dimension('z')])
 
+    def test_dataset_process_index(self):
+        df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
+                          columns=['x', 'y', 'z'])
+        ds = Dataset(df, 'index')
+        self.assertEqual(ds.kdims, [Dimension('index')])
+        self.assertEqual(ds.vdims, [Dimension('x'), Dimension('y'), Dimension('z')])
+
     def test_dataset_extract_kdims_and_vdims_no_bounds(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},
                           columns=['x', 'y', 'z'])

--- a/tests/teststatselements.py
+++ b/tests/teststatselements.py
@@ -24,6 +24,13 @@ class StatisticalElementTest(ComparisonTestCase):
         self.assertEqual(dist.kdims, [Dimension('Value')])
         self.assertEqual(dist.vdims, [Dimension('Density')])
 
+    def test_distribution_series_constructor(self):
+        if pd is None:
+            raise SkipTest("Test requires pandas")
+        dist = Distribution(pd.Series([0, 1, 2], name='Value'))
+        self.assertEqual(dist.kdims, [Dimension('Value')])
+        self.assertEqual(dist.vdims, [Dimension('Density')])
+
     def test_distribution_dict_constructor(self):
         dist = Distribution({'Value': [0, 1, 2]})
         self.assertEqual(dist.kdims, [Dimension('Value')])


### PR DESCRIPTION
This PR adds support for handling pandas and dask ``Series`` and single column ``DataFrame``s by resetting their index, turning it into a dimension. It should not have any backwards compatibility issues, except that constructing a ``Dataset`` from a single column ``DataFrame`` will now use the index and make it a dimension, while previously it would have just had the single column as a dimension. In all other cases it would have previously errored.