### PR TITLE
Added support for the labmode comms

### DIFF
--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -272,8 +272,8 @@ class JupyterCommManager(CommManager):
     }
 
     JupyterCommManager.prototype.register_target = function(plot_id, comm_id, msg_handler) {
-      if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {
-        var comm_manager = Jupyter.notebook.kernel.comm_manager;
+      if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
+        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;
         comm_manager.register_target(comm_id, function(comm) {
           comm.on_msg(msg_handler);
         });
@@ -287,8 +287,8 @@ class JupyterCommManager(CommManager):
     JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {
       if (comm_id in window.HoloViews.comms) {
         return HoloViews.comms[comm_id];
-      } else if ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null)) {
-        var comm_manager = Jupyter.notebook.kernel.comm_manager;
+      } else if ((window.comm_manager || (window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
+        var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;
         var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);
         if (msg_handler) {
           comm.on_msg(msg_handler);

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -287,7 +287,7 @@ class JupyterCommManager(CommManager):
     JupyterCommManager.prototype.get_client_comm = function(plot_id, comm_id, msg_handler) {
       if (comm_id in window.HoloViews.comms) {
         return HoloViews.comms[comm_id];
-      } else if ((window.comm_manager || (window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
+      } else if (window.comm_manager || ((window.Jupyter !== undefined) && (Jupyter.notebook.kernel != null))) {
         var comm_manager = window.comm_manager || Jupyter.notebook.kernel.comm_manager;
         var comm = comm_manager.new_comm(comm_id, {}, {}, {}, comm_id);
         if (msg_handler) {


### PR DESCRIPTION
This small change allows HoloViews comms to support [labmode](https://github.com/pyviz/labmode). To be clear about the responsibilities of labmode:

1. Labmode will not be defining ``Jupyter`` on the root so this is a pure fallback (and if ``Jupyter`` ever does get stubbed, it will have to support enough of the same API that this PR can be reverted).
2. Labmode is responsible for mirroring the Jupyter comms API.

I just want to make it clear that I don't want to add any more labmode specific code to HoloViews. This PR is simple enough that the only point I see for discussion is whether the check should be for ``window.comm_manager`` or maybe something else labmode can set...