### PR TITLE
Ensure HoloMap.opts and .options apply to elements

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -72,6 +72,55 @@ class HoloMap(UniformNdMapping, Overlayable):
         return self.groupby(dimensions, container_type=NdLayout, **kwargs)
 
 
+    def opts(self, options=None, backend=None, clone=True, **kwargs):
+        """
+        Applies options on an object or nested group of objects in a
+        by options group returning a new object with the options
+        applied. If the options are to be set directly on the object a
+        simple format may be used, e.g.:
+
+            obj.opts(style={'cmap': 'viridis'}, plot={'show_title': False})
+
+        If the object is nested the options must be qualified using
+        a type[.group][.label] specification, e.g.:
+
+            obj.opts({'Image': {'plot':  {'show_title': False},
+                                'style': {'cmap': 'viridis}}})
+
+        If no opts are supplied all options on the object will be reset.
+        Disabling clone will modify the object inplace.
+        """
+        data = OrderedDict([(k, v.opts(options, backend, clone, **kwargs))
+                             for k, v in self.data.items()])
+        return self.clone(data)
+
+
+    def options(self, options=None, backend=None, clone=True, **kwargs):
+        """
+        Applies options on an object or nested group of objects in a
+        flat format returning a new object with the options
+        applied. If the options are to be set directly on the object a
+        simple format may be used, e.g.:
+
+            obj.options(cmap='viridis', show_title=False)
+
+        If the object is nested the options must be qualified using
+        a type[.group][.label] specification, e.g.:
+
+            obj.options('Image', cmap='viridis', show_title=False)
+
+        or using:
+
+            obj.options({'Image': dict(cmap='viridis', show_title=False)})
+
+        If no options are supplied all options on the object will be reset.
+        Disabling clone will modify the object inplace.
+        """
+        data = OrderedDict([(k, v.options(options, backend, clone, **kwargs))
+                             for k, v in self.data.items()])
+        return self.clone(data)
+
+
     def split_overlays(self):
         """
         Given a UniformNdMapping of Overlays of N layers, split out the layers into

--- a/tests/core/teststoreoptions.py
+++ b/tests/core/teststoreoptions.py
@@ -3,7 +3,7 @@ Unit tests of the StoreOptions class used to control custom options on
 Store as used by the %opts magic.
 """
 import numpy as np
-from holoviews import Overlay, Curve, Image
+from holoviews import Overlay, Curve, Image, HoloMap
 from holoviews.core.options import Store, StoreOptions
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews import plotting              # noqa Register backends
@@ -100,4 +100,13 @@ class TestStoreOptionsCall(ComparisonTestCase):
         self.assertEqual(Store.lookup_options('matplotlib',
             layout, 'plot').kwargs['hspace'], 10)
 
+    def test_holomap_opts(self):
+        hmap = HoloMap({0: Image(np.random.rand(10,10))}).opts(plot=dict(xaxis=None))
+        opts = Store.lookup_options('matplotlib', hmap.last, 'plot')
+        self.assertIs(opts.kwargs['xaxis'], None)
+
+    def test_holomap_options(self):
+        hmap = HoloMap({0: Image(np.random.rand(10,10))}).options(xaxis=None)
+        opts = Store.lookup_options('matplotlib', hmap.last, 'plot')
+        self.assertIs(opts.kwargs['xaxis'], None)
 


### PR DESCRIPTION
Makes HoloMap consistent with DynamicMap such that any options applied to it, get passed down to the objects contained by the HoloMap.

- [x] Fixes https://github.com/ioam/holoviews/issues/2408
- [x] Adds tests