### PR TITLE
Replaced badge with monthly download badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![PyPI](https://img.shields.io/pypi/v/holoviews.svg)](https://pypi.python.org/pypi/holoviews)
 [![Conda](https://anaconda.org/ioam/holoviews/badges/installer/conda.svg)](https://anaconda.org/ioam/holoviews)
-[![Downloads](https://anaconda.org/ioam/holoviews/badges/downloads.svg)](https://anaconda.org/ioam/holoviews)
+[![Downloads](https://s3.amazonaws.com/pubbadges/holoviews_current.svg)](https://anaconda.org/ioam/holoviews)
 [![BuildStatus](https://travis-ci.org/ioam/holoviews.svg?branch=master)](https://travis-ci.org/ioam/holoviews)
 [![holoviewsDocs](http://buildbot.holoviews.org:8010/png?builder=website)](http://buildbot.holoviews.org:8010/waterfall)
 [![Coveralls](https://img.shields.io/coveralls/ioam/holoviews.svg)](https://coveralls.io/r/ioam/holoviews)


### PR DESCRIPTION
The current conda download badge only takes into account downloads from the ioam channel even though that is not even the most popular channel for installing holoviews (conda-forge is). This replaces the badge with a badge that shows rolling monthly download stats aggregating over conda and PyPI. Reporting 6-7k downloads per month looks a lot better than 20k all time downloads which is just totally wrong.