### PR TITLE
Fix bokeh SideHistogram colormapper CustomJS

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -371,8 +371,8 @@ class SideHistogramPlot(ColorbarPlot, HistogramPlot):
     _callback = """
     color_mapper.low = cb_data['geometry']['y0'];
     color_mapper.high = cb_data['geometry']['y1'];
-    source.trigger('change')
-    main_source.trigger('change')
+    source.change.emit()
+    main_source.change.emit()
     """
 
     def get_data(self, element, ranges, style):


### PR DESCRIPTION
The API for triggering change events in Bokeh clientside has changed. This updates it to use the new API, since we've pinned bokeh to recent versions this is safe and has no backward compatibility implications.