### PR TITLE
Fixed bug finding Layout label

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1195,7 +1195,7 @@ def get_ndmapping_label(ndmapping, attr):
             el = next(els)
         except StopIteration:
             return None
-        if not el._auxiliary_component:
+        if not getattr(el, '_auxiliary_component', True):
             label = getattr(el, attr)
     if attr == 'group':
         tp = type(el).__name__


### PR DESCRIPTION
Fixes a bug revealed by https://github.com/ioam/holoviews/pull/2331 currently messing with some tests. Before that PR it would try to access Layout.label and simply return a new Layout node, but now this causes issues.