### PR TITLE
Use nanosecond resolution for datashader sampling

### DIFF
--- a/holoviews/core/sheetcoords.py
+++ b/holoviews/core/sheetcoords.py
@@ -224,14 +224,16 @@ class SheetCoordinateSystem(object):
         # to be flipped, because the points are moving down in the
         # sheet as the y index increases in the matrix.
         xdensity = self.__xdensity
-        if isinstance(x, datetime_types):
+        if ((isinstance(x, np.ndarray) and x.dtype.kind == 'M') or
+            isinstance(x, datetime_types)):
             xdensity = np.timedelta64(int(round(1./xdensity)), self._time_unit)
             float_col = (x-self.lbrt[0]) / xdensity
         else:
             float_col = (x-self.lbrt[0]) * xdensity
 
         ydensity = self.__ydensity
-        if isinstance(y, datetime_types):
+        if ((isinstance(y, np.ndarray) and y.dtype.kind == 'M') or
+            isinstance(y, datetime_types)):
             ydensity = np.timedelta64(int(round(1./ydensity)), self._time_unit)
             float_row = (self.lbrt[3]-y) / ydensity
         else:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1554,7 +1554,10 @@ def dt_to_int(value, time_unit='us'):
     """
     Converts a datetime type to an integer with the supplied time unit.
     """
-    tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
+    if time_unit == 'ns':
+        tscale = 1./np.timedelta64(1, time_unit).tolist()
+    else:
+        tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
     if pd and isinstance(value, pd.Timestamp):
         value = value.to_pydatetime()
     elif isinstance(value, np.datetime64):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -295,6 +295,8 @@ def validate_regular_sampling(img, dimension, rtol=10e-9):
     dim = img.get_dimension(dimension)
     diffs = np.diff(img.dimension_values(dim, expanded=False))
     vals = np.unique(diffs)
+    if vals.dtype.kind == 'm':
+        rtol = rtol*1000
     if len(vals) > 1 and np.abs(vals.min()-vals.max()) > diffs.min()*rtol:
         raise ValueError("%s dimension %s is not evenly sampled, "
                          "please use the QuadMesh element for "

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -284,19 +284,20 @@ def connect_edges(graph):
     return paths
 
 
-def validate_regular_sampling(img, dimension, rtol=10e-9):
+def validate_regular_sampling(img, dimension, rtol=10e-9, dt_rtol=10e-6):
     """
     Validates regular sampling of Image elements ensuring that
     coordinates the difference in sampling steps is at most rtol times
     the smallest sampling step. By default ensures the largest
     sampling difference is less than one billionth of the smallest
-    sampling step.
+    sampling step. dt_rtol specifies a separate tolerance for datetime
+    types, which currently only allow for microsecond resolution.
     """
     dim = img.get_dimension(dimension)
     diffs = np.diff(img.dimension_values(dim, expanded=False))
     vals = np.unique(diffs)
     if vals.dtype.kind == 'm':
-        rtol = rtol*1000
+        rtol = dt_rtol
     if len(vals) > 1 and np.abs(vals.min()-vals.max()) > diffs.min()*rtol:
         raise ValueError("%s dimension %s is not evenly sampled, "
                          "please use the QuadMesh element for "

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -321,6 +321,22 @@ class ImageGridInterfaceTest(ImageInterfaceTest):
         self.assertEqual(image.xdensity, 0.5)
         self.assertEqual(image.ydensity, 1e-5)
 
+    def test_sample_datetime_yaxis(self):
+        start = np.datetime64(dt.datetime.today())
+        end = start+np.timedelta64(1, 's')
+        xs = date_range(start, end, 10)
+        image = Image((xs, self.ys, self.array))
+        curve = image.sample(x=xs[3])
+        self.assertEqual(curve, Curve((self.ys, self.array[:, 3]), 'y', 'z'))
+
+    def test_sample_datetime_yaxis(self):
+        start = np.datetime64(dt.datetime.today())
+        end = start+np.timedelta64(1, 's')
+        ys = date_range(start, end, 10)
+        image = Image((self.xs, ys, self.array))
+        curve = image.sample(y=ys[3])
+        self.assertEqual(curve, Curve((self.xs, self.array[3]), 'x', 'z'))
+
     def test_range_datetime_xdim(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')
@@ -474,6 +490,12 @@ class ImageIrisInterfaceTest(ImageGridInterfaceTest):
         raise SkipTest("Not supported")
 
     def test_aggregate_with_spreadfn(self):
+        raise SkipTest("Not supported")
+
+    def test_sample_datetime_xaxis(self):
+        raise SkipTest("Not supported")
+
+    def test_sample_datetime_yaxis(self):
         raise SkipTest("Not supported")
 
 


### PR DESCRIPTION
Datashader operations sometimes have issues with regular sampling. This is because ``Image`` types (or rather SheetCoordinateSystems) only handle microsecond resolution, however the issue can be avoided by having the datashader operation to use nanosecond resolution internally and converting back to microseconds before constructing the Image.

Also ended up having to define a lower sampling tolerance again because SheetCoordinateSystem only handles microsecond resolution.

- [x] Fixes https://github.com/ioam/holoviews/issues/2276 and ioam/holoviews#2280