### PR TITLE
Mesh improvements

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -444,26 +444,28 @@ class regrid(ResamplingOperation):
         the width and height are clipped to what is available on the
         source array.""")
 
-    def _process(self, element, key=None):
-        if ds_version <= '0.5.0':
-            raise RuntimeError('regrid operation requires datashader>=0.6.0')
-
+    def _get_xarrays(self, element, coords, xtype, ytype):
         x, y = element.kdims
-        info = self._get_sampling(element, x, y)
-        (x_range, y_range), _, (width, height), (xtype, ytype) = info
-
-        coords = tuple(element.dimension_values(d, expanded=False)
-                       for d in [x, y])
-        coord_dict = {x.name: coords[0], y.name: coords[1]}
         dims = [y.name, x.name]
-        arrays = []
+        irregular = any(element.interface.irregular(element, d)
+                        for d in dims)
+        if irregular:
+            coord_dict = {x.name: (('y', 'x'), coords[0]),
+                          y.name: (('y', 'x'), coords[1])}
+        else:
+            coord_dict = {x.name: coords[0], y.name: coords[1]}
+
+        arrays = {}
         for vd in element.vdims:
             if element.interface is XArrayInterface:
                 xarr = element.data[vd.name]
                 if 'datetime' in (xtype, ytype):
                     xarr = xarr.copy()
-                if dims != xarr.dims:
+                if dims != xarr.dims and not irregular:
                     xarr = xarr.transpose(*dims)
+            elif irregular:
+                arr = element.dimension_values(vd, flat=False)
+                xarr = xr.DataArray(arr, coords=coord_dict, dims=['y', 'x'])
             else:
                 arr = element.dimension_values(vd, flat=False)
                 xarr = xr.DataArray(arr, coords=coord_dict, dims=dims)
@@ -471,7 +473,20 @@ class regrid(ResamplingOperation):
                 xarr[x.name] = [dt_to_int(v) for v in xarr[x.name].values]
             if ytype == "datetime":
                 xarr[y.name] = [dt_to_int(v) for v in xarr[y.name].values]
-            arrays.append(xarr)
+            arrays[vd.name] = xarr
+        return arrays
+
+
+    def _process(self, element, key=None):
+        if ds_version <= '0.5.0':
+            raise RuntimeError('regrid operation requires datashader>=0.6.0')
+
+        x, y = element.kdims
+        coords = tuple(element.dimension_values(d, expanded=False)
+                       for d in [x, y])
+        info = self._get_sampling(element, x, y)
+        (x_range, y_range), _, (width, height), (xtype, ytype) = info
+        arrays = self._get_xarrays(element, coords, xtype, ytype)
 
         # Disable upsampling if requested
         (xstart, xend), (ystart, yend) = (x_range, y_range)
@@ -489,23 +504,24 @@ class regrid(ResamplingOperation):
         # Get expanded or bounded ranges
         cvs = ds.Canvas(plot_width=width, plot_height=height,
                         x_range=x_range, y_range=y_range)
-        regridded = []
-        for xarr in arrays:
+        regridded = {}
+        for vd, xarr in arrays.items():
             rarray = cvs.raster(xarr, upsample_method=self.p.interpolation,
                                 downsample_method=self.p.aggregator)
             if xtype == "datetime":
                 rarray[x.name] = rarray[x.name].astype('datetime64[us]')
             if ytype == "datetime":
                 rarray[y.name] = rarray[y.name].astype('datetime64[us]')
-            regridded.append(rarray)
+            regridded[vd] = rarray
 
-        regridded = xr.Dataset({vd.name: xarr for vd, xarr in zip(element.vdims, regridded)})
+        regridded = xr.Dataset(regridded)
         if xtype == 'datetime':
             xstart, xend = np.array([xstart, xend]).astype('datetime64[us]')
         if ytype == 'datetime':
             ystart, yend = np.array([ystart, yend]).astype('datetime64[us]')  
         bbox = BoundingBox(points=[(xstart, ystart), (xend, yend)])
-        return element.clone(regridded, bounds=bbox, datatype=['xarray'])
+        return element.clone(regridded, bounds=bbox,
+                             datatype=['xarray']+element.datatype)
 
 
 class trimesh_rasterize(aggregate):

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -166,7 +166,7 @@ class QuadMeshPlot(ColorbarPlot):
     show_legend = param.Boolean(default=False, doc="""
         Whether to show legend for the plot.""")
 
-    _plot_methods = dict(single='rect')
+    _plot_methods = dict(single='quad')
     style_opts = ['cmap', 'color'] + line_properties + fill_properties
 
     def get_data(self, element, ranges, style):
@@ -197,8 +197,8 @@ class QuadMeshPlot(ColorbarPlot):
             XS, YS = [], []
             for x, y, zval in zip(X, Y, zvals):
                 if np.isfinite(zval):
-                    XS.append(x)
-                    YS.append(y)
+                    XS.append(list(x[:-1]))
+                    YS.append(list(y[:-1]))
             data = {'xs': XS, 'ys': YS, z.name: zvals[np.isfinite(zvals)]}
         else:
             xc, yc = (element.interface.coords(element, x, edges=True),


### PR DESCRIPTION
Improvements for handling QuadMesh and TriMesh. Both @jbednar and I have been writing up documentation on dealing with meshes of different kinds and in doing so both of us hit some things that make it awkward to work with TriMeshes in particular at the moment. In particular in order to pass in a set of vertices with associated values you previously would have to construct a set of Nodes or Points yourself and pass those into the ``TriMesh`` constructor. With this change you can now pass in a pandas DataFrame of vertices and it will correctly infer the value dimension.

Secondly this PR refactors the regrid operation in such a way that a bunch of the code can be reused by regridding operations in other packages (specifically xESMF based regridding in GeoViews).

Finally this PR changes the way bokeh QuadMesh plots are created avoiding binary serialization. Sending a bunch of small array chunks seems to confuse bokeh and cause errors and actually adds more overhead than simply sending the data without binary transfer.