### PR TITLE
Add Element.__contains__ method

### DIFF
--- a/doc/Tutorials/Columnar_Data.ipynb
+++ b/doc/Tutorials/Columnar_Data.ipynb
@@ -315,7 +315,7 @@
    "source": [
     "xs = np.arange(10)\n",
     "curve = hv.Curve(zip(xs, np.exp(xs)))\n",
-    "curve * hv.Scatter(zip(xs, curve)) + curve.table()"
+    "curve * hv.Scatter(curve) + curve.table()"
    ]
   },
   {

--- a/examples/user_guide/07-Tabular_Datasets.ipynb
+++ b/examples/user_guide/07-Tabular_Datasets.ipynb
@@ -340,7 +340,7 @@
    "source": [
     "xs = np.arange(10)\n",
     "curve = hv.Curve(zip(xs, np.exp(xs)))\n",
-    "curve * hv.Scatter(zip(xs, curve)) + curve.table()"
+    "curve * hv.Scatter(curve) + curve.table()"
    ]
   },
   {

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -68,6 +68,15 @@ class Element(ViewableElement, Composable, Overlayable):
         """
         return True
 
+
+    def __contains__(self, dimension):
+        """
+        Allows checking whether a Dimension is in the Elements key or
+        value dimensions.
+        """
+        return dimension in self.dimensions()
+
+
     __bool__ = __nonzero__
 
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -77,6 +77,13 @@ class Element(ViewableElement, Composable, Overlayable):
         return dimension in self.dimensions()
 
 
+    def __iter__(self):
+        """
+        Disable iterator interface.
+        """
+        raise NotImplementedError('Iteration on Elements is not supported.')
+
+
     __bool__ = __nonzero__
 
 

--- a/tests/core/testelement.py
+++ b/tests/core/testelement.py
@@ -1,4 +1,3 @@
-from unittest import SkipTest
 from holoviews.core import Dimension, Element
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -23,5 +22,5 @@ class ElementTests(ComparisonTestCase):
     def test_value_dimension_string_in_element(self):
         self.assertTrue('C' in self.element)
 
-    def test_constant_dimension_string_in_element(self):
-        self.assertTrue('Z' in self.element)
+    def test_dimension_string_not_in_element(self):
+        self.assertFalse('D' in self.element)

--- a/tests/core/testelement.py
+++ b/tests/core/testelement.py
@@ -1,0 +1,27 @@
+from unittest import SkipTest
+from holoviews.core import Dimension, Element
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class ElementTests(ComparisonTestCase):
+
+    def setUp(self):
+        self.element = Element([], kdims=['A', 'B'], vdims=['C'])
+
+    def test_key_dimension_in_element(self):
+        self.assertTrue(Dimension('A') in self.element)
+
+    def test_value_dimension_in_element(self):
+        self.assertTrue(Dimension('C') in self.element)
+
+    def test_dimension_not_in_element(self):
+        self.assertFalse(Dimension('D') in self.element)
+
+    def test_key_dimension_string_in_element(self):
+        self.assertTrue('A' in self.element)
+
+    def test_value_dimension_string_in_element(self):
+        self.assertTrue('C' in self.element)
+
+    def test_constant_dimension_string_in_element(self):
+        self.assertTrue('Z' in self.element)


### PR DESCRIPTION
As discussed in https://github.com/ioam/holoviews/issues/540 this PR adds a ``__contains__`` method to Element types. This is consistent with the way xarray and pandas handle the ``__contains__`` method, and makes the common task of checking whether an element contains a particular dimension easier.

- [x] Implements https://github.com/ioam/holoviews/issues/540
- [x] Add tests