### PR TITLE
Fixed expansion of Cycles of unequal lengths

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -392,7 +392,7 @@ class Options(param.Parameterized):
        skipping over invalid keywords or not. May only be specified at
        the class level.""")
 
-    def __init__(self, key=None, allowed_keywords=[], merge_keywords=True, **kwargs):
+    def __init__(self, key=None, allowed_keywords=[], merge_keywords=True, max_cycles=None, **kwargs):
 
         invalid_kws = []
         for kwarg in sorted(kwargs.keys()):
@@ -412,6 +412,7 @@ class Options(param.Parameterized):
         self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
         opt_generator = self._expand_options(self.kwargs)
         self._options = []
+        self._max_cycles = max_cycles
         if any(isinstance(v, Cycle) for v in self.kwargs.values()):
             self._opt_generator = opt_generator
         else:
@@ -484,7 +485,7 @@ class Options(param.Parameterized):
         """
         kwargs = {kw: (arg[num] if isinstance(arg, Cycle) else arg)
                   for kw, arg in self.kwargs.items()}
-        return self(**kwargs)
+        return self(max_cycles=num, **kwargs)
 
 
     def __getitem__(self, index):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -452,11 +452,11 @@ class Options(param.Parameterized):
 
     def max_cycles(self, num):
         """
-        Truncates all contained Cycle objects to a maximum number
-        of Cycles and returns a new Options object with the
-        truncated or resampled Cycles.
+        Truncates all contained Palette objects to a maximum number
+        of samples and returns a new Options object containing the
+        truncated or resampled Palettes.
         """
-        kwargs = {kw: (arg[num] if isinstance(arg, Cycle) else arg)
+        kwargs = {kw: (arg[num] if isinstance(arg, Palette) else arg)
                   for kw, arg in self.kwargs.items()}
         return self(max_cycles=num, **kwargs)
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -482,7 +482,7 @@ class Options(param.Parameterized):
             options[key] = values[index % len(values)]
 
         static = {k:v for k,v in self.kwargs.items() if not isinstance(v, Cycle)}
-        return dict(static,**options)
+        return dict(static, **options)
 
 
     @property

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -37,6 +37,7 @@ import traceback
 import difflib
 from contextlib import contextmanager
 from collections import OrderedDict, defaultdict
+from itertools import cycle
 
 import numpy as np
 
@@ -409,7 +410,14 @@ class Options(param.Parameterized):
                          % (repr(invalid_kws), str(allowed_keywords)))
 
         self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
-        self._options = self._expand_options(kwargs)
+        opt_generator = self._expand_options(self.kwargs)
+        self._options = []
+        if any(isinstance(v, Cycle) for v in self.kwargs.values()):
+            self._opt_generator = opt_generator
+        else:
+            self._opt_generator = None
+            self._options = [next(opt_generator)]
+
         allowed_keywords = (allowed_keywords if isinstance(allowed_keywords, Keywords)
                             else Keywords(allowed_keywords))
         super(Options, self).__init__(allowed_keywords=allowed_keywords,
@@ -445,20 +453,22 @@ class Options(param.Parameterized):
 
     def _expand_options(self, kwargs):
         """
-        Expand out Cycle objects into multiple sets of keyword values.
+        Generator that expands Cycle objects into multiple sets of keyword values.
 
-        To elaborate, the full Cartesian product over the supplied
-        Cycle objects is expanded into a list, allowing infinite,
-        cyclic indexing in the __getitem__ method."""
+        Independently cycles through each cycle values. The __getitem__
+        method will lazily evaluate the expanded options up to the requested
+        cycle.
+        """
         filter_static = dict((k,v) for (k,v) in kwargs.items() if not isinstance(v, Cycle))
         filter_cycles = [(k,v) for (k,v) in kwargs.items() if isinstance(v, Cycle)]
-
-        if not filter_cycles: return [kwargs]
-
-        filter_names, filter_values = list(zip(*filter_cycles))
-
-        cyclic_tuples = list(zip(*[val.values for val in filter_values]))
-        return [dict(zip(filter_names, tps), **filter_static) for tps in cyclic_tuples]
+        if filter_cycles:
+            filter_names, filter_values = list(zip(*filter_cycles))
+        else:
+            filter_names, filter_values = [], []
+        cycles = [cycle(val.values) for val in filter_values]
+        while True:
+            cyclic_style = {n: next(c) for n, c in zip(filter_names, cycles)}
+            yield dict(cyclic_style, **filter_static)
 
 
     def keys(self):
@@ -482,13 +492,18 @@ class Options(param.Parameterized):
         Infinite cyclic indexing of options over the integers,
         looping over the set of defined Cycle objects.
         """
-        return dict(self._options[index % len(self._options)])
+        if self._opt_generator is None:
+            return dict(self._options[0])
+        if index >= len(self._options):
+            eval_range = range(index-len(self._options)+1)
+            self._options += [next(self._opt_generator) for _ in eval_range]
+        return dict(self._options[index])
 
 
     @property
     def options(self):
         "Access of the options keywords when no cycles are defined."
-        if len(self._options) == 1:
+        if self._opt_generator is None:
             return dict(self._options[0])
         else:
             raise Exception("The options property may only be used with non-cyclic Options.")

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -471,10 +471,8 @@ class Options(param.Parameterized):
         Infinite cyclic indexing of options over the integers,
         looping over the set of defined Cycle objects.
         """
-        if len(self.kwargs) == 0 and index==0:
+        if len(self.kwargs) == 0:
             return {}
-        elif len(self.kwargs) == 0:
-            raise IndexError('Empty options object only has a zero index')
 
         cycles = {k:v.values for k,v in self.kwargs.items() if isinstance(v, Cycle)}
         options = {}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -775,7 +775,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             max_cycles = None
         else:
             style_element = element
-            max_cycles = len(self.style._options)
+            max_cycles = self.style._max_cycles
         style = self.lookup_options(style_element, 'style')
         self.style = style.max_cycles(max_cycles) if max_cycles else style
 

--- a/tests/core/testoptions.py
+++ b/tests/core/testoptions.py
@@ -130,6 +130,19 @@ class TestCycle(ComparisonTestCase):
         self.assertEqual(opts[5], {'one': 'c', 'two': 3})
 
 
+    def test_cycle_expansion_unequal(self):
+        cycle1 = Cycle(values=['a', 'b', 'c', 'd'])
+        cycle2 = Cycle(values=[1, 2, 3])
+
+        opts = Options('test', one=cycle1, two=cycle2)
+        self.assertEqual(opts[0], {'one': 'a', 'two': 1})
+        self.assertEqual(opts[1], {'one': 'b', 'two': 2})
+        self.assertEqual(opts[2], {'one': 'c', 'two': 3})
+        self.assertEqual(opts[3], {'one': 'd', 'two': 1})
+        self.assertEqual(opts[4], {'one': 'a', 'two': 2})
+        self.assertEqual(opts[5], {'one': 'b', 'two': 3})
+
+
     def test_cycle_slice(self):
         cycle1 = Cycle(values=['a', 'b', 'c'])[2]
         cycle2 = Cycle(values=[1, 2, 3])
@@ -137,8 +150,8 @@ class TestCycle(ComparisonTestCase):
         opts = Options('test', one=cycle1, two=cycle2)
         self.assertEqual(opts[0], {'one': 'a', 'two': 1})
         self.assertEqual(opts[1], {'one': 'b', 'two': 2})
-        self.assertEqual(opts[2], {'one': 'a', 'two': 1})
-        self.assertEqual(opts[3], {'one': 'b', 'two': 2})
+        self.assertEqual(opts[2], {'one': 'a', 'two': 3})
+        self.assertEqual(opts[3], {'one': 'b', 'two': 1})
 
 
     def test_options_property_disabled(self):

--- a/tests/core/testoptions.py
+++ b/tests/core/testoptions.py
@@ -154,6 +154,16 @@ class TestCycle(ComparisonTestCase):
         self.assertEqual(opts[3], {'one': 'b', 'two': 1})
 
 
+    def test_cyclic_property_true(self):
+        cycle1 = Cycle(values=['a', 'b', 'c'])
+        opts = Options('test', one=cycle1, two='two')
+        self.assertEqual(opts.cyclic, True)
+
+    def test_cyclic_property_false(self):
+        opts = Options('test', one='one', two='two')
+        self.assertEqual(opts.cyclic, False)
+
+
     def test_options_property_disabled(self):
         cycle1 = Cycle(values=['a', 'b', 'c'])
         opts = Options('test', one=cycle1)

--- a/tests/plotting/bokeh/testcurveplot.py
+++ b/tests/plotting/bokeh/testcurveplot.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from holoviews.core import NdOverlay, HoloMap, DynamicMap
 from holoviews.core.options import Cycle, Palette
-from holoviews.core.util import pd
+from holoviews.core.util import pd, basestring
 from holoviews.element import Curve
 from holoviews.plotting.util import rgb2hex
 from holoviews.streams import PointerX
@@ -55,7 +55,8 @@ class TestCurvePlot(TestBokehPlot):
         colors = palette[3].values
         plot = bokeh_renderer.get_plot(hmap)
         for subp, color in zip(plot.subplots.values(), colors):
-            self.assertEqual(subp.handles['glyph'].line_color, rgb2hex(color))
+            color = color if isinstance(color, basestring) else rgb2hex(color)
+            self.assertEqual(subp.handles['glyph'].line_color, color)
 
     def test_batched_curve_line_color_and_color(self):
         opts = {'NdOverlay': dict(plot=dict(legend_limit=0)),


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/ioam/holoviews/issues/2333, ensuring that cycles of unequal color are expanded by cycling over each item individually. It will try to expand the styles up to the defined max_cycles or until the combined cycle starts repeating. To prevent combinatorial explosion the total number of cycles is clipped at 1000.

- [x] Addresses https://github.com/ioam/holoviews/issues/2333 and fixes https://github.com/ioam/holoviews/issues/1852
- [x] Added unit tests