### PR TITLE
More notebook flakes checking

### DIFF
--- a/examples/user_guide/08-Gridded_Datasets.ipynb
+++ b/examples/user_guide/08-Gridded_Datasets.ipynb
@@ -13,6 +13,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import xarray as xr\n",
     "import numpy as np\n",
     "import holoviews as hv\n",
     "hv.extension('matplotlib')\n",


### PR DESCRIPTION
I used python27 for flake checking, and got this for examples/user_guide/Plotting_with_Matplotlib.ipynb:

```
__init__.py                 80 ERROR    Notebook JSON is invalid: u'name' is a required property

Failed validating u'required' in notebook[u'properties'][u'metadata'][u'properties'][u'language_info']:

On instance[u'metadata'][u'language_info']:
{}
```

I didn't understand it, so opened in jupyter notebook server:

<img width="1075" alt="screen shot 2018-03-20 at 9 11 32 pm" src="https://user-images.githubusercontent.com/1929/37683578-f43fdd62-2c84-11e8-94a6-fcb85e94df46.png">

I still didn't understand it, but I ran my local notebook metadata stripping tool, and that seemed to make it work and I can kind of see why...but please check the change makes sense to you.


I've also fixed the mistake I made in #2439 (my change there was correctly flagged by nbsmoke here - I'd made a mistake, probably because I was editing lots of notebooks at the same time).
