### PR TITLE
Add scroll_to_selection bokeh Table style option

### DIFF
--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -16,7 +16,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
     width = param.Number(default=400)
 
     style_opts = ['row_headers', 'selectable', 'editable',
-                  'sortable', 'fit_columns']
+                  'sortable', 'fit_columns', 'scroll_to_selection']
 
     finalize_hooks = param.HookList(default=[], doc="""
         Optional list of hooks called when finalizing a column.


### PR DESCRIPTION
Adds ``scroll_to_selection`` style option for bokeh TablePlot which is often useful when streaming data.