### PR TITLE
Fixed drawing of bokeh QuadMesh

### DIFF
--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -1290,8 +1290,8 @@ class TestBokehPlotInstantiation(ComparisonTestCase):
         self.assertEqual(source.data['dh'][0], 1)
 
     def test_quadmesh_invert_axes(self):
-        arr = np.array([[0, 1, 2], [3, 4,  5]])
-        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True))
+        arr = np.array([[0, 1, 2], [3, 4, 5]])
+        qmesh = QuadMesh(Image(arr)).opts(plot=dict(invert_axes=True, tools=['hover']))
         plot = bokeh_renderer.get_plot(qmesh)
         source = plot.handles['source']
         self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False).flatten())


### PR DESCRIPTION
Fixed bug mentioned by @ea42gh in https://github.com/ioam/holoviews/issues/2232.

```python
np.random.seed(123)
x = np.array(sorted(1000*np.random.random(10)))
y = np.linspace(0,9,10)
z = np.random.normal(size=(10,10))
hv.QuadMesh((x, y, z))
```

Old drawing behavior:

<img width="305" alt="screen shot 2018-01-03 at 1 02 44 pm" src="https://user-images.githubusercontent.com/1550771/34521593-6da7d4f6-f086-11e7-802a-b98000744cd4.png">

Fixed drawing behavior:

<img width="304" alt="screen shot 2018-01-03 at 1 02 22 pm" src="https://user-images.githubusercontent.com/1550771/34521598-7596198e-f086-11e7-8261-b6b6f78534e7.png">

For comparison purposes the matplotlib version:

![image](https://user-images.githubusercontent.com/1550771/34521627-9af7e400-f086-11e7-91d8-bc050db58481.png)
