### PR TITLE
Fixed transposed expanded grid coords

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -317,7 +317,7 @@ class GridInterface(DictInterface):
             return data.T.flatten() if flat else data
         elif expanded:
             data = cls.coords(dataset, dim.name, expanded=True)
-            return data.flatten() if flat else data
+            return data.T.flatten() if flat else data
         else:
             return cls.coords(dataset, dim.name, ordered=True)
 

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -169,7 +169,7 @@ class CubeInterface(GridInterface):
             return data.T.flatten() if flat else data
         elif expanded:
             data = cls.coords(dataset, dim.name, expanded=True)
-            return data.flatten() if flat else data
+            return data.T.flatten() if flat else data
         else:
             return cls.coords(dataset, dim.name, ordered=True)
 

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -271,7 +271,7 @@ class XArrayInterface(GridInterface):
             return data.T.flatten() if flat else data
         elif expanded:
             data = cls.coords(dataset, dim.name, expanded=True)
-            return data.flatten() if flat else data
+            return data.T.flatten() if flat else data
         else:
             return cls.coords(dataset, dim.name, ordered=True)
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1489,7 +1489,7 @@ def expand_grid_coords(dataset, dim):
     arrays = [dataset.interface.coords(dataset, d.name, True)
               for d in dataset.kdims]
     idx = dataset.get_dimension_index(dim)
-    return cartesian_product(arrays, flat=False)[idx]
+    return cartesian_product(arrays, flat=False)[idx].T
 
 
 def dt64_to_dt(dt64):

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1228,12 +1228,12 @@ class GridTests(object):
                          expanded_xs)
 
     def test_dataset_dim_vals_grid_kdims_expanded_xs(self):
-        expanded_xs = np.array([[0, 0, 0], [1, 1, 1]])
+        expanded_xs = np.array([[0, 1], [0, 1], [0, 1]])
         self.assertEqual(self.dataset_grid.dimension_values(0, flat=False),
                          expanded_xs)
 
     def test_dataset_dim_vals_grid_kdims_expanded_xs_inv(self):
-        expanded_xs = np.array([[0, 0, 0], [1, 1, 1]])
+        expanded_xs = np.array([[0, 1], [0, 1], [0, 1]])
         self.assertEqual(self.dataset_grid_inv.dimension_values(0, flat=False),
                          expanded_xs)
 
@@ -1258,16 +1258,22 @@ class GridTests(object):
                          expanded_ys)
 
     def test_dataset_dim_vals_grid_kdims_expanded_ys(self):
-        expanded_ys = np.array([[0.1, 0.2, 0.3],
-                                [0.1, 0.2, 0.3]])
+        expanded_ys = np.array([[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]])
         self.assertEqual(self.dataset_grid.dimension_values(1, flat=False),
                          expanded_ys)
 
     def test_dataset_dim_vals_grid_kdims_expanded_ys_inv(self):
-        expanded_ys = np.array([[0.1, 0.2, 0.3],
-                                [0.1, 0.2, 0.3]])
+        expanded_ys = np.array([[0.1, 0.1], [0.2, 0.2], [0.3, 0.3]])
         self.assertEqual(self.dataset_grid_inv.dimension_values(1, flat=False),
                          expanded_ys)
+
+    def test_dataset_dim_vals_dimensions_match_shape(self):
+        self.assertEqual(len(set(self.dataset_grid.dimension_values(i, flat=False).shape
+                                 for i in range(3))), 1)
+
+    def test_dataset_dim_vals_dimensions_match_shape_inv(self):
+        self.assertEqual(len(set(self.dataset_grid_inv.dimension_values(i, flat=False).shape
+                                 for i in range(3))), 1)
 
     def test_dataset_dim_vals_grid_vdims_zs_flat(self):
         expanded_zs = np.array([0, 2, 4, 1, 3, 5])


### PR DESCRIPTION
In investigating a bug in the ``Surface`` element I discovered that expanded coordinates are seemingly transposed from the expected orientation. Additionally the ImageInterface.coords method did not allow returning coordinate edges (rather than centers) like the other grid based interfaces.

If this PR passes there's clearly a gap in the unit tests, if it fails I'll have to investigate why this seemingly didn't cause issues or remove workarounds that were put in place elsewhere to make this work.