### PR TITLE
Small bokeh plot fixes

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -82,7 +82,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
         mapping = dict(x=dims[xidx], y=dims[yidx])
         data = {}
 
-        if not self.static_source:
+        if not self.static_source or self.batched:
             xdim, ydim = dims[xidx], dims[yidx]
             data[xdim] = element.dimension_values(xidx)
             data[ydim] = element.dimension_values(yidx)
@@ -269,7 +269,7 @@ class CurvePlot(ElementPlot):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
         x = element.get_dimension(xidx).name
         y = element.get_dimension(yidx).name
-        if self.static_source:
+        if self.static_source and not self.batched:
             return {}, dict(x=x, y=y), style
 
         if 'steps' in self.interpolation:

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -2,7 +2,7 @@ import param
 
 from bokeh.models.widgets import (
     DataTable, TableColumn, NumberEditor, NumberFormatter, DateFormatter,
-    TimeEditor, StringFormatter, StringEditor, IntEditor
+    DateEditor, StringFormatter, StringEditor, IntEditor
 )
 
 from ...core import Dataset, Dimension
@@ -85,7 +85,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
                 dimtype = element.get_dimension_type(0)
                 dformat = Dimension.type_formatters.get(dimtype, '%Y-%m-%d %H:%M:%S')
                 formatter = DateFormatter(format=dformat)
-                editor = TimeEditor()
+                editor = DateEditor()
             else:
                 formatter = StringFormatter()
                 editor = StringEditor()

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -81,7 +81,7 @@ class TablePlot(BokehPlot, GenericElementPlot):
             elif kind == 'f':
                 formatter = NumberFormatter(format='0,0.0[00000]')
                 editor = NumberEditor()
-            elif kind == 'M' or (kind == 'O' and type(data[col][0]) in datetime_types):
+            elif kind == 'M' or (kind == 'O' and len(data[col]) and type(data[col][0]) in datetime_types):
                 dimtype = element.get_dimension_type(0)
                 dformat = Dimension.type_formatters.get(dimtype, '%Y-%m-%d %H:%M:%S')
                 formatter = DateFormatter(format=dformat)

--- a/tests/plotting/bokeh/testtabular.py
+++ b/tests/plotting/bokeh/testtabular.py
@@ -1,0 +1,58 @@
+from datetime import datetime as dt
+from unittest import SkipTest
+
+from holoviews.core.spaces import DynamicMap
+from holoviews.core.options import Store
+from holoviews.element import Table
+from holoviews.element.comparison import ComparisonTestCase
+from holoviews.streams import CDSStream
+
+try:
+    from bokeh.models.widgets import (
+        DataTable, TableColumn, NumberEditor, NumberFormatter, DateFormatter,
+        DateEditor, StringFormatter, StringEditor, IntEditor
+    )
+    from holoviews.plotting.bokeh.callbacks import CDSCallback
+    from holoviews.plotting.bokeh.renderer import BokehRenderer
+    bokeh_renderer = BokehRenderer.instance(mode='server')
+except:
+    bokeh_renderer = None
+
+
+class TestBokehTablePlot(ComparisonTestCase):
+
+    def setUp(self):
+        self.previous_backend = Store.current_backend
+        if not bokeh_renderer:
+            raise SkipTest("Bokeh required to test plot instantiation")
+        Store.current_backend = 'bokeh'
+
+    def tearDown(self):
+        Store.current_backend = self.previous_backend
+        bokeh_renderer.last_plot = None
+
+    def test_table_plot(self):
+        table = Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
+        plot = bokeh_renderer.get_plot(table)
+        dims = table.dimensions()
+        formatters = (NumberFormatter, NumberFormatter, StringFormatter)
+        editors = (IntEditor, NumberEditor, StringEditor)
+        for dim, fmt, edit, column in zip(dims, formatters, editors, plot.state.columns):
+            self.assertEqual(column.title, dim.pprint_label)
+            self.assertIsInstance(column.formatter, fmt)
+            self.assertIsInstance(column.editor, edit)
+
+    def test_table_plot_datetimes(self):
+        table = Table([dt.now(), dt.now()], 'Date')
+        plot = bokeh_renderer.get_plot(table)
+        column = plot.state.columns[0]
+        self.assertEqual(column.title, 'Date')
+        self.assertIsInstance(column.formatter, DateFormatter)
+        self.assertIsInstance(column.editor, DateEditor)
+
+    def test_table_plot_callback(self):
+        table = Table(([1, 2, 3], [1., 2., 3.], ['A', 'B', 'C']), ['x', 'y'], 'z')
+        CDSStream(source=table)
+        plot = bokeh_renderer.get_plot(table)
+        self.assertEqual(len(plot.callbacks), 1)
+        self.assertIsInstance(plot.callbacks[0], CDSCallback)


### PR DESCRIPTION
Fixes two bugs in bokeh plots:

1. Introduced recently when improving TablePlot erroneously assuming the data is non-empty.
2. Batched plots are ending up with the wrong colors due to static source optimization. Disabled for the time being, correctness more important than speed.