### PR TITLE
Added options for toolbars on Layout and Grid plots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -336,6 +336,9 @@ class GridPlot(CompositePlot, GenericCompositePlot):
 
           {'title': '15pt'}""")
 
+    merge_tools = param.Boolean(default=True, doc="""
+        Whether to merge all the tools into a single toolbar""")
+
     shared_xaxis = param.Boolean(default=False, doc="""
         If enabled the x-axes of the GridSpace will be drawn from the
         objects inside the Grid rather than the GridSpace dimensions.""")
@@ -343,6 +346,13 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     shared_yaxis = param.Boolean(default=False, doc="""
         If enabled the x-axes of the GridSpace will be drawn from the
         objects inside the Grid rather than the GridSpace dimensions.""")
+
+    toolbar = param.ObjectSelector(default='above',
+                                   objects=["above", "below",
+                                            "left", "right", None],
+                                   doc="""
+        The toolbar location, must be one of 'above', 'below',
+        'left', 'right', None.""")
 
     xaxis = param.ObjectSelector(default=True,
                                  objects=['bottom', 'top', None, True, False], doc="""
@@ -461,7 +471,8 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             else:
                 passed_plots.append(None)
 
-        plot = gridplot(plots[::-1])
+        plot = gridplot(plots[::-1], toolbar_position=self.toolbar,
+                        merge_tools=self.merge_tools)
         plot = self._make_axes(plot)
 
         title = self._get_title(self.keys[-1])
@@ -548,8 +559,18 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         share their Bokeh data source allowing for linked brushing
         and other linked behaviors.""")
 
+    merge_tools = param.Boolean(default=True, doc="""
+        Whether to merge all the tools into a single toolbar""")
+
     tabs = param.Boolean(default=False, doc="""
         Whether to display overlaid plots in separate panes""")
+
+    toolbar = param.ObjectSelector(default='above',
+                                   objects=["above", "below",
+                                            "left", "right", None],
+                                   doc="""
+        The toolbar location, must be one of 'above', 'below',
+        'left', 'right', None.""")
 
     def __init__(self, layout, keys=None, **params):
         super(LayoutPlot, self).__init__(layout, keys=keys, **params)
@@ -756,7 +777,9 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         else:
             plots = filter_toolboxes(plots)
             plots, width = pad_plots(plots)
-            layout_plot = gridplot(children=plots, width=width, **kwargs)
+            layout_plot = gridplot(children=plots, width=width,
+                                   toolbar_position=self.toolbar,
+                                   merge_tools=self.merge_tools, **kwargs)
 
         title = self._get_title(self.keys[-1])
         if title:


### PR DESCRIPTION
Adds options to disable merging of toolbars and setting the toolbar position on bokeh's LayoutPlot and GridPlot.

* Addresses https://github.com/ioam/holoviews/issues/1977