### PR TITLE
Fixed Renderer widget export

### DIFF
--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -47,6 +47,8 @@ class PlotlyRenderer(Renderer):
     widgets = {'scrubber': PlotlyScrubberWidget,
                'widgets': PlotlySelectionWidget}
 
+    backend_dependencies = {'js': (get_plotlyjs(),)}
+
     comm_msg_handler = plotly_msg_handler
 
     _loaded = False

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -303,7 +303,7 @@ class Renderer(Exporter):
 
         data, metadata = {}, {}
         if isinstance(plot, NdWidget):
-            js, html = plot()
+            js, html = plot(as_script=True)
             plot_id = plot.plot_id
         else:
             html, js = self._figure_data(plot, as_script=True, **kwargs)
@@ -518,8 +518,11 @@ class Renderer(Exporter):
         if info or key:
             raise Exception('Renderer does not support saving metadata to file.')
 
-        with StoreOptions.options(obj, options, **kwargs):
-            plot = self_or_cls.get_plot(obj)
+        if isinstance(obj, (Plot, NdWidget)):
+            plot = obj
+        else:
+            with StoreOptions.options(obj, options, **kwargs):
+                plot = self_or_cls.get_plot(obj)
 
         if (fmt in list(self_or_cls.widgets.keys())+['auto']) and len(plot) > 1:
             with StoreOptions.options(obj, options, **kwargs):
@@ -528,8 +531,7 @@ class Renderer(Exporter):
                 self_or_cls.export_widgets(plot, basename, fmt)
             return
 
-        with StoreOptions.options(obj, options, **kwargs):
-            rendered = self_or_cls(plot, fmt)
+        rendered = self_or_cls(plot, fmt)
         if rendered is None: return
         (data, info) = rendered
         encoded = self_or_cls.encode(rendered)

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -137,16 +137,23 @@ class NdWidget(param.Parameterized):
                                                      id=self.id+'_client',
                                                      on_msg=self._process_update)
 
+
     def _process_update(self, msg):
         if 'content' not in msg:
             raise ValueError('Received widget comm message has no content.')
         self.update(msg['content'])
 
-    def __call__(self):
+
+    def __call__(self, as_script=False):
         data = self._get_data()
         html = self.render_html(data)
         js = self.render_js(data)
-        return js, html
+        if as_script:
+            return js, html
+        js = '<script type="text/javascript">%s</script>' % js
+        html = '\n'.join([html, js])
+        return html
+
 
     def _get_data(self):
         delay = int(1000./self.display_options.get('fps', 5))


### PR DESCRIPTION
After adding JupyterLab support the widgets were returning separate HTML and JS components which were not appropriately assembled into a single document on export.

This PR restores the old behavior on ``NdWidgets`` and adds a keyword to return the components separately matching the keyword on ``Renderer._figure_data``.

- [x] Fixes https://github.com/ioam/holoviews/issues/2381