### PR TITLE
Allow sharing of PolyEditTool across multiple streams

### DIFF
--- a/examples/reference/streams/bokeh/PolyEdit.ipynb
+++ b/examples/reference/streams/bokeh/PolyEdit.ipynb
@@ -50,7 +50,7 @@
     "\n",
     "    After selecting one or more vertices press BACKSPACE while the mouse cursor is within the plot area.\n",
     "    \n",
-    "As a simple example we will draw a number of boxes by displaying them using a ``Polygons`` element and then link that element to a ``PolyEdit`` stream. You may also supply a ``vertex_style`` dictionary defining the visual attributes of the vertices once you double tapped a polygon:"
+    "As a simple example we will draw a number of boxes and ellipses by displaying them using a ``Polygons`` element and then link that element to two ``PolyEdit`` streams. Enabling the ``shared`` option allows editing multiple ``Polygons``/``Paths`` with the same tool.  You may also supply a ``vertex_style`` dictionary defining the visual attributes of the vertices once you double tapped a polygon:"
    ]
   },
   {
@@ -62,8 +62,11 @@
     "%%opts Polygons [width=400 height=400] (fill_alpha=0.4)\n",
     "polys = hv.Polygons([hv.Box(*i, spec=np.random.rand()/3)\n",
     "                     for i in np.random.rand(10, 2)])\n",
-    "poly_edit = streams.PolyEdit(source=polys, vertex_style={'color': 'red'})\n",
-    "polys"
+    "ovals = hv.Polygons([hv.Ellipse(*i, spec=np.random.rand()/3)\n",
+    "                     for i in np.random.rand(10, 2)])\n",
+    "poly_edit = streams.PolyEdit(source=polys, vertex_style={'color': 'red'}, shared=True)\n",
+    "poly_edit2 = streams.PolyEdit(source=ovals, shared=True)\n",
+    "polys * ovals"
    ]
   },
   {

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -967,11 +967,16 @@ class PolyEditCallback(CDSCallback):
             param.main.warning('PolyEdit requires bokeh >= 0.12.14')
             return
         plot = self.plot
-        vertex_style = dict(size=10, **self.streams[0].vertex_style)
-        r1 = plot.state.scatter([], [], **vertex_style)
-        vertex_tool = PolyEditTool(renderers=[plot.handles['glyph_renderer']],
-                                   vertex_renderer=r1)
-        plot.state.tools.append(vertex_tool)
+        vertex_tool = None
+        if all(s.shared for s in self.streams):
+            tools = [tool for tool in plot.state.tools if isinstance(tool, PolyEditTool)]
+            vertex_tool = tools[0] if tools else None
+        if vertex_tool is None:
+            vertex_style = dict(size=10, **self.streams[0].vertex_style)
+            r1 = plot.state.scatter([], [], **vertex_style)
+            vertex_tool = PolyEditTool(vertex_renderer=r1)
+            plot.state.tools.append(vertex_tool)
+        vertex_tool.renderers.append(plot.handles['glyph_renderer'])
         super(PolyEditCallback, self).initialize()
 
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -833,6 +833,12 @@ class CDSStream(LinkedStream):
 class PointDraw(CDSStream):
     """
     Attaches a PointAddTool and syncs the datasource.
+
+    drag: boolean
+        Whether to enable dragging of polygons and paths
+
+    empty_value: int/float/string/None
+        The value to insert on non-position columns when adding a new polygon
     """
 
     def __init__(self, empty_value=None, drag=True, **params):
@@ -859,6 +865,12 @@ class PointDraw(CDSStream):
 class PolyDraw(CDSStream):
     """
     Attaches a PolyDrawTool and syncs the datasource.
+
+    drag: boolean
+        Whether to enable dragging of polygons and paths
+
+    empty_value: int/float/string/None
+        The value to insert on non-position columns when adding a new polygon
     """
 
     def __init__(self, empty_value=None, drag=True, **params):
@@ -922,8 +934,17 @@ class BoxEdit(CDSStream):
 class PolyEdit(PolyDraw):
     """
     Attaches a PolyEditTool and syncs the datasource.
+
+    shared: boolean
+        Whether PolyEditTools should be shared between multiple elements
+
+    vertex_style: dict
+        A dictionary specifying the style options for the vertices.
+        The usual bokeh style options apply, e.g. fill_color,
+        line_alpha, size, etc.
     """
 
-    def __init__(self, vertex_style={}, **params):
+    def __init__(self, vertex_style={}, shared=True, **params):
+        self.shared = shared
         self.vertex_style = vertex_style
         super(PolyEdit, self).__init__(**params)


### PR DESCRIPTION
The PolyEditTool can edit multiple renderers at once, so this exposes an option to share the tool across multiple PolyEdit streams. Also since we're not using parameters for Stream settings I've added docstrings to describe the options.

- [x] Add tests
- [x] Update PolyEdit reference notebook