### PR TITLE
Handle range on heterogeneously typed Dataset column

### DIFF
--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -287,8 +287,9 @@ class Interface(param.Parameterized):
             return np.NaN, np.NaN
         else:
             try:
+                assert column.dtype.kind not in 'SUO'
                 return (np.nanmin(column), np.nanmax(column))
-            except TypeError:
+            except (AssertionError, TypeError):
                 column = [v for v in util.python2sort(column) if v is not None]
                 if not len(column):
                     return np.NaN, np.NaN

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -290,6 +290,8 @@ class Interface(param.Parameterized):
                 return (np.nanmin(column), np.nanmax(column))
             except TypeError:
                 column = [v for v in util.python2sort(column) if v is not None]
+                if not len(column):
+                    return np.NaN, np.NaN
                 return column[0], column[-1]
 
     @classmethod

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -289,7 +289,7 @@ class Interface(param.Parameterized):
             try:
                 return (np.nanmin(column), np.nanmax(column))
             except TypeError:
-                column.sort()
+                column = [v for v in util.python2sort(column) if v is not None]
                 return column[0], column[-1]
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -141,6 +141,7 @@ class PandasInterface(Interface):
                 column = column.sort(inplace=False)
             else:
                 column = column.sort_values()
+            column = column[~column.isin([None])]
             return column.iloc[0], column.iloc[-1]
         else:
             return (column.min(), column.max())

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -142,6 +142,8 @@ class PandasInterface(Interface):
             else:
                 column = column.sort_values()
             column = column[~column.isin([None])]
+            if not len(column):
+                return np.NaN, np.NaN
             return column.iloc[0], column.iloc[-1]
         else:
             return (column.min(), column.max())
@@ -290,6 +292,16 @@ class PandasInterface(Interface):
             return columns.data[dimensions]
         else:
             return columns.data.copy()
+
+
+    @classmethod
+    def array(cls, dataset, dimensions):
+        if not dimensions:
+            dimensions = dataset.dimensions(label='name')
+        else:
+            dimensions = [dataset.get_dimensions(d).name for d in dimensions]
+        inds = [dataset.data.columns.index(dim.name) for dim in dimensions]
+        return dataset.data.values[:, inds]
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -295,16 +295,6 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def array(cls, dataset, dimensions):
-        if not dimensions:
-            dimensions = dataset.dimensions(label='name')
-        else:
-            dimensions = [dataset.get_dimensions(d).name for d in dimensions]
-        inds = [dataset.data.columns.index(dim.name) for dim in dimensions]
-        return dataset.data.values[:, inds]
-
-
-    @classmethod
     def iloc(cls, dataset, index):
         rows, cols = index
         scalar = False

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -722,7 +722,7 @@ def max_range(ranges):
                 values = [(v1.to_datetime64(), v2.to_datetime64()) for v1, v2 in values]
             arr = np.array(values)
             if arr.dtype.kind in 'OSU':
-                arr = np.sort([v for v in arr.flat if not is_nan(v)])
+                arr = list(python2sort([v for v in arr.flat if not is_nan(v) and v is not None]))
                 return arr[0], arr[-1]
             if arr.dtype.kind in 'M':
                 return arr[:, 0].min(), arr[:, 1].max()

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -473,6 +473,10 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
         self.assertEqual(dataset.redim(**{'X-label':'X'}), dataset_redim)
         self.assertEqual(dataset.redim(**{'x':'X'}), dataset_redim)
 
+    def test_dataset_mixed_type_range(self):
+        ds = Dataset((['A', 'B', 'C', None],), 'A')
+        self.assertEqual(ds.range(0), ('A', 'C'))
+
     def test_dataset_sort_vdim_ht(self):
         dataset = Dataset({'x':self.xs, 'y':-self.ys},
                           kdims=['x'], vdims=['y'])


### PR DESCRIPTION
Calling range on a heterogeneously typed column currently causes all kinds of issues (including errors) due to python 3 sorting semantics. While range should generally not be called on object or string dtype columns it currently is so this needs to work robustly for the time being. Therefore this PR uses the python2sort utility to do the sorting robustly in python3.