### PR TITLE
Improved validation for nested DynamicMaps and other invalid nestings

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -16,7 +16,7 @@ from ...core.options import Store, SkipRendering
 from ...core.util import int_to_roman, int_to_alpha, basestring
 from ..plot import (DimensionedPlot, GenericLayoutPlot, GenericCompositePlot,
                     GenericElementPlot)
-from ..util import attach_streams
+from ..util import attach_streams, collate, displayable
 from .util import compute_ratios, fix_aspect
 
 
@@ -371,6 +371,8 @@ class GridPlot(CompositePlot):
             # Create subplot
             if type(view) in (Layout, NdLayout):
                 raise SkipRendering("Cannot plot nested Layouts.")
+            if not displayable(view):
+                view = collate(view)
             if view is not None:
                 vtype = view.type if isinstance(view, HoloMap) else view.__class__
                 opts = self.lookup_options(view, 'plot').options
@@ -1009,6 +1011,8 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         for pos in positions:
             # Pos will be one of 'main', 'top' or 'right' or None
             view = layout.get(pos, None)
+            if not displayable(view):
+                view = collate(view)
             ax = axes.get(pos, None)
             if view is None or not view.traverse(lambda x: x, [Element]):
                 projections.append(None)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -24,7 +24,7 @@ def displayable(obj):
                                         for o in obj):
         return False
     if isinstance(obj, HoloMap):
-        return not (obj.type in [Layout, GridSpace, NdLayout])
+        return not (obj.type in [Layout, GridSpace, NdLayout, DynamicMap])
     if isinstance(obj, (GridSpace, Layout, NdLayout)):
         for el in obj.values():
             if not displayable(el):
@@ -49,6 +49,13 @@ def collate(obj):
 
         return obj.collate()
     if isinstance(obj, DynamicMap):
+        if obj.type in [DynamicMap, HoloMap]:
+            obj_name = obj.type.__name__
+            raise Exception("Nesting a %s inside a DynamicMap is not "
+                            "supported. Ensure that the DynamicMap callback "
+                            "returns an Element or (Nd)Overlay. If you have "
+                            "applied an operation ensure it is not dynamic by "
+                            "setting dynamic=False." % obj_name)
         return obj.collate()
     if isinstance(obj, HoloMap):
         display_warning.warning("Nesting {0}s within a {1} makes it difficult "


### PR DESCRIPTION
This PR extends the validation of nesting structures we perform during plotting. Currently when plotting a DynamicMap which returns another DynamicMap you receive an obscure error, this PR ensures you get a sensible error, which describes the two most common scenarios under which this might occur: 1) the callback actually returns a DynamicMap 2) an operation with dynamic=True was applied.

This PR also extends the validation of invalid nesting structures to Layouts/GridSpaces which contain objects which are invalidly nested.

- [x] Addresses https://github.com/ioam/holoviews/issues/2392