### PR TITLE
Correctly register pandas matplotlib conversions

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -27,8 +27,9 @@ mpl_ge_150 = LooseVersion(mpl.__version__) >= '1.5.0'
 
 if pd:
     try:
-        pandas.plotting.register_matplotlib_converters()
-    except:
+        from pandas.plotting import register_matplotlib_converters
+        register_matplotlib_converters()
+    except ImportError:
         from pandas.tseries import converter
         converter.register()
 


### PR DESCRIPTION
Fixed issue registering the matplotlib conversion hooks for datetime types when using pandas 0.22.0. The register function does not seem to exist where pandas says it does, so I'm now importing it explicitly from the converter module.