### PR TITLE
Set bgcolor default to None

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -49,7 +49,7 @@ legend_dimensions = ['label_standoff', 'label_width', 'label_height', 'glyph_wid
 
 class ElementPlot(BokehPlot, GenericElementPlot):
 
-    bgcolor = param.Parameter(default='white', doc="""
+    bgcolor = param.Parameter(default=None, allow_None=True, doc="""
         Background color of the plot.""")
 
     border = param.Number(default=10, doc="""


### PR DESCRIPTION
This is a tiny change which I think is an improvement:

1. This allows bokeh themes to change the background color instead of always setting it to white.
2. The default background color without theming is white anyway, so it should not affect anything that isn't themed.

I think the same logic applies to matplotlib but a quick rgrep suggests it is more complicated:

![image](https://user-images.githubusercontent.com/890576/35347594-7cf4d762-012d-11e8-9fbf-05d20611369c.png)
