### PR TITLE
Implemented dynamic split_overlays

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1229,8 +1229,8 @@ class DynamicMap(HoloMap):
         """
         if not len(self):
             raise ValueError('Cannot split DynamicMap before it has been initialized')
-        elif not issubclass(self.type, Overlay):
-            return None, self
+        elif not issubclass(self.type, CompositeOverlay):
+            return [None], self
 
         from ..util import Dynamic
         keys = list(self.last.keys())

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1233,7 +1233,7 @@ class DynamicMap(HoloMap):
             return [None], self
 
         from ..util import Dynamic
-        keys = list(self.last.keys())
+        keys = list(self.last.data.keys())
         dmaps = []
         for key in keys:
             def cb(obj, overlay_key=key, **kwargs):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1230,7 +1230,7 @@ class DynamicMap(HoloMap):
         if not len(self):
             raise ValueError('Cannot split DynamicMap before it has been initialized')
         elif not issubclass(self.type, CompositeOverlay):
-            return [None], self
+            return None, self
 
         from ..util import Dynamic
         keys = list(self.last.data.keys())

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1775,3 +1775,35 @@ def numpy_scalar_to_python(scalar):
     elif np.issubclass_(scalar_type, np.int_):
         return int(scalar)
     return scalar
+
+
+def closest_match(match, specs, depth=0):
+    """
+    Recursively iterates over type, group, label and overlay key,
+    finding the closest matching spec.
+    """
+    new_specs = []
+    match_lengths = []
+    for i, spec in specs:
+        if spec[0] == match[0]:
+            new_specs.append((i, spec[1:]))
+        else:
+            if is_number(match[0]) and is_number(spec[0]):
+                match_length = -abs(match[0]-spec[0])
+            elif all(isinstance(s[0], basestring) for s in [spec, match]):
+                match_length = max(i for i in range(len(match[0]))
+                                   if match[0].startswith(spec[0][:i]))
+            else:
+                match_length = 0
+            match_lengths.append((i, match_length, spec[0]))
+
+    if len(new_specs) == 1:
+        return new_specs[0][0]
+    elif new_specs:
+        depth = depth+1
+        return closest_match(match[1:], new_specs, depth)
+    else:
+        if depth == 0 or not match_lengths:
+            return None
+        else:
+            return sorted(match_lengths, key=lambda x: -x[1])[0][0]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1452,7 +1452,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         elif element is not None:
             self.current_frame = element
             self.current_key = key
-        items = element.items() if element else []
+        items = [] if element is None else list(element.data.items())
 
         if isinstance(self.hmap, DynamicMap):
             range_obj = element

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -846,7 +846,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             range_obj = element
         else:
             range_obj = self.hmap
-        items = [] if element is None else element.items()
+        items = [] if element is None else list(element.data.items())
 
         if not empty:
             ranges = self.compute_ranges(range_obj, key, ranges)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -13,8 +13,8 @@ from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     Overlay, GridSpace, NdLayout, Store, NdOverlay)
 from ..core.options import Cycle
 from ..core.spaces import get_nested_streams
-from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
-                         get_overlay_spec, unique_iterator, closest_match)
+from ..core.util import (match_spec, wrap_tuple, basestring, get_overlay_spec,
+                         unique_iterator, closest_match)
 from ..streams import LinkedStream
 
 def displayable(obj):

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -14,7 +14,7 @@ from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
 from ..core.options import Cycle
 from ..core.spaces import get_nested_streams
 from ..core.util import (match_spec, is_number, wrap_tuple, basestring,
-                         get_overlay_spec, unique_iterator)
+                         get_overlay_spec, unique_iterator, closest_match)
 from ..streams import LinkedStream
 
 def displayable(obj):
@@ -421,39 +421,6 @@ def dynamic_update(plot, subplot, key, overlay, items):
         return closest, None, False
     matched = specs[closest][1]
     return closest, matched, match_spec == matched
-
-
-def closest_match(match, specs, depth=0):
-    """
-    Recursively iterates over type, group, label and overlay key,
-    finding the closest matching spec.
-    """
-    new_specs = []
-    match_lengths = []
-    for i, spec in specs:
-        if spec[0] == match[0]:
-            new_specs.append((i, spec[1:]))
-        else:
-            if is_number(match[0]) and is_number(spec[0]):
-                match_length = -abs(match[0]-spec[0])
-            elif all(isinstance(s[0], basestring) for s in [spec, match]):
-                matches = [i for i in range(len(match[0]))
-                           if match[0].startswith(spec[0][:i])]
-                match_length = max(matches) if matches else 0
-            else:
-                match_length = 0
-            match_lengths.append((i, match_length, spec[0]))
-
-    if len(new_specs) == 1:
-        return new_specs[0][0]
-    elif new_specs:
-        depth = depth+1
-        return closest_match(match[1:], new_specs, depth)
-    else:
-        if depth == 0 or not match_lengths:
-            return None
-        else:
-            return sorted(match_lengths, key=lambda x: -x[1])[0][0]
 
 
 def map_colors(arr, crange, cmap, hex=True):


### PR DESCRIPTION
This PR ensures that ``DynamicMap.split_overlays`` does something that at least makes sense and matches what the plotting code is already doing internally. None of the logic here is new so I'm pretty confident about the change. 

- [x] Fixes https://github.com/ioam/holoviews/issues/2782
- [x] Fixes https://github.com/ioam/holoviews/issues/2284
- [x] Implements  https://github.com/ioam/holoviews/issues/2254