### PR TITLE
Fixed bokeh server Callback queue bug

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -388,7 +388,6 @@ class ServerCallback(MessageCallback):
         if not self._queue:
             self._active = False
             return
-        self._queue = []
         # Get unique event types in the queue
         events = list(OrderedDict([(event.event_name, event)
                                    for event in self._queue]).values())


### PR DESCRIPTION
A previous PR seems to have introduced a bug which clears the event queue before it is processed when using ``on_event`` based stream callbacks such the Tap event.

Fixes: https://github.com/ioam/holoviews/issues/2231
  