### PR TITLE
Datashader fixes

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1569,14 +1569,20 @@ def dt_to_int(value, time_unit='us'):
     """
     Converts a datetime type to an integer with the supplied time unit.
     """
-    if time_unit == 'ns':
-        tscale = 1
+    if isinstance(value, np.datetime64):
+        value = np.datetime64(value, 'ns')
+        if time_unit == 'ns':
+            tscale = 1
+        else:
+            tscale = (np.timedelta64(1, time_unit)/np.timedelta64(1, 'ns')) * 1000.
+    elif time_unit == 'ns':
+        tscale = 1000.
     else:
         tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
     if pd and isinstance(value, pd.Timestamp):
         value = value.to_pydatetime()
     elif isinstance(value, np.datetime64):
-        value = np.datetime64(value, 'ns').tolist()
+        value = value.tolist()
     if isinstance(value, (int, long)):
         # Handle special case of nanosecond precision which cannot be
         # represented by python datetime

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1570,13 +1570,13 @@ def dt_to_int(value, time_unit='us'):
     Converts a datetime type to an integer with the supplied time unit.
     """
     if time_unit == 'ns':
-        tscale = 1./np.timedelta64(1, time_unit).tolist()
+        tscale = 1
     else:
         tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
     if pd and isinstance(value, pd.Timestamp):
         value = value.to_pydatetime()
     elif isinstance(value, np.datetime64):
-        value = value.tolist()
+        value = np.datetime64(value, 'ns').tolist()
     if isinstance(value, (int, long)):
         # Handle special case of nanosecond precision which cannot be
         # represented by python datetime

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -151,8 +151,8 @@ class ResamplingOperation(Operation):
             ytype = 'datetime'
         elif not np.isfinite(ystart) and not np.isfinite(yend):
             if element.get_dimension_type(y) in datetime_types:
-                xstart, xend = 0, 10000
-                xtype = 'datetime'
+                ystart, yend = 0, 10000
+                ytype = 'datetime'
             else:
                 ystart, yend = 0, 1
         elif ystart == yend:

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -255,7 +255,7 @@ class aggregate(ResamplingOperation):
                 paths = [p.compute() if isinstance(p, dd.DataFrame) else p for p in paths]
                 df = pd.concat(paths)
         else:
-            df = paths[0]
+            df = paths[0] if paths else pd.DataFrame([], columns=[x.name, y.name])
         if category and df[category].dtype.name != 'category':
             df[category] = df[category].astype('category')
 
@@ -359,6 +359,10 @@ class aggregate(ResamplingOperation):
         if x is None or y is None:
             xarray = xr.DataArray(np.full((height, width), np.NaN, dtype=np.float32),
                                   dims=['y', 'x'], coords={'x': xs, 'y': ys})
+            return self.p.element_type(xarray)
+        elif not len(data):
+            xarray = xr.DataArray(np.full((height, width), np.NaN, dtype=np.float32),
+                                  dims=[y.name, x.name], coords={x.name: xs, y.name: ys})
             return self.p.element_type(xarray)
 
         cvs = ds.Canvas(plot_width=width, plot_height=height,

--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -77,6 +77,20 @@ class DatashaderAggregateTests(ComparisonTestCase):
                          datatype=['xarray'], bounds=bounds, vdims='Count')
         self.assertEqual(img, expected)
 
+    def test_aggregate_curve_datetimes_microsecond_timebase(self):
+        dates = pd.date_range(start="2016-01-01", end="2016-01-03", freq='1D')
+        xstart = np.datetime64('2015-12-31T23:59:59.723518000', 'us')
+        xend = np.datetime64('2016-01-03T00:00:00.276482000', 'us')
+        curve = Curve((dates, [1, 2, 3]))
+        img = aggregate(curve, width=2, height=2, x_range=(xstart, xend), dynamic=False)
+        bounds = (np.datetime64('2015-12-31T23:59:59.585277000'), 1.0,
+                  np.datetime64('2016-01-03T00:00:00.414723000'), 3.0)
+        dates = [np.datetime64('2016-01-01T11:59:59.861759000',),
+                 np.datetime64('2016-01-02T12:00:00.138241000')]
+        expected = Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
+                         datatype=['xarray'], bounds=bounds, vdims='Count')
+        self.assertEqual(img, expected)
+
     def test_aggregate_ndoverlay(self):
         ds = Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
         ndoverlay = ds.to(Points, ['x', 'y'], [], 'z').overlay()

--- a/tests/testcoreutils.py
+++ b/tests/testcoreutils.py
@@ -558,20 +558,44 @@ class TestDatetimeUtils(unittest.TestCase):
         dt = datetime.datetime(2017, 1, 1)
         self.assertEqual(dt_to_int(dt), 1483228800000000.0)
 
-    def test_datetime64_to_us_int(self):
+    def test_datetime64_s_to_ns_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 's')
+        self.assertEqual(dt_to_int(dt, 'ns'), 1483228800000000000000.0)
+
+    def test_datetime64_us_to_ns_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 'us')
+        self.assertEqual(dt_to_int(dt, 'ns'), 1483228800000000000000.0)
+
+    def test_datetime64_to_ns_int(self):
         dt = np.datetime64(datetime.datetime(2017, 1, 1))
+        self.assertEqual(dt_to_int(dt, 'ns'), 1483228800000000000000.0)
+
+    def test_datetime64_us_to_us_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 'us')
+        self.assertEqual(dt_to_int(dt), 1483228800000000.0)
+
+    def test_datetime64_s_to_us_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 's')
         self.assertEqual(dt_to_int(dt), 1483228800000000.0)
 
     def test_timestamp_to_us_int(self):
         dt = pd.Timestamp(datetime.datetime(2017, 1, 1))
         self.assertEqual(dt_to_int(dt), 1483228800000000.0)
-    
+
     def test_datetime_to_s_int(self):
         dt = datetime.datetime(2017, 1, 1)
         self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
 
     def test_datetime64_to_s_int(self):
         dt = np.datetime64(datetime.datetime(2017, 1, 1))
+        self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
+
+    def test_datetime64_us_to_s_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 'us')
+        self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
+
+    def test_datetime64_s_to_s_int(self):
+        dt = np.datetime64(datetime.datetime(2017, 1, 1), 's')
         self.assertEqual(dt_to_int(dt, 's'), 1483228800.0)
 
     def test_timestamp_to_s_int(self):


### PR DESCRIPTION
Addresses another bug in the datashader handling of datetimes, when the range is not supplied with nanosecond resolution. Also adds a test and some extra handling for datashading empty objects.