### PR TITLE
Bokeh renderer fixes

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -37,7 +37,7 @@ var plot = Bokeh.index["{plot_id}"];
 
 if ("{plot_id}" in HoloViews.receivers) {{
   var receiver = HoloViews.receivers["{plot_id}"];
-}} else if (Bokeh.protocol !== undefined) {{
+}} else if (Bokeh.protocol === undefined) {{
   return;
 }} else {{
   var receiver = new Bokeh.protocol.Receiver();
@@ -277,7 +277,7 @@ class BokehRenderer(Renderer):
                 b64 = base64.b64encode(data).decode("utf-8")
                 (mime_type, tag) = MIME_TYPES[fmt], HTML_TAGS[fmt]
                 src = HTML_TAGS['base64'].format(mime_type=mime_type, b64=b64)
-                data = tag.format(src=src, mime_type=mime_type, css='')
+                div = tag.format(src=src, mime_type=mime_type, css='')
                 js = ''
         else:
             try:
@@ -292,7 +292,7 @@ class BokehRenderer(Renderer):
 
         plot.document = doc
         if as_script:
-            return data, js
+            return div, js
         return data
 
 

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+import base64
 import logging
 
 import param
@@ -14,7 +15,7 @@ from bokeh.server.server import Server
 
 from ...core import Store, HoloMap
 from ..plot import Plot, GenericElementPlot
-from ..renderer import Renderer, MIME_TYPES
+from ..renderer import Renderer, MIME_TYPES, HTML_TAGS
 from .widgets import BokehScrubberWidget, BokehSelectionWidget, BokehServerWidgets
 from .util import attach_periodic, compute_plot_size, bokeh_version
 
@@ -114,11 +115,8 @@ class BokehRenderer(Renderer):
         elif isinstance(plot, tuple(self.widgets.values())):
             return plot(), info
         elif fmt == 'png':
-            from bokeh.io.export import get_screenshot_as_png
-            img = get_screenshot_as_png(plot.state, None)
-            imgByteArr = BytesIO()
-            img.save(imgByteArr, format='PNG')
-            return imgByteArr.getvalue(), info
+            png = self._figure_data(plot, fmt=fmt, doc=doc)
+            return png, info
         elif fmt == 'html':
             html = self._figure_data(plot, doc=doc)
             html = "<div style='display: table; margin: 0 auto;'>%s</div>" % html
@@ -268,19 +266,34 @@ class BokehRenderer(Renderer):
         # but at the holoviews level these are not issues
         logger = logging.getLogger(bokeh.core.validation.check.__file__)
         logger.disabled = True
-        try:
-            js, div, _ = notebook_content(model, comm_id)
-            html = NOTEBOOK_DIV.format(plot_script=js, plot_div=div)
-            html = encode_utf8(html)
-            doc.hold()
-        except:
+
+        if fmt == 'png':
+            from bokeh.io.export import get_screenshot_as_png
+            img = get_screenshot_as_png(plot.state, None)
+            imgByteArr = BytesIO()
+            img.save(imgByteArr, format='PNG')
+            data = imgByteArr.getvalue()
+            if as_script:
+                b64 = base64.b64encode(data).decode("utf-8")
+                (mime_type, tag) = MIME_TYPES[fmt], HTML_TAGS[fmt]
+                src = HTML_TAGS['base64'].format(mime_type=mime_type, b64=b64)
+                data = tag.format(src=src, mime_type=mime_type, css='')
+                js = ''
+        else:
+            try:
+                js, div, _ = notebook_content(model, comm_id)
+                html = NOTEBOOK_DIV.format(plot_script=js, plot_div=div)
+                data = encode_utf8(html)
+                doc.hold()
+            except:
+                logger.disabled = False
+                raise
             logger.disabled = False
-            raise
-        logger.disabled = False
+
         plot.document = doc
         if as_script:
-            return div, js
-        return html
+            return data, js
+        return data
 
 
     def diff(self, plot, binary=True):

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -309,7 +309,7 @@ class Renderer(Exporter):
             js, html = plot(as_script=True)
             plot_id = plot.plot_id
         else:
-            html, js = self._figure_data(plot, as_script=True, **kwargs)
+            html, js = self._figure_data(plot, fmt, as_script=True, **kwargs)
             plot_id = plot.id
             if comm and plot.comm is not None and self.comm_msg_handler:
                 msg_handler = self.comm_msg_handler.format(plot_id=plot_id)


### PR DESCRIPTION
Fixes two bugs introduced in the JupyterLab refactor:

1) Fixes png export by correctly handling it in ``_figure_data`` (where it should be handled)
2) Fixes wrong logic in bokeh message handler, which incorrectly skipped messages when Bokeh.protocol was defined.