### PR TITLE
Optimize range computations

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -166,8 +166,8 @@ class XArrayInterface(GridInterface):
         else:
             data = dataset.data[dim]
             dmin, dmax = data.min().data, data.max().data
-            if dask and isinstance(dmin, dask.array.Array):
-                dmin, dmax = dmin.compute(), dmax.compute()
+        if dask and isinstance(dmin, dask.array.Array):
+            dmin, dmax = dask.array.compute(dmin, dmax)
         dmin = dmin if np.isscalar(dmin) else dmin.item()
         dmax = dmax if np.isscalar(dmax) else dmax.item()
         return dmin, dmax

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -445,11 +445,11 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
     def range(self, dim, data_range=True):
         idx = self.get_dimension_index(dim)
         dimension = self.get_dimension(dim)
-        low, high = super(Image, self).range(dim, data_range)
         if idx in [0, 1] and data_range and dimension.range == (None, None):
             if self.interface.datatype == 'image':
                 l, b, r, t = self.bounds.lbrt()
                 return (b, t) if idx else (l, r)
+            low, high = super(Image, self).range(dim, data_range)
             density = self.ydensity if idx else self.xdensity
             halfd = (1./density)/2.
             if isinstance(low, datetime_types):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1038,7 +1038,10 @@ class ColorbarPlot(ElementPlot):
 
         ncolors = None if factors is None else len(factors)
         if dim:
-            low, high = ranges.get(dim.name, element.range(dim.name))
+            if dim.name in ranges:
+                low, high = ranges.get(dim.name)
+            else:
+                low, high = element.range(dim.name)
         else:
             low, high = None, None
 


### PR DESCRIPTION
In benchmarking HoloViews for the pangeo project which will predominantly use dask arrays wrapped using xarray I identified a number of bottlenecks in the range calculations, which are being done inefficiently or unnecessarily.