### PR TITLE
Allowed custom sampling tolerance

### DIFF
--- a/examples/reference/elements/bokeh/Image.ipynb
+++ b/examples/reference/elements/bokeh/Image.ipynb
@@ -100,6 +100,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The constructor of ``Image`` attempts to validate the input data by ensuring it is regularly sampled. In some cases, your data may be not be regularly sampled to a sufficiently high precision in which case you qill see an exception recommending the use of [``QuadMesh``](./QuadMesh.ipynb) instead. If you see this message and are sure that the ``Image`` element is appropriate, you can set the ``rtol`` value in the constructor to allow a higher deviation in sample spacing than the default of ``10e-6``. Alternatively, you can set this globally using ``hv.config.image_rtol`` as described in the [Installing and Configuring](../../../user_guide/Installing_and_Configuring.ipynb) user guide.\n",
+    "\n",
     "One additional way to create Image objects is via the separate [ImaGen](http://ioam.github.io/imagen) library, which creates parameterized streams of images for experiments, simulations, or machine-learning applications.\n",
     "\n",
     "For full documentation and the available style and plot options, use ``hv.help(hv.Image).``"

--- a/examples/reference/elements/matplotlib/Image.ipynb
+++ b/examples/reference/elements/matplotlib/Image.ipynb
@@ -100,6 +100,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "The constructor of ``Image`` attempts to validate the input data by ensuring it is regularly sampled. In some cases, your data may be not be regularly sampled to a sufficiently high precision in which case you qill see an exception recommending the use of [``QuadMesh``](./QuadMesh.ipynb) instead. If you see this message and are sure that the ``Image`` element is appropriate, you can set the ``rtol`` value in the constructor to allow a higher deviation in sample spacing than the default of ``10e-6``. Alternatively, you can set this globally using ``hv.config.image_rtol`` as described in the [Installing and Configuring](../../../user_guide/Installing_and_Configuring.ipynb) user guide.\n",
+    "\n",
+    "\n",
     "One additional way to create Image objects is via the separate [ImaGen](http://ioam.github.io/imagen) library, which creates parameterized streams of images for experiments, simulations, or machine-learning applications.\n",
     "\n",
     "For full documentation and the available style and plot options, use ``hv.help(hv.Image).``"

--- a/examples/user_guide/Installing_and_Configuring.ipynb
+++ b/examples/user_guide/Installing_and_Configuring.ipynb
@@ -113,6 +113,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "In addition to backwards-compatibility options, ``hv.config`` holds some global options:\n",
+    "\n",
+    "* ``image_rtol``: The tolerance used to enforce regular sampling for regular, gridded data. Used to validate ``Image`` data.\n",
+    "\n",
+    "This option allows you to set the ``rtol`` parameter of [``Image``](../reference/elements/bokeh/Image.ipynb) elements globally.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Improved tab-completion\n",
     "\n",
     "Both ``Layout`` and ``Overlay`` are designed around convenient tab-completion, with the expectation of upper-case names being listed first. In recent versions of Jupyter/IPython there has been a regression whereby the tab-completion is no longer case-sensitive. This can be fixed with:"

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -73,10 +73,11 @@ class Config(param.ParameterizedFunction):
        recommended that users switch this on to update any uses of
        __call__ as it will be deprecated in future.""")
 
-    rtol = param.Number(default=10e-6, doc="""
-      The tolerance used to enforce regular sampling for gridded data
-      where regular sampling is expected. Expressed as the maximal
-      allowable sampling difference between sample locations.""")
+    image_rtol = param.Number(default=10e-6, doc="""
+      The tolerance used to enforce regular sampling for regular,
+      gridded data where regular sampling is expected. Expressed as the
+      maximal allowable sampling difference between sample
+      locations.""")
 
     def __call__(self, **params):
         self.set_param(**params)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -73,6 +73,11 @@ class Config(param.ParameterizedFunction):
        recommended that users switch this on to update any uses of
        __call__ as it will be deprecated in future.""")
 
+    rtol = param.Number(default=10e-6, doc="""
+      The tolerance used to enforce regular sampling for gridded data
+      where regular sampling is expected. Expressed as the maximal
+      allowable sampling difference between sample locations.""")
+
     def __call__(self, **params):
         self.set_param(**params)
         return self

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -269,7 +269,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
 
         # Ensure coordinates are regularly sampled
 
-        rtol = config.rtol if rtol is None else rtol
+        rtol = config.image_rtol if rtol is None else rtol
         validate_regular_sampling(self, 0, rtol)
         validate_regular_sampling(self, 1, rtol)
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -5,7 +5,7 @@ import numpy as np
 import colorsys
 import param
 
-from ..core import util
+from ..core import util, config
 from ..core.data import ImageInterface, GridInterface
 from ..core import Dimension, Element2D, Overlay, Dataset
 from ..core.boundingregion import BoundingRegion, BoundingBox
@@ -232,7 +232,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         The dimension description of the data held in the matrix.""")
 
     def __init__(self, data, kdims=None, vdims=None, bounds=None, extents=None,
-                 xdensity=None, ydensity=None, **params):
+                 xdensity=None, ydensity=None, rtol=None, **params):
         if isinstance(data, Image):
             bounds = bounds or data.bounds
             xdensity = xdensity or data.xdensity
@@ -268,8 +268,10 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
                                  % (self.shape, len(self.vdims)))
 
         # Ensure coordinates are regularly sampled
-        validate_regular_sampling(self, 0)
-        validate_regular_sampling(self, 1)
+
+        rtol = config.rtol if rtol is None else rtol
+        validate_regular_sampling(self, 0, rtol)
+        validate_regular_sampling(self, 1, rtol)
 
 
     def __setstate__(self, state):

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -295,8 +295,9 @@ def validate_regular_sampling(img, dimension, rtol=10e-6):
     dim = img.get_dimension(dimension)
     diffs = np.diff(img.dimension_values(dim, expanded=False))
     vals = np.unique(diffs)
+    msg = ("{clsname} dimension {dim} is not evenly sampled to rtol "
+           "tolerance of {rtol}, please use the QuadMesh element for "
+           "unevenly or irregularly sampled data.")
     if len(vals) > 1 and np.abs(vals.min()-vals.max()) > diffs.min()*rtol:
-        raise ValueError("%s dimension %s is not evenly sampled, "
-                         "please use the QuadMesh element for "
-                         "unevenly or irregularly sampled data." %
-                         (type(img).__name__, dim))
+        raise ValueError(msg.format(clsname=type(img).__name__,
+                                    dim=dim, rtol=rtol))

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -284,20 +284,17 @@ def connect_edges(graph):
     return paths
 
 
-def validate_regular_sampling(img, dimension, rtol=10e-9, dt_rtol=10e-6):
+def validate_regular_sampling(img, dimension, rtol=10e-6):
     """
     Validates regular sampling of Image elements ensuring that
     coordinates the difference in sampling steps is at most rtol times
     the smallest sampling step. By default ensures the largest
-    sampling difference is less than one billionth of the smallest
-    sampling step. dt_rtol specifies a separate tolerance for datetime
-    types, which currently only allow for microsecond resolution.
+    sampling difference is less than one millionth of the smallest
+    sampling step.
     """
     dim = img.get_dimension(dimension)
     diffs = np.diff(img.dimension_values(dim, expanded=False))
     vals = np.unique(diffs)
-    if vals.dtype.kind == 'm':
-        rtol = dt_rtol
     if len(vals) > 1 and np.abs(vals.min()-vals.max()) > diffs.min()*rtol:
         raise ValueError("%s dimension %s is not evenly sampled, "
                          "please use the QuadMesh element for "

--- a/tests/element/testimage.py
+++ b/tests/element/testimage.py
@@ -1,0 +1,42 @@
+"""
+Unit tests of Image elements
+"""
+
+import numpy as np
+from holoviews.element import  Image, Curve
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class TestImage(ComparisonTestCase):
+
+    def setUp(self):
+        self.array1 = np.array([(0, 1, 2), (3, 4, 5)])
+
+    def test_image_init(self):
+        image = Image(self.array1)
+        self.assertEqual(image.xdensity, 3)
+        self.assertEqual(image.ydensity, 2)
+
+    def test_image_index(self):
+        image = Image(self.array1)
+        self.assertEqual(image[-.33, -0.25], 3)
+
+
+    def test_image_sample(self):
+        image = Image(self.array1)
+        self.assertEqual(image.sample(y=0.25),
+                         Curve(np.array([(-0.333333, 0), (0, 1), (0.333333, 2)]),
+                               kdims=['x'], vdims=['z']))
+
+    def test_image_range_masked(self):
+        arr = np.random.rand(10,10)-0.5
+        arr = np.ma.masked_where(arr<=0, arr)
+        rrange = Image(arr).range(2)
+        self.assertEqual(rrange, (np.min(arr), np.max(arr)))
+
+    def test_empty_image(self):
+        Image([])
+        Image(None)
+        Image(np.array([]))
+        Image(np.zeros((0, 0)))
+

--- a/tests/element/testimage.py
+++ b/tests/element/testimage.py
@@ -3,6 +3,7 @@ Unit tests of Image elements
 """
 
 import numpy as np
+import holoviews as hv
 from holoviews.element import  Image, Curve
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -40,3 +41,30 @@ class TestImage(ComparisonTestCase):
         Image(np.array([]))
         Image(np.zeros((0, 0)))
 
+    def test_image_rtol_failure(self):
+        vals = np.random.rand(20,20)
+        xs = np.linspace(0,10,20)
+        ys = np.linspace(0,10,20)
+        ys[-1] += 0.001
+
+        regexp = 'Image dimension ys is not evenly sampled(.+?)'
+        with self.assertRaisesRegexp(ValueError, regexp):
+            Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
+
+    def test_image_rtol_constructor(self):
+        vals = np.random.rand(20,20)
+        xs = np.linspace(0,10,20)
+        ys = np.linspace(0,10,20)
+        ys[-1] += 0.001
+        Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals', rtol=10e-3)
+
+
+    def test_image_rtol_config(self):
+        vals = np.random.rand(20,20)
+        xs = np.linspace(0,10,20)
+        ys = np.linspace(0,10,20)
+        ys[-1] += 0.001
+        image_rtol = hv.config.image_rtol
+        hv.config.image_rtol = 10e-3
+        Image({'vals':vals, 'xs':xs, 'ys':ys}, ['xs','ys'], 'vals')
+        hv.config.image_rtol = image_rtol

--- a/tests/testdynamic.py
+++ b/tests/testdynamic.py
@@ -452,7 +452,7 @@ class DynamicCallableMemoize(ComparisonTestCase):
         del dmap.data[(0,)]
         second = dmap[0]
         self.assertIsNot(first, second)
-        
+
     def test_dynamic_callable_memoize(self):
         # Always memoized only one of each held
         def history_callback(x, history=deque(maxlen=10)):

--- a/tests/testraster.py
+++ b/tests/testraster.py
@@ -14,18 +14,9 @@ class TestRaster(ComparisonTestCase):
     def test_raster_init(self):
         Raster(self.array1)
 
-    def test_image_init(self):
-        image = Image(self.array1)
-        self.assertEqual(image.xdensity, 3)
-        self.assertEqual(image.ydensity, 2)
-
     def test_raster_index(self):
         raster = Raster(self.array1)
         self.assertEqual(raster[0, 1], 3)
-
-    def test_image_index(self):
-        image = Image(self.array1)
-        self.assertEqual(image[-.33, -0.25], 3)
 
     def test_raster_sample(self):
         raster = Raster(self.array1)
@@ -33,29 +24,11 @@ class TestRaster(ComparisonTestCase):
                          Curve(np.array([(0, 0), (1, 1), (2, 2)]),
                                kdims=['x'], vdims=['z']))
 
-    def test_image_sample(self):
-        image = Image(self.array1)
-        self.assertEqual(image.sample(y=0.25),
-                         Curve(np.array([(-0.333333, 0), (0, 1), (0.333333, 2)]),
-                               kdims=['x'], vdims=['z']))
-
     def test_raster_range_masked(self):
         arr = np.random.rand(10,10)-0.5
         arr = np.ma.masked_where(arr<=0, arr)
         rrange = Raster(arr).range(2)
         self.assertEqual(rrange, (np.min(arr), np.max(arr)))
-
-    def test_image_range_masked(self):
-        arr = np.random.rand(10,10)-0.5
-        arr = np.ma.masked_where(arr<=0, arr)
-        rrange = Image(arr).range(2)
-        self.assertEqual(rrange, (np.min(arr), np.max(arr)))
-
-    def test_empty_image(self):
-        Image([])
-        Image(None)
-        Image(np.array([]))
-        Image(np.zeros((0, 0)))
 
 
 
@@ -74,7 +47,7 @@ class TestQuadMesh(ComparisonTestCase):
         self.assertEqual(qmesh.vdims, img.vdims)
         self.assertEqual(qmesh.group, img.group)
         self.assertEqual(qmesh.label, img.label)
-        
+
     def test_quadmesh_to_trimesh(self):
         qmesh = QuadMesh(([0, 1], [0, 1], np.array([[0, 1], [2, 3]])))
         trimesh = qmesh.trimesh()


### PR DESCRIPTION
The tolerance for all types is now consistent with datetimes, you can now specify a global tolerance value using ``hv.config`` and tolerance values per ``Image`` by specifying ``rtol`` in the constructor.

TODO:

- [x] Add unit tests.
- [x] Add docs.