### PR TITLE
Implemented and standardized GridSpace/NdLayout overlay operations

### DIFF
--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -354,37 +354,6 @@ class NdLayout(UniformNdMapping):
         return clone
 
 
-    def __mul__(self, other, reverse=False):
-        if isinstance(other, NdLayout):
-            from .overlay import Overlay
-            if self.kdims != other.kdims:
-                raise KeyError("Can only overlay two NdLayouts with "
-                               "non-matching key dimensions.")
-            items = []
-            self_keys = list(self.data.keys())
-            other_keys = list(other.data.keys())
-            for key in unique_iterator(self_keys+other_keys):
-                self_el = self.data.get(key)
-                other_el = other.data.get(key)
-                if self_el is None:
-                    item = [other_el]
-                elif other_el is None:
-                    item = [self_el]
-                elif reverse:
-                    item = [other_el, self_el]
-                else:
-                    item = [self_el, other_el]
-                items.append((key, Overlay(item)))
-            return self.clone(items)
-
-        overlayed_items = [(k, other * el if reverse else el * other)
-                           for k, el in self.items()]
-        return self.clone(overlayed_items)
-
-
-    def __rmul__(self, other):
-        return self.__mul__(other, reverse=True)
-
 
 
 # To be removed after 1.3.0

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -16,7 +16,7 @@ import param
 from .dimension import Dimension, Dimensioned, ViewableElement
 from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
 from .tree import AttrTree
-from .util import unique_array, get_path, make_path_unique, int_to_roman
+from .util import (unique_array, get_path, make_path_unique, int_to_roman)
 from . import traversal
 
 
@@ -349,7 +349,6 @@ class NdLayout(UniformNdMapping):
         clone._max_cols = self._max_cols
         clone.id = self.id
         return clone
-
 
 
 

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -351,6 +351,23 @@ class NdLayout(UniformNdMapping):
         return clone
 
 
+    def __mul__(self, other, reverse=False):
+        if isinstance(other, NdLayout):
+            if set(self.keys()) != set(other.keys()):
+                raise KeyError("Can only overlay two NdLayouts if their keys match")
+            zipped = zip(self.keys(), self.values(), other.values())
+            overlayed_items = [(k, el1 * el2) for (k, el1, el2) in zipped]
+            return self.clone(overlayed_items)
+
+        overlayed_items = [(k, other * el if reverse else el * other)
+                           for k, el in self.items()]
+        return self.clone(overlayed_items)
+
+
+    def __rmul__(self, other):
+        return self.__mul__(other, reverse=True)
+
+
 
 # To be removed after 1.3.0
 class Warning(param.Parameterized): pass

--- a/holoviews/core/layout.py
+++ b/holoviews/core/layout.py
@@ -16,10 +16,7 @@ import param
 from .dimension import Dimension, Dimensioned, ViewableElement
 from .ndmapping import OrderedDict, NdMapping, UniformNdMapping
 from .tree import AttrTree
-from .util import (
-    unique_array, get_path, make_path_unique, int_to_roman,
-    unique_iterator
-)
+from .util import unique_array, get_path, make_path_unique, int_to_roman
 from . import traversal
 
 

--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -233,7 +233,7 @@ class Overlay(Layout, CompositeOverlay):
 
 
 
-class NdOverlay(UniformNdMapping, CompositeOverlay, Overlayable):
+class NdOverlay(Overlayable, UniformNdMapping, CompositeOverlay):
     """
     An NdOverlay allows a group of NdOverlay to be overlaid together. NdOverlay can
     be indexed out of an overlay and an overlay is an iterable that iterates

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1458,38 +1458,6 @@ class GridSpace(UniformNdMapping):
             raise Exception('Grids can have no more than two dimensions.')
 
 
-    def __mul__(self, other, reverse=False):
-        if isinstance(other, GridSpace):
-            if self.kdims != other.kdims:
-                raise KeyError("Can only overlay two GridSpaces with "
-                               "non-matching key dimensions.")
-            items = []
-            self_keys = list(self.data.keys())
-            other_keys = list(other.data.keys())
-            for key in util.unique_iterator(self_keys+other_keys):
-                self_el = self.data.get(key)
-                other_el = other.data.get(key)
-                if self_el is None:
-                    item = [other_el]
-                elif other_el is None:
-                    item = [self_el]
-                elif reverse:
-                    item = [other_el, self_el]
-                else:
-                    item = [self_el, other_el]
-                items.append((key, Overlay(item)))
-            print(items)
-            return self.clone(items)
-
-        overlayed_items = [(k, other * el if reverse else el * other)
-                           for k, el in self.items()]
-        return self.clone(overlayed_items)
-
-
-    def __rmul__(self, other):
-        return self.__mul__(other, reverse=True)
-
-
     def __lshift__(self, other):
         if isinstance(other, (ViewableElement, UniformNdMapping)):
             return AdjointLayout([self, other])

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1458,22 +1458,21 @@ class GridSpace(UniformNdMapping):
             raise Exception('Grids can have no more than two dimensions.')
 
 
-    def __mul__(self, other):
+    def __mul__(self, other, reverse=False):
         if isinstance(other, GridSpace):
             if set(self.keys()) != set(other.keys()):
-                raise KeyError("Can only overlay two ParameterGrids if their keys match")
+                raise KeyError("Can only overlay two GridSpaces if their keys match")
             zipped = zip(self.keys(), self.values(), other.values())
             overlayed_items = [(k, el1 * el2) for (k, el1, el2) in zipped]
             return self.clone(overlayed_items)
-        elif isinstance(other, UniformNdMapping) and len(other) == 1:
-            view = other.last
-        elif isinstance(other, UniformNdMapping) and len(other) != 1:
-            raise Exception("Can only overlay with HoloMap of length 1")
-        else:
-            view = other
 
-        overlayed_items = [(k, el * view) for k, el in self.items()]
+        overlayed_items = [(k, other * el if reverse else el * other)
+                           for k, el in self.items()]
         return self.clone(overlayed_items)
+
+
+    def __rmul__(self, other):
+        return self.__mul__(other, reverse=True)
 
 
     def __lshift__(self, other):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1460,11 +1460,26 @@ class GridSpace(UniformNdMapping):
 
     def __mul__(self, other, reverse=False):
         if isinstance(other, GridSpace):
-            if set(self.keys()) != set(other.keys()):
-                raise KeyError("Can only overlay two GridSpaces if their keys match")
-            zipped = zip(self.keys(), self.values(), other.values())
-            overlayed_items = [(k, el1 * el2) for (k, el1, el2) in zipped]
-            return self.clone(overlayed_items)
+            if self.kdims != other.kdims:
+                raise KeyError("Can only overlay two GridSpaces with "
+                               "non-matching key dimensions.")
+            items = []
+            self_keys = list(self.data.keys())
+            other_keys = list(other.data.keys())
+            for key in util.unique_iterator(self_keys+other_keys):
+                self_el = self.data.get(key)
+                other_el = other.data.get(key)
+                if self_el is None:
+                    item = [other_el]
+                elif other_el is None:
+                    item = [self_el]
+                elif reverse:
+                    item = [other_el, self_el]
+                else:
+                    item = [self_el, other_el]
+                items.append((key, Overlay(item)))
+            print(items)
+            return self.clone(items)
 
         overlayed_items = [(k, other * el if reverse else el * other)
                            for k, el in self.items()]

--- a/tests/core/testlayouts.py
+++ b/tests/core/testlayouts.py
@@ -1,4 +1,5 @@
 from holoviews import AdjointLayout, NdLayout, GridSpace, Layout, Element, HoloMap
+from holoviews.element import HLine
 from holoviews.element.comparison import ComparisonTestCase
 
 
@@ -113,6 +114,44 @@ class NdLayoutTest(CompositeTest):
         grid = NdLayout([(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)])
         self.assertEqual(grid.shape, (1,4))
 
+    def test_ndlayout_overlay_element(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = NdLayout(items)
+        hline = HLine(0)
+        overlaid_grid = grid * hline
+        expected = NdLayout([(k, v*hline) for k, v in items])
+        self.assertEqual(overlaid_grid, expected)
+
+    def test_ndlayout_overlay_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = NdLayout(items)
+        hline = HLine(0)
+        overlaid_grid = hline * grid
+        expected = NdLayout([(k, hline*v) for k, v in items])
+        self.assertEqual(overlaid_grid, expected)
+
+    def test_ndlayout_overlay_ndlayout(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = NdLayout(items)
+        items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
+        grid2 = NdLayout(items2)
+
+        expected_items = [(0, self.view1*self.view2), (1, self.view2*self.view1),
+                          (2, self.view3*self.view2), (3, self.view2*self.view3)]
+        expected = NdLayout(expected_items)
+        self.assertEqual(grid*grid2, expected)
+
+    def test_ndlayout_overlay_ndlayout_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = NdLayout(items)
+        items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
+        grid2 = NdLayout(items2)
+
+        expected_items = [(0, self.view2*self.view1), (1, self.view1*self.view2),
+                          (2, self.view2*self.view3), (3, self.view3*self.view2)]
+        expected = NdLayout(expected_items)
+        self.assertEqual(grid2*grid, expected)
+
 
 class GridTest(CompositeTest):
 
@@ -121,3 +160,41 @@ class GridTest(CompositeTest):
         keys = [(0,0), (0,1), (1,0), (1,1)]
         grid = GridSpace(zip(keys, vals))
         self.assertEqual(grid.shape, (2,2))
+
+    def test_ndlayout_overlay_element(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        hline = HLine(0)
+        overlaid_grid = grid * hline
+        expected = GridSpace([(k, v*hline) for k, v in items], 'X')
+        self.assertEqual(overlaid_grid, expected)
+
+    def test_ndlayout_overlay_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        hline = HLine(0)
+        overlaid_grid = hline * grid
+        expected = GridSpace([(k, hline*v) for k, v in items], 'X')
+        self.assertEqual(overlaid_grid, expected)
+
+    def test_ndlayout_overlay_ndlayout(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
+        grid2 = GridSpace(items2, 'X')
+
+        expected_items = [(0, self.view1*self.view2), (1, self.view2*self.view1),
+                          (2, self.view3*self.view2), (3, self.view2*self.view3)]
+        expected = GridSpace(expected_items, 'X')
+        self.assertEqual(grid*grid2, expected)
+
+    def test_ndlayout_overlay_ndlayout_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
+        grid2 = GridSpace(items2, 'X')
+
+        expected_items = [(0, self.view2*self.view1), (1, self.view1*self.view2),
+                          (2, self.view2*self.view3), (3, self.view3*self.view2)]
+        expected = GridSpace(expected_items, 'X')
+        self.assertEqual(grid2*grid, expected)

--- a/tests/core/testlayouts.py
+++ b/tests/core/testlayouts.py
@@ -1,4 +1,4 @@
-from holoviews import AdjointLayout, NdLayout, GridSpace, Layout, Element, HoloMap
+from holoviews import AdjointLayout, NdLayout, GridSpace, Layout, Element, HoloMap, Overlay
 from holoviews.element import HLine
 from holoviews.element.comparison import ComparisonTestCase
 
@@ -152,6 +152,32 @@ class NdLayoutTest(CompositeTest):
         expected = NdLayout(expected_items)
         self.assertEqual(grid2*grid, expected)
 
+    def test_ndlayout_overlay_ndlayout_partial(self):
+        items = [(0, self.view1), (1, self.view2), (3, self.view2)]
+        grid = NdLayout(items, 'X')
+        items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
+        grid2 = NdLayout(items2, 'X')
+
+        expected_items = [(0, Overlay([self.view1, self.view2])),
+                          (1, Overlay([self.view2])),
+                          (2, Overlay([self.view2])),
+                          (3, Overlay([self.view2, self.view3]))]
+        expected = NdLayout(expected_items, 'X')
+        self.assertEqual(grid*grid2, expected)
+
+    def test_ndlayout_overlay_ndlayout_partial_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (3, self.view2)]
+        grid = NdLayout(items, 'X')
+        items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
+        grid2 = NdLayout(items2, 'X')
+
+        expected_items = [(0, Overlay([self.view2, self.view1])),
+                          (1, Overlay([self.view2])),
+                          (2, Overlay([self.view2])),
+                          (3, Overlay([self.view3, self.view2]))]
+        expected = NdLayout(expected_items, 'X')
+        self.assertEqual(grid2*grid, expected)
+
 
 class GridTest(CompositeTest):
 
@@ -161,7 +187,7 @@ class GridTest(CompositeTest):
         grid = GridSpace(zip(keys, vals))
         self.assertEqual(grid.shape, (2,2))
 
-    def test_ndlayout_overlay_element(self):
+    def test_gridspace_overlay_element(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
         grid = GridSpace(items, 'X')
         hline = HLine(0)
@@ -169,7 +195,7 @@ class GridTest(CompositeTest):
         expected = GridSpace([(k, v*hline) for k, v in items], 'X')
         self.assertEqual(overlaid_grid, expected)
 
-    def test_ndlayout_overlay_reverse(self):
+    def test_gridspace_overlay_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
         grid = GridSpace(items, 'X')
         hline = HLine(0)
@@ -177,7 +203,7 @@ class GridTest(CompositeTest):
         expected = GridSpace([(k, hline*v) for k, v in items], 'X')
         self.assertEqual(overlaid_grid, expected)
 
-    def test_ndlayout_overlay_ndlayout(self):
+    def test_gridspace_overlay_gridspace(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
         grid = GridSpace(items, 'X')
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
@@ -188,7 +214,7 @@ class GridTest(CompositeTest):
         expected = GridSpace(expected_items, 'X')
         self.assertEqual(grid*grid2, expected)
 
-    def test_ndlayout_overlay_ndlayout_reverse(self):
+    def test_gridspace_overlay_gridspace_reverse(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
         grid = GridSpace(items, 'X')
         items2 = [(0, self.view2), (1, self.view1), (2, self.view2), (3, self.view3)]
@@ -198,3 +224,30 @@ class GridTest(CompositeTest):
                           (2, self.view2*self.view3), (3, self.view3*self.view2)]
         expected = GridSpace(expected_items, 'X')
         self.assertEqual(grid2*grid, expected)
+
+    def test_gridspace_overlay_gridspace_partial(self):
+        items = [(0, self.view1), (1, self.view2), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
+        grid2 = GridSpace(items2, 'X')
+
+        expected_items = [(0, Overlay([self.view1, self.view2])),
+                          (1, Overlay([self.view2])),
+                          (2, Overlay([self.view2])),
+                          (3, Overlay([self.view2, self.view3]))]
+        expected = GridSpace(expected_items, 'X')
+        self.assertEqual(grid*grid2, expected)
+
+    def test_gridspace_overlay_gridspace_partial_reverse(self):
+        items = [(0, self.view1), (1, self.view2), (3, self.view2)]
+        grid = GridSpace(items, 'X')
+        items2 = [(0, self.view2), (2, self.view2), (3, self.view3)]
+        grid2 = GridSpace(items2, 'X')
+
+        expected_items = [(0, Overlay([self.view2, self.view1])),
+                          (1, Overlay([self.view2])),
+                          (2, Overlay([self.view2])),
+                          (3, Overlay([self.view3, self.view2]))]
+        expected = GridSpace(expected_items, 'X')
+        self.assertEqual(grid2*grid, expected)
+        


### PR DESCRIPTION
This PR makes ``NdLayout.__mul__`` consistent with ``GridSpace.__mul__``. Both are homogeneous layout containers and should therefore overlay in the same way. Adding ``__mul__ `` support for Layout as discussed in the corresponding issue is imo a different topic that would require more discussion. In that case I think the suggested semantics are more confusing than helpful while the semantics for NdLayout/GridSpace are well defined. In the ``GridSpace*GridSpace`` or ``NdLayout*NdLayout`` items can be matched up based on their keys while zipping Layouts will surprise at least some people.

- [x] Addresses https://github.com/ioam/holoviews/issues/2075
- [x] Adds unit tests