### PR TITLE
Fixed bokeh bug with offset being undefined

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -738,6 +738,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         plots = [[] for _ in range(self.rows)]
         tab_titles = {}
         insert_rows, insert_cols = [], []
+        offset = 0
         for r, c in self.coords:
             subplot = self.subplots.get((r, c), None)
             if subplot is not None:


### PR DESCRIPTION
Fixes a small bug in bokeh which occurs in certain layouts containing ``Empty`` objects.

- [x] Fixes https://github.com/ioam/holoviews/issues/2378