### PR TITLE
Matplotlib plotting fixes

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -7,6 +7,7 @@ from matplotlib.colors import ListedColormap
 from ...core import Layout, Collator, GridMatrix, config
 from ...core.options import Cycle, Palette, Options
 from ...core.overlay import NdOverlay, Overlay
+from ...core.util import pd
 from ...element import * # noqa (API import)
 from ..plot import PlotSelector
 from .annotation import * # noqa (API import)
@@ -23,6 +24,10 @@ from .renderer import MPLRenderer
 
 
 mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
+
+if pd:
+    from pandas.tseries import converter
+    converter.register()
 
 
 def set_style(key):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -823,7 +823,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
         else:
             leg_spec = self.legend_specs[self.legend_position]
             if self.legend_cols: leg_spec['ncol'] = self.legend_cols
-            leg = axis.legend(data.keys(), data.values(),
+            leg = axis.legend(list(data.keys()), list(data.values()),
                               title=title, scatterpoints=1,
                               **dict(leg_spec, **self._fontsize('legend')))
             title_fontsize = self._fontsize('legend_title')


### PR DESCRIPTION
In recent versions of pandas the matplotlib unit conversions for pandas datetime types is no longer automatic, this ensures that if pandas is available they are registered with matplotlib. The PR also fixes a bug handling legends in Python 3.