### PR TITLE
Provide full control over bokeh grid styles

### DIFF
--- a/examples/user_guide/Plotting_with_Bokeh.ipynb
+++ b/examples/user_guide/Plotting_with_Bokeh.ipynb
@@ -262,6 +262,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Grid lines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Grid lines can be controlled throught the combination of ``show_grid`` and ``gridstyle`` parameters. The ``gridstyle`` allows specifying a number of options including:\n",
+    "\n",
+    "* ``grid_line_color``\n",
+    "* ``grid_line_alpha``\n",
+    "* ``grid_line_dash``\n",
+    "* ``grid_line_width``\n",
+    "* ``grid_bounds``\n",
+    "* ``grid_band``\n",
+    "\n",
+    "These options may also be applied to minor grid lines by prepending the ``'minor_'`` prefix and may be applied to a specific axis by replacing ``'grid_`` with ``'xgrid_'`` or ``'ygrid_'``. Here we combine some of these options to generate a complex grid pattern:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grid_style = {'grid_line_color': 'black', 'grid_line_width': 1.5, 'ygrid_bounds': (0.3, 0.7),\n",
+    "              'minor_xgrid_line_color': 'lightgray', 'xgrid_line_dash': [4, 4]}\n",
+    "\n",
+    "hv.Points(np.random.rand(10, 2)).options(gridstyle=grid_style, show_grid=True, size=5, width=600)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Containers\n",
     "\n",
     "The bokeh plotting extension also supports a number of additional features relating to container components."

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -65,6 +65,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
           {'ticks': '20pt', 'title': '15pt', 'ylabel': '5px', 'xlabel': '5px'}""")
 
+    gridstyle = param.Dict(default={}, doc="""
+        Allows customizing the grid style, e.g. grid_line_color defines
+        the line color for both grids while xgrid_line_color exclusively
+        customizes the x-axis grid lines.""")
+
     labelled = param.List(default=['x', 'y'], doc="""
         Whether to plot the 'x' and 'y' labels.""")
 
@@ -457,6 +462,18 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if not self.show_grid:
             plot.xgrid.grid_line_color = None
             plot.ygrid.grid_line_color = None
+        else:
+            replace = ['bounds', 'bands']
+            style_items = list(self.gridstyle.items())
+            both = {k: v for k, v in style_items if k.startswith('grid_') or k.startswith('minor_grid')}
+            xgrid = {k.replace('xgrid', 'grid'): v for k, v in style_items if 'xgrid' in k}
+            ygrid = {k.replace('ygrid', 'grid'): v for k, v in style_items if 'ygrid' in k}
+            xopts = {k.replace('grid_', '') if any(r in k for r in replace) else k: v
+                     for k, v in dict(both, **xgrid).items()}
+            yopts = {k.replace('grid_', '') if any(r in k for r in replace) else k: v
+                     for k, v in dict(both, **ygrid).items()}
+            plot.xgrid[0].update(**xopts)
+            plot.ygrid[0].update(**yopts)
 
 
     def _update_ranges(self, element, ranges):

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -82,3 +82,15 @@ class TestElementPlotPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].formatter, FuncTickFormatter)
 
+    def test_element_grid_options(self):
+        grid_style = {'grid_line_color': 'blue', 'grid_line_width': 1.5, 'ygrid_bounds': (0.3, 0.7),
+                      'minor_xgrid_line_color': 'lightgray', 'xgrid_line_dash': [4, 4]}
+        curve = Curve(range(10)).options(show_grid=True, gridstyle=grid_style)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(plot.state.xgrid[0].grid_line_color, 'blue')
+        self.assertEqual(plot.state.xgrid[0].grid_line_width, 1.5)
+        self.assertEqual(plot.state.xgrid[0].grid_line_dash, [4, 4])
+        self.assertEqual(plot.state.xgrid[0].minor_grid_line_color, 'lightgray')
+        self.assertEqual(plot.state.ygrid[0].grid_line_color, 'blue')
+        self.assertEqual(plot.state.ygrid[0].grid_line_width, 1.5)
+        self.assertEqual(plot.state.ygrid[0].bounds, (0.3, 0.7))


### PR DESCRIPTION
Provides control over grid styling in the bokeh backend.

- [x] Addresses https://github.com/ioam/holoviews/issues/1903 and should fix https://github.com/ioam/holoviews/issues/1967
- [x] Adds unit tests
- [x] Adds documentation entry