### PR TITLE
Ensured Tree types do not create lowercase node on attribute access

### DIFF
--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -221,20 +221,23 @@ class AttrTree(object):
 
         if not any(identifier.startswith(prefix)
                    for prefix in type(self)._disabled_prefixes):
-            identifier = type(self)._sanitizer(identifier, escape=False)
+            sanitized = type(self)._sanitizer(identifier, escape=False)
+        else:
+            sanitized = identifier
 
-        if identifier in self.children:
-            return self.__dict__[identifier]
+        if sanitized in self.children:
+            return self.__dict__[sanitized]
 
-        if not identifier.startswith('_'):
-            self.children.append(identifier)
+        if not sanitized.startswith('_') and identifier[0].isupper():
+            self.children.append(sanitized)
             dir_mode = self.__dict__['_dir_mode']
-            child_tree = self.__class__(identifier=identifier,
+            child_tree = self.__class__(identifier=sanitized,
                                         parent=self, dir_mode=dir_mode)
-            self.__dict__[identifier] = child_tree
+            self.__dict__[sanitized] = child_tree
             return child_tree
         else:
-            raise AttributeError
+            raise AttributeError('%r object has no attribute %s.' %
+                                 (type(self).__name__, identifier))
 
 
     def __iter__(self):

--- a/holoviews/core/tree.py
+++ b/holoviews/core/tree.py
@@ -211,7 +211,6 @@ class AttrTree(object):
         else:
             path_item = self
             for i, identifier in enumerate(split_label[:-1]):
-                path = split_label[i:]
                 path_item = path_item[identifier]
             del path_item[split_label[-1]]
 

--- a/tests/core/testtree.py
+++ b/tests/core/testtree.py
@@ -1,0 +1,90 @@
+from holoviews.core.element import AttrTree
+from holoviews.element.comparison import ComparisonTestCase
+
+
+class AttrTreeTest(ComparisonTestCase):
+    "For testing of AttrTree"
+
+    def setUp(self):
+        self.tree = AttrTree([(('A', 'I'), 1), (('B', 'II'), 2)])
+
+    def test_access_nodes(self):
+        self.assertEqual(self.tree.A.I, 1)
+        self.assertEqual(self.tree.B.II, 2)
+
+    def test_uppercase_attribute_create_node(self):
+        self.assertIsInstance(self.tree.C, AttrTree)
+
+    def test_uppercase_setattr(self):
+        self.tree.C = 3
+        self.assertEqual(self.tree.C, 3)
+
+    def test_deep_setattr(self):
+        self.tree.C.I = 3
+        self.assertEqual(self.tree.C.I, 3)
+
+    def test_lowercase_attribute_error(self):
+        with self.assertRaises(AttributeError):
+            self.tree.c
+
+    def test_number_getitem_key_error(self):
+        with self.assertRaises(KeyError):
+            self.tree['2']
+
+    def test_lowercase_getitem_key_error(self):
+        with self.assertRaises(KeyError):
+            self.tree['c']
+
+    def test_uppercase_getitem(self):
+        self.assertEqual(self.tree['A']['I'], 1)
+        self.assertEqual(self.tree['B']['II'], 2)
+
+    def test_uppercase_setitem(self):
+        self.tree['C'] = 1
+        self.assertEqual(self.tree.C, 1)
+
+    def test_deep_getitem(self):
+        self.assertEqual(self.tree[('A', 'I')], 1)
+        self.assertEqual(self.tree[('B', 'II')], 2)
+
+    def test_deep_getitem_str(self):
+        self.assertEqual(self.tree['A.I'], 1)
+        self.assertEqual(self.tree['B.II'], 2)
+        
+    def test_deep_setitem(self):
+        self.tree[('C', 'I')] = 3
+        self.assertEqual(self.tree.C.I, 3)
+
+    def test_deep_setitem_str(self):
+        self.tree['C.I'] = 3
+        self.assertEqual(self.tree.C.I, 3)
+        
+    def test_delitem(self):
+        Btree = self.tree.B
+        del self.tree['B']
+        self.assertIsNot(self.tree.B, Btree)
+        self.assertNotIn(('B', 'II'), self.tree.data)
+
+    def test_delitem_on_node(self):
+        del self.tree.B['II']
+        self.assertNotEqual(self.tree.B.II, 2)
+        self.assertNotIn(('B', 'II'), self.tree.data)
+        self.assertNotIn(('II',), self.tree.B)
+
+    def test_delitem_keyerror(self):
+        with self.assertRaises(KeyError):
+            del self.tree['C']
+        
+    def test_deep_delitem(self):
+        BTree = self.tree.B
+        del self.tree[('B', 'II')]
+        self.assertIsInstance(self.tree.B.II, AttrTree)
+        self.assertIs(self.tree.B, BTree)
+        self.assertNotIn(('B', 'II'), self.tree.data)
+
+    def test_deep_delitem_str(self):
+        BTree = self.tree.B
+        del self.tree['B.II']
+        self.assertIsInstance(self.tree.B.II, AttrTree)
+        self.assertIs(self.tree.B, BTree)
+        self.assertNotIn(('B', 'II'), self.tree.data)


### PR DESCRIPTION
As discussed in https://github.com/ioam/holoviews/issues/1182, Tree based objects (e.g. Overlay and Layout) should not insert new lower-case nodes when the attribute is lower case.