### PR TITLE
Ensure linked streams are resolved on HoloMap and Table objects

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -179,39 +179,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         self._shared = {'x': False, 'y': False}
 
 
-    def _construct_callbacks(self):
-        """
-        Initializes any callbacks for streams which have defined
-        the plotted object as a source.
-        """
-        if isinstance(self, OverlayPlot):
-            zorders = []
-        elif self.batched:
-            zorders = list(range(self.zorder, self.zorder+len(self.hmap.last)))
-        else:
-            zorders = [self.zorder]
-
-        if isinstance(self, OverlayPlot) and not self.batched:
-            sources = []
-        elif not self.static or isinstance(self.hmap, DynamicMap):
-            sources = [(i, o) for i, inputs in self.stream_sources.items()
-                       for o in inputs if i in zorders]
-        else:
-            sources = [(self.zorder, self.hmap.last)]
-        cb_classes = set()
-        for _, source in sources:
-            streams = Stream.registry.get(id(source), [])
-            registry = Stream._callbacks['bokeh']
-            cb_classes |= {(registry[type(stream)], stream) for stream in streams
-                           if type(stream) in registry and stream.linked}
-        cbs = []
-        sorted_cbs = sorted(cb_classes, key=lambda x: id(x[0]))
-        for cb, group in groupby(sorted_cbs, lambda x: x[0]):
-            cb_streams = [s for _, s in group]
-            cbs.append(cb(self, cb_streams, source))
-        return cbs
-
-
     def _hover_opts(self, element):
         if self.batched:
             dims = list(self.hmap.last.kdims)

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -30,9 +30,9 @@ class TablePlot(BokehPlot, GenericElementPlot):
         self.handles = {} if plot is None else self.handles['plot']
         element_ids = self.hmap.traverse(lambda x: id(x), [Dataset, ItemTable])
         self.static = len(set(element_ids)) == 1 and len(self.keys) == len(self.hmap)
-        self.callbacks = [] # Callback support on tables not implemented
+        self.callbacks = self._construct_callbacks()
         self.streaming = [s for s in self.streams if isinstance(s, Buffer)]
-
+        self.static_source = False
 
     def _execute_hooks(self, element):
         """

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -117,6 +117,13 @@ def compute_overlayable_zorders(obj, path=[]):
         if isinstance(obj, CompositeOverlay):
             for z, o in enumerate(obj):
                 zorder_map[z] = [o, obj]
+        elif isinstance(obj, HoloMap):
+            for el in obj.values():
+                if isinstance(el, CompositeOverlay):
+                    for k, v in compute_overlayable_zorders(el, path).items():
+                        zorder_map[k] += v + [obj]
+                else:
+                    zorder_map[0] += [obj, el]
         else:
             if obj not in zorder_map[0]:
                 zorder_map[0].append(obj)

--- a/tests/testbinneddatasets.py
+++ b/tests/testbinneddatasets.py
@@ -10,6 +10,7 @@ from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
+from holoviews.core.util import OrderedDict
 from holoviews.element import Histogram, QuadMesh
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -177,9 +178,10 @@ class Irregular2DBinsTest(ComparisonTestCase):
             import xarray as xr
         except:
             raise SkipError("Test requires xarray")
+        coords = OrderedDict([('lat', (('y', 'x'), self.ys)),
+                              ('lon', (('y', 'x'), self.xs))])
         da = xr.DataArray(self.zs, dims=['y', 'x'],
-                          coords = {'lat': (('y', 'x'), self.ys),
-                                    'lon': (('y', 'x'), self.xs)}, name='z')
+                          coords=coords, name='z')
         dataset = Dataset(da)
 
         # Ensure that dimensions are inferred correctly

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -4,7 +4,7 @@ from nose.plugins.attrib import attr
 import numpy as np
 
 from holoviews import NdOverlay, Overlay
-from holoviews.core.spaces import DynamicMap
+from holoviews.core.spaces import DynamicMap, HoloMap
 from holoviews.core.options import Store, Cycle
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.element import Curve, Area, Points
@@ -20,6 +20,19 @@ except:
 
 
 class TestOverlayableZorders(ComparisonTestCase):
+
+    def test_compute_overlayable_zorders_holomap(self):
+        hmap = HoloMap({0: Points([])})
+        sources = compute_overlayable_zorders(hmap)
+        self.assertEqual(sources[0], [hmap, hmap.last])
+
+    def test_compute_overlayable_zorders_with_overlaid_holomap(self):
+        points = Points([])
+        hmap = HoloMap({0: points})
+        curve = Curve([])
+        combined = hmap*curve
+        sources = compute_overlayable_zorders(combined)
+        self.assertEqual(sources[0], [points, combined.last, combined])
 
     def test_dynamic_compute_overlayable_zorders_two_mixed_layers(self):
         area = Area(range(10))


### PR DESCRIPTION
There was a bug in the code that caused non-static and non-dynamic plots not to correctly resolve streams registered on an Element or HoloMap, this PR ensures that this is now resolved correctly. Additionally it adds support for resolving linked streams on bokeh's TablePlot which was previously not possible (because it was not implemented).