### PR TITLE
added muted_alpha option to Distribution

### DIFF
--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -156,6 +156,7 @@ if not config.style_17:
     options.Points = Options('plot', show_frame=True)
 
 options.Histogram = Options('style', line_color='black', fill_color=Cycle())
+options.Distribution = Options('style', muted_alpha=0.2)
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
 options.Bars = Options('style', color=Cycle(), line_color='black', width=0.8)
@@ -232,4 +233,4 @@ options.Polygons = Options('style', muted_alpha=0.2)
 
 # Statistics
 options.Distribution = Options('style', fill_color=Cycle(), line_color='black',
-                               fill_alpha=0.5)
+                               fill_alpha=0.5, muted_alpha=0.2)

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -155,8 +155,7 @@ options.Points = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap
 if not config.style_17:
     options.Points = Options('plot', show_frame=True)
 
-options.Histogram = Options('style', line_color='black', fill_color=Cycle())
-options.Distribution = Options('style', muted_alpha=0.2)
+options.Histogram = Options('style', line_color='black', fill_color=Cycle(), muted_alpha=0.2)
 options.ErrorBars = Options('style', color='black')
 options.Spread = Options('style', color=Cycle(), alpha=0.6, line_color='black')
 options.Bars = Options('style', color=Cycle(), line_color='black', width=0.8)


### PR DESCRIPTION
Allows Distribution and Histogram elements to make use of muted legends when using the bokeh backend (as suggested in https://github.com/ioam/holoviews/issues/2170).