### PR TITLE
Apply utc offset to bokeh callback datetimes

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -53,7 +53,8 @@ def convert_timestamp(timestamp):
     """
     Converts bokehJS timestamp to datetime64.
     """
-    return np.datetime64(dt.datetime.fromtimestamp(timestamp/1000.))
+    datetime = dt.datetime.fromtimestamp(timestamp, dt.timezone.utc)
+    return np.datetime64(datetime.replace(tzinfo=None))
 
 
 def rgba_tuple(rgba):


### PR DESCRIPTION
This fixes an issue dynamically regridding data. The problem was that when bokeh sent datetimes back to Python those were in the local timezone and therefore did not necessarily match the data. By applying an UTC offset to the callback values it seems the bug is fixed. However I don't pretend to know enough about timezones in general to know whether this will cause other issues.

- [x] Fixes https://github.com/ioam/holoviews/issues/2459