### PR TITLE
Renderer and Widget bug fixes

### DIFF
--- a/holoviews/plotting/mpl/mplwidgets.js
+++ b/holoviews/plotting/mpl/mplwidgets.js
@@ -19,7 +19,7 @@ var MPLMethods = {
     } else {
       this.update_cache();
     }
-    if (this.dynamic | !this.cached) {
+    if (this.dynamic | !this.cached | (this.current_vals === undefined)) {
       this.update(0)
     } else {
       this.set_frame(this.current_vals[0], 0)

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -78,7 +78,7 @@ class PlotlyRenderer(Renderer):
             return diff
 
 
-    def _figure_data(self, plot, divuuid=None, comm=True, as_script=False, width=800, height=600):
+    def _figure_data(self, plot, fmt=None, divuuid=None, comm=True, as_script=False, width=800, height=600):
         figure = plot.state
         if divuuid is None:
             divuuid = plot.id


### PR DESCRIPTION
The recent PRs to add Dimension.default and JupyterLab support caused some small issues for the widgets and renderers. This PR fixes two bugs:

1. Initializing the matplotlib scrubber widget now works again
2. Fixes the signature of PlotlyRenderer._figure_data so it no longer errors.