### PR TITLE
Xarray warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ before-script:
 script:
   - export HOLOVIEWSRC=`pwd`'/holoviews.rc'
   - echo 'import holoviews as hv;hv.config(style_17=True);hv.config.warn_options_call=True' > holoviews.rc
-  - nosetests --with-doctest --with-coverage --cover-package=holoviews
+  - nosetests --with-doctest --with-coverage --cover-package=holoviews -v
   - cd doc/nbpublisher; chmod +x test_notebooks.py; BOKEH_DEV=True ./test_notebooks.py
   - chmod +x concat_html.py; ./concat_html.py ../test_data ../test_html
   - cd ../../; mv doc/Tutorials/.coverage ./.coverage.notebooks

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -384,7 +384,7 @@ class aggregate(ResamplingOperation):
 
         dfdata = PandasInterface.as_dframe(data)
         agg = getattr(cvs, glyph)(dfdata, x.name, y.name, self.p.aggregator)
-        if 'x_axis' in agg and 'y_axis' in agg:
+        if 'x_axis' in agg.coords and 'y_axis' in agg.coords:
             agg = agg.rename({'x_axis': x, 'y_axis': y})
         if xtype == 'datetime':
             agg[x.name] = agg[x.name].astype('datetime64[us]')

--- a/tests/testdatashader.py
+++ b/tests/testdatashader.py
@@ -98,7 +98,7 @@ class DatashaderRegridTests(ComparisonTestCase):
     def test_regrid_mean_xarray_transposed(self):
         img = Image((range(10), range(5), np.arange(10) * np.arange(5)[np.newaxis].T),
                     datatype=['xarray'])
-        img.data = img.data.T
+        img.data = img.data.transpose()
         regridded = regrid(img, width=2, height=2, dynamic=False)
         expected = Image(([2., 7.], [0.75, 3.25], [[1, 5], [6, 22]]))
         self.assertEqual(regridded, expected)


### PR DESCRIPTION
Fixes deprecation warnings raised due to recent changes in xarray. Also changes the unit tests on Travis to be verbose, making it easier to track down warnings.

Fixes: https://github.com/ioam/holoviews/issues/2229