### PR TITLE
Avoid rerendering of overlaid DynamicMaps with non-triggered streams

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -570,10 +570,11 @@ def get_nested_dmaps(dmap):
     """
     Get all DynamicMaps referenced by the supplied DynamicMap's callback.
     """
+    if not isinstance(dmap, DynamicMap):
+        return []
     dmaps = [dmap]
     for o in dmap.callback.inputs:
-        if isinstance(o, DynamicMap):
-            dmaps.extend(get_nested_dmaps(o))
+        dmaps.extend(get_nested_dmaps(o))
     return list(set(dmaps))
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1461,9 +1461,18 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
         if element and not self.overlaid and not self.tabs and not self.batched:
             self._update_ranges(element, ranges)
-            
+
+        # Determine which stream (if any) triggered the update
+        triggering = [stream for stream in self.streams if stream._triggering]
+
         for k, subplot in self.subplots.items():
             el = None
+
+            # Skip updates to subplots when its streams is not one of
+            # the streams that initiated the update
+            if triggering and all(s not in triggering for s in subplot.streams):
+                continue
+
             # If in Dynamic mode propagate elements to subplots
             if isinstance(self.hmap, DynamicMap) and element:
                 # In batched mode NdOverlay is passed to subplot directly

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -6,7 +6,7 @@ import numpy as np
 import param
 
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
-                    Overlay, GridSpace, NdLayout, Store)
+                    Overlay, GridSpace, NdLayout, Store, NdOverlay)
 from ..core.options import Cycle
 from ..core.spaces import get_nested_streams
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
@@ -172,6 +172,52 @@ def compute_overlayable_zorders(obj, path=[]):
             if o not in zorder_map[offset+z]:
                 zorder_map[offset+z].append(o)
     return zorder_map
+
+
+def is_dynamic_overlay(dmap):
+    """
+    Traverses a DynamicMap graph and determines if any components
+    were overlaid dynamically (i.e. by * on a DynamicMap).
+    """
+    if not isinstance(dmap, DynamicMap):
+        return False
+    elif dmap.callback._is_overlay:
+        return True
+    else:
+        return any(is_dynamic_overlay(dm) for dm in dmap.callback.inputs)
+
+
+def split_dmap_overlay(obj, depth=0):
+    """
+    Splits a DynamicMap into the original component layers it was
+    constructed from by traversing the graph to search for dynamically
+    overlaid components (i.e. constructed by using * on a DynamicMap).
+    Useful for assigning subplots of an OverlayPlot the streams that
+    are responsible for driving their updates. Allows the OverlayPlot
+    to determine if a stream update should redraw a particular
+    subplot.
+    """
+    layers = []
+    if isinstance(obj, DynamicMap):
+        if issubclass(obj.type, NdOverlay) and not depth:
+            for v in obj.last.values():
+                layers.append(obj)
+        elif issubclass(obj.type, Overlay):
+            if obj.callback.inputs and is_dynamic_overlay(obj):
+                for inp in obj.callback.inputs:
+                    layers += split_dmap_overlay(inp, depth+1)
+            else:
+                for v in obj.last.values():
+                    layers.append(obj)
+        else:
+            layers.append(obj)
+        return layers
+    if isinstance(obj, Overlay):
+        for k, v in obj.items():
+            layers.append(v)
+    else:
+        layers.append(obj)
+    return layers
 
 
 def initialize_dynamic(obj):

--- a/tests/testplotutils.py
+++ b/tests/testplotutils.py
@@ -7,9 +7,12 @@ from holoviews import NdOverlay, Overlay
 from holoviews.core.spaces import DynamicMap, HoloMap
 from holoviews.core.options import Store, Cycle
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews.element import Curve, Area, Points
+from holoviews.element import (Image, Scatter, Curve, Text, Points,
+                               Area, VectorField, HLine, Path)
+from holoviews.operation import operation
 from holoviews.plotting.util import (
-    compute_overlayable_zorders, get_min_distance, process_cmap)
+    compute_overlayable_zorders, get_min_distance, process_cmap,
+    initialize_dynamic, split_dmap_overlay)
 from holoviews.streams import PointerX
 
 try:
@@ -317,6 +320,109 @@ class TestOverlayableZorders(ComparisonTestCase):
         self.assertNotIn(curve, sources[2])
 
 
+class TestSplitDynamicMapOverlay(ComparisonTestCase):
+    """
+    Tests the split_dmap_overlay utility
+    """
+
+    def setUp(self):
+        self.dmap_element = DynamicMap(lambda: Image([]))
+        self.dmap_overlay = DynamicMap(lambda: Overlay([Curve([]), Points([])]))
+        self.dmap_ndoverlay = DynamicMap(lambda: NdOverlay({0: Curve([]), 1: Curve([])}))
+        self.element = Scatter([])
+        self.el1, self.el2 = Path([]), HLine(0)
+        self.overlay = Overlay([self.el1, self.el2])
+        self.ndoverlay = NdOverlay({0: VectorField([]), 1: VectorField([])})
+
+    def test_dmap_ndoverlay(self):
+        test = self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [self.dmap_ndoverlay, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay(self):
+        test = self.dmap_overlay
+        initialize_dynamic(test)
+        layers = [self.dmap_overlay, self.dmap_overlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_element_mul_dmap_overlay(self):
+        test = self.dmap_element * self.dmap_overlay
+        initialize_dynamic(test)
+        layers = [self.dmap_element, self.dmap_overlay, self.dmap_overlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_element_mul_dmap_ndoverlay(self):
+        test = self.dmap_element * self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [self.dmap_element, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_element_mul_element(self):
+        test = self.dmap_element * self.element
+        initialize_dynamic(test)
+        layers = [self.dmap_element, self.element]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_element_mul_overlay(self):
+        test = self.dmap_element * self.overlay
+        initialize_dynamic(test)
+        layers = [self.dmap_element, self.el1, self.el2]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_element_mul_ndoverlay(self):
+        test = self.dmap_element * self.ndoverlay
+        initialize_dynamic(test)
+        layers = [self.dmap_element, self.ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_mul_dmap_ndoverlay(self):
+        test = self.dmap_overlay * self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [self.dmap_overlay, self.dmap_overlay, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_mul_element(self):
+        test = self.dmap_overlay * self.element
+        initialize_dynamic(test)
+        layers = [self.dmap_overlay, self.dmap_overlay, self.element]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_mul_overlay(self):
+        test = self.dmap_overlay * self.overlay
+        initialize_dynamic(test)
+        layers = [self.dmap_overlay, self.dmap_overlay, self.el1, self.el2]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_all_combinations(self):
+        test = (self.dmap_overlay * self.element * self.dmap_ndoverlay *
+                self.overlay * self.dmap_element * self.ndoverlay)
+        initialize_dynamic(test)
+        layers = [self.dmap_overlay, self.dmap_overlay, self.element,
+                  self.dmap_ndoverlay, self.el1, self.el2, self.dmap_element,
+                  self.ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_operation_mul_dmap_ndoverlay(self):
+        mapped = operation(self.dmap_overlay)
+        test = mapped * self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [mapped, mapped, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_linked_operation_mul_dmap_ndoverlay(self):
+        mapped = operation(self.dmap_overlay, link_inputs=True)
+        test = mapped * self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [mapped, mapped, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
+
+    def test_dmap_overlay_linked_operation_mul_dmap_ndoverlay(self):
+        mapped = self.dmap_overlay.map(lambda x: x.get(0), Overlay)
+        test = mapped * self.element * self.dmap_ndoverlay
+        initialize_dynamic(test)
+        layers = [mapped, self.element, self.dmap_ndoverlay]
+        self.assertEqual(split_dmap_overlay(test), layers)
 
 
 class TestPlotColorUtils(ComparisonTestCase):


### PR DESCRIPTION
This PR addresses a very hairy issue that's probably responsible for a fair number of bugs. I'll first outline the issue and then describe the solution I've come up with. This PR will require some very thorough testing since it messes with some very central code.

The main issue is that when a DynamicMap returns an Overlay it is not immediately clear whether the constituent parts of that Overlay were each supplied by another DynamicMap or whether the user defined callback directly returns an Overlay. Secondly it is worth knowing that when a DynamicMap that returns Overlays has streams on it, the streams will trigger updates on the whole OverlayPlot rather than the specific ElementPlot it might have been originally attached to (for important reasons I won't get into). This means that all the items in the Overlay will get re-rendered even if they shouldn't be. This rerendering on it's own can have implications when there are complex stream dependencies between different elements, e.g. when two layers are linked bi-directionally. In the worst case this will result in loops, while in the best case it will break the rendering of the plot.

The secondary issue is that each subplot of the OverlayPlot is given a DynamicMap that does not necessarily correspond to the thing it's actually rendering. This in turn can cause validation issues if that DynamicMap is actually called (which it ideally shouldn't be) because the thing it's returning may not match what has been put in its cache. This is because ``DynamicMap`` does not have its own ``split_overlays`` method implementation and simply uses the ``HoloMap.split_overlays`` method which is technically incorrect (but does sort of work in most scenarios).

The aim then should be for the OverlayPlot to only trigger rendering of the specific Elements that should actually be redrawn. However due to the way the OverlayPlot tries to split up the overlaid DynamicMap it actually has no idea which component triggered the update. The appropriate solution therefore is for the ``split_overlays`` method on DynamicMap to correctly split up the DynamicMap into the original DynamicMaps that the user composed using the ``*`` operator.

This should result in more optimized updates and fix a number of annoying bugs.

Related to https://github.com/ioam/holoviews/issues/493 and https://github.com/ioam/holoviews/pull/2174