### PR TITLE
Made pandas autoindexing behavior backwards compatible

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -38,8 +38,13 @@ class PandasInterface(Interface):
         if util.is_series(data):
             data = data.to_frame()
         if util.is_dataframe(data):
-            if eltype._auto_indexable_1d and len(data.columns) == 1:
-                data = data.reset_index()
+            ncols = len(data.columns)
+            index_names = data.index.names if isinstance(data, pd.DataFrame) else [data.index.name]
+            if index_names == [None]:
+                index_names = ['index']
+            if eltype._auto_indexable_1d and ncols == 1 and kdims is None:
+                kdims = list(index_names)
+
             if isinstance(kdim_param.bounds[1], int):
                 ndim = min([kdim_param.bounds[1], len(kdim_param.default)])
             else:
@@ -58,7 +63,6 @@ class PandasInterface(Interface):
                 vdims = list(data.columns[:nvdim if nvdim else None])
 
             # Handle reset of index if kdims reference index by name
-            index_names = data.index.names if isinstance(data, pd.DataFrame) else [data.index.name]
             for kd in kdims:
                 if isinstance(kd, Dimension): kd = kd.name
                 if kd in data.columns:
@@ -70,6 +74,12 @@ class PandasInterface(Interface):
             if any(isinstance(d, (np.int64, int)) for d in kdims+vdims):
                 raise DataError("pandas DataFrame column names used as dimensions "
                                 "must be strings not integers.", cls)
+
+            if kdims:
+                kdim = kdims[0].name if isinstance(kdims[0], Dimension) else kdims[0]
+                if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
+                    data = data.copy()
+                    data[kdim] = np.arange(len(data))
         else:
             # Check if data is of non-numeric type
             # Then use defined data type

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -79,7 +79,7 @@ class PandasInterface(Interface):
                 kdim = kdims[0].name if isinstance(kdims[0], Dimension) else kdims[0]
                 if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
                     data = data.copy()
-                    data[kdim] = np.arange(len(data))
+                    data.insert(0, kdim, np.arange(len(data)))
         else:
             # Check if data is of non-numeric type
             # Then use defined data type

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -887,11 +887,19 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
 
     def test_dataset_series_construct(self):
         ds = Dataset(pd.Series([1, 2, 3], name='A'))
-        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), ['index', 'A']))
+        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
+
+    def test_dataset_df_construct_autoindex(self):
+        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'test', 'A')
+        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'test', 'A'))
+
+    def test_dataset_df_construct_not_autoindex(self):
+        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'index', 'A')
+        self.assertEqual(ds, Dataset(([1, 2, 3], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_single_column_construct(self):
         ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A']))
-        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), ['index', 'A']))
+        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_extract_vdims(self):
         df = pd.DataFrame({'x': [1, 2, 3], 'y': [1, 2, 3], 'z': [1, 2, 3]},


### PR DESCRIPTION
Recent changes to the way pandas indexes are handled caused a regression in the behavior of the interface when passing in a single column dataframe. This restores the old behavior while still allowing the use of the index on a single column dataframe.

- [x] Fixes https://github.com/ioam/holoviews/issues/2400