### PR TITLE
Miscellaneous stream fixes

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -56,6 +56,10 @@ class MessageCallback(object):
             except AttributeError:
                 self.comm = Comm(plot)
         self.source = source
+        self.reset()
+
+
+    def reset(self):
         self.handle_ids = defaultdict(dict)
         self.callbacks = []
         self.plot_handles = {}

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -497,6 +497,8 @@ class SpreadPlot(ElementPlot):
 
 class AreaPlot(SpreadPlot):
 
+    _stream_data = False # Plot does not support streaming data
+
     def get_extents(self, element, ranges):
         vdims = element.vdims
         vdim = vdims[0].name

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -240,6 +240,9 @@ class BokehPlot(DimensionedPlot):
                     else:
                         renderer.update(source=new_source)
                     plot.handles['source'] = new_source
+                    for callback in plot.callbacks:
+                        callback.reset()
+                        callback.initialize()
                 shared_sources.append(new_source)
                 source_cols[id(new_source)] = [c for c in new_source.data]
         self.handles['shared_sources'] = shared_sources

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -80,6 +80,9 @@ class TablePlot(BokehPlot, GenericElementPlot):
         self._execute_hooks(element)
         self.drawn = True
 
+        for cb in self.callbacks:
+            cb.initialize()
+
         return table
 
 


### PR DESCRIPTION
Includes three small fixes:

* AreaPlot no longer allows streaming data (because the glyph type doesn't allow it)
* TablePlot initializes stream callbacks
* When a data source is shared across multiple plots callbacks are reinitialized