### PR TITLE
Define custom css for JupyterLab slider

### DIFF
--- a/holoviews/plotting/widgets/jsslider.css
+++ b/holoviews/plotting/widgets/jsslider.css
@@ -22,6 +22,9 @@ form.holoform {
     padding-right: 0.8em;
     padding-top: 0.4em;
     padding-bottom: 0.4em;
+	box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+	margin-bottom: 20px;
+	border: 1px solid #e3e3e3;
 }
 
 div.holowidgets {
@@ -68,4 +71,15 @@ div.hologroup {
 
 .holowidgets .ui-resizable-s {
 	visibility: hidden
+}
+
+.noUi-handle {
+	width: 20px !important;
+    height: 20px !important;
+    left: -5px !important;
+    top: -5px !important;
+}
+
+.noUi-handle:before, .noUi-handle:after {
+	visibility: hidden;
 }


### PR DESCRIPTION
Has no effect on the CSS design in the classic notebook but overrides improves the styling for JupyterLab which does not include bootstrap.css.

<img width="1218" alt="screen shot 2018-03-19 at 12 54 32 am" src="https://user-images.githubusercontent.com/1550771/37573470-2134c5f6-2b10-11e8-8c29-3c0a48290ff7.png">

There's still some things that could be improved but I haven't been able to figure out a way without affecting the styling in the classic notebook.