### PR TITLE
Handle streamz 0.3.0 API changes

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -431,7 +431,11 @@ class Buffer(Pipe):
                 from streamz.dataframe import StreamingDataFrame, StreamingSeries
                 loaded = True
             except ImportError:
-                loaded = False
+                try:
+                    from streamz.dataframe import DataFrame as StreamingDataFrame, Series as StreamingSeries
+                    loaded = True
+                except ImportError:
+                    loaded = False
             if not loaded or not isinstance(data, (StreamingDataFrame, StreamingSeries)):
                 raise ValueError("Buffer must be initialized with pandas DataFrame, "
                                  "streamz.StreamingDataFrame or streamz.StreamingSeries.")


### PR DESCRIPTION
The streamz 0.3.0 release changed the names of the StreamingDataFrame and StreamingSeries to just DataFrame and Series, this PR ensures that the HoloViews Buffer stream supports both old and new versions of streamz.

- [x] Fixes https://github.com/ioam/holoviews/issues/2409