### PR TITLE
Implement precomputing of datashader input data

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -91,9 +91,12 @@ class ResamplingOperation(Operation):
         e.g. when trying to display an interactive plot a second time.""")
 
     precompute = param.Boolean(default=False, doc="""
-       Whether to apply precomputing operations, if available.
-       Precomputing is in some cases useful to avoid repeating
-       expensive operations on the same inputs.""")
+        Whether to apply precomputing operations. Precomputing can
+        speed up resampling operations by avoiding unnecessary
+        recomputation if the supplied element does not change between
+        calls. The cost of enabling this option is that the memory
+        used to represent this internal state is not freed between
+        calls.""")
 
     @bothmethod
     def instance(self_or_cls,**params):

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -23,7 +23,7 @@ except:
     hammer_bundle, connect_edges = object, object
 
 from ..core import (Operation, Element, Dimension, NdOverlay,
-                    CompositeOverlay, Dataset)
+                    CompositeOverlay, Dataset, Overlay)
 from ..core.data import PandasInterface, XArrayInterface
 from ..core.sheetcoords import BoundingBox
 from ..core.util import get_param_values, basestring, datetime_types, dt_to_int
@@ -716,6 +716,8 @@ class shade(Operation):
         if isinstance(element, NdOverlay):
             bounds = element.last.bounds
             element = self.concatenate(element)
+        elif isinstance(element, Overlay):
+            return element.map(self._process, [Element])
         else:
             bounds = element.bounds
 


### PR DESCRIPTION
An initial go at https://github.com/ioam/holoviews/issues/2196. It allows datashader operation to precompute results, which can be used by the operation. For now only implemented for TriMesh rasterization but should be straightforward enough to do for other aggregation (although unnecessary for rasters).

I'm still considering how to improve this further. I think memoizing the precomputed results based on the element ID would be sufficient but will continue thinking about it.