### PR TITLE
Notebook flake fixes.

### DIFF
--- a/examples/getting_started/4-Gridded_Datasets.ipynb
+++ b/examples/getting_started/4-Gridded_Datasets.ipynb
@@ -14,7 +14,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import holoviews as hv\n",
     "hv.extension('bokeh', 'matplotlib')"
    ]

--- a/examples/user_guide/01-Annotating_Data.ipynb
+++ b/examples/user_guide/01-Annotating_Data.ipynb
@@ -14,7 +14,6 @@
    "outputs": [],
    "source": [
     "import holoviews as hv\n",
-    "import holoviews.util\n",
     "hv.extension('bokeh')"
    ]
   },

--- a/examples/user_guide/04-Dimensioned_Containers.ipynb
+++ b/examples/user_guide/04-Dimensioned_Containers.ipynb
@@ -21,7 +21,6 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
-    "import pandas as pd\n",
     "import holoviews as hv\n",
     "hv.notebook_extension('bokeh')\n",
     "%opts Curve (line_width=1)"

--- a/examples/user_guide/08-Gridded_Datasets.ipynb
+++ b/examples/user_guide/08-Gridded_Datasets.ipynb
@@ -13,7 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xarray as xr\n",
     "import numpy as np\n",
     "import holoviews as hv\n",
     "hv.extension('matplotlib')\n",

--- a/examples/user_guide/11-Responding_to_Events.ipynb
+++ b/examples/user_guide/11-Responding_to_Events.ipynb
@@ -15,7 +15,6 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
-    "import numpy as np\n",
     "hv.extension('bokeh')"
    ]
   },

--- a/examples/user_guide/13-Data_Pipelines.ipynb
+++ b/examples/user_guide/13-Data_Pipelines.ipynb
@@ -13,7 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
     "from bokeh.sampledata import stocks\n",

--- a/examples/user_guide/14-Large_Data.ipynb
+++ b/examples/user_guide/14-Large_Data.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import datashader as ds\n",
-    "from holoviews.operation.datashader import aggregate, shade, datashade, dynspread\n",
+    "from holoviews.operation.datashader import aggregate, datashade, dynspread\n",
     "from holoviews.operation import decimate\n",
     "hv.extension('bokeh')\n",
     "decimate.max_samples=1000\n",

--- a/examples/user_guide/16-Dashboards.ipynb
+++ b/examples/user_guide/16-Dashboards.ipynb
@@ -13,7 +13,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import pandas as pd\n",
     "import holoviews as hv\n",
     "from bokeh.sampledata import stocks\n",
@@ -67,7 +66,7 @@
     "import param\n",
     "import paramnb\n",
     "\n",
-    "class StockExplorer(hv.streams.Stream):\n",
+    "class StockExplorer(Stream):\n",
     "    \n",
     "    rolling_window = param.Integer(default=10, bounds=(1, 365))\n",
     "    \n",

--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -387,6 +387,7 @@
    "source": [
     "def show_callback():\n",
     "    server.show('/')\n",
+    "TODO: where does loop come from?\n",
     "loop.add_callback(show_callback)\n",
     "server.start()\n",
     "# Outside the notebook ioloop needs to be started\n",
@@ -551,8 +552,6 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "\n",
-    "from bokeh.application.handlers import FunctionHandler\n",
-    "from bokeh.application import Application\n",
     "from bokeh.io import show\n",
     "from bokeh.layouts import layout\n",
     "from bokeh.models import Slider, Button\n",

--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -385,12 +385,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def show_callback():\n",
-    "    server.show('/')\n",
-    "TODO: where does loop come from?\n",
-    "loop.add_callback(show_callback)\n",
     "server.start()\n",
+    "server.show('/')\n",
+    "\n",
     "# Outside the notebook ioloop needs to be started\n",
+    "# from tornado.ioloop import IOLoop\n",
+    "# loop = IOLoop.current()\n",
     "# loop.start() "
    ]
   },

--- a/examples/user_guide/Exporting_and_Archiving.ipynb
+++ b/examples/user_guide/Exporting_and_Archiving.ipynb
@@ -32,7 +32,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import holoviews as hv\n",
     "from holoviews.operation import contours\n",
     "hv.extension()"

--- a/examples/user_guide/Network_Graphs.ipynb
+++ b/examples/user_guide/Network_Graphs.ipynb
@@ -206,7 +206,6 @@
    "outputs": [],
    "source": [
     "%%opts Graph [tools=['hover']]\n",
-    "import networkx as nx\n",
     "G = nx.karate_club_graph()\n",
     "hv.Graph.from_networkx(G, nx.layout.circular_layout).redim.range(**padding)"
    ]

--- a/examples/user_guide/Plots_and_Renderers.ipynb
+++ b/examples/user_guide/Plots_and_Renderers.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "renderer = holoviews.plotting.mpl.MPLRenderer.instance(dpi=120)"
+    "renderer = hv.plotting.mpl.MPLRenderer.instance(dpi=120)"
    ]
   },
   {

--- a/examples/user_guide/Plots_and_Renderers.ipynb
+++ b/examples/user_guide/Plots_and_Renderers.ipynb
@@ -83,8 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from holoviews.plotting.mpl import MPLRenderer\n",
-    "renderer = MPLRenderer.instance(dpi=120)"
+    "renderer = holoviews.plotting.mpl.MPLRenderer.instance(dpi=120)"
    ]
   },
   {

--- a/examples/user_guide/Tips_and_Tricks.ipynb
+++ b/examples/user_guide/Tips_and_Tricks.ipynb
@@ -20,7 +20,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
     "import holoviews as hv\n",
     "hv.extension('bokeh')"
    ]


### PR DESCRIPTION
Following on from #2091, I did some more work on a notebook flakes tool, and ran it on examples/. This PR is the result.

Notes:
* examples/user_guide/Deploying_Bokeh_Apps.ipynb: `loop` comes up as being an undefined name; is it?
* examples/user_guide/Plots_and_Renderers.ipynb: `holoviews.plotting.mpl` is imported near the start, but is unused. I made it be used. You might not like the change. An alternative supported by the flakes tool would be to add `#noqa: reason` to the `holoviews.plotting.mpl` import, and reverting the change I've made here.