### PR TITLE
Support Datashader spread operation

### DIFF
--- a/examples/user_guide/14-Large_Data.ipynb
+++ b/examples/user_guide/14-Large_Data.ipynb
@@ -153,7 +153,14 @@
     "\n",
     "The Datashader examples above treat points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it.\n",
     "\n",
-    "However, many monitors are sufficiently high resolution that the resulting point or line can be difficult to see---a single pixel may not actually be visible on its own, and its color may likely be very difficult to make out.  To compensate for this, HoloViews provides access to Datashader's image-based \"spreading\", which makes isolated pixels \"spread\" into adjacent ones for visibility.  Because the amount of spreading that's useful depends on how close the datapoints are to each other on screen, the most useful such function is `dynspread`, which spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between pixels.  You can compare the results in the two plots below after zooming in:"
+    "However, many monitors are sufficiently high resolution that the resulting point or line can be difficult to see---a single pixel may not actually be visible on its own, and its color may likely be very difficult to make out.  To compensate for this, HoloViews provides access to Datashader's image-based \"spreading\", which makes isolated pixels \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
+    "\n",
+    "1. ``spread``: fixed spreading of a certain number of pixels, which is useful if you want to be sure how much spreading is done regardless of the properties of the data.\n",
+    "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between pixels.  \n",
+    "\n",
+    "Dynamic spreading is typically more useful, because it adjusts depending on how close the datapoints are to each other on screen. You can see the effect of ``dynspread\n",
+    "\n",
+    "You can compare the results in the two plots below after zooming in:"
    ]
   },
   {


### PR DESCRIPTION
HoloViews has long supported Datashader's ``dynspread`` operation, but not the simpler fixed ``spread`` version.  Made a new abstract class with code and parameters common to both, and added new ``spread`` operation.