### PR TITLE
Fixed bug in bokeh BarPlot colormapping integer values

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -772,7 +772,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         # Merge data and mappings
         mapping.update(cmapping)
         for k, cd in cdata.items():
-            if self.color_index is None and cd.dtype.kind in 'if':
+            if isinstance(cmapper, CategoricalColorMapper) and cd.dtype.kind in 'if':
                 cd = categorize_array(cd, cdim)
             if k not in data or len(data[k]) != [len(data[key]) for key in data if key != k][0]:
                 data[k].append(cd)

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -971,7 +971,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         source = plot.handles['source']
         self.assertEqual([tuple(x) for x in source.data['xoffsets']],
                          [('A', '0'), ('B', '0'), ('A', '1')])
-        self.assertEqual(list(source.data['Category']), [0, 0, 1])
+        self.assertEqual(list(source.data['Category']), ['0', '0', '1'])
         self.assertEqual(source.data['Value'], np.array([1, 2, -1]))
         x_range = plot.handles['x_range']
         self.assertEqual(x_range.factors, [('A', '0'), ('A', '1'), ('B', '0'), ('B', '1')])
@@ -981,7 +981,7 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
                     kdims=['Index', 'Category'], vdims=['Value'])
         plot = bokeh_renderer.get_plot(bars.opts(plot=dict(stack_index=1)))
         source = plot.handles['source']
-        self.assertEqual(list(source.data['Category']), [1, 0, 0])
+        self.assertEqual(list(source.data['Category']), ['1', '0', '0'])
         self.assertEqual(list(source.data['Index']), ['A', 'A', 'B'])
         self.assertEqual(source.data['top'], np.array([0, 1, 2]))
         self.assertEqual(source.data['bottom'], np.array([-1, 0, 0]))


### PR DESCRIPTION
When using a CategoricalColorMapper integer values need to be transformed. The logic to apply this transformation was incorrect leading to BokehJS errors in certain cases.