### PR TITLE
Addition of Bokeh theme support to BokehRenderer

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -32,9 +32,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -45,9 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hv.extension('bokeh')"
@@ -77,9 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from holoviews.plotting.bokeh.element import (line_properties, fill_properties,\n",
@@ -101,9 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "curve_opts = dict(line_width=10, line_color='indianred', line_dash='dotted', line_alpha=0.5)\n",
@@ -141,9 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Points.A [width=300 height=300] Points.B [width=600 height=300]\n",
@@ -167,9 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "points = hv.Points(np.exp(xs)) \n",
@@ -201,9 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Overlay [width=600 legend_position='top_left'] Curve (muted_alpha=0.5 muted_color='black')\n",
@@ -234,9 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Points [size_index='z' tools=['hover']] HeatMap [toolbar='above' tools=['hover']]\n",
@@ -257,9 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Overlay [show_legend=False height=400 width=600] \n",
@@ -282,7 +264,7 @@
    "source": [
     "## Containers\n",
     "\n",
-    "The bokeh plotting extension also supports additional features relating to container components."
+    "The bokeh plotting extension also supports a number of additional features relating to container components."
    ]
   },
   {
@@ -302,9 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Overlay [tabs=True] Image [width=400 height=400]\n",
@@ -339,9 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Histogram [width=600] (alpha=0.8 muted_fill_alpha=0.1)\n",
@@ -372,9 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "points = hv.Points(np.random.randn(500,2))\n",
@@ -391,9 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "img.hist(num_bins=100, dimension=['x', 'y'], weight_dimension='z', mean_weighted=True) +\\\n",
@@ -417,9 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hmap = hv.HoloMap({phase: img.clone(np.sin(x**2+y**2+phase))\n",
@@ -451,9 +423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Points [tools=['hover']] (size=5) HeatMap [tools=['hover']] \n",
@@ -482,9 +452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Points [tools=['box_select', 'lasso_select', 'tap']] (size=10 nonselection_color='red' color='blue')\n",
@@ -510,9 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', '\\t')"
@@ -528,9 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Scatter [tools=['box_select', 'lasso_select']] Layout [shared_axes=True shared_datasource=True]\n",
@@ -548,9 +512,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%opts Scatter [tools=['box_select', 'lasso_select', 'hover'] border=0] Histogram {+axiswise}\n",
@@ -564,6 +526,83 @@
    "metadata": {},
    "source": [
     "The [Reference Gallery](http://holoviews.org/reference/index.html) shows examples of all the Elements supported for Bokeh, in a format that can be compared with the corresponding matplotlib versions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Theming\n",
+    "\n",
+    "Bokeh supports theming via the [Theme object](https://bokeh.pydata.org/en/latest/docs/reference/themes.html) object which can also be using in HoloViews. Applying a Bokeh theme is useful when you need to set detailed aesthetic options not directly exposed via the HoloViews style options.\n",
+    "\n",
+    "To apply a Bokeh theme, you will need to create a ``Theme`` object:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bokeh.themes.theme import Theme\n",
+    "\n",
+    "theme = Theme(\n",
+    "    json={\n",
+    "'attrs' : {\n",
+    "    'Figure' : {\n",
+    "        'background_fill_color': '#2F2F2F',\n",
+    "        'border_fill_color': '#2F2F2F',\n",
+    "        'outline_line_color': '#444444',\n",
+    "    },\n",
+    "    'Grid': {\n",
+    "        'grid_line_dash': [6, 4],\n",
+    "        'grid_line_alpha': .3,\n",
+    "    },\n",
+    "    \n",
+    "    'Axis': {\n",
+    "        'major_label_text_color': 'white',\n",
+    "        'axis_label_text_color': 'white',\n",
+    "        'major_tick_line_color': 'white',\n",
+    "        'minor_tick_line_color': 'white',\n",
+    "        'axis_line_color': \"white\"\n",
+    "    }\n",
+    "  }\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Instead of supplying a JSON object, you can also create a Bokeh ``Theme`` object from a [YAML file](https://bokeh.pydata.org/en/latest/docs/reference/themes.html). Once the ``Theme`` object is created, you can apply it by setting it on the ``theme`` property of the current Bokeh renderer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.renderer('bokeh').theme = theme"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The theme will then be applied to subsequent plots:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Curve [bgcolor='grey']\n",
+    "xs = np.linspace(0, np.pi*4, 100)\n",
+    "hv.Curve((xs, np.sin(xs)), label='foo')"
    ]
   }
  ],

--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -32,7 +32,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -43,7 +45,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hv.extension('bokeh')"
@@ -73,7 +77,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from holoviews.plotting.bokeh.element import (line_properties, fill_properties,\n",
@@ -95,7 +101,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "curve_opts = dict(line_width=10, line_color='indianred', line_dash='dotted', line_alpha=0.5)\n",
@@ -133,7 +141,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Points.A [width=300 height=300] Points.B [width=600 height=300]\n",
@@ -157,7 +167,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "points = hv.Points(np.exp(xs)) \n",
@@ -189,7 +201,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Overlay [width=600 legend_position='top_left'] Curve (muted_alpha=0.5 muted_color='black')\n",
@@ -220,7 +234,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Points [size_index='z' tools=['hover']] HeatMap [toolbar='above' tools=['hover']]\n",
@@ -241,10 +257,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "%%opts Overlay [show_legend=False height=400 width=600] ErrorBars (line_width=5) Scatter [jitter=0.2] (alpha=0.2 size=6)\n",
+    "%%opts Overlay [show_legend=False height=400 width=600] \n",
+    "%%opts ErrorBars (line_width=5) Scatter [jitter=0.2] (alpha=0.2 size=6)\n",
     "\n",
     "overlay = hv.NdOverlay({group: hv.Scatter(([group]*100, np.random.randn(100)*(i+1)+i))\n",
     "                        for i, group in enumerate(['A', 'B', 'C', 'D', 'E'])})\n",
@@ -261,7 +280,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Containers"
+    "## Containers\n",
+    "\n",
+    "The bokeh plotting extension also supports additional features relating to container components."
    ]
   },
   {
@@ -281,7 +302,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Overlay [tabs=True] Image [width=400 height=400]\n",
@@ -316,7 +339,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Histogram [width=600] (alpha=0.8 muted_fill_alpha=0.1)\n",
@@ -347,7 +372,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "points = hv.Points(np.random.randn(500,2))\n",
@@ -364,7 +391,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "img.hist(num_bins=100, dimension=['x', 'y'], weight_dimension='z', mean_weighted=True) +\\\n",
@@ -388,7 +417,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "hmap = hv.HoloMap({phase: img.clone(np.sin(x**2+y**2+phase))\n",
@@ -420,10 +451,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "%%opts Points [tools=['hover']] (size=5) HeatMap [tools=['hover']] Histogram [tools=['hover']] Layout [shared_axes=False]\n",
+    "%%opts Points [tools=['hover']] (size=5) HeatMap [tools=['hover']] \n",
+    "%%opts Histogram [tools=['hover']] Layout [shared_axes=False]\n",
     "error = np.random.rand(100, 3)\n",
     "heatmap_data = {(chr(65+i),chr(97+j)):i*j for i in range(5) for j in range(5) if i!=j}\n",
     "data = [np.random.normal() for i in range(10000)]\n",
@@ -448,7 +482,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Points [tools=['box_select', 'lasso_select', 'tap']] (size=10 nonselection_color='red' color='blue')\n",
@@ -474,7 +510,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "macro_df = pd.read_csv('http://assets.holoviews.org/macro.csv', '\\t')"
@@ -490,7 +528,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Scatter [tools=['box_select', 'lasso_select']] Layout [shared_axes=True shared_datasource=True]\n",
@@ -508,7 +548,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "%%opts Scatter [tools=['box_select', 'lasso_select', 'hover'] border=0] Histogram {+axiswise}\n",

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -23,6 +23,7 @@ from .util import attach_periodic, compute_plot_size
 from bokeh.io.notebook import load_notebook
 from bokeh.protocol import Protocol
 from bokeh.embed.notebook import encode_utf8, notebook_content
+from bokeh.themes.theme import Theme
 
 NOTEBOOK_DIV = """
 {plot_div}
@@ -33,6 +34,9 @@ NOTEBOOK_DIV = """
 
 
 class BokehRenderer(Renderer):
+
+    theme = param.ClassSelector(default=None, class_=Theme, allow_None=True, doc="""
+       The applicable Bokeh Theme object (if any).""")
 
     backend = param.String(default='bokeh', doc="The backend name.")
 
@@ -212,6 +216,11 @@ class BokehRenderer(Renderer):
         for m in model.references():
             m._document = None
         doc.add_root(model)
+
+        if self.theme:
+            from bokeh.io import curdoc
+            curdoc().theme = self.theme
+
         comm_id = plot.comm.id if plot.comm else None
         # Bokeh raises warnings about duplicate tools and empty subplots
         # but at the holoviews level these are not issues

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -183,14 +183,14 @@ class Renderer(Exporter):
         return plot
 
 
-    def _validate(self, obj, fmt):
+    def _validate(self, obj, fmt, **kwargs):
         """
         Helper method to be used in the __call__ method to get a
         suitable plot or widget object and the appropriate format.
         """
         if isinstance(obj, tuple(self.widgets.values())):
             return obj, 'html'
-        plot = self.get_plot(obj, renderer=self)
+        plot = self.get_plot(obj, renderer=self, **kwargs)
 
         fig_formats = self.mode_formats['fig'][self.mode]
         holomap_formats = self.mode_formats['holomap'][self.mode]


### PR DESCRIPTION

On current bokeh master, a PR has been merged which (re)enables bokeh themes in the notebook: bokeh/bokeh#7325. Bokeh themes in general is something HoloViews should support for extra control over options that might not be exposed via plot/style options. In addition, we do support style files for matplotlib so it makes sense to support Bokeh themes as the analogous concept.

This PR shows one way this could work (you will need the latest bokeh master for this to work) using a theme file:

![image](https://user-images.githubusercontent.com/890576/34085591-1107b4d0-e38b-11e7-9b24-e9e71087a849.png)

Or using a JSON spec (not a great theme but it gets the point across!):

![image](https://user-images.githubusercontent.com/890576/34085604-36f3a816-e38b-11e7-8c01-726af14727ac.png)

I'm not committed to this API (though it seems ok to me) and I wonder if I should do a bokeh version check? This won't cause any errors/exceptions if you use an earlier bokeh version but the theming won't work either.
