### PR TITLE
Attempt at unpinning dask to fix conda constraint errors on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=4.2.0 param matplotlib=2.1.2 xarray
   - source activate test-environment
   - conda install -c conda-forge  iris plotly flexx --quiet
-  - conda install -c bokeh datashader dask=0.16.1 bokeh=0.12.14 selenium
+  - conda install -c bokeh datashader dask bokeh=0.12.14 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;
     fi


### PR DESCRIPTION
Attempt at fixing:

```
UnsatisfiableError: The following specifications were found to be in conflict:
dask 0.16.1* -> dask-core 0.16.1.*
iris -> dask >=0.17.1
Use "conda info <package>" to see the dependencies for each package.
```