### PR TITLE
QuadMesh and irregular xarray data fixes

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -116,6 +116,27 @@ class XArrayInterface(GridInterface):
 
 
     @classmethod
+    def validate(cls, dataset, vdims=True):
+        Interface.validate(dataset, vdims)
+        # Check whether irregular (i.e. multi-dimensional) coordinate
+        # array dimensionality matches
+        irregular = []
+        for kd in dataset.kdims:
+            if cls.irregular(dataset, kd):
+                irregular.append((kd, dataset.data[kd.name].dims))
+        if irregular:
+            nonmatching = ['%s: %s' % (kd, dims) for kd, dims in irregular[1:]
+                           if dims != irregular[0][1]]
+            if nonmatching:
+                nonmatching = ['%s: %s' % irregular[0]] + nonmatching
+                raise DataError("The dimensions of coordinate arrays "
+                                "on irregular data must match. The "
+                                "following kdims were found to have "
+                                "non-matching array dimensions:\n\n%s"
+                                % ('\n'.join(nonmatching)), cls)
+
+
+    @classmethod
     def range(cls, dataset, dimension):
         dim = dataset.get_dimension(dimension, strict=True).name
         if dataset._binned and dimension in dataset.kdims:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -217,15 +217,15 @@ class XArrayInterface(GridInterface):
         irregular = cls.irregular(dataset, dim) if dim in dataset.kdims else False
         irregular_kdims = [d for d in dataset.kdims if cls.irregular(dataset, d)]
         if irregular_kdims:
-            irregular_dims = list(dataset.data[irregular_kdims[0].name].coords.dims)
+            virtual_coords = list(dataset.data[irregular_kdims[0].name].coords.dims)
         else:
-            irregular_dims = []
+            virtual_coords = []
         if dim in dataset.vdims or irregular:
-            coord_dims = list(dataset.data[dim.name].dims)
+            data_coords = list(dataset.data[dim.name].dims)
             if dask and isinstance(data, dask.array.Array):
                 data = data.compute()
-            data = cls.canonicalize(dataset, data, coord_dims=coord_dims,
-                                    irregular_dims=irregular_dims)
+            data = cls.canonicalize(dataset, data, data_coords=data_coords,
+                                    virtual_coords=virtual_coords)
             return data.T.flatten() if flat else data
         elif expanded:
             data = cls.coords(dataset, dim.name, expanded=True)

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -667,8 +667,9 @@ class QuadMesh(Dataset, Element2D):
         vertices = (xs.T.flatten(), ys.T.flatten())
 
         # Generate triangle simplexes
-        s0 = self.dimension_values(2, flat=False).shape[0]
-        t1 = np.arange(len(self))
+        shape = self.dimension_values(2, flat=False).shape
+        s0 = shape[0]
+        t1 = np.arange(np.product(shape))
         js = (t1//s0)
         t1s = js*(s0+1)+t1%s0
         t2s = t1s+1

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -688,11 +688,11 @@ class QuadMesh(Dataset, Element2D):
         # Construct TriMesh
         params = util.get_param_values(self)
         params['kdims'] = params['kdims'] + TriMesh.node_type.kdims[2:]
-        node_params = {k: v for k, v in params.items() if k != 'vdims'}
         nodes = TriMesh.node_type(vertices+(np.arange(len(vertices[0])),),
-                                  **node_params)
-        params = {k: v for k, v in params.items() if k != 'kdims'}
-        return TriMesh(((ts,), nodes), **params)
+                                  **{k: v for k, v in params.items()
+                                     if k != 'vdims'})
+        return TriMesh(((ts,), nodes), **{k: v for k, v in params.items()
+                                          if k != 'kdims'})
 
 
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -194,7 +194,12 @@ class QuadMeshPlot(ColorbarPlot):
                     for d in dims]
             X, Y = colormesh(X, Y)
             zvals = zdata.T.flatten() if self.invert_axes else zdata.flatten()
-            data = {'xs': list(X), 'ys': list(Y), z.name: zvals}
+            XS, YS = [], []
+            for x, y, zval in zip(X, Y, zvals):
+                if np.isfinite(zval):
+                    XS.append(x)
+                    YS.append(y)
+            data = {'xs': XS, 'ys': YS, z.name: zvals[np.isfinite(zvals)]}
         else:
             xc, yc = (element.interface.coords(element, x, edges=True),
                       element.interface.coords(element, y, edges=True))

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -255,21 +255,6 @@ class QuadMeshPlot(ColorbarPlot):
         return {'artist': artist, 'locs': locs}
 
 
-    def update_handles(self, key, axis, element, ranges, style):
-        cmesh = self.handles['artist']
-        data, style, axis_kwargs = self.get_data(element, ranges, style)
-        locs = style.get('locs')
-        old_locs = self.handles.get('locs')
-        if None in (locs, old_locs) or (locs == old_locs).all():
-            cmesh.set_array(data[-1].flatten())
-            cmesh.set_clim((style['vmin'], style['vmax']))
-            if 'norm' in style:
-                cmesh.norm = style['norm']
-            return axis_kwargs
-        return super(QuadMeshPlot, self).update_handles(key, axis, element,
-                                                        ranges, style)
-
-
 class RasterGridPlot(GridPlot, OverlayPlot):
     """
     RasterGridPlot evenly spaces out plots of individual projections on

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from holoviews.core.spaces import HoloMap
 from holoviews.core.data import Dataset
+from holoviews.core.data.interface import DataError
 from holoviews.element import Histogram, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -198,6 +199,19 @@ class Irregular2DBinsTest(ComparisonTestCase):
         self.assertEqual(dataset.dimension_values('lat'), self.ys.T.flatten())
         self.assertEqual(dataset.dimension_values('z', expanded=False), np.array([0, 1]))
         self.assertEqual(dataset.dimension_values('A'), zs.T.flatten())
+
+    def test_construct_from_xarray_with_invalid_irregular_coordinate_arrays(self):
+        try:
+            import xarray as xr
+        except:
+            raise SkipError("Test requires xarray")
+        zs = np.arange(48*6).reshape(2, 4, 6, 6)
+        da = xr.DataArray(zs, dims=['z', 'y', 'x', 'b'],
+                          coords = {'lat': (('y', 'b'), self.ys),
+                                    'lon': (('y', 'x'), self.xs),
+                                    'z': [0, 1]}, name='A')
+        with self.assertRaises(DataError):
+            Dataset(da, ['z', 'lon', 'lat'])
 
     def test_3d_xarray_with_constant_dim_canonicalized_to_2d(self):
         try:

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -199,6 +199,19 @@ class Irregular2DBinsTest(ComparisonTestCase):
         self.assertEqual(dataset.dimension_values('z', expanded=False), np.array([0, 1]))
         self.assertEqual(dataset.dimension_values('A'), zs.T.flatten())
 
+    def test_3d_xarray_with_constant_dim_canonicalized_to_2d(self):
+        try:
+            import xarray as xr
+        except:
+            raise SkipError("Test requires xarray")
+        zs = np.arange(24).reshape(1, 4, 6)
+        da = xr.DataArray(zs, dims=['z', 'y', 'x'],
+                          coords = {'lat': (('y', 'x'), self.ys),
+                                    'lon': (('y', 'x'), self.xs),
+                                    'z': [0]}, name='A')
+        dataset = Dataset(da, ['lon', 'lat'], 'A')
+        self.assertEqual(dataset.dimension_values('A', flat=False).ndim, 2)
+        
     def test_groupby_3d_from_xarray(self):
         try:
             import xarray as xr

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -6,6 +6,7 @@ from unittest import SkipTest
 
 import numpy as np
 
+from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
@@ -179,7 +180,12 @@ class Irregular2DBinsTest(ComparisonTestCase):
         da = xr.DataArray(self.zs, dims=['y', 'x'],
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs)}, name='z')
-        dataset = Dataset(da, ['lon', 'lat'], 'z')
+        dataset = Dataset(da)
+
+        # Ensure that dimensions are inferred correctly
+        self.assertEqual(dataset.kdims, [Dimension('lat'), Dimension('lon')])
+        self.assertEqual(dataset.vdims, [Dimension('z')])
+
         # Ensure that canonicalization works on multi-dimensional coordinates
         self.assertEqual(dataset.dimension_values('lon', flat=False), self.xs)
         self.assertEqual(dataset.dimension_values('lat', flat=False), self.ys)

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -180,8 +180,9 @@ class Irregular2DBinsTest(ComparisonTestCase):
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs)}, name='z')
         dataset = Dataset(da, ['lon', 'lat'], 'z')
-        self.assertEqual(dataset.dimension_values('lon'), self.xs.T.flatten())
-        self.assertEqual(dataset.dimension_values('lat'), self.ys.T.flatten())
+        # Ensure that canonicalization works on multi-dimensional coordinates
+        self.assertEqual(dataset.dimension_values('lon', flat=False), self.xs)
+        self.assertEqual(dataset.dimension_values('lat', flat=False), self.ys)
         self.assertEqual(dataset.dimension_values('z'), self.zs.T.flatten())
 
     def test_construct_3d_from_xarray(self):
@@ -219,12 +220,15 @@ class Irregular2DBinsTest(ComparisonTestCase):
         except:
             raise SkipError("Test requires xarray")
         zs = np.arange(24).reshape(1, 4, 6)
+        # Construct DataArray with additional constant dimension
         da = xr.DataArray(zs, dims=['z', 'y', 'x'],
                           coords = {'lat': (('y', 'x'), self.ys),
                                     'lon': (('y', 'x'), self.xs),
                                     'z': [0]}, name='A')
+        # Declare Dataset without declaring constant dimension
         dataset = Dataset(da, ['lon', 'lat'], 'A')
-        self.assertEqual(dataset.dimension_values('A', flat=False).ndim, 2)
+        # Ensure that canonicalization drops the constant dimension
+        self.assertEqual(dataset.dimension_values('A', flat=False), zs[0])
         
     def test_groupby_3d_from_xarray(self):
         try:


### PR DESCRIPTION
Three separate fixes for irregular gridded data and QuadMeshes. 

1) Ensures that xarray data is correctly canonicalized as previously constant dimensions were not appropriately squeezed out by the XArrayInterface.

2) Improved QuadMesh.trimesh method ensuring that key dimensions are inherited

3) Simplifies the matplotlib QuadMeshPlot

4) Add inference for xarray multi-dimensional (irregular) coordinate variables

These are all issues I ran into while implementing https://github.com/ioam/geoviews/pull/116.

- [x] Add unit test for canonicalizing xarray Dataset with constant dimension 
  