### PR TITLE
Fixed categorical coloring of Contours in matplotlib

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -213,7 +213,7 @@ class DictInterface(Interface):
         if np.isscalar(values):
             if not expanded:
                 return np.array([values])
-            values = np.full(len(dataset), values)
+            values = np.full(len(dataset), values, dtype=np.array(values).dtype)
         else:
             if not expanded:
                 return util.unique_array(values)

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -85,9 +85,12 @@ class ContourPlot(PathPlot):
             return (paths,), style, {}
 
         if element.level is not None:
-            style['array'] = np.full(len(paths), element.level)
+            array = np.full(len(paths), element.level)
         else:
-            style['array'] = element.dimension_values(cdim, expanded=False)
+            array = element.dimension_values(cdim, expanded=False)
+        if array.dtype.kind not in 'if':
+            array = np.searchsorted(np.unique(array), array)
+        style['array']= array
         self._norm_kwargs(element, ranges, style, cdim)
         style['clim'] = style.pop('vmin'), style.pop('vmax')
         return (paths,), style, {}

--- a/tests/testplotinstantiation.py
+++ b/tests/testplotinstantiation.py
@@ -341,6 +341,15 @@ class TestMPLPlotInstantiation(ComparisonTestCase):
         self.assertIsInstance(cmap, ListedColormap)
         self.assertEqual(cmap.colors, colors)
 
+    def test_contours_categorical_color(self):
+        path = Contours([{('x', 'y'): np.random.rand(10, 2), 'z': cat}
+                     for cat in ('B', 'A', 'B')],
+                    vdims='z').opts(plot=dict(color_index='z'))
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array(), np.array([1, 0, 1]))
+
+
 
 class TestBokehPlotInstantiation(ComparisonTestCase):
 


### PR DESCRIPTION
As the title says, Contours/Polygons in matplotlib did not handle categorical values for the ``color_index``.