### PR TITLE
Fixed bug in bokeh TablePlot not escaping dimensions correctly

### DIFF
--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -70,9 +70,23 @@ class TablePlot(BokehPlot, GenericElementPlot):
             source = self._init_datasource(data)
         self.handles['source'] = source
 
+        columns = self._get_columns(element, data)
+        style['reorderable'] = False
+        table = DataTable(source=source, columns=columns, height=self.height,
+                          width=self.width, **style)
+        self.handles['plot'] = table
+        self.handles['glyph_renderer'] = table
+        self._execute_hooks(element)
+        self.drawn = True
+
+        for cb in self.callbacks:
+            cb.initialize()
+
+        return table
+
+    def _get_columns(self, element, data):
         columns = []
-        dims = element.dimensions()
-        for d in dims:
+        for d in element.dimensions():
             col = dimension_sanitizer(d.name)
             kind = data[col].dtype.kind
             if kind == 'i':
@@ -89,21 +103,10 @@ class TablePlot(BokehPlot, GenericElementPlot):
             else:
                 formatter = StringFormatter()
                 editor = StringEditor()
-            column = TableColumn(field=d.name, title=d.pprint_label,
+            column = TableColumn(field=dimension_sanitizer(d.name), title=d.pprint_label,
                                  editor=editor, formatter=formatter)
             columns.append(column)
-        style['reorderable'] = False
-        table = DataTable(source=source, columns=columns, height=self.height,
-                          width=self.width, **style)
-        self.handles['plot'] = table
-        self.handles['glyph_renderer'] = table
-        self._execute_hooks(element)
-        self.drawn = True
-
-        for cb in self.callbacks:
-            cb.initialize()
-
-        return table
+        return columns
 
 
     def update_frame(self, key, ranges=None, plot=None):

--- a/tests/plotting/bokeh/testtabular.py
+++ b/tests/plotting/bokeh/testtabular.py
@@ -42,6 +42,13 @@ class TestBokehTablePlot(ComparisonTestCase):
             self.assertIsInstance(column.formatter, fmt)
             self.assertIsInstance(column.editor, edit)
 
+    def test_table_plot_escaped_dimension(self):
+        table = Table([1, 2, 3], ['A Dimension'])
+        plot = bokeh_renderer.get_plot(table)
+        source = plot.handles['source']
+        renderer = plot.handles['glyph_renderer']
+        self.assertEqual(list(source.data.keys())[0], renderer.columns[0].field)
+
     def test_table_plot_datetimes(self):
         table = Table([dt.now(), dt.now()], 'Date')
         plot = bokeh_renderer.get_plot(table)


### PR DESCRIPTION
The dimension names were not escaped on bokeh's TablePlot, resulting in no data being displayed when plotting Table containing columns with spaces or special characters in them.