### PR TITLE
Allow specifying Bivariate levels

### DIFF
--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -150,6 +150,9 @@ class bivariate_kde(Operation):
     filled = param.Boolean(default=False, doc="""
         Controls whether to return filled or unfilled contours.""")
 
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+
     n_samples = param.Integer(default=100, doc="""
         Number of samples to compute the KDE over.""")
 
@@ -219,6 +222,6 @@ class bivariate_kde(Operation):
 
         img = Image((xs, ys, f.T), kdims=element.dimensions()[:2], vdims=[vdim], **params)
         if self.p.contours:
-            cntr = contours(img, filled=self.p.filled)
+            cntr = contours(img, filled=self.p.filled, levels=self.p.levels)
             return cntr.clone(cntr.data[1:], **params)
         return img

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -49,6 +49,10 @@ class BivariatePlot(PolygonPlot):
     filled = param.Boolean(default=False, doc="""
         Whether the bivariate contours should be filled.""")
 
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+
+
 
 
 class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -38,6 +38,10 @@ class BivariatePlot(PolygonPlot):
     filled = param.Boolean(default=False, doc="""
         Whether the bivariate contours should be filled.""")
 
+    levels = param.ClassSelector(default=10, class_=(list, int), doc="""
+        A list of scalar values used to specify the contour levels.""")
+
+
 
 
 class BoxPlot(ChartPlot):

--- a/tests/operation/testoperation.py
+++ b/tests/operation/testoperation.py
@@ -57,8 +57,9 @@ class OperationTests(ComparisonTestCase):
     def test_image_contours(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_contours = contours(img, levels=[0.5])
-        contour = Contours([[(-0.5,  0.416667, 0.5), (-0.25, 0.5, 0.5)],
-                             [(0.25, 0.5, 0.5), (0.5, 0.45, 0.5)]],
+        contour = Contours([[(-0.5,  0.416667, 0.5), (-0.25, 0.5, 0.5),
+                             (np.NaN, np.NaN, 0.5), (0.25, 0.5, 0.5),
+                             (0.5, 0.45, 0.5)]],
                             vdims=img.vdims)
         self.assertEqual(op_contours, contour)
 
@@ -66,8 +67,8 @@ class OperationTests(ComparisonTestCase):
     def test_image_contours_filled(self):
         img = Image(np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]]))
         op_contours = contours(img, filled=True, levels=[2, 2.5])
-        data = [[(0., 0.333333, 2.25), (0.5, 0.3, 2.25), (0.5, 0.25, 2.25), (0., 0.25, 2.25),
-                 (-0.5, 0.08333333, 2.25), (-0.5, 0.16666667, 2.25), (0., 0.33333333, 2.25)]]
+        data = [[(0., 0.333333, 2), (0.5, 0.3, 2), (0.5, 0.25, 2), (0., 0.25, 2),
+                 (-0.5, 0.08333333, 2), (-0.5, 0.16666667, 2), (0., 0.33333333, 2)]]
         polys = Polygons(data, vdims=img.vdims)
         self.assertEqual(op_contours, polys)
 

--- a/tests/operation/teststatsoperations.py
+++ b/tests/operation/teststatsoperations.py
@@ -7,7 +7,7 @@ except:
 
 import numpy as np
 
-from holoviews import Distribution, Bivariate, Area, Image
+from holoviews import Distribution, Bivariate, Area, Image, Contours, Polygons
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.stats import (univariate_kde, bivariate_kde)
 
@@ -47,6 +47,20 @@ class KDEOperationTests(ComparisonTestCase):
         img = Image(np.array([[0, 0], [27711861.782675, 0]]),
                     bounds=(-2, -2, 6, 6), vdims=['Density'])
         self.assertEqual(kde, img)
+
+    def test_bivariate_kde_contours(self):
+        bivariate = Bivariate(np.random.rand(100, 2))
+        kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
+                            y_range=(0, 1), contours=True, levels=10)
+        self.assertIsInstance(kde, Contours)
+        self.assertEqual(len(kde.data), 10)
+
+    def test_bivariate_kde_contours_filled(self):
+        bivariate = Bivariate(np.random.rand(100, 2))
+        kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
+                            y_range=(0, 1), contours=True, filled=True, levels=10)
+        self.assertIsInstance(kde, Polygons)
+        self.assertEqual(len(kde.data), 10)
 
     def test_bivariate_kde_nans(self):
         kde = bivariate_kde(self.bivariate_nans, n_samples=2, x_range=(0, 4),


### PR DESCRIPTION
This PR allows specifying levels for the Bivariate element as requested in #2099. Additionally it also ensures that the contours operation actually generates the requested number of levels, which was not the case before. Probably changes some test data but it's a clear bug fix.

- [x] Addresses https://github.com/ioam/holoviews/issues/2099
- [x] Added unit tests