### PR TITLE
speedup TriMesh.edgepaths by a factor 20

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -495,10 +495,12 @@ class TriMesh(Graph):
 
         simplices = self.array([0, 1, 2]).astype(np.int32)
         pts = self.nodes.array([0, 1]).astype(float)
-        empty = np.array([[np.NaN, np.NaN]])
-        paths = [arr for tri in pts[simplices] for arr in
-                 (tri[[0, 1, 2, 0], :], empty)][:-1]
-        edgepaths = self.edge_type([np.concatenate(paths)],
+        pts = pts[simplices]
+        paths = np.pad(pts[:, [0, 1, 2, 0], :],
+                       pad_width=((0, 0), (0, 1), (0, 0)),
+                       mode='constant',
+                       constant_values=np.nan).reshape(-1, 2)[:-1]
+        edgepaths = self.edge_type([paths],
                                     kdims=self.nodes.kdims[:2])
         self._edgepaths = edgepaths
         return edgepaths


### PR DESCRIPTION
Based on what I did for https://github.com/python-adaptive/adaptive/commit/9f481562b0118199d4011667e857ed8eb764a2a5 I made these changes here too.

The numbers say everything :)
```python
# with this PR
%timeit trimesh.edgepaths 
4.7 ms ± 271 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# @ master
%timeit trimesh.edgepaths
86.6 ms ± 5.65 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```