### PR TITLE
Avoid computing frame ranges for dynamic plots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -422,8 +422,9 @@ class GridPlot(CompositePlot, GenericCompositePlot):
     def _create_subplots(self, layout, ranges):
         subplots = OrderedDict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
+        keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
-                                    for key in self.keys])
+                                    for key in keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         for i, coord in enumerate(layout.keys(full_grid=True)):
             r = i % self.rows
@@ -612,8 +613,9 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         layout_count = 0
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         frame_ranges = self.compute_ranges(layout, None, None)
+        keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
-                                    for key in self.keys])
+                                    for key in keys])
         layout_items = layout.grid_items()
         layout_dimensions = layout.kdims if isinstance(layout, NdLayout) else None
         layout_subplots, layouts, paths = {}, {}, {}

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -361,8 +361,9 @@ class GridPlot(CompositePlot):
             self.handles['fig'].set_size_inches(self.fig_inches)
         subplots, subaxes = OrderedDict(), OrderedDict()
         frame_ranges = self.compute_ranges(layout, None, ranges)
+        keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
-                                    for key in self.keys])
+                                    for key in keys])
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         r, c = (0, 0)
         for coord in layout.keys(full_grid=True):
@@ -883,8 +884,9 @@ class LayoutPlot(GenericLayoutPlot, CompositePlot):
         tight = self.tight
         collapsed_layout = layout.clone(shared_data=False, id=layout.id)
         frame_ranges = self.compute_ranges(layout, None, None)
+        keys = self.keys[:1] if self.dynamic else self.keys
         frame_ranges = OrderedDict([(key, self.compute_ranges(layout, key, frame_ranges))
-                                    for key in self.keys])
+                                    for key in keys])
         layout_subplots, layout_axes = {}, {}
         for r, c in self.coords:
             # Compute the layout type from shape


### PR DESCRIPTION
In the past Plot.keys would only initialize with the first key when plotting DynamicMaps, however at some point it was generalized such that it would contain all possible dynamic key combinations. This causes issues for the range computation because if framewise it will compute evaluate the entire dynamic parameter space on initialization, which is completely infeasible in many cases. This restores the old behavior of only computing the first frame range on initialization.

- [x] Fixes https://github.com/ioam/holoviews/issues/2373