### PR TITLE
Support for JupyterLab

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -11,7 +11,7 @@ from ..core.tree import AttrTree
 from ..core.options import Store
 from ..element.comparison import ComparisonTestCase
 from ..util import extension
-from ..plotting.renderer import Renderer
+from ..plotting.renderer import Renderer, MIME_TYPES
 from .magics import load_magics
 from .display_hooks import display  # noqa (API import)
 from .display_hooks import set_display_hooks
@@ -101,10 +101,6 @@ class notebook_extension(extension):
        behavior. """)
 
     _loaded = False
-
-    JS_MIME_TYPE = 'application/javascript'
-
-    JL_MIME_TYPE = 'application/vnd.bokehjs_load.v0+json'
 
     def __call__(self, *args, **params):
         super(notebook_extension, self).__call__(*args, **params)
@@ -243,8 +239,8 @@ class notebook_extension(extension):
         publish_display_data(data={'text/html': html})
         if JS:
             publish_display_data(data={
-                cls.JS_MIME_TYPE   : widgetjs,
-                cls.JL_MIME_TYPE   : widgetjs
+                MIME_TYPES['js']   : widgetjs,
+                MIME_TYPES['load'] : widgetjs
             })
 
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -8,6 +8,7 @@ import sys, traceback
 
 import IPython
 from IPython import get_ipython
+from IPython.display import publish_display_data
 
 import holoviews
 from holoviews.plotting import Plot
@@ -59,7 +60,12 @@ def render(obj, **kwargs):
     # Drop back to png if pdf selected, notebook PDF rendering is buggy
     if renderer.fig == 'pdf':
         renderer = renderer.instance(fig='png')
-    return renderer.html(obj, **kwargs)
+
+    data, metadata = renderer.components(obj, **kwargs)
+    html = data.pop('text/html')
+    publish_display_data({'text/html': html})
+    if data or metadata:
+        publish_display_data(data, metadata=metadata)
 
 
 def single_frame_plot(obj):
@@ -175,7 +181,12 @@ def element_display(element, max_frames):
     renderer = Store.renderers[backend]
     if renderer.fig == 'pdf':
         renderer = renderer.instance(fig='png')
-    return renderer.html(element, fmt=renderer.fig)
+
+    data, metadata = renderer.components(element)
+    html = data.pop('text/html')
+    publish_display_data({'text/html': html})
+    if data or metadata:
+        publish_display_data(data, metadata=metadata)
 
 
 @display_hook

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -66,6 +66,7 @@ def render(obj, **kwargs):
     publish_display_data({'text/html': html})
     if data or metadata:
         publish_display_data(data, metadata=metadata)
+    return ''
 
 
 def single_frame_plot(obj):
@@ -187,6 +188,7 @@ def element_display(element, max_frames):
     publish_display_data({'text/html': html})
     if data or metadata:
         publish_display_data(data, metadata=metadata)
+    return ''
 
 
 @display_hook

--- a/holoviews/ipython/load_notebook.html
+++ b/holoviews/ipython/load_notebook.html
@@ -1,5 +1,3 @@
-{{ widgetjs }}
-
 {{ widgetcss }}
 
 {% if logo %}

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -36,3 +36,6 @@ var BokehMethods = {
 // Extend Bokeh widgets with backend specific methods
 extend(BokehSelectionWidget.prototype, BokehMethods);
 extend(BokehScrubberWidget.prototype, BokehMethods);
+
+window.HoloViews.BokehSelectionWidget = BokehSelectionWidget
+window.HoloViews.BokehScrubberWidget = BokehScrubberWidget

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -182,7 +182,7 @@ class CustomJSCallback(MessageCallback):
             var events = unique_events(comm_state.event_buffer);
             for (var i=0; i<events.length; i++) {{
                 var data = events[i];
-                var comm = HoloViewsWidget.comms[data["comm_id"]];
+                var comm = HoloViews.comms[data["comm_id"]];
                 comm.send(data);
             }}
             comm_state.event_buffer = [];
@@ -193,7 +193,7 @@ class CustomJSCallback(MessageCallback):
           // and unblocking Comm if event queue empty
           msg = JSON.parse(msg.content.data);
           var comm_id = msg["comm_id"]
-          var comm_state = HoloViewsWidget.comm_state[comm_id];
+          var comm_state = HoloViews.comm_state[comm_id];
           if (comm_state.event_buffer.length) {{
             process_events(comm_state);
             comm_state.blocked = true;
@@ -212,22 +212,22 @@ class CustomJSCallback(MessageCallback):
         // Initialize Comm
         if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {{
           var comm_manager = Jupyter.notebook.kernel.comm_manager;
-          var comm = HoloViewsWidget.comms["{comm_id}"];
+          var comm = HoloViews.comms["{comm_id}"];
           if (comm == null) {{
             comm = comm_manager.new_comm("{comm_id}", {{}}, {{}}, {{}});
             comm.on_msg(on_msg);
             comm_manager["{comm_id}"] = comm;
-            HoloViewsWidget.comms["{comm_id}"] = comm;
+            HoloViews.comms["{comm_id}"] = comm;
           }}
         }} else {{
           return
         }}
 
         // Initialize event queue and timeouts for Comm
-        var comm_state = HoloViewsWidget.comm_state["{comm_id}"];
+        var comm_state = HoloViews.comm_state["{comm_id}"];
         if (comm_state === undefined) {{
             comm_state = {{event_buffer: [], blocked: false, time: Date.now()}}
-            HoloViewsWidget.comm_state["{comm_id}"] = comm_state
+            HoloViews.comm_state["{comm_id}"] = comm_state
         }}
 
         // Add current event to queue and process queue if not blocked

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -248,10 +248,11 @@ class BokehRenderer(Renderer):
         return html
 
     def components(self, obj, fmt=None, css=None, comm=True, **kwargs):
-        if isinstance(obj, Plot):
+        if isinstance(obj, (Plot, NdWidget)):
             plot = obj
         else:
             plot, fmt =  self._validate(obj, fmt)
+
         if isinstance(plot, NdWidget):
             js, html = plot()
             root = plot.plot.state._id

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -31,10 +31,6 @@ NOTEBOOK_DIV = """
 </script>
 """
 
-JS_MIME_TYPE = 'application/javascript'
-
-EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json'
-
 
 class BokehRenderer(Renderer):
 
@@ -263,8 +259,8 @@ class BokehRenderer(Renderer):
             js, html = self._figure_data(plot, fmt='html', as_script=True, **kwargs)
             html = "<div style='display: table; margin: 0 auto;'>%s</div>" % html
             root = plot.state._id
-        return ({'text/html': html, JS_MIME_TYPE: js, EXEC_MIME_TYPE: ""},
-                {EXEC_MIME_TYPE: {"id": root}})
+        return ({'text/html': html, MIME_TYPES['js']: js, MIME_TYPES['exec']: ""},
+                {MIME_TYPES['exec']: {"id": root}})
 
 
     def diff(self, plot, binary=True):

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -247,7 +247,8 @@ class BokehWidget(NdWidget):
         # Get initial frame to draw immediately
         msg, metadata = self.renderer.components(self.plot)
         data = super(BokehWidget, self)._get_data()
-        return dict(data, init_html=msg['text/html'], init_js=msg['application/javascript'])
+        return dict(data, init_html=msg['text/html'],
+                    init_js=msg['application/javascript'])
 
     def encode_frames(self, frames):
         if self.export_json:

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -245,9 +245,9 @@ class BokehWidget(NdWidget):
 
     def _get_data(self):
         # Get initial frame to draw immediately
-        init_frame = self._plot_figure(0, fig_format='html')
+        msg, metadata = self.renderer.components(self.plot)
         data = super(BokehWidget, self)._get_data()
-        return dict(data, init_frame=init_frame)
+        return dict(data, init_html=msg['text/html'], init_js=msg['application/javascript'])
 
     def encode_frames(self, frames):
         if self.export_json:
@@ -273,13 +273,10 @@ class BokehWidget(NdWidget):
         first call and
         """
         self.plot.update(idx)
-        if self.embed or fig_format == 'html':
-            if fig_format == 'html':
-                msg = self.renderer.html(self.plot, fig_format)
-            else:
-                patch = self.renderer.diff(self.plot, binary=False)
-                msg = serialize_json(dict(content=patch.content,
-                                          root=self.plot.state._id))
+        if self.embed:
+            patch = self.renderer.diff(self.plot, binary=False)
+            msg = serialize_json(dict(content=patch.content,
+                                      root=self.plot.state._id))
             return msg
 
 

--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -43,3 +43,6 @@ var MPLMethods = {
 // Extend MPL widgets with backend specific methods
 extend(MPLSelectionWidget.prototype, MPLMethods);
 extend(MPLScrubberWidget.prototype, MPLMethods);
+
+window.HoloViews.MPLSelectionWidget = MPLSelectionWidget
+window.HoloViews.MPLScrubberWidget = MPLScrubberWidget

--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -22,10 +22,6 @@ from .util import get_tight_bbox
 class OutputWarning(param.Parameterized):pass
 outputwarning = OutputWarning(name='Warning')
 
-JS_MIME_TYPE = 'application/javascript'
-
-EXEC_MIME_TYPE = 'application/vnd.bokehjs_exec.v0+json'
-
 
 class MPLRenderer(Renderer):
     """
@@ -236,7 +232,7 @@ class MPLRenderer(Renderer):
             plot, fmt =  self._validate(obj, fmt)
         if isinstance(plot, NdWidget):
             js, html = plot()
-            jsdata = {JS_MIME_TYPE: js, 'application/vnd.bokehjs_load.v0+json': js}
+            jsdata = {MIME_TYPES['js']: js, MIME_TYPES['load']: js}
         else:
             html = self.html(plot)
             jsdata = {}

--- a/holoviews/plotting/mpl/widgets.py
+++ b/holoviews/plotting/mpl/widgets.py
@@ -6,8 +6,6 @@ from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 
 class MPLWidget(NdWidget):
 
-    CDN = param.Dict(default=dict(NdWidget.CDN))
-
     extensionjs = param.String(default='mplwidgets.js', doc="""
         Optional javascript extension file for a particular backend.""")
 

--- a/holoviews/plotting/plotly/plotlywidgets.js
+++ b/holoviews/plotting/plotly/plotlywidgets.js
@@ -40,3 +40,6 @@ var PlotlyMethods = {
 // Extend Plotly widgets with backend specific methods
 extend(PlotlySelectionWidget.prototype, PlotlyMethods);
 extend(PlotlyScrubberWidget.prototype, PlotlyMethods);
+
+window.HoloViews.PlotlySelectionWidget = PlotlySelectionWidget;
+window.HoloViews.PlotlyScrubberWidget = PlotlyScrubberWidget;

--- a/holoviews/plotting/plotly/widgets.py
+++ b/holoviews/plotting/plotly/widgets.py
@@ -10,9 +10,10 @@ class PlotlyWidget(NdWidget):
 
     def _get_data(self):
         # Get initial frame to draw immediately
-        init_frame = self._plot_figure(0, fig_format='html')
+        msg, metadata = self.renderer.components(self.plot, divuuid=self.id, comm=False)
         data = super(PlotlyWidget, self)._get_data()
-        return dict(data, init_frame=init_frame)
+        return dict(data, init_html=msg['text/html'],
+                    init_js=msg['application/javascript'])
 
     def encode_frames(self, frames):
         frames = json.dumps(frames).replace('</', r'<\/')
@@ -24,13 +25,8 @@ class PlotlyWidget(NdWidget):
         first call and
         """
         self.plot.update(idx)
-        if self.embed or fig_format == 'html':
-            if fig_format == 'html':
-                msg = self.renderer.figure_data(self.plot,
-                                                divuuid=self.id, comm=False)
-            else:
-                msg = self.renderer.diff(self.plot)
-            return msg
+        if self.embed:
+            return self.renderer.diff(self.plot)
 
 
 class PlotlySelectionWidget(PlotlyWidget, SelectionWidget):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -288,6 +288,7 @@ class Renderer(Exporter):
             return html
 
 
+
     def static_html(self, obj, fmt=None, template=None):
         """
         Generates a static HTML with the rendered object in the
@@ -386,7 +387,7 @@ class Renderer(Exporter):
 
 
     @classmethod
-    def html_assets(cls, core=True, extras=True, backends=None):
+    def html_assets(cls, core=True, extras=True, backends=None, script=False):
         """
         Returns JS and CSS and for embedding of widgets.
         """
@@ -426,8 +427,11 @@ class Renderer(Exporter):
             js_data = dep.get('js', [])
             if isinstance(js_data, tuple):
                 for js in js_data:
-                    js_html += '\n<script type="text/javascript">%s</script>' % js
-            else:
+                    if script:
+                        js_html += js
+                    else:
+                        js_html += '\n<script type="text/javascript">%s</script>' % js
+            elif not script:
                 for js in js_data:
                     js_html += '\n<script src="%s" type="text/javascript"></script>' % js
             css_data = dep.get('css', [])
@@ -438,7 +442,10 @@ class Renderer(Exporter):
                 for css in css_data:
                     css_html += '\n<link rel="stylesheet" href="%s">' % css
 
-        js_html += '\n<script type="text/javascript">%s</script>' % widgetjs
+        if script:
+            js_html += widgetjs
+        else:
+            js_html += '\n<script type="text/javascript">%s</script>' % widgetjs
         css_html += '\n<style>%s</style>' % widgetcss
 
         return unicode(js_html), unicode(css_html)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -49,8 +49,11 @@ MIME_TYPES = {
     'webm': 'video/webm',
     'mp4':  'video/mp4',
     'pdf':  'application/pdf',
-    'html':  'text/html',
-    'json':  'text/json',
+    'html': 'text/html',
+    'json': 'text/json',
+    'js':   'application/javascript',
+    'exec': 'application/vnd.bokehjs_exec.v0+json',
+    'load': 'application/vnd.bokehjs_load.v0+json',
     'server': None
 }
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -52,8 +52,8 @@ MIME_TYPES = {
     'html': 'text/html',
     'json': 'text/json',
     'js':   'application/javascript',
-    'exec': 'application/vnd.bokehjs_exec.v0+json',
-    'load': 'application/vnd.bokehjs_load.v0+json',
+    'exec': 'application/vnd.holoviews_exec.v0+json',
+    'load': 'application/vnd.holoviews_load.v0+json',
     'server': None
 }
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -89,9 +89,6 @@ class NdWidget(param.Parameterized):
     # Javascript include options #
     ##############################
 
-    CDN = param.Dict(default={'underscore': 'https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js',
-                              'jQueryUI':   'https://code.jquery.com/ui/1.10.4/jquery-ui.min.js'})
-
     css = param.String(default=None, doc="""
         Defines the local CSS file to be loaded for this widget.""")
 
@@ -142,7 +139,13 @@ class NdWidget(param.Parameterized):
 
     def _get_data(self):
         delay = int(1000./self.display_options.get('fps', 5))
-        CDN = {k: v[:-3] for k, v in self.CDN.items()}
+        CDN = {}
+        for name, resources in self.plot.renderer.core_dependencies.items():
+            if 'js' in resources:
+                CDN[name] = resources['js'][0][6:]
+        for name, resources in self.plot.renderer.extra_dependencies.items():
+            if 'js' in resources:
+                CDN[name] = resources['js'][0][6:]
         name = type(self).__name__
         cached = str(self.embed).lower()
         load_json = str(self.export_json).lower()

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -134,15 +134,15 @@ class NdWidget(param.Parameterized):
         templateLoader = jinja2.FileSystemLoader(subdirs)
         self.jinjaEnv = jinja2.Environment(loader=templateLoader)
 
-
     def __call__(self):
-        return self.render_html(self._get_data())
-
+        data = self._get_data()
+        html = self.render_html(data)
+        js = self.render_js(data)
+        return js, html
 
     def _get_data(self):
         delay = int(1000./self.display_options.get('fps', 5))
         CDN = {k: v[:-3] for k, v in self.CDN.items()}
-        template = self.jinjaEnv.get_template(self.base_template)
         name = type(self).__name__
         cached = str(self.embed).lower()
         load_json = str(self.export_json).lower()
@@ -155,11 +155,16 @@ class NdWidget(param.Parameterized):
         return dict(CDN=CDN, frames=self.get_frames(), delay=delay,
                     cached=cached, load_json=load_json, mode=mode, id=self.id,
                     Nframes=len(self.plot), widget_name=name, json_path=json_path,
-                    widget_template=template, dynamic=dynamic)
+                    dynamic=dynamic)
 
 
     def render_html(self, data):
-        template = self.jinjaEnv.get_template(self.template)
+        template = self.jinjaEnv.get_template(self.html_template)
+        return template.render(**data)
+
+
+    def render_js(self, data):
+        template = self.jinjaEnv.get_template(self.js_template)
         return template.render(**data)
 
 
@@ -177,6 +182,7 @@ class NdWidget(param.Parameterized):
             frames = dict(frames)
         return json.dumps(frames)
 
+
     def save_json(self, frames):
         """
         Saves frames data into a json file at the
@@ -189,6 +195,7 @@ class NdWidget(param.Parameterized):
         with open(path, 'w') as f:
             json.dump(frames, f)
         self.json_data = frames
+
 
     def _plot_figure(self, idx):
         with self.renderer.state():
@@ -222,10 +229,10 @@ class ScrubberWidget(NdWidget):
     on a simple server.
     """
 
-    base_template = param.String('jsscrubber.jinja', doc="""
+    html_template = param.String('htmlscrubber.jinja', doc="""
         The jinja2 template used to generate the html output.""")
 
-    template = param.String('jsscrubber.jinja', doc="""
+    js_template = param.String('jsscrubber.jinja', doc="""
         The jinja2 template used to generate the html output.""")
 
 
@@ -248,13 +255,13 @@ class SelectionWidget(NdWidget):
     to json and dynamically loaded from a server.
     """
 
-    base_template = param.String('jsslider.jinja', doc="""
-        The jinja2 template used to generate the html output.""")
-
     css = param.String(default='jsslider.css', doc="""
         Defines the local CSS file to be loaded for this widget.""")
 
-    template = param.String('jsslider.jinja', doc="""
+    html_template = param.String('htmlslider.jinja', doc="""
+        The jinja2 template used to generate the html output.""")
+
+    js_template = param.String('jsslider.jinja', doc="""
         The jinja2 template used to generate the html output.""")
 
     ##############################
@@ -344,7 +351,7 @@ class SelectionWidget(NdWidget):
             escaped_dim = dimension_sanitizer(dim_str)
             widget_data = dict(dim=escaped_dim, dim_label=dim_str,
                                dim_idx=idx, vals=dim_vals, type=widget_type,
-                               visibility=visibility, step=step, next_dim=next_dim,
+                               visibility=visibility, step=step, next_dim=next_dim or None,
                                next_vals=next_vals, labels=value_labels)
 
             widgets.append(widget_data)

--- a/holoviews/plotting/widgets/htmlscrubber.jinja
+++ b/holoviews/plotting/widgets/htmlscrubber.jinja
@@ -1,0 +1,24 @@
+<div class="animation" align="center">
+    <div id="_anim_img{{ id }}">
+        {% block init_frame %}
+            {{ init_frame }}
+        {% endblock %}
+    </div>
+    <br>
+    <input id="_anim_slider{{ id }}" type="range" style="width:350px" name="points" min="0" max="1" step="1" value="0" oninput="anim{{ id }}.set_frame(parseInt(this.value));"></input>
+    <br>
+    <button onclick="anim{{ id }}.slower()" style="text-align: center">&#8211;</button>
+    <button onclick="anim{{ id }}.first_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;&#9664;</button>
+    <button onclick="anim{{ id }}.previous_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;</button>
+    <button onclick="anim{{ id }}.reverse_animation()" style="text-align: center; min-width: 40px">&#9664;</button>
+    <button onclick="anim{{ id }}.pause_animation()" style="text-align: center; min-width: 40px">&#9616;&nbsp;&#9612;</button>
+    <button onclick="anim{{ id }}.play_animation()" style="text-align: center; min-width: 40px">&#9654;</button>
+    <button onclick="anim{{ id }}.next_frame()" style="text-align: center; min-width: 40px">&#9654;&#9612;</button>
+    <button onclick="anim{{ id }}.last_frame()" style="text-align: center; min-width: 40px">&#9654;&#9654;&#9612;</button>
+    <button onclick="anim{{ id }}.faster()" style="text-align: center">+</button>
+    <form action="#n" name="_anim_loop_select{{ id }}" class="anim_control">
+        <input type="radio" name="state" value="once" {once_checked}> Once </input>
+        <input type="radio" name="state" value="loop" {loop_checked}> Loop </input>
+        <input type="radio" name="state" value="reflect" {reflect_checked}> Reflect </input>
+    </form>
+</div>

--- a/holoviews/plotting/widgets/htmlscrubber.jinja
+++ b/holoviews/plotting/widgets/htmlscrubber.jinja
@@ -1,21 +1,21 @@
 <div class="animation" align="center">
     <div id="_anim_img{{ id }}">
         {% block init_frame %}
-            {{ init_frame }}
+            {{ init_html }}
         {% endblock %}
     </div>
     <br>
-    <input id="_anim_slider{{ id }}" type="range" style="width:350px" name="points" min="0" max="1" step="1" value="0" oninput="anim{{ id }}.set_frame(parseInt(this.value));"></input>
+    <input id="_anim_slider{{ id }}" type="range" style="width:350px" name="points" min="0" max="1" step="1" value="0" oninput="HoloViews.index['{{ id }}'].set_frame(parseInt(this.value));"></input>
     <br>
-    <button onclick="anim{{ id }}.slower()" style="text-align: center">&#8211;</button>
-    <button onclick="anim{{ id }}.first_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;&#9664;</button>
-    <button onclick="anim{{ id }}.previous_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;</button>
-    <button onclick="anim{{ id }}.reverse_animation()" style="text-align: center; min-width: 40px">&#9664;</button>
-    <button onclick="anim{{ id }}.pause_animation()" style="text-align: center; min-width: 40px">&#9616;&nbsp;&#9612;</button>
-    <button onclick="anim{{ id }}.play_animation()" style="text-align: center; min-width: 40px">&#9654;</button>
-    <button onclick="anim{{ id }}.next_frame()" style="text-align: center; min-width: 40px">&#9654;&#9612;</button>
-    <button onclick="anim{{ id }}.last_frame()" style="text-align: center; min-width: 40px">&#9654;&#9654;&#9612;</button>
-    <button onclick="anim{{ id }}.faster()" style="text-align: center">+</button>
+    <button onclick="HoloViews.index['{{ id }}'].slower()" style="text-align: center">&#8211;</button>
+    <button onclick="HoloViews.index['{{ id }}'].first_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;&#9664;</button>
+    <button onclick="HoloViews.index['{{ id }}'].previous_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;</button>
+    <button onclick="HoloViews.index['{{ id }}'].reverse_animation()" style="text-align: center; min-width: 40px">&#9664;</button>
+    <button onclick="HoloViews.index['{{ id }}'].pause_animation()" style="text-align: center; min-width: 40px">&#9616;&nbsp;&#9612;</button>
+    <button onclick="HoloViews.index['{{ id }}'].play_animation()" style="text-align: center; min-width: 40px">&#9654;</button>
+    <button onclick="HoloViews.index['{{ id }}'].next_frame()" style="text-align: center; min-width: 40px">&#9654;&#9612;</button>
+    <button onclick="HoloViews.index['{{ id }}'].last_frame()" style="text-align: center; min-width: 40px">&#9654;&#9654;&#9612;</button>
+    <button onclick="HoloViews.index['{{ id }}'].faster()" style="text-align: center">+</button>
     <form action="#n" name="_anim_loop_select{{ id }}" class="anim_control">
         <input type="radio" name="state" value="once" {once_checked}> Once </input>
         <input type="radio" name="state" value="loop" {loop_checked}> Loop </input>

--- a/holoviews/plotting/widgets/htmlslider.jinja
+++ b/holoviews/plotting/widgets/htmlslider.jinja
@@ -1,0 +1,36 @@
+<div class="hololayout row row-fluid">
+  <div class="holoframe" id="display_area{{ id }}">
+    <div id="_anim_img{{ id }}">
+      {% block init_frame %}
+      {{ init_html }}
+      {% endblock %}
+    </div>
+  </div>
+  <div class="holowidgets" id="widget_area{{ id }}">
+    <form class="holoform well" id="form{{ id }}">
+      {% for widget_data in widgets %}
+      {% if widget_data['type'] == 'slider' %}
+      <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
+        <label for="textInput{{ id }}_{{ widget_data['dim'] }}">
+          <strong>{{ widget_data['dim_label'] }}:</strong>
+        </label>
+        <div class="holowell row row-fluid">
+          <div class="hologroup">
+            <input type="text" class="holotext form-control input-small"
+                   id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" readonly>
+          </div>
+          <div class="holoslider"
+               id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>
+        </div>
+      </div>
+      {% elif widget_data['type']=='dropdown' %}
+        <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
+          <label for="textInput{{ id }}_{{ widget_data['dim'] }}"><strong>{{ widget_data['dim_label'] }}:</strong></label>
+          <select class="holoselect form-control" id="_anim_widget{{ id }}_{{ widget_data['dim'] }}" >
+          </select>
+        </div>
+        {% endif %}
+        {% endfor %}
+        </form>
+    </div>
+</div>

--- a/holoviews/plotting/widgets/jsscrubber.jinja
+++ b/holoviews/plotting/widgets/jsscrubber.jinja
@@ -1,43 +1,15 @@
-<div class="animation" align="center">
-    <div id="_anim_img{{ id }}">
-        {% block init_frame %}
-            {{ init_frame }}
-        {% endblock %}
-    </div>
-    <br>
-    <input id="_anim_slider{{ id }}" type="range" style="width:350px" name="points" min="0" max="1" step="1" value="0" oninput="anim{{ id }}.set_frame(parseInt(this.value));"></input>
-    <br>
-    <button onclick="anim{{ id }}.slower()" style="text-align: center">&#8211;</button>
-    <button onclick="anim{{ id }}.first_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;&#9664;</button>
-    <button onclick="anim{{ id }}.previous_frame()" style="text-align: center; min-width: 40px">&#9616;&#9664;</button>
-    <button onclick="anim{{ id }}.reverse_animation()" style="text-align: center; min-width: 40px">&#9664;</button>
-    <button onclick="anim{{ id }}.pause_animation()" style="text-align: center; min-width: 40px">&#9616;&nbsp;&#9612;</button>
-    <button onclick="anim{{ id }}.play_animation()" style="text-align: center; min-width: 40px">&#9654;</button>
-    <button onclick="anim{{ id }}.next_frame()" style="text-align: center; min-width: 40px">&#9654;&#9612;</button>
-    <button onclick="anim{{ id }}.last_frame()" style="text-align: center; min-width: 40px">&#9654;&#9654;&#9612;</button>
-    <button onclick="anim{{ id }}.faster()" style="text-align: center">+</button>
-    <form action="#n" name="_anim_loop_select{{ id }}" class="anim_control">
-        <input type="radio" name="state" value="once" {once_checked}> Once </input>
-        <input type="radio" name="state" value="loop" {loop_checked}> Loop </input>
-        <input type="radio" name="state" value="reflect" {reflect_checked}> Reflect </input>
-    </form>
-</div>
+/* Instantiate the {{ widget_name }} class. */
+/* The IDs given should match those used in the template above. */
+(function() {
+    var frame_data = {{ frames | safe }};
 
-
-<script language="javascript">
-    /* Instantiate the {{ widget_name }} class. */
-    /* The IDs given should match those used in the template above. */
-    (function() {
-        var frame_data = {{ frames | safe }};
-
-        function create_widget() {
-            setTimeout(function() {
-                anim{{ id }} = new {{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
-            }, 0);
-        }
-
-        {% block create_widget %}
-            create_widget();
-        {% endblock %}
-    })()
-</script>
+    function create_widget() {
+        setTimeout(function() {
+            anim = new HoloViews.{{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
+            window.HoloViews.index[id] = anim;
+        }, 0);
+    }
+    {% block create_widget %}
+    create_widget();
+    {% endblock %}
+})()

--- a/holoviews/plotting/widgets/jsscrubber.jinja
+++ b/holoviews/plotting/widgets/jsscrubber.jinja
@@ -6,10 +6,12 @@
     function create_widget() {
         setTimeout(function() {
             anim = new HoloViews.{{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
-            window.HoloViews.index[id] = anim;
+            HoloViews.index['{{ id }}'] = anim;
         }, 0);
     }
     {% block create_widget %}
     create_widget();
+
+	{{ init_js }}
     {% endblock %}
 })()

--- a/holoviews/plotting/widgets/jsscrubber.jinja
+++ b/holoviews/plotting/widgets/jsscrubber.jinja
@@ -5,7 +5,7 @@ function create_scrubber() {
 
     function create_widget() {
         setTimeout(function() {
-            anim = new HoloViews.{{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
+            var anim = new HoloViews.{{ widget_name }}(frame_data, {{ Nframes }}, "{{ id }}", {{ delay }}, {{ load_json }}, "{{ mode }}", {{ cached }}, "{{ json_path }}", {{ dynamic }});
             HoloViews.index['{{ id }}'] = anim;
         }, 0);
     }

--- a/holoviews/plotting/widgets/jsscrubber.jinja
+++ b/holoviews/plotting/widgets/jsscrubber.jinja
@@ -1,6 +1,6 @@
 /* Instantiate the {{ widget_name }} class. */
 /* The IDs given should match those used in the template above. */
-(function() {
+function create_scrubber() {
     var frame_data = {{ frames | safe }};
 
     function create_widget() {
@@ -14,4 +14,20 @@
 
 	{{ init_js }}
     {% endblock %}
-})()
+};
+if (!window.$) {
+  var script = document.createElement('script');
+  document.head.appendChild(script);
+  script.type = 'text/javascript';
+  script.src = '{{ CDN['jQuery'] }}';
+  script.onload = function() {
+  var script2 = document.createElement('script');
+  document.head.appendChild(script2);
+  script2.type = 'text/javascript';
+  script2.src = '{{ CDN['require'] }}';
+  script2.onload = create_scrubber;
+  };
+} else {
+  create_scrubber()
+}
+

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -11,7 +11,7 @@ function create_jsslider() {
   var notFound = "{{ notFound }}";
   function create_widget() {
     setTimeout(function() {
-      anim = new HoloViews.{{ widget_name }}(frame_data, "{{ id }}", widget_ids,
+      var anim = new HoloViews.{{ widget_name }}(frame_data, "{{ id }}", widget_ids,
     keyMap, dim_vals, notFound, {{ load_json }}, "{{ mode }}",
     {{ cached }}, "{{ json_path}}", {{ dynamic }});
 	  HoloViews.index['{{ id }}'] = anim;

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -34,12 +34,12 @@ if (!window.$) {
   var script = document.createElement('script'); 
   document.head.appendChild(script);    
   script.type = 'text/javascript';
-  script.src = "//ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js";
+  script.src = '{{ CDN['jQuery'] }}';
   script.onload = function() {
   var script2 = document.createElement('script'); 
   document.head.appendChild(script2);
   script2.type = 'text/javascript';
-  script2.src = "//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js";
+  script2.src = '{{ CDN['require'] }}';
   script2.onload = create_jsslider;
   };
 } else {

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -1,252 +1,47 @@
-<div class="hololayout row row-fluid">
-  <div class="holoframe" id="display_area{{ id }}">
-    <div id="_anim_img{{ id }}">
-      {% block init_frame %}
-      {{ init_frame }}
-      {% endblock %}
-    </div>
-  </div>
-  <div class="holowidgets" id="widget_area{{ id }}">
-    <form class="holoform well" id="form{{ id }}">
-      {% for widget_data in widgets %}
-      {% if widget_data['type'] == 'slider' %}
-      <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
-        <label for="textInput{{ id }}_{{ widget_data['dim'] }}">
-          <strong>{{ widget_data['dim_label'] }}:</strong>
-        </label>
-        <div class="holowell row row-fluid">
-          <div class="hologroup">
-            <input type="text" class="holotext form-control input-small"
-                   id="textInput{{ id }}_{{ widget_data['dim'] }}" value="" readonly>
-          </div>
-          <div class="holoslider"
-               id="_anim_widget{{ id }}_{{ widget_data['dim'] }}"></div>
-        </div>
-      </div>
-	  <script>
-	    function init_slider() {
-        // Slider JS Block START
-        function loadcssfile(filename){
-            var fileref=document.createElement("link")
-            fileref.setAttribute("rel", "stylesheet")
-            fileref.setAttribute("type", "text/css")
-            fileref.setAttribute("href", filename)
-            document.getElementsByTagName("head")[0].appendChild(fileref)
-        }
-        loadcssfile("https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css");
-        /* Check if jQuery and jQueryUI have been loaded
-           otherwise load with require.js */
-        var jQuery = window.jQuery,
-            // check for old versions of jQuery
-            oldjQuery = jQuery && !!jQuery.fn.jquery.match(/^1\.[0-4](\.|$)/),
-            jquery_path = '',
-            paths = {},
-            noConflict;
-        var jQueryUI = jQuery.ui;
-        // check for jQuery
-        if (!jQuery || oldjQuery) {
-            // load if it's not available or doesn't meet min standards
-            paths.jQuery = jQuery;
-            noConflict = !!oldjQuery;
-        } else {
-            // register the current jQuery
-            define('jquery', [], function() { return jQuery; });
-        }
-        if (!jQueryUI) {
-            paths.jQueryUI = "{{ CDN['jQueryUI'] }}"
-        } else {
-            define('jQueryUI', [], function() { return jQuery.ui; });
-        }
-        paths.underscore = "{{ CDN['underscore'] }}";
-        var jquery_require = {
-            paths: paths,
-            shim: {
-                "jQueryUI": {
-                    exports:"$",
-                    deps: ['jquery']
-                },
-                "underscore": {
-                    exports: '_'
-                }
-            }
-        }
-        require.config(jquery_require);
-        require(["jQueryUI", "underscore"], function(jUI, _){
-            if (noConflict) $.noConflict(true);
-            var vals = {{ widget_data['vals'] }};
-            var next_vals = {{ widget_data['next_vals'] }};
-            if ({{ dynamic }} && vals.constructor === Array) {
-                var min = parseFloat(vals[0]);
-                var max = parseFloat(vals[vals.length-1]);
-                var step = {{ widget_data['step'] }};
-                var labels = [min];
-            } else {
-                var min = 0;
-                if ({{ dynamic }}) {
-                    var max = Object.keys(vals).length - 1;
-                } else {
-                    var max = vals.length - 1;
-                }
-                var step = 1;
-				var labels = {{ widget_data['labels'] }};
-            }
-			function adjustFontSize(text) {
-				var width_ratio = (text.parent().width()/8)/text.val().length;
-				var size = Math.min(0.9, Math.max(0.6, width_ratio))+'em';
-				text.css('font-size', size);
-			}
-            var slider = $('#_anim_widget{{ id }}_{{ widget_data['dim'] }}');
-			slider.slider({
-                animate: "fast",
-                min: min,
-                max: max,
-                step: step,
-                value: min,
-                dim_vals: vals,
-                dim_labels: labels,
-                next_vals: next_vals,
-                slide: function(event, ui) {
-                    var vals = slider.slider("option", "dim_vals");
-                    var next_vals = slider.slider("option", "next_vals");
-                    var labels = slider.slider("option", "dim_labels");
-                    if ({{ dynamic }}) {
-					    var dim_val = ui.value;
-					    if (vals.constructor === Array) {
-						   var label = ui.value;
-						} else {
-						   var label = labels[ui.value];
-						}
-                    } else {
-                        var dim_val = vals[ui.value];
-						var label = labels[ui.value];
-                    }
-					var text = $('#textInput{{ id }}_{{ widget_data['dim'] }}');
-					text.val(label);
-					adjustFontSize(text);
-                    anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
-                    if (Object.keys(next_vals).length > 0) {
-                        var new_vals = next_vals[dim_val];
-                        var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
-                        update_widget(next_widget, new_vals);
-                    }
-                }
-            });
-            slider.keypress(function(event) {
-                if (event.which == 80 || event.which == 112) {
-                    var start = slider.slider("option", "value");
-                    var stop =  slider.slider("option", "max");
-                    for (var i=start; i<=stop; i++) {
-                        var delay = i*{{ delay }};
-                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
-                            var val = {value:i};
-                            slider.slider('value',i);
-                            slider.slider("option", "slide")(null, val);
-                        }, slider), delay);}, slider)(i);
-                    }
-                }
-                if (event.which == 82 || event.which == 114) {
-                    var start = slider.slider("option", "value");
-                    var stop =  slider.slider("option", "min");
-                    var count = 0;
-                    for (var i=start; i>=stop; i--) {
-                        var delay = count*{{ delay }};
-                        count = count + 1;
-                        $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
-                            var val = {value:i};
-                            slider.slider('value',i);
-                            slider.slider("option", "slide")(null, val);
-                        }, slider), delay);}, slider)(i);
-                    }
-                }
-            });
-			var textInput = $('#textInput{{ id }}_{{ widget_data['dim'] }}')
-			textInput.val(labels[0]);
-			adjustFontSize(textInput);
-        });
-		}
-        $(document).ready(init_slider)
-        // Slider JS Block END
-        </script>
-        {% elif widget_data['type']=='dropdown' %}
-        <div class="form-group control-group holoformgroup" style='{{ widget_data['visibility'] }}'>
-          <label for="textInput{{ id }}_{{ widget_data['dim'] }}"><strong>{{ widget_data['dim_label'] }}:</strong></label>
-          <select class="holoselect form-control" id="_anim_widget{{ id }}_{{ widget_data['dim'] }}" >
-          </select>
-        </div>
-        <script>
-        function init_dropdown() {
-        var widget = $("#_anim_widget{{ id }}_{{ widget_data['dim'] }}");
-        var vals = {{ widget_data['vals'] }};
-        var labels = {{ widget_data['labels'] }};
-        widget.data('values', vals)
-        for (var i=0; i<vals.length; i++){
-			if ({{ dynamic }}) {
-		       var val = vals[i];
-			} else {
-			   var val = i;
-			}
-            widget.append($("<option>", {
-                value: val,
-                text: labels[i]
-            }));
-        };
-        widget.data("next_vals", {{ widget_data['next_vals'] }});
-        widget.on('change', function(event, ui) {
-		    if ({{ dynamic }}) {
-                var dim_val = parseInt(this.value);
-			} else {
-			    var dim_val = $.data(this, 'values')[this.value];
-			}
-            var next_vals = $.data(this, "next_vals");
-            if (Object.keys(next_vals).length > 0) {
-                var new_vals = next_vals[dim_val];
-                var next_widget = $('#_anim_widget{{ id }}_{{ widget_data['next_dim'] }}');
-                update_widget(next_widget, new_vals);
-            }
-			if (anim{{ id }}) {
-                anim{{ id }}.set_frame(dim_val, {{ widget_data['dim_idx'] }});
-            }
-
-        });
-        }
-        $(document).ready(init_dropdown)
-        </script>
-        {% endif %}
-        {% endfor %}
-        </form>
-    </div>
-</div>
-
-
-<script language="javascript">
 /* Instantiate the {{ widget_name }} class. */
 /* The IDs given should match those used in the template above. */
-(function() {
-	if (jQuery.ui !== undefined) {
-		$("#display_area{{ id }}").resizable({
-			resize: function(event, ui) {
-				$("#widget_area{{ id }}").width($(this).parent().width()-ui.size.width);
-			}
-		});
-		$("#widget_area{{ id }}").resizable();
-	}
-    var widget_ids = new Array({{ Nwidget }});
-    {% for dim in dimensions %}
-    widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";
-    {% endfor %}
-    var frame_data = {{ frames | safe }};
-    var dim_vals = {{ init_dim_vals }};
-    var keyMap = {{ key_data }};
-    var notFound = "{{ notFound }}";
-    function create_widget() {
-        setTimeout(function() {
-            anim{{ id }} = new {{ widget_name }}(frame_data, "{{ id }}", widget_ids,
-				keyMap, dim_vals, notFound, {{ load_json }}, "{{ mode }}",
-				{{ cached }}, "{{ json_path}}", {{ dynamic }});
-        }, 0);
-    }
-    {% block create_widget %}
-    create_widget();
-    {% endblock %}
-})();
-</script>
+function create_jsslider() {
+  var widget_ids = new Array({{ Nwidget }});
+  {% for dim in dimensions %}
+  widget_ids[{{ loop.index0 }}] = "_anim_widget{{ id }}_{{ dim }}";
+  {% endfor %}
+  var frame_data = {{ frames | safe }};
+  var dim_vals = {{ init_dim_vals }};
+  var keyMap = {{ key_data }};
+  var notFound = "{{ notFound }}";
+  function create_widget() {
+    setTimeout(function() {
+      anim = new HoloViews.{{ widget_name }}(frame_data, "{{ id }}", widget_ids,
+    keyMap, dim_vals, notFound, {{ load_json }}, "{{ mode }}",
+    {{ cached }}, "{{ json_path}}", {{ dynamic }});
+	  HoloViews.index['{{ id }}'] = anim;
+    }, 0);
+  }
+  {% block create_widget %}
+  {% for widget_data in widgets %}
+  {% if widget_data['type'] == 'slider' %}
+  window.HoloViews.init_slider('{{  id  }}', '{{ widget_data['dim'] }}', {{ widget_data['vals'] }}, {{ widget_data['next_vals'] }}, {{ widget_data['labels'] }}, {{ dynamic }}, {{ widget_data['step'] }}, '{{ widget_data['next_dim'] }}', {{ widget_data['dim_idx'] }}, '{{ CDN['jQueryUI'] }}', '{{ CDN['underscore'] }}')
+	
+  {% elif widget_data['type']=='dropdown' %}
+  {% endif %}
+  {% endfor %}
+  create_widget();
+  {{ init_js }}
+  {% endblock %}
+};
+
+if (!window.$) {
+  var script = document.createElement('script'); 
+  document.head.appendChild(script);    
+  script.type = 'text/javascript';
+  script.src = "//ajax.googleapis.com/ajax/libs/jquery/3.1.0/jquery.min.js";
+  script.onload = function() {
+  var script2 = document.createElement('script'); 
+  document.head.appendChild(script2);
+  script2.type = 'text/javascript';
+  script2.src = "//cdnjs.cloudflare.com/ajax/libs/require.js/2.3.5/require.min.js";
+  script2.onload = create_jsslider;
+  };
+} else {
+  create_jsslider()
+}

--- a/holoviews/plotting/widgets/jsslider.jinja
+++ b/holoviews/plotting/widgets/jsslider.jinja
@@ -20,9 +20,9 @@ function create_jsslider() {
   {% block create_widget %}
   {% for widget_data in widgets %}
   {% if widget_data['type'] == 'slider' %}
-  window.HoloViews.init_slider('{{  id  }}', '{{ widget_data['dim'] }}', {{ widget_data['vals'] }}, {{ widget_data['next_vals'] }}, {{ widget_data['labels'] }}, {{ dynamic }}, {{ widget_data['step'] }}, '{{ widget_data['next_dim'] }}', {{ widget_data['dim_idx'] }}, '{{ CDN['jQueryUI'] }}', '{{ CDN['underscore'] }}')
-	
+  HoloViews.init_slider('{{  id  }}', '{{ widget_data['dim'] }}', {{ widget_data['vals'] }}, {{ widget_data['next_vals'] }}, {{ widget_data['labels'] }}, {{ dynamic }}, {{ widget_data['step'] }}, '{{ widget_data['next_dim'] }}', {{ widget_data['dim_idx'] }}, '{{ CDN['jQueryUI'] }}', '{{ CDN['underscore'] }}')
   {% elif widget_data['type']=='dropdown' %}
+  HoloViews.init_dropdown('{{  id  }}', '{{ widget_data['dim'] }}', {{ widget_data['vals'] }}, {{ widget_data['next_vals'] }}, {{ widget_data['labels'] }}, '{{ widget_data['next_dim'] }}', {{ widget_data['dim_idx'] }}, {{ dynamic }})
   {% endif %}
   {% endfor %}
   create_widget();

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -35,22 +35,23 @@ HoloViewsWidget.prototype.dynamic_update = function(current){
   if(this.dynamic) {
     current = JSON.stringify(current);
   }
-  function callback(initialized, msg){
+  var that = this
+  function callback(msg){
     /* This callback receives data from Python as a string
        in order to parse it correctly quotes are sliced off*/
-    if (msg.content.ename != undefined) {
-      this.process_error(msg);
+	if (msg.content.ename != undefined) {
+      that.process_error(msg);
     }
     if (msg.msg_type != "execute_result") {
       console.log("Warning: HoloViews callback returned unexpected data for key: (", current, ") with the following content:", msg.content)
     } else {
       if (msg.content.data['text/plain'].includes('Complete')) {
-        if (this.queue.length > 0) {
-          this.time = Date.now();
-          this.dynamic_update(this.queue[this.queue.length-1]);
-          this.queue = [];
+        if (that.queue.length > 0) {
+          that.time = Date.now();
+          that.dynamic_update(that.queue[that.queue.length-1]);
+          that.queue = [];
         } else {
-          this.wait = false;
+          that.wait = false;
         }
         return
       }
@@ -59,7 +60,7 @@ HoloViewsWidget.prototype.dynamic_update = function(current){
   this.current = current;
   if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {
     var kernel = Jupyter.notebook.kernel;
-    callbacks = {iopub: {output: callback}};
+    var callbacks = {iopub: {output: callback}};
     var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
     kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
   }

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -373,11 +373,11 @@ function init_slider(id, dim, values, next_vals, labels, dynamic, step, next_dim
     define('jquery', [], function() { return jQuery; });
   }
   if (!jQueryUI) {
-    paths.jQueryUI = jQueryUI_CDN
+	paths.jQueryUI = jQueryUI_CDN.slice(null, -3);
   } else {
     define('jQueryUI', [], function() { return jQuery.ui; });
   }
-  paths.underscore = UNDERSCORE_CDN;
+  paths.underscore = UNDERSCORE_CDN.slice(null, -3);
   var jquery_require = {
     paths: paths,
     shim: {

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -200,7 +200,7 @@ ScrubberWidget.prototype = new HoloViewsWidget;
 
 ScrubberWidget.prototype.set_frame = function(frame){
   this.current_frame = frame;
-  widget = document.getElementById(this.slider_id);
+  var widget = document.getElementById(this.slider_id);
   if (widget === null) {
     this.pause_animation();
     return
@@ -442,7 +442,7 @@ function init_slider(id, dim, values, next_vals, labels, dynamic, step, next_dim
         var text = $('#textInput'+id+'_'+dim);
         text.val(label);
         adjustFontSize(text);
-        window.HoloViews.index[id].set_frame(dim_val, dim_idx);
+        HoloViews.index[id].set_frame(dim_val, dim_idx);
         if (Object.keys(next_vals).length > 0) {
           var new_vals = next_vals[dim_val];
           var next_widget = $('#_anim_widget'+id+'_'+next_dim);
@@ -484,10 +484,8 @@ function init_slider(id, dim, values, next_vals, labels, dynamic, step, next_dim
   });
 }
 
-function init_dropdown(id, dim, vals, labels, next_vals, next_dim, dim_idx, dynamic) {
+function init_dropdown(id, dim, vals, next_vals, labels, next_dim, dim_idx, dynamic) {
   var widget = $("#_anim_widget"+id+'_'+dim);
-  var vals = values;
-  var labels = labels;
   widget.data('values', vals)
   for (var i=0; i<vals.length; i++){
     if (dynamic) {
@@ -513,7 +511,7 @@ function init_dropdown(id, dim, vals, labels, next_vals, next_dim, dim_idx, dyna
       var next_widget = $('#_anim_widget'+id+'_'+next_dim);
       update_widget(next_widget, new_vals);
     }
-	widgets = window.HoloViews.index[id]
+	var widgets = HoloViews.index[id]
     if (widgets) {
       widgets.set_frame(dim_val, dim_idx);
     }

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -1,8 +1,5 @@
-function HoloViewsWidget(){
+function HoloViewsWidget() {
 }
-
-HoloViewsWidget.comms = {};
-HoloViewsWidget.comm_state = {};
 
 HoloViewsWidget.prototype.init_slider = function(init_val){
   if(this.load_json) {
@@ -20,7 +17,6 @@ HoloViewsWidget.prototype.populate_cache = function(idx){
 }
 
 HoloViewsWidget.prototype.process_error = function(msg){
-
 }
 
 HoloViewsWidget.prototype.from_json = function() {
@@ -63,7 +59,7 @@ HoloViewsWidget.prototype.dynamic_update = function(current){
   this.current = current;
   if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {
     var kernel = Jupyter.notebook.kernel;
-    callbacks = {iopub: {output: $.proxy(callback, this, this.initialized)}};
+    callbacks = {iopub: {output: callback}};
     var cmd = "holoviews.plotting.widgets.NdWidget.widgets['" + this.id + "'].update(" + current + ")";
     kernel.execute("import holoviews;" + cmd, callbacks, {silent : false});
   }
@@ -73,9 +69,9 @@ HoloViewsWidget.prototype.update_cache = function(force){
   var frame_len = Object.keys(this.frames).length;
   for (var i=0; i<frame_len; i++) {
     if(!this.load_json || this.dynamic)  {
-      frame = Object.keys(this.frames)[i];
+      var frame = Object.keys(this.frames)[i];
     } else {
-      frame = i;
+      var frame = i;
     }
     if(!(frame in this.cache) || force) {
       if ((frame in this.cache) && force) { this.cache[frame].remove() }
@@ -139,8 +135,8 @@ SelectionWidget.prototype.get_key = function(current_vals) {
   var key = "(";
   for (var i=0; i<this.slider_ids.length; i++)
   {
-    val = this.current_vals[i];
-    if (!(typeof val === 'string')) {
+    let val = this.current_vals[i];
+	if (!(typeof val === 'string')) {
       if (val % 1 === 0) { val = val.toFixed(1); }
       else { val = val.toFixed(10); val = val.slice(0, val.length-1);}
     }
@@ -345,4 +341,194 @@ function update_widget(widget, values) {
     widget.data('value', 0);
     widget.trigger("change");
   };
+}
+
+function init_slider(id, dim, values, next_vals, labels, dynamic, step, next_dim,
+                     dim_idx, jQueryUI_CDN, UNDERSCORE_CDN) {
+	// Slider JS Block START
+  function loadcssfile(filename){
+    var fileref=document.createElement("link")
+    fileref.setAttribute("rel", "stylesheet")
+    fileref.setAttribute("type", "text/css")
+    fileref.setAttribute("href", filename)
+    document.getElementsByTagName("head")[0].appendChild(fileref)
+  }
+  loadcssfile("https://code.jquery.com/ui/1.10.4/themes/smoothness/jquery-ui.css");
+  /* Check if jQuery and jQueryUI have been loaded
+     otherwise load with require.js */
+  var jQuery = window.jQuery,
+    // check for old versions of jQuery
+    oldjQuery = jQuery && !!jQuery.fn.jquery.match(/^1\.[0-4](\.|$)/),
+    jquery_path = '',
+    paths = {},
+    noConflict;
+  var jQueryUI = jQuery.ui;
+  // check for jQuery
+  if (!jQuery || oldjQuery) {
+    // load if it's not available or doesn't meet min standards
+    paths.jQuery = jQuery;
+    noConflict = !!oldjQuery;
+  } else {
+    // register the current jQuery
+    define('jquery', [], function() { return jQuery; });
+  }
+  if (!jQueryUI) {
+    paths.jQueryUI = jQueryUI_CDN
+  } else {
+    define('jQueryUI', [], function() { return jQuery.ui; });
+  }
+  paths.underscore = UNDERSCORE_CDN;
+  var jquery_require = {
+    paths: paths,
+    shim: {
+      "jQueryUI": {
+        exports:"$",
+        deps: ['jquery']
+      },
+      "underscore": {
+        exports: '_'
+      }
+    }
+  }
+  require.config(jquery_require);
+  require(["jQueryUI", "underscore"], function(jUI, _){
+    if (noConflict) $.noConflict(true);
+    var vals = values;
+    if (dynamic && vals.constructor === Array) {
+      var min = parseFloat(vals[0]);
+      var max = parseFloat(vals[vals.length-1]);
+      var step = step;
+      var wlabels = [min];
+    } else {
+      var min = 0;
+      if (dynamic) {
+        var max = Object.keys(vals).length - 1;
+      } else {
+        var max = vals.length - 1;
+      }
+      var step = 1;
+      var wlabels = labels;
+    }
+    function adjustFontSize(text) {
+      var width_ratio = (text.parent().width()/8)/text.val().length;
+      var size = Math.min(0.9, Math.max(0.6, width_ratio))+'em';
+      text.css('font-size', size);
+    }
+    var slider = $('#_anim_widget'+id+'_'+dim);
+    slider.slider({
+      animate: "fast",
+      min: min,
+      max: max,
+      step: step,
+      value: min,
+      dim_vals: vals,
+      dim_labels: wlabels,
+      next_vals: next_vals,
+      slide: function(event, ui) {
+        var vals = slider.slider("option", "dim_vals");
+        var next_vals = slider.slider("option", "next_vals");
+        var dlabels = slider.slider("option", "dim_labels");
+        if (dynamic) {
+          var dim_val = ui.value;
+          if (vals.constructor === Array) {
+            var label = ui.value;
+          } else {
+            var label = dlabels[ui.value];
+          }
+        } else {
+          var dim_val = vals[ui.value];
+          var label = dlabels[ui.value];
+        }
+        var text = $('#textInput'+id+'_'+dim);
+        text.val(label);
+        adjustFontSize(text);
+        window.HoloViews.index[id].set_frame(dim_val, dim_idx);
+        if (Object.keys(next_vals).length > 0) {
+          var new_vals = next_vals[dim_val];
+          var next_widget = $('#_anim_widget'+id+'_'+next_dim);
+          update_widget(next_widget, new_vals);
+        }
+      }
+    });
+    slider.keypress(function(event) {
+      if (event.which == 80 || event.which == 112) {
+        var start = slider.slider("option", "value");
+        var stop =  slider.slider("option", "max");
+        for (var i=start; i<=stop; i++) {
+          var delay = i*delay;
+          $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+            var val = {value:i};
+            slider.slider('value',i);
+            slider.slider("option", "slide")(null, val);
+          }, slider), delay);}, slider)(i);
+        }
+      }
+      if (event.which == 82 || event.which == 114) {
+        var start = slider.slider("option", "value");
+        var stop =  slider.slider("option", "min");
+        var count = 0;
+        for (var i=start; i>=stop; i--) {
+          var delay = count*delay;
+          count = count + 1;
+          $.proxy(function doSetTimeout(i) { setTimeout($.proxy(function() {
+            var val = {value:i};
+            slider.slider('value',i);
+            slider.slider("option", "slide")(null, val);
+          }, slider), delay);}, slider)(i);
+        }
+      }
+    });
+    var textInput = $('#textInput'+id+'_'+dim)
+    textInput.val(labels[0]);
+    adjustFontSize(textInput);
+  });
+}
+
+function init_dropdown(id, dim, vals, labels, next_vals, next_dim, dim_idx, dynamic) {
+  var widget = $("#_anim_widget"+id+'_'+dim);
+  var vals = values;
+  var labels = labels;
+  widget.data('values', vals)
+  for (var i=0; i<vals.length; i++){
+    if (dynamic) {
+      var val = vals[i];
+    } else {
+      var val = i;
+    }
+    widget.append($("<option>", {
+      value: val,
+      text: labels[i]
+    }));
+  };
+  widget.data("next_vals", next_vals);
+  widget.on('change', function(event, ui) {
+    if (dynamic) {
+      var dim_val = parseInt(this.value);
+    } else {
+      var dim_val = $.data(this, 'values')[this.value];
+    }
+    var next_vals = $.data(this, "next_vals");
+    if (Object.keys(next_vals).length > 0) {
+      var new_vals = next_vals[dim_val];
+      var next_widget = $('#_anim_widget'+id+'_'+next_dim);
+      update_widget(next_widget, new_vals);
+    }
+	widgets = window.HoloViews.index[id]
+    if (widgets) {
+      widgets.set_frame(dim_val, dim_idx);
+    }
+  });
+}
+
+if (!window.HoloViews) {
+  window.HoloViews = {
+    ScrubberWidget: ScrubberWidget,
+    SelectionWidget: SelectionWidget,
+    update_widget: update_widget,
+    init_slider: init_slider,
+    init_dropdown: init_dropdown,
+    comms: {},
+    comm_state: {},
+    index: {}
+  }
 }


### PR DESCRIPTION
This PR adds initial support for working in JupyterLab. So far it supports plotting static plots and embedded widgets by piggybacking on top of the bokeh JupyterLab extension. To make that work I have to do a number of pretty terrible things such as dynamically loading jQuery and require, so in the long term this isn't a good solution. However in the long term we plan on rewriting the widgets anyway, so this is a stopgap solution to get our foot in the door.

The main changes that were required to get this to work were:

* Put the HoloViews widgets and JS utilities into a global HoloViews namespace (rather than making them all global)
* Split the core JS code from the HTML and JS templates
* Add ``Renderer.components`` method which returns data and metadata dictionaries both indexed by ``MIME_TYPE``
* Have the display hooks render the HTML with publish_display_data and then publish the JS code in a separate step

Current issues:

* The display hooks were designed to return the HTML rather than publishing it using ``publish_display_data``, however an HTML blob cannot work in this new approach since the HTML needs to be published before the JS code.
* No handling of Comms yet, this will follow in a later PR which isolates all comm code on ``HoloViews.CommManager`` so we can ship a CommManager that handles Jupyter Notebook & JupyterLab but also allow overriding the CommManager for other environments.

<img width="1575" alt="screen shot 2018-02-22 at 1 46 49 pm" src="https://user-images.githubusercontent.com/1550771/36541767-e09a2988-17d6-11e8-9c2c-abe64be110c8.png">
