### PR TITLE
Fixed irregular binning validation

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -84,6 +84,8 @@ class GridInterface(DictInterface):
         kdim_names = [d.name if isinstance(d, Dimension) else d for d in kdims]
         vdim_names = [d.name if isinstance(d, Dimension) else d for d in vdims]
         expected = tuple([len(data[kd]) for kd in kdim_names])
+        irregular_shape = data[kdim_names[0]].shape if kdim_names else ()
+        valid_shape = irregular_shape if len(irregular_shape) > 1 else expected[::-1]
         shapes = tuple([data[kd].shape for kd in kdim_names])
         for vdim in vdim_names:
             shape = data[vdim].shape
@@ -96,10 +98,10 @@ class GridInterface(DictInterface):
                             'match the expected dimensionality indicated '
                             'by the key dimensions. Expected %d-D array, '
                             'found %d-D array.' % (vdim, len(expected), len(shape)))
-            elif any((s!=e and (s+1)!=e) for s, e in zip(shape, expected[::-1])):
+            elif any((s!=e and (s+1)!=e) for s, e in zip(shape, valid_shape)):
                 raise error('Key dimension values and value array %s '
                             'shapes do not match. Expected shape %s, '
-                            'actual shape: %s' % (vdim, expected[::-1], shape), cls)
+                            'actual shape: %s' % (vdim, valid_shape, shape), cls)
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
 

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -157,12 +157,12 @@ class Binned2DTest(ComparisonTestCase):
 class Irregular2DBinsTest(ComparisonTestCase):
 
     def setUp(self):
-        lon, lat = np.meshgrid(np.linspace(-20, 20, 5), np.linspace(0, 30, 4))
+        lon, lat = np.meshgrid(np.linspace(-20, 20, 6), np.linspace(0, 30, 4))
         lon += lat/10
         lat += lon/10
         self.xs = lon
         self.ys = lat
-        self.zs = np.arange(20).reshape(4, 5)
+        self.zs = np.arange(24).reshape(4, 6)
 
     def test_construct_from_dict(self):
         dataset = Dataset((self.xs, self.ys, self.zs), ['x', 'y'], 'z')
@@ -188,7 +188,7 @@ class Irregular2DBinsTest(ComparisonTestCase):
             import xarray as xr
         except:
             raise SkipError("Test requires xarray")
-        zs = np.arange(40).reshape(2, 4, 5)
+        zs = np.arange(48).reshape(2, 4, 6)
         da = xr.DataArray(zs, dims=['z', 'y', 'x'],
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs),
@@ -204,7 +204,7 @@ class Irregular2DBinsTest(ComparisonTestCase):
             import xarray as xr
         except:
             raise SkipError("Test requires xarray")
-        zs = np.arange(40).reshape(2, 4, 5)
+        zs = np.arange(48).reshape(2, 4, 6)
         da = xr.DataArray(zs, dims=['z', 'y', 'x'],
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs),


### PR DESCRIPTION
Due to poorly chosen test cases I didn't notice that the validation for irregular array data did not work for arrays that are not of shape ``(N[+1], N[+1], ...)``. This PR fixes this issue and changes the tests so they test for non-square cases.
  
  