### PR TITLE
Avoid zero division warnings in live data user guide

### DIFF
--- a/examples/user_guide/06-Live_Data.ipynb
+++ b/examples/user_guide/06-Live_Data.ipynb
@@ -70,7 +70,7 @@
    "source": [
     "import holoviews as hv\n",
     "import numpy as np\n",
-    "hv.extension()"
+    "hv.extension('matplotlib')"
    ]
   },
   {
@@ -94,7 +94,7 @@
     "def waves_image(alpha, beta):\n",
     "    return hv.Image(np.sin(((ys/alpha)**alpha+beta)*xs))\n",
     "\n",
-    "waves_image(0,0) + waves_image(0,4)"
+    "waves_image(1,0) + waves_image(1,4)",
    ]
   },
   {
@@ -152,7 +152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dmap[0,1] + dmap.select(alpha=1, beta=2)"
+    "dmap[1,2] + dmap.select(alpha=1, beta=2)",
    ]
   },
   {
@@ -177,7 +177,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dmap.redim.range(alpha=(0,5.0), beta=(1,5.0))"
+    "dmap.redim.range(alpha=(1,5.0), beta=(1,6.0))",
    ]
   },
   {
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dmap.redim.values(alpha=[0,1,2], beta=[0.1, 1.0, 2.5])"
+    "dmap.redim.values(alpha=[1,2,3], beta=[0.1, 1.0, 2.5])",
    ]
   },
   {


### PR DESCRIPTION
Addresses #2250. I also thought it was worth making the backend explicit when loading the extension. Was there a good reason not to?