### PR TITLE
Raise non-gridded data errors on raster types

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -7,6 +7,7 @@ import param
 
 from ..core import util
 from ..core.data import ImageInterface, GridInterface
+from ..core.data.interface import DataError
 from ..core import Dimension, Element2D, Overlay, Dataset
 from ..core.boundingregion import BoundingRegion, BoundingBox
 from ..core.sheetcoords import SheetCoordinateSystem, Slice
@@ -243,6 +244,11 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
             or (isinstance(data, np.ndarray) and data.size == 0)):
             data = np.zeros((2, 2))
         Dataset.__init__(self, data, kdims=kdims, vdims=vdims, extents=extents, **params)
+        if not self.interface.gridded:
+            raise DataError("%s type expects gridded data, %s is columnar."
+                            "To display columnar data as gridded use the HeatMap "
+                            "element or aggregate the data." %
+                            (type(self).__name__, self.interface.__name__))
 
         dim2, dim1 = self.interface.shape(self, gridded=True)[:2]
         if bounds is None:
@@ -635,8 +641,6 @@ class QuadMesh(Dataset, Element2D):
     2D arrays for the x-/y-coordinates and grid values.
     """
 
-    datatype = param.List(default=['grid', 'xarray'])
-
     group = param.String(default="QuadMesh", constant=True)
 
     kdims = param.List(default=[Dimension('x'), Dimension('y')],
@@ -645,6 +649,15 @@ class QuadMesh(Dataset, Element2D):
     vdims = param.List(default=[Dimension('z')], bounds=(1, None))
 
     _binned = True
+
+    def __init__(self, data, kdims=None, vdims=None, **params):
+        super(QuadMesh, self).__init__(data, kdims, vdims, **params)
+        if not self.interface.gridded:
+            raise DataError("%s type expects gridded data, %s is columnar."
+                            "To display columnar data as gridded use the HeatMap "
+                            "element or aggregate the data." %
+                            (type(self).__name__, self.interface.__name__))
+
 
     def __setstate__(self, state):
         """


### PR DESCRIPTION
As outlined in https://github.com/ioam/holoviews/issues/1745, trying to use the .to method to display columnar data as gridded currently throws an obscure error. This PR ensures a more informative error is raised. 