### PR TITLE
Fixed MPLRenderer anim output regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=4.2.0 param matplotlib=2.1.2 xarray
   - source activate test-environment
-  - conda install -c conda-forge  iris plotly flexx --quiet
+  - conda install -c conda-forge  iris plotly flexx ffmpeg --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.14 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/examples/user_guide/Plotting_with_Matplotlib.ipynb
+++ b/examples/user_guide/Plotting_with_Matplotlib.ipynb
@@ -133,16 +133,29 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Animated GIF support"
+    "## Animation support"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ``'matplotlib'`` backend supports animated GIF output.  This is useful for output to web pages that users can view without needing to interact with.  It can also be useful for creating descriptive pages for HoloViews constructs that require a live Python/Jupyter server rather than just a web page - see for example [DynamicMap](../reference/containers/matplotlib/DynamicMap.ipynb).\n",
+    "The ``'matplotlib'`` backend supports animated outputs either as video (using mp4 or webm formats) or as animated GIFS. This is useful for output to web pages that users can view without needing to interact with.  It can also be useful for creating descriptive pages for HoloViews constructs that require a live Python/Jupyter server rather than just a web page - see for example [DynamicMap](../reference/containers/matplotlib/DynamicMap.ipynb).\n",
     "\n",
-    "Note that GIF support requires [ImageMagick](http://www.imagemagick.org) which is installed by default on many Linux installations and may be installed on OSX using [brew](http://brew.sh) . For more information on how to install ImageMagick (including Windows instructions) see the [installation page](http://www.imagemagick.org/script/binary-releases.php)."
+    "### GIF\n",
+    "\n",
+    "Note that GIF support requires [ImageMagick](http://www.imagemagick.org) which is installed by default on many Linux installations and may be installed on OSX using [brew](http://brew.sh) . For more information on how to install ImageMagick (including Windows instructions) see the [installation page](http://www.imagemagick.org/script/binary-releases.php).\n",
+    "\n",
+    "In recent versions of matplotlib (>=2.2.0) GIF output can also be generated using [pillow](https://pillow.readthedocs.io/en/latest/), which can be installed using ``conda install pillow`` or ``pip install pillow``.\n",
+    "\n",
+    "We can switch to 'gif' output in one of two ways, either by using the ``%%output`` magic setting the ``holomap='gif'`` option or by directly modifying the renderer with:\n",
+    "\n",
+    "```python\n",
+    "renderer = hv.renderer('matplotlib')\n",
+    "renderer.holomap = 'gif'\n",
+    "```\n",
+    "\n",
+    "Here we will plot an animation of the function we specified above, and also specify the ``fps`` (frames per second) to control the speed of the animation:"
    ]
   },
   {
@@ -152,16 +165,35 @@
    "outputs": [],
    "source": [
     "%%opts Image [xaxis='bare', yaxis='bare' show_title=False, colorbar=True]  (cmap='fire')\n",
-    "%%output holomap='gif'\n",
+    "%%output holomap='gif' fps=5\n",
+    "hv.HoloMap([(t, hv.Image(g(X,Y, 4 * np.sin(np.pi*t)))) for t in np.linspace(0,1,21)]) "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Videos\n",
     "\n",
+    "Video output in matplotlib depends on ffmpeg, which may be [compiled from source](https://trac.ffmpeg.org/wiki/CompilationGuide), installed from conda using ``conda install ffmpeg``, or installed on OSX using brew using ``brew install ffmpeg``.\n",
+    "\n",
+    "To demonstrate we will plot the same animation as above but this time as a video:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [xaxis='bare', yaxis='bare' show_title=False, colorbar=True]  (cmap='fire')\n",
+    "%%output holomap='mp4'\n",
     "hv.HoloMap([(t, hv.Image(g(X,Y, 4 * np.sin(np.pi*t)))) for t in np.linspace(0,1,21)]) "
    ]
   }
  ],
  "metadata": {
   "language_info": {
-   "name": "python",
-   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/tests/plotting/matplotlib/testrenderer.py
+++ b/tests/plotting/matplotlib/testrenderer.py
@@ -70,6 +70,7 @@ class MPLRendererTest(ComparisonTestCase):
         data, metadata = self.renderer.components(self.map1, 'gif')
         self.assertIn("<img src='data:image/gif", data['text/html'])
 
+    @attr(optional=1) # Requires ffmpeg
     def test_render_mp4(self):
         data, metadata = self.renderer.components(self.map1, 'mp4')
         self.assertIn("<source src='data:video/mp4", data['text/html'])

--- a/tests/plotting/matplotlib/testrenderer.py
+++ b/tests/plotting/matplotlib/testrenderer.py
@@ -74,8 +74,3 @@ class MPLRendererTest(ComparisonTestCase):
     def test_render_mp4(self):
         data, metadata = self.renderer.components(self.map1, 'mp4')
         self.assertIn("<source src='data:video/mp4", data['text/html'])
-
-    @attr(optional=1) # Requires ffmpeg with libvpx
-    def test_render_webm(self):
-        data, metadata = self.renderer.components(self.map1, 'webm')
-        self.assertIn("<source src='data:video/webm", data['text/html'])

--- a/tests/plotting/matplotlib/testrenderer.py
+++ b/tests/plotting/matplotlib/testrenderer.py
@@ -66,4 +66,15 @@ class MPLRendererTest(ComparisonTestCase):
         w, h = self.renderer.get_size(plot)
         self.assertEqual((w, h), (288, 288))
 
+    def test_render_gif(self):
+        data, metadata = self.renderer.components(self.map1, 'gif')
+        self.assertIn("<img src='data:image/gif", data['text/html'])
 
+    def test_render_mp4(self):
+        data, metadata = self.renderer.components(self.map1, 'mp4')
+        self.assertIn("<source src='data:video/mp4", data['text/html'])
+
+    @attr(optional=1) # Requires ffmpeg with libvpx
+    def test_render_webm(self):
+        data, metadata = self.renderer.components(self.map1, 'webm')
+        self.assertIn("<source src='data:video/webm", data['text/html'])


### PR DESCRIPTION
During the update to the renderer code to make it work in JupyterLab a regression was introduced to rendering animation output using matplotlib (e.g. gif, mp4 and webm output). This PR fixes the regression.

Additionally this switches to the pillow animation writer for matplotlib>=2.2.0, which provides an easy way to generate gifs on windows.

- [x] Added unit tests
- [x] Addresses https://github.com/ioam/holoviews/issues/385, https://github.com/ioam/holoviews/issues/2095
- [x] Improved documentation of animation support