### PR TITLE
Pass operation to Operation hooks

### DIFF
--- a/holoviews/core/operation.py
+++ b/holoviews/core/operation.py
@@ -62,9 +62,10 @@ class Operation(param.ParameterizedFunction):
         for dynamic interaction with the plot.""")
 
     # Hooks to allow external libraries to extend existing operations.
-    # Preprocessor hooks should accept the input element and return a
-    # dictionary of data which will be made available to the
-    # postprocessor hooks in additional to the processed element
+    # Preprocessor hooks should accept the operation and input element
+    # and return a dictionary of data which will be made available to
+    # the postprocessor hooks as kwargs in addition to the operation
+    # and processed element
     _preprocess_hooks = []
     _postprocess_hooks = []
 
@@ -116,10 +117,10 @@ class Operation(param.ParameterizedFunction):
         """
         kwargs = {}
         for hook in self._preprocess_hooks:
-            kwargs.update(hook(element))
+            kwargs.update(hook(self, element))
         ret = self._process(element, key)
         for hook in self._postprocess_hooks:
-            ret = hook(ret, **kwargs)
+            ret = hook(self, ret, **kwargs)
         return ret
 
 

--- a/tests/testoperation.py
+++ b/tests/testoperation.py
@@ -157,8 +157,8 @@ class OperationTests(ComparisonTestCase):
     def test_pre_and_postprocess_hooks(self):
         pre_backup = operation._preprocess_hooks
         post_backup = operation._postprocess_hooks
-        operation._preprocess_hooks = [lambda x: {'label': str(x.id)}]
-        operation._postprocess_hooks = [lambda x, **kwargs: x.clone(**kwargs)]
+        operation._preprocess_hooks = [lambda op, x: {'label': str(x.id)}]
+        operation._postprocess_hooks = [lambda op, x, **kwargs: x.clone(**kwargs)]
         curve = Curve([1, 2, 3])
         self.assertEqual(operation(curve).label, str(curve.id))
         operation._preprocess_hooks = pre_backup


### PR DESCRIPTION
Recently we added hooks to operations which could do some pre- and post-processing on the data. The current implementation only passes the processed object itself when it would be more general if it also passed in the operation itself, which can be useful e.g. to apply pre-processing the operation parameters. The specific use-case I have in mind is ensuring that GeoViews returns RangeXY stream bounds in the correct coordinate system.