### PR TITLE
Deprioritized array interface

### DIFF
--- a/doc/Tutorials/Columnar_Data.ipynb
+++ b/doc/Tutorials/Columnar_Data.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xs = range(10)\n",
+    "xs = np.arange(10)\n",
     "ys = np.exp(xs)\n",
     "\n",
     "table = hv.Table((xs, ys), kdims=['x'], vdims=['y'])\n",
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(type(hv.Scatter((xs, ys), datatype=['array']).data))\n",
+    "print(type(hv.Scatter((xs.astype('float64'), ys), datatype=['array']).data))\n",
     "print(type(hv.Scatter((xs, ys), datatype=['dictionary']).data))\n",
     "print(type(hv.Scatter((xs, ys), datatype=['dataframe']).data))"
    ]

--- a/examples/user_guide/07-Tabular_Datasets.ipynb
+++ b/examples/user_guide/07-Tabular_Datasets.ipynb
@@ -73,7 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xs = range(10)\n",
+    "xs = np.arange(10)\n",
     "ys = np.exp(xs)\n",
     "\n",
     "table = hv.Table((xs, ys), 'x', 'y')\n",
@@ -201,7 +201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note these include grid based datatypes, which are covered in [Gridded Datasets](http://holoviews.org/user_guide/Gridded_Datasets.html). To select a particular storage format explicitly, supply one or more allowed datatypes:"
+    "Note these include grid based datatypes, which are covered in [Gridded Datasets](http://holoviews.org/user_guide/Gridded_Datasets.html). To select a particular storage format explicitly, supply one or more allowed datatypes (note that the 'array' interface only supports data with matching types):"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(type(hv.Scatter((xs, ys), datatype=['array']).data))\n",
+    "print(type(hv.Scatter((xs.astype('float64'), ys), datatype=['array']).data))\n",
     "print(type(hv.Scatter((xs, ys), datatype=['dictionary']).data))\n",
     "print(type(hv.Scatter((xs, ys), datatype=['dataframe']).data))"
    ]

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -17,12 +17,12 @@ from .grid import GridInterface
 from .multipath import MultiInterface         # noqa (API import)
 from .image import ImageInterface             # noqa (API import)
 
-datatypes = ['array', 'dictionary', 'grid']
+datatypes = ['dictionary', 'grid']
 
 try:
     import pandas as pd # noqa (Availability import)
     from .pandas import PandasInterface
-    datatypes = ['array', 'dataframe', 'dictionary', 'grid', 'ndelement']
+    datatypes = ['dataframe', 'dictionary', 'grid', 'ndelement', 'array']
     DFColumns = PandasInterface
 except ImportError:
     pass
@@ -52,6 +52,9 @@ try:
     datatypes.append('dask')
 except ImportError:
     pass
+
+if 'array' not in datatypes:
+    datatypes.append('array')
 
 from ..dimension import Dimension, process_dimensions
 from ..element import Element

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -33,7 +33,9 @@ class ArrayInterface(Interface):
                       d for d in kdims + vdims]
         if ((isinstance(data, dict) or util.is_dataframe(data)) and
             all(d in data for d in dimensions)):
-            dataset = [data[d] for d in dimensions]
+            dataset = [d if isinstance(d, np.ndarray) else np.asarray(data[d]) for d in dimensions]
+            if len(set(d.dtype for d in dataset)) > 1:
+                raise ValueError('ArrayInterface expects all columns to be of the same dtype')
             data = np.column_stack(dataset)
         elif isinstance(data, dict) and not all(d in data for d in dimensions):
             dict_data = sorted(data.items())
@@ -41,10 +43,10 @@ class ArrayInterface(Interface):
                             for k, v in dict_data))
             data = np.column_stack(dataset)
         elif isinstance(data, tuple):
-            data = [np.asarray(d) for d in data]
-            if any(arr.ndim > 1 for arr in data):
-                raise ValueError('ArrayInterface expects data to be of flat shape.')
-            if cls.expanded(data):
+            data = [d if isinstance(d, np.ndarray) else np.asarray(d) for d in data]
+            if len(set(d.dtype for d in data)) > 1:
+                raise ValueError('ArrayInterface expects all columns to be of the same dtype')
+            elif cls.expanded(data):
                 data = np.column_stack(data)
             else:
                 raise ValueError('ArrayInterface expects data to be of uniform shape.')

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -34,7 +34,7 @@ class ArrayInterface(Interface):
         if ((isinstance(data, dict) or util.is_dataframe(data)) and
             all(d in data for d in dimensions)):
             dataset = [d if isinstance(d, np.ndarray) else np.asarray(data[d]) for d in dimensions]
-            if len(set(d.dtype for d in dataset)) > 1:
+            if len(set(d.dtype.kind for d in dataset)) > 1:
                 raise ValueError('ArrayInterface expects all columns to be of the same dtype')
             data = np.column_stack(dataset)
         elif isinstance(data, dict) and not all(d in data for d in dimensions):
@@ -44,7 +44,7 @@ class ArrayInterface(Interface):
             data = np.column_stack(dataset)
         elif isinstance(data, tuple):
             data = [d if isinstance(d, np.ndarray) else np.asarray(d) for d in data]
-            if len(set(d.dtype for d in data)) > 1:
+            if len(set(d.dtype.kind for d in data)) > 1:
                 raise ValueError('ArrayInterface expects all columns to be of the same dtype')
             elif cls.expanded(data):
                 data = np.column_stack(data)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -692,6 +692,8 @@ class interpolate_curve(Operation):
         if self.p.interpolation not in INTERPOLATE_FUNCS:
             return element
         x, y = element.dimension_values(0), element.dimension_values(1)
+        if 'f' in (x.dtype.kind, y.dtype.kind):
+            x, y = x.astype('float'), y.astype('float')
         array = INTERPOLATE_FUNCS[self.p.interpolation](x, y)
         dvals = tuple(element.dimension_values(d) for d in element.dimensions()[2:])
         return element.clone((array[0, :].astype(x.dtype), array[1, :].astype(y.dtype))+dvals)

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -849,6 +849,20 @@ class ArrayDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
 
+    def test_dataset_sort_hm(self):
+        ds = Dataset(([2, 2, 1], [2,1,2], [1, 2, 3]),
+                     kdims=['x', 'y'], vdims=['z']).sort()
+        ds_sorted = Dataset(([1, 2, 2], [2, 1, 2], [3, 2, 1]),
+                            kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(ds.sort(), ds_sorted)
+
+    def test_dataset_sort_reverse_hm(self):
+        ds = Dataset(([2, 1, 2, 1], [2, 2, 1, 1], [0, 1, 2, 3]),
+                     kdims=['x', 'y'], vdims=['z'])
+        ds_sorted = Dataset(([2, 2, 1, 1], [2, 1, 2, 1], [0, 2, 1, 3]),
+                            kdims=['x', 'y'], vdims=['z'])
+        self.assertEqual(ds.sort(reverse=True), ds_sorted)
+
 
 
 class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):


### PR DESCRIPTION
Finally implements https://github.com/ioam/holoviews/issues/1236, this is long overdue since the ArrayInterface mostly just causes troubles due to mixed types. With this change you should only ever end up with an ArrayInterface when you pass in an ``NxM`` array explicitly.