### PR TITLE
Change inspect.getargspec to inspect.getfullargspec in order to fix the DeprecationWarning

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1,4 +1,4 @@
-import inspect, re, time, sys
+import re, time, sys
 from distutils.version import LooseVersion
 from collections import defaultdict
 import datetime as dt
@@ -31,7 +31,8 @@ except:
 
 from ...core.options import abbreviated_exception
 from ...core.overlay import Overlay
-from ...core.util import basestring, unique_array, callable_name, pd, dt64_to_dt
+from ...core.util import (basestring, unique_array, callable_name, pd,
+                          dt64_to_dt, _getargspec)
 from ...core.spaces import get_nested_dmaps, DynamicMap
 
 from ..util import dim_axis_label, rgb2hex
@@ -379,7 +380,7 @@ def py2js_tickformatter(formatter, msg=''):
         param.main.warning(msg+error)
         return
 
-    args = inspect.getargspec(formatter).args
+    args = _getargspec(formatter).args
     arg_define = 'var %s = tick;' % args[0] if args else ''
     return_js = 'return formatter();\n'
     jsfunc = '\n'.join([arg_define, jscode, return_js])

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -1,12 +1,11 @@
 import re
-import inspect
 import warnings
 
 import numpy as np
 from matplotlib import ticker
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
 
-from ...core.util import basestring
+from ...core.util import basestring, _getargspec
 from ...element import Raster, RGB
 
 
@@ -18,7 +17,7 @@ def wrap_formatter(formatter):
     if isinstance(formatter, ticker.Formatter):
         return formatter
     elif callable(formatter):
-        args = [arg for arg in inspect.getargspec(formatter).args
+        args = [arg for arg in _getargspec(formatter).args
                 if arg != 'self']
         wrapped = formatter
         if len(args) == 1:


### PR DESCRIPTION
 In Python 3.6 I keep getting the following warning:
```
/home/tinkerer/.conda/envs/dev/lib/python3.6/site-packages/ipykernel/__main__.py:2: DeprecationWarning: inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec()
```

When creating some kind of composite object this warning is often printed a dozen times.