### PR TITLE
Fixed bug setting bokeh toolbar location

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -95,6 +95,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     tools = param.List(default=[], doc="""
         A list of plugin tools to use on the plot.""")
 
+    toolbar = param.ObjectSelector(default='right',
+                                   objects=["above", "below",
+                                            "left", "right", None],
+                                   doc="""
+        The toolbar location, must be one of 'above', 'below',
+        'left', 'right', None.""")
+
     _categorical = False
 
     # Declares the default types for continuous x- and y-axes

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -67,7 +67,7 @@ class BokehPlot(DimensionedPlot):
         The formatting string for the title of this plot, allows defining
         a label group separator and dimension labels.""")
 
-    toolbar = param.ObjectSelector(default='right',
+    toolbar = param.ObjectSelector(default='above',
                                    objects=["above", "below",
                                             "left", "right", None],
                                    doc="""
@@ -476,7 +476,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             else:
                 passed_plots.append(None)
 
-        plot = gridplot(plots[::-1], toolbar_position=self.toolbar,
+        plot = gridplot(plots[::-1], toolbar_location=self.toolbar,
                         merge_tools=self.merge_tools)
         plot = self._make_axes(plot)
 
@@ -776,7 +776,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             plots = filter_toolboxes(plots)
             plots, width = pad_plots(plots)
             layout_plot = gridplot(children=plots, width=width,
-                                   toolbar_position=self.toolbar,
+                                   toolbar_location=self.toolbar,
                                    merge_tools=self.merge_tools, **kwargs)
 
         title = self._get_title(self.keys[-1])

--- a/tests/plotting/bokeh/testgridplot.py
+++ b/tests/plotting/bokeh/testgridplot.py
@@ -7,7 +7,8 @@ from holoviews.operation import gridmatrix
 from .testplot import TestBokehPlot, bokeh_renderer
 
 try:
-    from bokeh.models import Div
+    from bokeh.layouts import Column
+    from bokeh.models import Div, ToolbarBox
 except:
     pass
 
@@ -98,3 +99,15 @@ class TestGridPlot(TestBokehPlot):
         self.assertEqual(data['B'], hmap1[1].dimension_values(1))
         self.assertEqual(data['C'], np.full_like(hmap1[1].dimension_values(0), np.NaN))
         self.assertEqual(data['D'], np.full_like(hmap1[1].dimension_values(0), np.NaN))
+
+    def test_grid_set_toolbar_location(self):
+        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').options(toolbar='left')
+        plot = bokeh_renderer.get_plot(grid)
+        self.assertIsInstance(plot.state, Column)
+        self.assertIsInstance(plot.state.children[0].children[0], ToolbarBox)
+
+    def test_grid_disable_toolbar(self):
+        grid = GridSpace({0: Curve([]), 1: Points([])}, 'X').options(toolbar=None)
+        plot = bokeh_renderer.get_plot(grid)
+        self.assertIsInstance(plot.state, Column)
+        self.assertEqual([p for p in plot.state.children if isinstance(p, ToolbarBox)], [])

--- a/tests/plotting/bokeh/testlayoutplot.py
+++ b/tests/plotting/bokeh/testlayoutplot.py
@@ -202,3 +202,15 @@ class TestLayoutPlot(TestBokehPlot):
         layout = Curve(range(10)) + NdOverlay() + HoloMap() + HoloMap({1: Image(np.random.rand(10,10))})
         plot = bokeh_renderer.get_plot(layout)
         self.assertEqual(len(plot.subplots.values()), 2)
+
+    def test_layout_set_toolbar_location(self):
+        layout = (Curve([]) + Points([])).options(toolbar='left')
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertIsInstance(plot.state, Row)
+        self.assertIsInstance(plot.state.children[0], ToolbarBox)
+
+    def test_layout_disable_toolbar(self):
+        layout = (Curve([]) + Points([])).options(toolbar=None)
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertIsInstance(plot.state, Column)
+        self.assertEqual(len(plot.state.children), 1)


### PR DESCRIPTION
The LayoutPlot and GridPlot were not using the correct keyword to set the toolbar location on a gridplot.

- [x] Fixes https://github.com/ioam/holoviews/issues/2370
- [x] Adds tests