### PR TITLE
Fixed broken error message for aggregate()

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -373,7 +373,7 @@ class aggregate(ResamplingOperation):
             if not dims:
                 raise ValueError("Aggregation column %s not found on %s element. "
                                  "Ensure the aggregator references an existing "
-                                 "dimension.")
+                                 "dimension." % (column,element))
             if isinstance(agg_fn, ds.count_cat):
                 name = '%s Count' % agg_fn.column
             vdims = [dims[0](column)]


### PR DESCRIPTION
When supplying an incorrect column name to aggregate() or datashade(), the error message is currently:

```
ValueError: Aggregation column %s not found on %s element. Ensure the aggregator references an existing dimension.
```

This PR fixes that to fill in what was presumably intended:

```
ValueError: Aggregation column z not found on :Points   [x,y] element. Ensure the aggregator references an existing dimension.
```