### PR TITLE
Trisurface renamed to TriSurface

### DIFF
--- a/doc/Tutorials/Bokeh_Elements.ipynb
+++ b/doc/Tutorials/Bokeh_Elements.ipynb
@@ -48,7 +48,7 @@
     "<dl class=\"dl-horizontal\">\n",
     "  <dt><a href=\"#Surface\"><code>Surface</code></a></dt><dd>Continuous collection of points in a three-dimensional space. <font color='red'>&#x2717;</font></dd>\n",
     "  <dt><a href=\"#Scatter3D\"><code>Scatter3D</code></a></dt><dd>Discontinuous collection of points in a three-dimensional space. <font color='red'>&#x2717;</font></dd>\n",
-    "  <dt><a href=\"#Trisurface\"><code>Trisurface</code></a></dt><dd>Continuous but irregular collection of points interpolated into a Surface using Delaunay triangulation. <font color='red'>&#x2717;</font></dd>\n",
+    "  <dt><a href=\"#TriSurface\"><code>TriSurface</code></a></dt><dd>Continuous but irregular collection of points interpolated into a Surface using Delaunay triangulation. <font color='red'>&#x2717;</font></dd>\n",
     "</dl>\n",
     "\n",
     "\n",
@@ -763,14 +763,14 @@
     "``Scatter3D`` is the equivalent of ``Scatter`` but for two key dimensions, rather than just one.\n",
     "\n",
     "\n",
-    "### ``Trisurface`` <a id='Trisurface'></a>"
+    "### ``TriSurface`` <a id='TriSurface'></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Trisurface`` Element renders any collection of 3D points as a Surface by applying Delaunay triangulation.  It thus supports arbitrary, non-gridded data, but it does not support indexing to find data values, since finding the closest ones would require a search."
+    "The ``TriSurface`` Element renders any collection of 3D points as a Surface by applying Delaunay triangulation.  It thus supports arbitrary, non-gridded data, but it does not support indexing to find data values, since finding the closest ones would require a search."
    ]
   },
   {
@@ -779,8 +779,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [fig_size=200] (cmap='hot_r')\n",
-    "hv.Trisurface((x.flat,y.flat,heights.flat))"
+    "%%opts TriSurface [fig_size=200] (cmap='hot_r')\n",
+    "hv.TriSurface((x.flat,y.flat,heights.flat))"
    ]
   },
   {
@@ -1418,5 +1418,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/doc/Tutorials/Columnar_Data.ipynb
+++ b/doc/Tutorials/Columnar_Data.ipynb
@@ -80,7 +80,7 @@
     "* 0D: BoxWhisker, Spikes, Distribution*, \n",
     "* 1D: Scatter, Curve, ErrorBars, Spread, Bars, BoxWhisker, Regression*\n",
     "* 2D: Points, HeatMap, Bars, BoxWhisker, Bivariate*\n",
-    "* 3D: Scatter3D, Trisurface, VectorField, BoxWhisker, Bars\n",
+    "* 3D: Scatter3D, TriSurface, VectorField, BoxWhisker, Bars\n",
     "\n",
     "\\* - requires Seaborn\n",
     "\n",

--- a/doc/Tutorials/Elements.ipynb
+++ b/doc/Tutorials/Elements.ipynb
@@ -44,7 +44,7 @@
     "<dl class=\"dl-horizontal\">\n",
     "  <dt><a href=\"#Surface\"><code>Surface</code></a></dt><dd>Continuous collection of points in a three-dimensional space.</dd>\n",
     "  <dt><a href=\"#Scatter3D\"><code>Scatter3D</code></a></dt><dd>Discontinuous collection of points in a three-dimensional space.</dd>\n",
-    "  <dt><a href=\"#Trisurface\"><code>Trisurface</code></a></dt><dd>Continuous but irregular collection of points interpolated into a Surface using Delaunay triangulation.</dd>\n",
+    "  <dt><a href=\"#TriSurface\"><code>TriSurface</code></a></dt><dd>Continuous but irregular collection of points interpolated into a Surface using Delaunay triangulation.</dd>\n",
     "</dl>\n",
     "\n",
     "\n",
@@ -796,14 +796,14 @@
     "``Scatter3D`` is the equivalent of ``Scatter`` but for two key dimensions, rather than just one.\n",
     "\n",
     "\n",
-    "### ``Trisurface`` <a id='Trisurface'></a>"
+    "### ``TriSurface`` <a id='TriSurface'></a>"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Trisurface`` Element renders any collection of 3D points as a Surface by applying Delaunay triangulation.  It thus supports arbitrary, non-gridded data, but it does not support indexing to find data values, since finding the closest ones would require a search."
+    "The ``TriSurface`` Element renders any collection of 3D points as a Surface by applying Delaunay triangulation.  It thus supports arbitrary, non-gridded data, but it does not support indexing to find data values, since finding the closest ones would require a search."
    ]
   },
   {
@@ -812,8 +812,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [fig_size=200] (cmap='hot_r')\n",
-    "hv.Trisurface((x.flat,y.flat,heights.flat))"
+    "%%opts TriSurface [fig_size=200] (cmap='hot_r')\n",
+    "hv.TriSurface((x.flat,y.flat,heights.flat))"
    ]
   },
   {
@@ -1454,5 +1454,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/gallery/demos/matplotlib/trisurf3d_demo.ipynb
+++ b/examples/gallery/demos/matplotlib/trisurf3d_demo.ipynb
@@ -62,7 +62,7 @@
     "# Compute z to make the pringle surface.\n",
     "z = np.sin(-x*y)\n",
     "\n",
-    "trisurface = hv.Trisurface((x, y, z))"
+    "trisurface = hv.TriSurface((x, y, z))"
    ]
   },
   {

--- a/examples/gallery/demos/plotly/trisurf3d_demo.ipynb
+++ b/examples/gallery/demos/plotly/trisurf3d_demo.ipynb
@@ -63,7 +63,7 @@
     "# Compute z to make the pringle surface.\n",
     "z = np.sin(-x*y)\n",
     "\n",
-    "trisurface = hv.Trisurface((x, y, z))"
+    "trisurface = hv.TriSurface((x, y, z))"
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/TriSurface.ipynb
+++ b/examples/reference/elements/matplotlib/TriSurface.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
     "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> Trisurface Element</dd>\n",
+    "  <dt>Title</dt> <dd> TriSurface Element</dd>\n",
     "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
-    "  <dt>Backends</dt> <dd><a href='../matplotlib/Trisurface.ipynb'>Matplotlib</a></dd>\n",
+    "  <dt>Backends</dt> <dd><a href='../matplotlib/TriSurface.ipynb'>Matplotlib</a></dd>\n",
     "\n",
     "</dl>\n",
     "</div>"
@@ -29,7 +29,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Trisurface`` Element renders any collection of 3D points as a surface by applying [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation). It is therefore useful for plotting an arbitrary collection of datapoints as a 3D surface. Like other 3D elements it supports ``azimuth``, ``elevation`` and ``distance`` plot options to control the camera position:"
+    "The ``TriSurface`` Element renders any collection of 3D points as a surface by applying [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation). It is therefore useful for plotting an arbitrary collection of datapoints as a 3D surface. Like other 3D elements it supports ``azimuth``, ``elevation`` and ``distance`` plot options to control the camera position:"
    ]
   },
   {
@@ -38,10 +38,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [azimuth=30 elevation=30 fig_size=200]\n",
+    "%%opts TriSurface [azimuth=30 elevation=30 fig_size=200]\n",
     "y,x = np.mgrid[-5:5, -5:5] * 0.1\n",
     "heights = np.sin(x**2+y**2)\n",
-    "hv.Trisurface((x.flat,y.flat,heights.flat))"
+    "hv.TriSurface((x.flat,y.flat,heights.flat))"
    ]
   },
   {
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [fig_size=200 colorbar=True] (cmap='fire')\n",
+    "%%opts TriSurface [fig_size=200 colorbar=True] (cmap='fire')\n",
     "\n",
     "u=np.linspace(0,2*np.pi, 24)\n",
     "v=np.linspace(-1,1, 8)\n",
@@ -71,7 +71,7 @@
     "y=tp*np.sin(u)\n",
     "z=0.5*v*np.sin(u/2.)\n",
     "\n",
-    "surface = hv.Trisurface((x, y, z), label='Moebius band')\n",
+    "surface = hv.TriSurface((x, y, z), label='Moebius band')\n",
     "surface"
    ]
   },
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full documentation and the available style and plot options, use ``hv.help(hv.Trisurface).``"
+    "For full documentation and the available style and plot options, use ``hv.help(hv.TriSurface).``"
    ]
   }
  ],

--- a/examples/reference/elements/plotly/TriSurface.ipynb
+++ b/examples/reference/elements/plotly/TriSurface.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "<div class=\"contentcontainer med left\" style=\"margin-left: -50px;\">\n",
     "<dl class=\"dl-horizontal\">\n",
-    "  <dt>Title</dt> <dd> Trisurface Element</dd>\n",
+    "  <dt>Title</dt> <dd> TriSurface Element</dd>\n",
     "  <dt>Dependencies</dt> <dd>Matplotlib</dd>\n",
-    "  <dt>Backends</dt> <dd><a href='../matplotlib/Trisurface.ipynb'>Matplotlib</a></dd> <dd><a href='./Trisurface.ipynb'>Plotly</a></dd>\n",
+    "  <dt>Backends</dt> <dd><a href='../matplotlib/TriSurface.ipynb'>Matplotlib</a></dd> <dd><a href='./TriSurface.ipynb'>Plotly</a></dd>\n",
     "</dl>\n",
     "</div>"
    ]
@@ -28,7 +28,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``Trisurface`` Element renders any collection of 3D points as a surface by applying [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation). It is therefore useful for plotting an arbitrary collection of datapoints as a 3D surface. Like other 3D elements it supports ``azimuth``, ``elevation`` and ``distance`` plot options to control the camera position:"
+    "The ``TriSurface`` Element renders any collection of 3D points as a surface by applying [Delaunay triangulation](https://en.wikipedia.org/wiki/Delaunay_triangulation). It is therefore useful for plotting an arbitrary collection of datapoints as a 3D surface. Like other 3D elements it supports ``azimuth``, ``elevation`` and ``distance`` plot options to control the camera position:"
    ]
   },
   {
@@ -37,10 +37,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [width=500 height=500]\n",
+    "%%opts TriSurface [width=500 height=500]\n",
     "y,x = np.mgrid[-5:5, -5:5] * 0.1\n",
     "heights = np.sin(x**2+y**2)\n",
-    "hv.Trisurface((x.flat,y.flat,heights.flat))"
+    "hv.TriSurface((x.flat,y.flat,heights.flat))"
    ]
   },
   {
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Trisurface [width=500 height=500 colorbar=True] (cmap='fire')\n",
+    "%%opts TriSurface [width=500 height=500 colorbar=True] (cmap='fire')\n",
     "\n",
     "u=np.linspace(0,2*np.pi, 24)\n",
     "v=np.linspace(-1,1, 8)\n",
@@ -70,7 +70,7 @@
     "y=tp*np.sin(u)\n",
     "z=0.5*v*np.sin(u/2.)\n",
     "\n",
-    "surface = hv.Trisurface((x, y, z), label='Moebius band')\n",
+    "surface = hv.TriSurface((x, y, z), label='Moebius band')\n",
     "surface"
    ]
   },
@@ -78,7 +78,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For full documentation and the available style and plot options, use ``hv.help(hv.Trisurface).``"
+    "For full documentation and the available style and plot options, use ``hv.help(hv.TriSurface).``"
    ]
   }
  ],

--- a/examples/topics/simulation/sri_model.ipynb
+++ b/examples/topics/simulation/sri_model.ipynb
@@ -576,7 +576,7 @@
    "outputs": [],
    "source": [
     "%%opts Layout [fig_size=200] \n",
-    "%%opts Trisurface (cmap='Reds_r' linewidth=0.1)\n",
+    "%%opts TriSurface (cmap='Reds_r' linewidth=0.1)\n",
     "(hv.Table(df).to.trisurface(['pVaccinated', 'Connections'],\n",
     "                        '$R_0$', [], group='$R_0$') +\n",
     "hv.Table(df).to.trisurface(['pVaccinated', 'Connections'],\n",

--- a/examples/user_guide/07-Tabular_Datasets.ipynb
+++ b/examples/user_guide/07-Tabular_Datasets.ipynb
@@ -87,7 +87,7 @@
     "* 0D: BoxWhisker, Spikes, Distribution*, \n",
     "* 1D: Scatter, Curve, ErrorBars, Spread, Bars, BoxWhisker, Regression*\n",
     "* 2D: Points, HeatMap, Bars, BoxWhisker, Bivariate*\n",
-    "* 3D: Scatter3D, Trisurface, VectorField, BoxWhisker, Bars\n",
+    "* 3D: Scatter3D, TriSurface, VectorField, BoxWhisker, Bars\n",
     "\n",
     "\\* - requires Seaborn\n",
     "\n",

--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -81,7 +81,7 @@ class ElementConversion(DataConversion):
         return Surface(heatmap.data, **dict(self._table.get_param_values(onlychanged=True)))
 
     def trisurface(self, kdims=None, vdims=None, groupby=None, **kwargs):
-        return self(Trisurface, kdims, vdims, groupby, **kwargs)
+        return self(TriSurface, kdims, vdims, groupby, **kwargs)
 
     def vectorfield(self, kdims=None, vdims=None, groupby=None, **kwargs):
         return self(VectorField, kdims, vdims, groupby, **kwargs)

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -52,6 +52,15 @@ class TriSurface(Element3D, Scatter):
     def __getitem__(self, slc):
         return Chart.__getitem__(self, slc)
 
+class Trisurface(TriSurface):
+    """
+    Old name for TriSurface. Retaining for backwards compatibility till
+    holoviews 2.0.
+    """
+
+    def __init__(self, *args, **kwargs):
+        self.warning('Please use TriSurface element instead')
+        super(TriSurface, self).__init__(*args, **kwargs)
 
 
 class Scatter3D(Element3D, Scatter):

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -52,11 +52,14 @@ class TriSurface(Element3D, Scatter):
     def __getitem__(self, slc):
         return Chart.__getitem__(self, slc)
 
+
 class Trisurface(TriSurface):
     """
     Old name for TriSurface. Retaining for backwards compatibility till
     holoviews 2.0.
     """
+
+    group = param.String(default='Trisurface', constant=True)
 
     def __init__(self, *args, **kwargs):
         self.warning('Please use TriSurface element instead')

--- a/holoviews/element/chart3d.py
+++ b/holoviews/element/chart3d.py
@@ -33,9 +33,9 @@ class Surface(Image, Element3D):
 
 
 
-class Trisurface(Element3D, Scatter):
+class TriSurface(Element3D, Scatter):
     """
-    Trisurface object represents a number of coordinates in 3D-space,
+    TriSurface object represents a number of coordinates in 3D-space,
     represented as a Surface of triangular polygons.
     """
 
@@ -44,10 +44,10 @@ class Trisurface(Element3D, Scatter):
                                 Dimension('z')])
 
     vdims = param.List(default=[], doc="""
-        Trisurface can have optional value dimensions,
+        TriSurface can have optional value dimensions,
         which may be mapped onto color and size.""")
 
-    group = param.String(default='Trisurface', constant=True)
+    group = param.String(default='TriSurface', constant=True)
 
     def __getitem__(self, slc):
         return Chart.__getitem__(self, slc)

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -164,7 +164,7 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[Area] =         cls.compare_area
         cls.equality_type_funcs[Scatter] =      cls.compare_scatter
         cls.equality_type_funcs[Scatter3D] =    cls.compare_scatter3d
-        cls.equality_type_funcs[Trisurface] =   cls.compare_trisurface
+        cls.equality_type_funcs[TriSurface] =   cls.compare_trisurface
         cls.equality_type_funcs[Histogram] =    cls.compare_histogram
         cls.equality_type_funcs[Bars] =         cls.compare_bars
         cls.equality_type_funcs[Spikes] =       cls.compare_spikes
@@ -535,7 +535,7 @@ class Comparison(ComparisonInterface):
         cls.compare_dataset(el1, el2, msg)
 
     @classmethod
-    def compare_trisurface(cls, el1, el2, msg='Trisurface'):
+    def compare_trisurface(cls, el1, el2, msg='TriSurface'):
         cls.compare_dataset(el1, el2, msg)
 
     @classmethod

--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -165,6 +165,7 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[Scatter] =      cls.compare_scatter
         cls.equality_type_funcs[Scatter3D] =    cls.compare_scatter3d
         cls.equality_type_funcs[TriSurface] =   cls.compare_trisurface
+        cls.equality_type_funcs[Trisurface] =   cls.compare_trisurface
         cls.equality_type_funcs[Histogram] =    cls.compare_histogram
         cls.equality_type_funcs[Bars] =         cls.compare_bars
         cls.equality_type_funcs[Spikes] =       cls.compare_spikes

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -135,7 +135,7 @@ Store.register({Curve: CurvePlot,
 
                 # Chart 3D
                 Surface: SurfacePlot,
-                Trisurface: TrisurfacePlot,
+                TriSurface: TriSurfacePlot,
                 Scatter3D: Scatter3DPlot,
 
                 # Tabular plots

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -136,6 +136,7 @@ Store.register({Curve: CurvePlot,
                 # Chart 3D
                 Surface: SurfacePlot,
                 TriSurface: TriSurfacePlot,
+                Trisurface: TriSurfacePlot, # Alias, remove in 2.0
                 Scatter3D: Scatter3DPlot,
 
                 # Tabular plots

--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -188,9 +188,9 @@ class SurfacePlot(Plot3D):
             
 
 
-class TrisurfacePlot(Plot3D):
+class TriSurfacePlot(Plot3D):
     """
-    Plots a trisurface given a Trisurface element, containing
+    Plots a trisurface given a TriSurface element, containing
     X, Y and Z coordinates.
     """
 

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -35,6 +35,7 @@ Store.register({Points: PointPlot,
                 Scatter3D: Scatter3dPlot,
                 Surface: SurfacePlot,
                 TriSurface: TriSurfacePlot,
+                Trisurface: TriSurfacePlot, # Alias, remove in 2.0
 
                 # Tabular
                 Table: TablePlot,

--- a/holoviews/plotting/plotly/__init__.py
+++ b/holoviews/plotting/plotly/__init__.py
@@ -34,7 +34,7 @@ Store.register({Points: PointPlot,
                 # 3D Plot
                 Scatter3D: Scatter3dPlot,
                 Surface: SurfacePlot,
-                Trisurface: TrisurfacePlot,
+                TriSurface: TriSurfacePlot,
 
                 # Tabular
                 Table: TablePlot,
@@ -62,7 +62,7 @@ options.Curve = Options('style', color=Cycle(), width=2)
 options.ErrorBars = Options('style', color='black')
 options.Scatter = Options('style', color=Cycle())
 options.Points = Options('style', color=Cycle())
-options.Trisurface = Options('style', cmap='viridis')
+options.TriSurface = Options('style', cmap='viridis')
 
 # Rasters
 options.Image = Options('style', cmap=dflt_cmap)

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -87,7 +87,7 @@ class Scatter3dPlot(ScatterPlot, Chart3DPlot):
                         z=element.dimension_values(2))
 
 
-class TrisurfacePlot(ColorbarPlot, Chart3DPlot):
+class TriSurfacePlot(ColorbarPlot, Chart3DPlot):
 
     style_opts = ['cmap']
 
@@ -95,7 +95,7 @@ class TrisurfacePlot(ColorbarPlot, Chart3DPlot):
         try:
             from scipy.spatial import Delaunay
         except:
-            SkipRendering("SciPy not available, cannot plot Trisurface")
+            SkipRendering("SciPy not available, cannot plot TriSurface")
         x, y, z = (element.dimension_values(i) for i in range(3))
         points2D = np.vstack([x, y]).T
         tri = Delaunay(points2D)


### PR DESCRIPTION
The branch is misnamed after deciding that ``TriMesh`` was not the inconsistent name but ``Trisurface`` was.