### PR TITLE
Correctly handle comms in bokeh<0.12.15

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -29,7 +29,7 @@ var BokehMethods = {
     }
   },
   init_comms: function() {
-    if (Bokeh.protocol.Receiver !== undefined) {
+    if (Bokeh.protocol !== undefined) {
       this.receiver = new Bokeh.protocol.Receiver()
     } else {
       this.receiver = null;

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -36,6 +36,8 @@ var plot = Bokeh.index["{plot_id}"];
 
 if ("{plot_id}" in HoloViews.receivers) {{
   var receiver = HoloViews.receivers["{plot_id}"];
+}} else if (Bokeh.protocol !== undefined) {{
+  return;
 }} else {{
   var receiver = new Bokeh.protocol.Receiver();
   HoloViews.receivers["{plot_id}"] = receiver;
@@ -235,6 +237,12 @@ class BokehRenderer(Renderer):
         plot.traverse(lambda x: attach_periodic(x), [GenericElementPlot])
         doc.add_root(root)
         return doc
+
+
+    def components(self, obj, fmt=None, comm=True, **kwargs):
+        # Bokeh has to handle comms directly in <0.12.15
+        comm = False if bokeh_version < '0.12.15' else comm
+        return super(BokehRenderer, self).components(obj,fmt, comm, **kwargs)
 
 
     def _figure_data(self, plot, fmt='html', doc=None, as_script=False, **kwargs):


### PR DESCRIPTION
In the JupyterLab PR we switched to handling the comm messages ourselves which does not work in bokeh versions <=0.12.14 however I did not guard against this case appropriately. This now ensures that Bokeh exposes the ``protocol`` module and only creates a comm for bokeh versions < 0.12.15.