### PR TITLE
Handled transposed xarray shapes correctly

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -38,6 +38,22 @@ class XArrayInterface(GridInterface):
 
 
     @classmethod
+    def shape(cls, dataset, gridded=False):
+        array = dataset.data[dataset.vdims[0].name]
+        if not any(cls.irregular(dataset, kd) for kd in dataset.kdims):
+            names = [kd.name for kd in dataset.kdims
+                     if kd.name in array.dims][::-1]
+            if not all(d in names for d in array.dims):
+                array = np.squeeze(array)
+            array = array.transpose(*names)
+        shape = array.shape
+        if gridded:
+            return shape
+        else:
+            return (np.product(shape), len(dataset.dimensions()))
+
+
+    @classmethod
     def init(cls, eltype, data, kdims, vdims):
         element_params = eltype.params()
         kdim_param = element_params['kdims']

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -111,9 +111,10 @@ class XArrayInterface(GridInterface):
             if vdims is None:
                 vdims = list(data.data_vars.keys())
             if kdims is None:
+                xrdims = list(data.dims)
                 kdims = [name for name in data.indexes.keys()
                          if isinstance(data[name].data, np.ndarray)]
-                xrdims = list(data.dims)
+                kdims = sorted(kdims, key=lambda x: (xrdims.index(x) if x in xrdims else float('inf'), x))
                 if set(xrdims) != set(kdims):
                     virtual_dims = [xd for xd in xrdims if xd not in kdims]
                     for c in data.coords:

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -436,13 +436,22 @@ class ImageXArrayInterfaceTest(ImageGridInterfaceTest):
             raise SkipTest('Test requires xarray')
         super(ImageXArrayInterfaceTest, self).setUp()
 
-    def test_dataarray_shape(self):
+    def test_dataarray_dimension_order(self):
         import xarray as xr
         x = np.linspace(-3, 7, 53)
         y = np.linspace(-5, 8, 89)
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
         img = Image(array)
+        self.assertEqual(img.kdims, [Dimension('x'), Dimension('y')])
+
+    def test_dataarray_shape(self):
+        import xarray as xr
+        x = np.linspace(-3, 7, 53)
+        y = np.linspace(-5, 8, 89)
+        z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
+        array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
+        img = Image(array, ['x', 'y'])
         self.assertEqual(img.interface.shape(img, gridded=True), (53, 89))
 
 
@@ -463,7 +472,7 @@ class ImageXArrayInterfaceTest(ImageGridInterfaceTest):
         z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
         array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
         img = Image(array)[1:3]
-        self.assertEqual(img.data, Image(array.sel(x=slice(1, 3))).data)
+        self.assertEqual(img['z'], Image(array.sel(x=slice(1, 3)))['z'])
 
 
 @attr(optional=1)

--- a/tests/testimageinterfaces.py
+++ b/tests/testimageinterfaces.py
@@ -24,7 +24,7 @@ class ImageInterfaceTest(ComparisonTestCase):
     def init_data(self):
         self.array = np.arange(10) * np.arange(10)[:, np.newaxis]
         self.image = Image(np.flipud(self.array), bounds=(-10, 0, 10, 10))
-        
+
     def tearDown(self):
         self.eltype.datatype = self.restore_datatype
 
@@ -428,6 +428,42 @@ class ImageGridInterfaceTest(ImageInterfaceTest):
 class ImageXArrayInterfaceTest(ImageGridInterfaceTest):
 
     datatype = 'xarray'
+
+    def setUp(self):
+        try:
+            import xarray as xr
+        except:
+            raise SkipTest('Test requires xarray')
+        super(ImageXArrayInterfaceTest, self).setUp()
+
+    def test_dataarray_shape(self):
+        import xarray as xr
+        x = np.linspace(-3, 7, 53)
+        y = np.linspace(-5, 8, 89)
+        z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
+        array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
+        img = Image(array)
+        self.assertEqual(img.interface.shape(img, gridded=True), (53, 89))
+
+
+    def test_dataarray_shape_transposed(self):
+        import xarray as xr
+        x = np.linspace(-3, 7, 53)
+        y = np.linspace(-5, 8, 89)
+        z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
+        array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
+        img = Image(array, ['y', 'x'])
+        self.assertEqual(img.interface.shape(img, gridded=True), (89, 53))
+
+
+    def test_select_on_transposed_dataarray(self):
+        import xarray as xr
+        x = np.linspace(-3, 7, 53)
+        y = np.linspace(-5, 8, 89)
+        z = np.exp(-1*(x**2 + y[:, np.newaxis]**2))
+        array = xr.DataArray(z, coords=[y, x], dims=['x', 'y'])
+        img = Image(array)[1:3]
+        self.assertEqual(img.data, Image(array.sel(x=slice(1, 3))).data)
 
 
 @attr(optional=1)


### PR DESCRIPTION
The XArray interface shape method was not taking into account data that was transposed relative to the key dimensions of the element resulting in wrong densities and causing further issues with selecting on the resulting object.

- [x] Fixes https://github.com/ioam/holoviews/issues/2258