### PR TITLE
Fixed empty Element visibility bug in bokeh plots

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -771,7 +771,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         renderer = self.handles.get('glyph_renderer', None)
         glyph = self.handles.get('glyph', None)
-        visible = bool(element)
+        visible = element is not None
         if hasattr(renderer, 'visible'):
             renderer.visible = visible
         if hasattr(glyph, 'visible'):

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -23,6 +23,11 @@ class TestElementPlotPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.outline_line_alpha, 0)
 
+    def test_empty_element_visibility(self):
+        curve = Curve([])
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertTrue(plot.handles['glyph_renderer'].visible)
+        
     def test_element_no_xaxis(self):
         curve = Curve(range(10)).opts(plot=dict(xaxis=None))
         plot = bokeh_renderer.get_plot(curve).state

--- a/tests/plotting/bokeh/testoverlayplot.py
+++ b/tests/plotting/bokeh/testoverlayplot.py
@@ -40,15 +40,6 @@ class TestOverlayPlot(TestBokehPlot):
         self.assertFalse(subplot1.handles['glyph_renderer'].visible)
         self.assertTrue(subplot2.handles['glyph_renderer'].visible)
 
-    def test_batched_empty_update_invisible(self):
-        hmap = HoloMap({i: NdOverlay({j: Curve(np.arange(i), label='A') for j in range(i%2)})
-                        for i in range(1, 4)})
-        opts = {'NdOverlay': {'legend_limit': 0}}
-        plot = list(bokeh_renderer.get_plot(hmap(plot=opts)).subplots.values())[0]
-        self.assertTrue(plot.handles['glyph_renderer'].visible)
-        plot.update((2,))
-        self.assertFalse(plot.handles['glyph_renderer'].visible)
-
     def test_hover_tool_instance_renderer_association(self):
         tooltips = [("index", "$index")]
         hover = HoverTool(tooltips=tooltips)


### PR DESCRIPTION
When using the drawing tools you often initialize the plot with an empty element, but currently empty elements make the glyph renderer invisible. This ensures that only missing elements set visible=False on the renderer.