### PR TITLE
Updated Deploying_Bokeh_Apps user guide

### DIFF
--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -207,7 +207,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "html = renderer.figure_data(hvplot)"
+    "html = renderer._figure_data(hvplot)"
    ]
   },
   {
@@ -358,7 +358,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Once we have a bokeh Application we can manually create a ``Server`` instance to deploy it. To start a ``Server`` instance we simply define a mapping between the URL paths and apps that we want to deploy. Additionally we define a port (defining ``port=0`` will use any open port), and the ``IOLoop``. To get an ``IOLoop`` we simply use ``IOLoop.current()``, which will already be running if working from within a notebook but will give you a new ``IOLoop`` outside a notebook context."
+    "Once we have a bokeh Application we can manually create a ``Server`` instance to deploy it. To start a ``Server`` instance we simply define a mapping between the URL paths and apps that we want to deploy. Additionally we define a port (defining ``port=0`` will use any open port)."
    ]
   },
   {
@@ -371,7 +371,7 @@
     "from bokeh.server.server import Server\n",
     "\n",
     "loop = IOLoop.current()\n",
-    "server = Server({'/': app}, port=0, loop=loop)"
+    "server = Server({'/': app}, port=0)"
    ]
   },
   {

--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -367,10 +367,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from tornado.ioloop import IOLoop\n",
     "from bokeh.server.server import Server\n",
     "\n",
-    "loop = IOLoop.current()\n",
     "server = Server({'/': app}, port=0)"
    ]
   },
@@ -609,9 +607,7 @@
     "    return doc\n",
     "\n",
     "# To display in the notebook\n",
-    "handler = FunctionHandler(modify_doc)\n",
-    "app = Application(handler)\n",
-    "show(app, notebook_url='localhost:8888')\n",
+    "show(modify_doc, notebook_url='localhost:8888')\n",
     "\n",
     "# To display in a script\n",
     "#    doc = modify_doc(curdoc()) "


### PR DESCRIPTION
Fixes two bugs in the bokeh apps documentation, ``_figure_data`` is now private (for consistency) and bokeh's ``Server`` no longer requires/accepts an explicit ioloop. The API around ``_figure_data`` still needs to be improved but ``BokehRenderer.figure_data`` no longer exists so at least things will work now.