### PR TITLE
Ensure select on dask arrays in GridInterface is lazy

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -621,7 +621,7 @@ class Dataset(Element):
         a new_type, which will inherit all shared parameters.
         """
         if 'datatype' not in overrides:
-            datatypes = [self.interface.datatype]+self.datatype
+            datatypes = [self.interface.datatype] + self.datatype
             overrides['datatype'] = list(unique_iterator(datatypes))
         return super(Dataset, self).clone(data, shared_data, new_type, *args, **overrides)
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -9,7 +9,7 @@ import numpy as np
 import param
 
 from ..dimension import redim
-from ..util import dimension_range
+from ..util import dimension_range, unique_iterator
 from .interface import Interface, iloc, ndloc
 from .array import ArrayInterface
 from .dictionary import DictInterface
@@ -609,6 +609,21 @@ class Dataset(Element):
         convert to other Element types.
         """
         return self._conversion_interface(self)
+
+
+    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+        """
+        Returns a clone of the object with matching parameter values
+        containing the specified args and kwargs.
+
+        If shared_data is set to True and no data explicitly supplied,
+        the clone will share data with the original. May also supply
+        a new_type, which will inherit all shared parameters.
+        """
+        if 'datatype' not in overrides:
+            datatypes = [self.interface.datatype]+self.datatype
+            overrides['datatype'] = list(unique_iterator(datatypes))
+        return super(Dataset, self).clone(data, shared_data, new_type, *args, **overrides)
 
 
     @property

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -616,7 +616,7 @@ class GridInterface(DictInterface):
             column = cls.values(dataset, dimension, flat=False)
         if column.dtype.kind == 'M':
             dmin, dmax = column.min(), column.max()
-            if isinstance(column, da.Array):
+            if da and isinstance(column, da.Array):
                 return dmin.compute(), dmax.compute()
             return dmin, dmax
         elif len(column) == 0:
@@ -624,7 +624,7 @@ class GridInterface(DictInterface):
         else:
             try:
                 dmin, dmax = (np.nanmin(column), np.nanmax(column))
-                if isinstance(column, da.Array):
+                if da and isinstance(column, da.Array):
                     return dmin.compute(), dmax.compute()
                 return dmin, dmax
             except TypeError:

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 from collections import OrderedDict, defaultdict, Iterable
 
 try:

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -619,7 +619,7 @@ class GridInterface(DictInterface):
         if column.dtype.kind == 'M':
             dmin, dmax = column.min(), column.max()
             if da and isinstance(column, da.Array):
-                return dmin.compute(), dmax.compute()
+                return da.compute(dmin, dmax)
             return dmin, dmax
         elif len(column) == 0:
             return np.NaN, np.NaN
@@ -627,7 +627,7 @@ class GridInterface(DictInterface):
             try:
                 dmin, dmax = (np.nanmin(column), np.nanmax(column))
                 if da and isinstance(column, da.Array):
-                    return dmin.compute(), dmax.compute()
+                    return da.compute(dmin, dmax)
                 return dmin, dmax
             except TypeError:
                 column.sort()

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -136,7 +136,7 @@ class ImageInterface(GridInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         """
         The set of samples available along a particular dimension.
         """

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -4,7 +4,7 @@ from ..boundingregion import BoundingBox
 from ..dimension import Dimension
 from ..element import Element
 from ..ndmapping import  NdMapping, item_check
-from ..sheetcoords import Slice
+from ..sheetcoords import Slice, SheetCoordinateSystem
 from .. import util
 from .grid import GridInterface
 from .interface import Interface, DataError
@@ -55,6 +55,9 @@ class ImageInterface(GridInterface):
 
         if not isinstance(data, np.ndarray) or data.ndim not in [2, 3]:
             raise ValueError('ImageInterface expects a 2D array.')
+        elif not issubclass(eltype, SheetCoordinateSystem):
+            raise ValueError('ImageInterface may only be used on elements '
+                             'that subclass SheetCoordinateSystem.')
 
         return data, {'kdims':kdims, 'vdims':vdims}, kwargs
 

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -156,12 +156,12 @@ class Interface(param.Parameterized):
             kdims = pvals.get('kdims') if kdims is None else kdims
             vdims = pvals.get('vdims') if vdims is None else vdims
 
-        if datatype is None:
-            datatype = eltype.datatype
-
         # Process Element data
         if (hasattr(data, 'interface') and issubclass(data.interface, Interface)):
-            if data.interface.datatype in datatype:
+            if datatype is None:
+                datatype = data.datatype
+
+            if data.interface.datatype in datatype and data.interface.datatype in eltype.datatype:
                 data = data.data
             elif data.interface.gridded:
                 gridded = OrderedDict([(kd.name, data.dimension_values(kd.name, expanded=False))
@@ -175,6 +175,9 @@ class Interface(param.Parameterized):
             data = tuple(data.dimension_values(d) for d in kdims+vdims)
         elif isinstance(data, util.generator_types):
             data = list(data)
+
+        if datatype is None:
+            datatype = eltype.datatype
 
         # Set interface priority order
         prioritized = [cls.interfaces[p] for p in datatype

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -159,7 +159,9 @@ class Interface(param.Parameterized):
         # Process Element data
         if (hasattr(data, 'interface') and issubclass(data.interface, Interface)):
             if datatype is None:
-                datatype = data.datatype
+                datatype = [dt for dt in data.datatype if dt in eltype.datatype]
+                if not datatype:
+                    datatype = eltype.datatype
 
             if data.interface.datatype in datatype and data.interface.datatype in eltype.datatype:
                 data = data.data

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -157,7 +157,7 @@ class CubeInterface(GridInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         """
         Returns an array of the values along the supplied dimension.
         """

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -253,7 +253,7 @@ class XArrayInterface(GridInterface):
 
 
     @classmethod
-    def values(cls, dataset, dim, expanded=True, flat=True):
+    def values(cls, dataset, dim, expanded=True, flat=True, compute=True):
         dim = dataset.get_dimension(dim, strict=True)
         data = dataset.data[dim.name].data
         irregular = cls.irregular(dataset, dim) if dim in dataset.kdims else False
@@ -264,7 +264,7 @@ class XArrayInterface(GridInterface):
             virtual_coords = []
         if dim in dataset.vdims or irregular:
             data_coords = list(dataset.data[dim.name].dims)
-            if dask and isinstance(data, dask.array.Array):
+            if compute and dask and isinstance(data, dask.array.Array):
                 data = data.compute()
             data = cls.canonicalize(dataset, data, data_coords=data_coords,
                                     virtual_coords=virtual_coords)

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -317,7 +317,7 @@ class Area(Curve):
             x, y = (area.dimension_values(i) for i in range(2))
             stacked[k] = area.clone((x, y+baseline, baseline), vdims=vdims,
                                     new_type=Area)
-            baseline += y
+            baseline = baseline+y
         return stacked
 
 

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -317,7 +317,7 @@ class Area(Curve):
             x, y = (area.dimension_values(i) for i in range(2))
             stacked[k] = area.clone((x, y+baseline, baseline), vdims=vdims,
                                     new_type=Area)
-            baseline = baseline+y
+            baseline = baseline + y
         return stacked
 
 

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1506,6 +1506,12 @@ class DaskGridDatasetTest(GridDatasetTest):
                                              self.grid_zs), kdims=['x', 'y'],
                                             vdims=['z'])
 
+    def test_select_lazy(self):
+        import dask.array as da
+        arr = da.from_array(np.arange(1, 12), 3)
+        ds = Dataset({'x': range(11), 'y': arr}, 'x', 'y')
+        self.assertIsInstance(ds.select(x=(0, 5)).data['y'], da.Array)
+
     def test_dataset_add_dimensions_values_hm(self):
         arr = da.from_array(np.arange(1, 12), 3)
         table =  self.dataset_hm.add_dimension('z', 1, arr, vdim=True)
@@ -1551,8 +1557,8 @@ class DaskGridDatasetTest(GridDatasetTest):
         array = da.from_array(np.random.rand(11, 11), 3)
         dataset = Dataset({'x':self.xs, 'y':self.y_ints, 'z': array},
                           kdims=['x', 'y'], vdims=['z'])
-        self.assertEqual(np.array(dataset.reduce(['x', 'y'], np.mean)),
-                         np.mean(array))
+        self.assertEqual((dataset.reduce(['x', 'y'], np.mean)),
+                         np.mean(array).compute())
 
     def test_dataset_2D_reduce_hm_alias(self):
         array = np.random.rand(11, 11)

--- a/tests/core/data/testimageinterfaces.py
+++ b/tests/core/data/testimageinterfaces.py
@@ -245,15 +245,17 @@ class ImageInterfaceTest(ComparisonTestCase):
                              Curve((xs, zs), kdims=['x'], vdims=['z']))
 
     def test_dataset_reindex_constant(self):
-        selected = Dataset(self.image.select(x=0))
-        reindexed = selected.reindex(['y'])
+        with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.image):
+            selected = Dataset(self.image.select(x=0))
+            reindexed = selected.reindex(['y'])
         data = Dataset(selected.columns(['y', 'z']),
                        kdims=['y'], vdims=['z'])
         self.assertEqual(reindexed, data)
 
     def test_dataset_reindex_non_constant(self):
-        ds = Dataset(self.image)
-        reindexed = ds.reindex(['y'])
+        with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.image):
+            ds = Dataset(self.image)
+            reindexed = ds.reindex(['y'])
         data = Dataset(ds.columns(['y', 'z']),
                        kdims=['y'], vdims=['z'])
         self.assertEqual(reindexed, data)
@@ -660,15 +662,17 @@ class RGBInterfaceTest(ComparisonTestCase):
                                             new_type=Curve))
 
     def test_dataset_reindex_constant(self):
-        ds = Dataset(self.rgb.select(x=0))
-        reindexed = ds.reindex(['y'], ['R'])
+        with DatatypeContext([self.datatype, 'dictionary', 'dataframe', 'grid'], self.rgb):
+            ds = Dataset(self.rgb.select(x=0))
+            reindexed = ds.reindex(['y'], ['R'])
         data = Dataset(ds.columns(['y', 'R']),
                        kdims=['y'], vdims=[ds.vdims[0]])
         self.assertEqual(reindexed, data)
 
     def test_dataset_reindex_non_constant(self):
-        ds = Dataset(self.rgb)
-        reindexed = ds.reindex(['y'], ['R'])
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe', 'grid'], self.rgb):
+            ds = Dataset(self.rgb)
+            reindexed = ds.reindex(['y'], ['R'])
         data = Dataset(ds.columns(['y', 'R']),
                        kdims=['y'], vdims=[ds.vdims[0]])
         self.assertEqual(reindexed, data)

--- a/tests/element/testelementconstructors.py
+++ b/tests/element/testelementconstructors.py
@@ -52,14 +52,14 @@ class ElementConstructorTest(ComparisonTestCase):
     def test_hist_curve_construct(self):
         hist = Histogram(Curve(([0.1, 0.3, 0.5], [2.1, 2.2, 3.3])))
         values = hist.dimension_values(1)
-        edges = hist.interface.coords(hist, hist.kdims[0], edges=True)
+        edges = hist.edges
         self.assertEqual(values, np.array([2.1, 2.2, 3.3]))
         self.assertEqual(edges, np.array([0, 0.2, 0.4, 0.6]))
 
     def test_hist_curve_int_edges_construct(self):
         hist = Histogram(Curve(range(3)))
         values = hist.dimension_values(1)
-        edges = hist.interface.coords(hist, hist.kdims[0], edges=True)
+        edges = hist.edges
         self.assertEqual(values, np.arange(3))
         self.assertEqual(edges, np.array([-.5, .5, 1.5, 2.5]))
 


### PR DESCRIPTION
Followup from https://github.com/ioam/holoviews/pull/2305 which ensures that select and sample operations are applied lazily and do not load the dask array into memory.