### PR TITLE
Ensure no information is lost when casting Image and Graph types

### DIFF
--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -176,6 +176,7 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[Graph] =        cls.compare_graph
         cls.equality_type_funcs[Nodes] =        cls.compare_nodes
         cls.equality_type_funcs[EdgePaths] =    cls.compare_edgepaths
+        cls.equality_type_funcs[TriMesh] =      cls.compare_trimesh
 
         # Tables
         cls.equality_type_funcs[ItemTable] =    cls.compare_itemtables
@@ -575,6 +576,10 @@ class Comparison(ComparisonInterface):
         cls.compare_nodes(el1.nodes, el2.nodes, msg)
         if el1._edgepaths or el2._edgepaths:
             cls.compare_edgepaths(el1.edgepaths, el2.edgepaths, msg)
+
+    @classmethod
+    def compare_trimesh(cls, el1, el2, msg='TriMesh'):
+        cls.compare_graph(el1, el2, msg)
 
     @classmethod
     def compare_nodes(cls, el1, el2, msg='Nodes'):

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -127,8 +127,11 @@ class Graph(Dataset, Element2D):
         if isinstance(data, tuple):
             data = data + (None,)* (3-len(data))
             edges, nodes, edgepaths = data
+        elif isinstance(data, type(self)):
+            edges, nodes, edgepaths = data, data.nodes, data._edgepaths
         else:
             edges, nodes, edgepaths = data, None, None
+
         if nodes is not None:
             node_info = None
             if isinstance(nodes, self.node_type):
@@ -422,6 +425,8 @@ class TriMesh(Graph):
         if isinstance(data, tuple):
             data = data + (None,)*(3-len(data))
             edges, nodes, edgepaths = data
+        elif isinstance(data, type(self)):
+            edges, nodes, edgepaths = data, data.nodes, data._edgepaths
         else:
             edges, nodes, edgepaths = data, None, None
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -233,6 +233,10 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
 
     def __init__(self, data, kdims=None, vdims=None, bounds=None, extents=None,
                  xdensity=None, ydensity=None, **params):
+        if isinstance(data, Image):
+            bounds = bounds or data.bounds
+            xdensity = xdensity or data.xdensity
+            ydensity = ydensity or data.ydensity
         extents = extents if extents else (None, None, None, None)
         if (data is None
             or (isinstance(data, (list, tuple)) and not data)

--- a/tests/testelementconstructors.py
+++ b/tests/testelementconstructors.py
@@ -3,7 +3,8 @@ import numpy as np
 from holoviews import (Dimension, Dataset, Curve, Path, Histogram,
                        HeatMap, Contours, Scatter, Points, Polygons,
                        VectorField, Spikes, Area, Bars, ErrorBars,
-                       BoxWhisker, Raster, Image, QuadMesh, RGB)
+                       BoxWhisker, Raster, Image, QuadMesh, RGB,
+                       Graph, TriMesh)
 from holoviews.element.comparison import ComparisonTestCase
 
 class ElementConstructorTest(ComparisonTestCase):
@@ -179,3 +180,26 @@ class ElementSignatureTest(ComparisonTestCase):
         self.assertEqual(qmesh.vdims, [Dimension('c')])
 
     
+class ElementConstructorTest(ComparisonTestCase):
+    """
+    Tests whether casting an element will faithfully copy data and
+    parameters. Important to check for elements where data is not all
+    held on .data attribute, e.g. Image bounds or Graph nodes and
+    edgepaths.
+    """
+
+    def test_image_casting(self):
+        img = Image([], bounds=2)
+        self.assertEqual(img, Image(img))
+
+    def test_rgb_casting(self):
+        rgb = RGB([], bounds=2)
+        self.assertEqual(rgb, RGB(rgb))
+
+    def test_graph_casting(self):
+        graph = Graph(([(0, 1)], [(0, 0, 0), (0, 1, 1)]))
+        self.assertEqual(graph, Graph(graph))
+
+    def test_trimesh_casting(self):
+        trimesh = TriMesh(([(0, 1, 2)], [(0, 0, 0), (0, 1, 1), (1, 1, 2)]))
+        self.assertEqual(trimesh, TriMesh(trimesh))


### PR DESCRIPTION
Generally casting between different or the same type is straightforward, however for Image and Graph types copying the ``.data`` and parameters is not sufficient. This PR adds special handling ensuring that Image bounds and densities and Graph/TriMesh nodes and edgepaths are inherited during casting.