### PR TITLE
Allow drawing colorbar on bokeh QuadMeshPlot

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -223,4 +223,6 @@ class QuadMeshPlot(ColorbarPlot):
             renderer = plot.patches(**properties)
         else:
             renderer = plot.quad(**properties)
+        if self.colorbar and 'color_mapper' in self.handles:
+            self._draw_colorbar(plot, self.handles['color_mapper'])
         return renderer, renderer.glyph

--- a/tests/plotting/bokeh/testquadmeshplot.py
+++ b/tests/plotting/bokeh/testquadmeshplot.py
@@ -4,6 +4,11 @@ from holoviews.element import QuadMesh, Image
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
+try:
+    from bokeh.models import ColorBar
+except:
+    pass
+
 
 class TestQuadMeshPlot(TestBokehPlot):
 
@@ -22,3 +27,12 @@ class TestQuadMeshPlot(TestBokehPlot):
         self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False).flatten())
         self.assertEqual(source.data['x'], qmesh.dimension_values(0))
         self.assertEqual(source.data['y'], qmesh.dimension_values(1))
+
+    def test_quadmesh_colorbar(self):
+        n = 21
+        xs = np.logspace(1, 3, n)
+        ys = np.linspace(1, 10, n)
+        qmesh = QuadMesh((xs, ys, np.random.rand(n-1, n-1))).options(colorbar=True)
+        plot = bokeh_renderer.get_plot(qmesh)
+        self.assertIsInstance(plot.handles['colorbar'], ColorBar)
+        self.assertIs(plot.handles['colorbar'].color_mapper, plot.handles['color_mapper'])


### PR DESCRIPTION
Colorbars weren't being drawn on bokeh QuadMesh plots. I'll double check all other plots that allow colormapping draw colorbars and add some tests.