### PR TITLE
Improved rasterize API

### DIFF
--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -198,7 +198,7 @@ class AggregationOperation(ResamplingOperation):
                     'min':   rd.min,
                     'max':   rd.max}
 
-    def _get_aggregator(self, element):
+    def _get_aggregator(self, element, add_field=True):
         agg = self.p.aggregator
         if isinstance(agg, basestring):
             if agg not in self._agg_methods:
@@ -223,7 +223,7 @@ class AggregationOperation(ResamplingOperation):
                                  '%s operation to. Declare the dimension '
                                  'to aggregate as part of the datashader '
                                  'aggregator.' % type(self).__name__)
-            agg = type(agg)(field)
+            agg = type(agg)(field if add_field else None)
         return agg
 
 
@@ -561,9 +561,10 @@ class regrid(AggregationOperation):
         # Apply regridding to each value dimension
         regridded = {}
         arrays = self._get_xarrays(element, coords, xtype, ytype)
+        agg_fn = self._get_aggregator(element, add_field=False)
         for vd, xarr in arrays.items():
             rarray = cvs.raster(xarr, upsample_method=self.p.interpolation,
-                                downsample_method=self._get_aggregator(element))
+                                downsample_method=agg_fn)
 
             # Convert datetime coordinates
             if xtype == "datetime":

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -336,7 +336,8 @@ class aggregate(AggregationOperation):
         x, y = element.last.dimensions()[0:2]
         info = self._get_sampling(element, x, y)
         (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
-        agg_params = dict({k: v for k, v in self.p.items() if k in aggregate.params()},
+        agg_params = dict({k: v for k, v in dict(self.get_param_values(), **self.p).items()
+                           if k in aggregate.params()},
                           x_range=x_range, y_range=y_range)
 
         # Optimize categorical counts by aggregating them individually

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 import datashader as ds
+import datashader.reductions as rd
 import datashader.transfer_functions as tf
 import dask.dataframe as dd
 from param.parameterized import bothmethod
@@ -175,7 +176,58 @@ class ResamplingOperation(Operation):
 
 
 
-class aggregate(ResamplingOperation):
+class AggregationOperation(ResamplingOperation):
+    """
+    AggregationOperation extends the ResamplingOperation defining an
+    aggregator parameter used to define a datashader Reduction.
+    """
+
+    aggregator = param.ClassSelector(class_=(ds.reductions.Reduction, basestring),
+                                     default=ds.count(), doc="""
+        Datashader reduction function used for aggregating the data.
+        The aggregator may also define a column to aggregate, if
+        no column is defined the first value dimension of the element
+        will be used. May also be defined as a string.""")
+
+    _agg_methods = {'first': rd.first,
+                    'last':  rd.last,
+                    'mode':  rd.mode,
+                    'mean':  rd.mean,
+                    'var':   rd.var,
+                    'std':   rd.std,
+                    'min':   rd.min,
+                    'max':   rd.max}
+
+    def _get_aggregator(self, element):
+        agg = self.p.aggregator
+        if isinstance(agg, basestring):
+            if agg not in self._agg_methods:
+                agg_methods = sorted(agg)
+                raise ValueError('Aggregation method %r is not know, '
+                                 'aggregator must be one of: %r' %
+                                 (agg, agg_methods))
+            agg = self._agg_methods[agg]()
+
+        elements = element.traverse(lambda x: x, [Element])
+        if agg.column is None and not isinstance(agg, rd.count):
+            if not elements:
+                raise ValueError('Could not find any elements to apply '
+                                 '%s operation to.' % type(self).__name__)
+            inner_element = elements[0]
+            if inner_element.vdims:
+                field = inner_element.vdims[0].name
+            elif isinstance(element, NdOverlay):
+                field = element.kdims[0].name
+            else:
+                raise ValueError('Could not determine dimension to apply '
+                                 '%s operation to. Declare the dimension '
+                                 'to aggregate as part of the datashader '
+                                 'aggregator.' % type(self).__name__)
+            agg = type(agg)(field)
+        return agg
+
+
+class aggregate(AggregationOperation):
     """
     aggregate implements 2D binning for any valid HoloViews Element
     type using datashader. I.e., this operation turns a HoloViews
@@ -200,8 +252,6 @@ class aggregate(ResamplingOperation):
     the linked plot.
     """
 
-    aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
-                                     default=ds.count())
 
     @classmethod
     def get_agg_data(cls, obj, category=None):
@@ -341,7 +391,7 @@ class aggregate(ResamplingOperation):
 
 
     def _process(self, element, key=None):
-        agg_fn = self.p.aggregator
+        agg_fn = self._get_aggregator(element)
         category = agg_fn.column if isinstance(agg_fn, ds.count_cat) else None
 
         if (isinstance(element, NdOverlay) and
@@ -384,7 +434,7 @@ class aggregate(ResamplingOperation):
                       datatype=['xarray'], vdims=vdims)
 
         dfdata = PandasInterface.as_dframe(data)
-        agg = getattr(cvs, glyph)(dfdata, x.name, y.name, self.p.aggregator)
+        agg = getattr(cvs, glyph)(dfdata, x.name, y.name, agg_fn)
         if 'x_axis' in agg.coords and 'y_axis' in agg.coords:
             agg = agg.rename({'x_axis': x, 'y_axis': y})
         if xtype == 'datetime':
@@ -406,7 +456,7 @@ class aggregate(ResamplingOperation):
 
 
 
-class regrid(ResamplingOperation):
+class regrid(AggregationOperation):
     """
     regrid allows resampling a HoloViews Image type using specified
     up- and downsampling functions defined using the aggregator and
@@ -417,10 +467,13 @@ class regrid(ResamplingOperation):
     with nan values.
     """
 
-    aggregator = param.ObjectSelector(default='mean',
-        objects=['first', 'last', 'mean', 'mode', 'std', 'var', 'min', 'max'], doc="""
-        Aggregation method.
-        """)
+    aggregator = param.ClassSelector(default=ds.mean(),
+                                     class_=(ds.reductions.Reduction, basestring),
+                                     doc="""
+        Datashader reduction function used for aggregating the data.
+        The aggregator may also define a column to aggregate, if
+        no column is defined the first value dimension of the element
+        will be used. May also be defined as a string.""")
 
     expand = param.Boolean(default=False, doc="""
        Whether the x_range and y_range should be allowed to expand
@@ -482,14 +535,13 @@ class regrid(ResamplingOperation):
         if ds_version <= '0.5.0':
             raise RuntimeError('regrid operation requires datashader>=0.6.0')
 
+        # Compute coords, anges and size
         x, y = element.kdims
-        coords = tuple(element.dimension_values(d, expanded=False)
-                       for d in [x, y])
+        coords = tuple(element.dimension_values(d, expanded=False) for d in [x, y])
         info = self._get_sampling(element, x, y)
         (x_range, y_range), _, (width, height), (xtype, ytype) = info
-        arrays = self._get_xarrays(element, coords, xtype, ytype)
 
-        # Disable upsampling if requested
+        # Disable upsampling by clipping size and ranges
         (xstart, xend), (ystart, yend) = (x_range, y_range)
         xspan, yspan = (xend-xstart), (yend-ystart)
         if not self.p.upsample and self.p.target is None:
@@ -503,20 +555,25 @@ class regrid(ResamplingOperation):
             height = min([int((yspan/eyspan) * len(coords[1])), height])
             width, height = max([width, 1]), max([height, 1])
 
-        # Get expanded or bounded ranges
         cvs = ds.Canvas(plot_width=width, plot_height=height,
                         x_range=x_range, y_range=y_range)
+
+        # Apply regridding to each value dimension
         regridded = {}
+        arrays = self._get_xarrays(element, coords, xtype, ytype)
         for vd, xarr in arrays.items():
             rarray = cvs.raster(xarr, upsample_method=self.p.interpolation,
-                                downsample_method=self.p.aggregator)
+                                downsample_method=self._get_aggregator(element))
+
+            # Convert datetime coordinates
             if xtype == "datetime":
                 rarray[x.name] = (rarray[x.name]/10e5).astype('datetime64[us]')
             if ytype == "datetime":
                 rarray[y.name] = (rarray[y.name]/10e5).astype('datetime64[us]')
             regridded[vd] = rarray
-
         regridded = xr.Dataset(regridded)
+
+        # Compute bounds (converting datetimes)
         if xtype == 'datetime':
             xstart, xend = (np.array([xstart, xend])/10e5).astype('datetime64[us]')
         if ytype == 'datetime':
@@ -534,8 +591,13 @@ class trimesh_rasterize(aggregate):
     data.
     """
 
-    aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
-                                     default=None)
+    aggregator = param.ClassSelector(default=ds.mean(),
+                                     class_=(ds.reductions.Reduction, basestring),
+                                     doc="""
+        Datashader reduction function used for aggregating the data.
+        The aggregator may also define a column to aggregate, if
+        no column is defined the first value dimension of the element
+        will be used. May also be defined as a string.""")
 
     interpolation = param.ObjectSelector(default='bilinear',
                                          objects=['bilinear', None], doc="""
@@ -580,7 +642,7 @@ class trimesh_rasterize(aggregate):
 
         vdim = element.vdims[0] if element.vdims else element.nodes.vdims[0]
         interpolate = bool(self.p.interpolation)
-        agg = cvs.trimesh(pts, simplices, agg=self.p.aggregator,
+        agg = cvs.trimesh(pts, simplices, agg=self._get_aggregator(element),
                           interp=interpolate, mesh=mesh)
         params = dict(get_param_values(element), kdims=[x, y],
                       datatype=['xarray'], vdims=[vdim])
@@ -600,7 +662,7 @@ class quadmesh_rasterize(trimesh_rasterize):
 
 
 
-class rasterize(ResamplingOperation):
+class rasterize(AggregationOperation):
     """
     Rasterize is a high-level operation which will rasterize any
     Element or combination of Elements aggregating it with the supplied
@@ -624,48 +686,36 @@ class rasterize(ResamplingOperation):
     """
 
     aggregator = param.ClassSelector(class_=ds.reductions.Reduction,
-                                     default=None)
+                                     default=None, doc="""
+        Datashader reduction function used for aggregating the data.
+        The aggregator may also define a column to aggregate, if
+        no column is defined the first value dimension of the element
+        will be used. May also be defined as a string.""")
 
     interpolation = param.ObjectSelector(default='bilinear',
                                          objects=['bilinear', None], doc="""
         The interpolation method to apply during rasterization.""")
 
-    def _process(self, element, key=None):
-        # Get input Images to avoid multiple rasterization
-        imgs = element.traverse(lambda x: x, [Image])
-
-        # Rasterize TriMeshes
-        tri_params = dict({k: v for k, v in self.p.items()
-                           if k in aggregate.params()}, dynamic=False)
-        trirasterize = trimesh_rasterize.instance(**tri_params)
-        trirasterize._precomputed = self._precomputed
-        element = element.map(trirasterize, TriMesh)
-        self._precomputed = trirasterize._precomputed
-
-        # Rasterize QuadMesh
-        quad_params = dict({k: v for k, v in self.p.items()
-                           if k in aggregate.params()}, dynamic=False)
-        quadrasterize = quadmesh_rasterize.instance(**quad_params)
-        quadrasterize._precomputed = self._precomputed
-        element = element.map(quadrasterize, QuadMesh)
-        self._precomputed = quadrasterize._precomputed
-
-        # Rasterize NdOverlay of objects
-        agg_params = dict({k: v for k, v in self.p.items()
-                           if k in aggregate.params()}, dynamic=False)
-        dsrasterize = aggregate.instance(**agg_params)
-        dsrasterize._precomputed = self._precomputed
-        predicate = lambda x: (isinstance(x, NdOverlay) and
+    _transforms = [(Image, regrid),
+                   (TriMesh, trimesh_rasterize),
+                   (QuadMesh, quadmesh_rasterize),
+                   (lambda x: (isinstance(x, NdOverlay) and
                                issubclass(x.type, Dataset)
-                               and not issubclass(x.type, Image))
-        element = element.map(dsrasterize, predicate)
+                               and not issubclass(x.type, Image)),
+                    aggregate),
+                   (lambda x: (isinstance(x, Dataset) and
+                               (not isinstance(x, Image))),
+                    aggregate)]
 
-        # Rasterize other Dataset types
-        predicate = lambda x: (isinstance(x, Dataset) and
-                               (not isinstance(x, Image) or x in imgs))
-        element = element.map(dsrasterize, predicate)
-        self._precomputed = dsrasterize._precomputed
-
+    def _process(self, element, key=None):
+        for predicate, transform in self._transforms:
+            op_params = dict({k: v for k, v in self.p.items()
+                              if k in transform.params() and v is not None},
+                             dynamic=False)
+            op = transform.instance(**op_params)
+            op._precomputed = self._precomputed
+            element = element.map(op, predicate)
+            self._precomputed = op._precomputed
         return element
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -213,7 +213,7 @@ class AggregationOperation(ResamplingOperation):
             agg = self._agg_methods[agg]()
 
         elements = element.traverse(lambda x: x, [Element])
-        if agg.column is None and not isinstance(agg, (rd.count, rd.any)):
+        if add_field and agg.column is None and not isinstance(agg, (rd.count, rd.any)):
             if not elements:
                 raise ValueError('Could not find any elements to apply '
                                  '%s operation to.' % type(self).__name__)
@@ -227,7 +227,7 @@ class AggregationOperation(ResamplingOperation):
                                  '%s operation to. Declare the dimension '
                                  'to aggregate as part of the datashader '
                                  'aggregator.' % type(self).__name__)
-            agg = type(agg)(field if add_field else None)
+            agg = type(agg)(field)
         return agg
 
 

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -189,14 +189,18 @@ class AggregationOperation(ResamplingOperation):
         no column is defined the first value dimension of the element
         will be used. May also be defined as a string.""")
 
-    _agg_methods = {'first': rd.first,
-                    'last':  rd.last,
-                    'mode':  rd.mode,
-                    'mean':  rd.mean,
-                    'var':   rd.var,
-                    'std':   rd.std,
-                    'min':   rd.min,
-                    'max':   rd.max}
+    _agg_methods = {
+        'any':   rd.any,
+        'count': rd.count,
+        'first': rd.first,
+        'last':  rd.last,
+        'mode':  rd.mode,
+        'mean':  rd.mean,
+        'var':   rd.var,
+        'std':   rd.std,
+        'min':   rd.min,
+        'max':   rd.max
+    }
 
     def _get_aggregator(self, element, add_field=True):
         agg = self.p.aggregator
@@ -209,7 +213,7 @@ class AggregationOperation(ResamplingOperation):
             agg = self._agg_methods[agg]()
 
         elements = element.traverse(lambda x: x, [Element])
-        if agg.column is None and not isinstance(agg, rd.count):
+        if agg.column is None and not isinstance(agg, (rd.count, rd.any)):
             if not elements:
                 raise ValueError('Could not find any elements to apply '
                                  '%s operation to.' % type(self).__name__)


### PR DESCRIPTION
This PR ensures that the ``rasterize`` and ``datashade`` operations correctly apply datashading operations to all elements that support it, specifically regridding of Image types can now also be invoked in this way. Secondly this PR improves handling for the aggregator functions, which may now be defined as strings or ``ds.reductions.Reduction`` types.
 
Adding documentation is a separate task which @jbednar volunteered for, specifically these two issues should be addressed by documentation updates:

https://github.com/ioam/holoviews/issues/1909
https://github.com/ioam/holoviews/issues/2158

The rasterize operation works by dispatching each Element type to a specific underlying operation with a specific default aggregator:

- ``Curve``/``Scatter``/``Points``/``Path``: ``aggregate`` (count)
- ``Image``/``RGB``/``HSV``: ``regrid`` (mean)
- ``TriMesh``: without vdims ``aggregate`` (count), with vdims ``trimesh_rasterize`` (mean)
- ``QuadMesh``: ``quadmesh_rasterize`` (mean)

- [x] Addresses https://github.com/ioam/holoviews/issues/2461
- [x] Add tests