### PR TITLE
Removed stray mentions of lancet

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - pygments
   - notebook
   - matplotlib
-  - lancet-ioam
   - pandas
   - seaborn
   - mpld3

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require={}
 # Notebook dependencies of IPython 3
 extras_require['notebook-dependencies'] = ['ipython', 'pyzmq', 'jinja2', 'tornado',
                                            'jsonschema',  'notebook', 'pygments']
-# IPython Notebook + matplotlib + Lancet
+# IPython Notebook + matplotlib
 extras_require['recommended'] = extras_require['notebook-dependencies'] + ['matplotlib']
 # Additional, useful third-party packages
 extras_require['extras'] = (['pandas', 'seaborn', 'bokeh>=0.12.10, <0.12.12']


### PR DESCRIPTION
Lancet was an optional dependency for pip, but became a required dependency for conda when the conda-forge recipe was created.  For clarity, especially while lancet is only available for some platforms, make sure that it's not included in anything but documentation.