### PR TITLE
Changed Image regular sampling validation

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -262,14 +262,17 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
                 raise ValueError("Input array has shape %r but %d value dimensions defined"
                                  % (self.shape, len(self.vdims)))
 
-        xvals = np.unique(np.diff(self.dimension_values(0, expanded=False)))
-        if len(xvals) > 1 and np.abs(xvals.min()-xvals.max()) > sys.float_info.epsilon*100:
+        xdiffs = np.diff(self.dimension_values(0, expanded=False))
+        xvals = np.unique(xdiffs)
+        if len(xvals) > 1 and np.abs(xvals.min()-xvals.max()) > xdiffs.min()*10e-9:
             raise ValueError("%s dimension %s is not evenly sampled, "
                              "please use the QuadMesh element for "
                              "unevenly or irregularly sampled data." %
                              (type(self).__name__, self.get_dimension(0)))
-        yvals = np.unique(np.diff(self.dimension_values(1, expanded=False)))
-        if len(yvals) > 1 and np.abs(yvals.min()-yvals.max()) > sys.float_info.epsilon*100:
+
+        ydiffs = np.diff(self.dimension_values(1, expanded=False))
+        yvals = np.unique(ydiffs)
+        if len(yvals) > 1 and np.abs(yvals.min()-yvals.max()) > ydiffs.min()*10e-9:
             raise ValueError("%s dimension %s is not evenly sampled, "
                              "please use the QuadMesh element for "
                              "unevenly or irregularly sampled data." %

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -14,7 +14,8 @@ from ..core.util import dimension_range, compute_density, datetime_types
 from .chart import Curve
 from .graphs import TriMesh
 from .tabular import Table
-from .util import compute_slice_bounds, categorical_aggregate2d
+from .util import (compute_slice_bounds, categorical_aggregate2d,
+                   validate_regular_sampling)
 
 
 class Raster(Element2D):
@@ -262,21 +263,9 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
                 raise ValueError("Input array has shape %r but %d value dimensions defined"
                                  % (self.shape, len(self.vdims)))
 
-        xdiffs = np.diff(self.dimension_values(0, expanded=False))
-        xvals = np.unique(xdiffs)
-        if len(xvals) > 1 and np.abs(xvals.min()-xvals.max()) > xdiffs.min()*10e-9:
-            raise ValueError("%s dimension %s is not evenly sampled, "
-                             "please use the QuadMesh element for "
-                             "unevenly or irregularly sampled data." %
-                             (type(self).__name__, self.get_dimension(0)))
-
-        ydiffs = np.diff(self.dimension_values(1, expanded=False))
-        yvals = np.unique(ydiffs)
-        if len(yvals) > 1 and np.abs(yvals.min()-yvals.max()) > ydiffs.min()*10e-9:
-            raise ValueError("%s dimension %s is not evenly sampled, "
-                             "please use the QuadMesh element for "
-                             "unevenly or irregularly sampled data." %
-                             (type(self).__name__, self.get_dimension(1)))
+        # Ensure coordinates are regularly sampled
+        validate_regular_sampling(self, 0)
+        validate_regular_sampling(self, 1)
 
 
     def __setstate__(self, state):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -282,3 +282,21 @@ def connect_edges(graph):
         end = end_ds.array(end_ds.kdims[:2])
         paths.append(np.array([start[0], end[0]]))
     return paths
+
+
+def validate_regular_sampling(img, dimension, rtol=10e-9):
+    """
+    Validates regular sampling of Image elements ensuring that
+    coordinates the difference in sampling steps is at most rtol times
+    the smallest sampling step. By default ensures the largest
+    sampling difference is less than one billionth of the smallest
+    sampling step.
+    """
+    dim = img.get_dimension(dimension)
+    diffs = np.diff(img.dimension_values(dim, expanded=False))
+    vals = np.unique(diffs)
+    if len(vals) > 1 and np.abs(vals.min()-vals.max()) > diffs.min()*rtol:
+        raise ValueError("%s dimension %s is not evenly sampled, "
+                         "please use the QuadMesh element for "
+                         "unevenly or irregularly sampled data." %
+                         (type(img).__name__, dim))


### PR DESCRIPTION
As is evident in https://github.com/ioam/holoviews/issues/2228, the new Image sampling validation which relies on machine floating point precision does not work correctly. This PR switches the validation strategy to one that ensures that the maximum difference in the sampling is one billionth (1e9) of the smallest sampling step. This works consistently based on my now more thorough testing and is still a very strict constraint to ensure regular sampling.