### PR TITLE
Fallback for unknown dask categories

### DIFF
--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -145,7 +145,10 @@ class DaskInterface(PandasInterface):
         if len(group_by) == 1:
             column = columns.data[group_by[0]]
             if column.dtype.name == 'category':
-                indices = ((ind,) for ind in column.cat.categories)
+                try:
+                    indices = ((ind,) for ind in column.cat.categories)
+                except NotImplementedError:
+                    indices = ((ind,) for ind in column.unique().compute())
             else:
                 indices = ((ind,) for ind in column.unique().compute())
         else:


### PR DESCRIPTION
When the categories on a categorical column aren't known it throws an NotImplementedError, in this case this falls back to getting the categories the usual way.