### PR TITLE
Fixed inverted colors for bokeh.palettes.mpl

### DIFF
--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -537,7 +537,7 @@ def bokeh_palette_to_palette(cmap, ncolors=None):
         if reverse: palette = palette[::-1]
     if len(palette) != ncolors:
         lpad, rpad = -0.5, 0.49999999999
-        palette = [palette[int(round(v))] for v in np.linspace(lpad, (len(palette)-1)+rpad, ncolors)]
+        palette = [palette[int(np.round(v))] for v in np.linspace(lpad, (len(palette)-1)+rpad, ncolors)]
     return palette
 
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -504,8 +504,8 @@ def bokeh_palette_to_palette(cmap, ncolors=None):
     from bokeh import palettes
 
     # Handle categorical colormaps to avoid interpolation
-    categorical = ('accent', 'category', 'dark', 'colorblind', 'pastel',
-                   'set1', 'set2', 'set3', 'paired')
+    categorical = ['accent', 'category', 'dark', 'colorblind', 'pastel',
+                   'set1', 'set2', 'set3', 'paired']
 
     reverse = cmap.endswith('_r')
     ncolors = ncolors or 256
@@ -515,6 +515,7 @@ def bokeh_palette_to_palette(cmap, ncolors=None):
         cmap = cmap.replace('tab', 'Category')
     if reverse:
         cmap = cmap[:-2]
+    reverse = not reverse if cmap in palettes.mpl else reverse
 
     # Process as bokeh palette
     palette = getattr(palettes, cmap, getattr(palettes, cmap.capitalize(), None))
@@ -539,6 +540,8 @@ def bokeh_palette_to_palette(cmap, ncolors=None):
                 palette = palette[::-1]
     elif callable(palette):
         palette = palette(ncolors)
+        if reverse:
+            palette = palette[::-1]
     if len(palette) != ncolors:
         palette = [palette[int(v)] for v in np.linspace(0, len(palette)-1, ncolors)]
     return palette

--- a/tests/plotting/testplotutils.py
+++ b/tests/plotting/testplotutils.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 from unittest import SkipTest
 from nose.plugins.attrib import attr
@@ -469,6 +469,10 @@ class TestMPLColormapUtils(ComparisonTestCase):
         colors = mplcmap_to_palette('Category20', 3)
         self.assertEqual(colors, ['#1f77b4', '#c5b0d5', '#9edae5'])
 
+    def test_mpl_colormap_categorical_reverse(self):
+        colors = mplcmap_to_palette('Category20_r', 3)
+        self.assertEqual(colors, ['#1f77b4', '#8c564b', '#9edae5'][::-1])
+
     def test_mpl_colormap_sequential(self):
         colors = mplcmap_to_palette('RdBu', 3)
         self.assertEqual(colors, ['#67001f', '#f6f6f6', '#053061'])
@@ -476,6 +480,10 @@ class TestMPLColormapUtils(ComparisonTestCase):
     def test_mpl_colormap_perceptually_uniform(self):
         colors = mplcmap_to_palette('viridis', 4)
         self.assertEqual(colors, ['#440154', '#30678d', '#35b778', '#fde724'])
+
+    def test_mpl_colormap_perceptually_uniform_reverse(self):
+        colors = mplcmap_to_palette('viridis_r', 4)
+        self.assertEqual(colors, ['#440154', '#30678d', '#35b778', '#fde724'][::-1])
 
 
 class TestBokehPaletteUtils(ComparisonTestCase):
@@ -497,13 +505,25 @@ class TestBokehPaletteUtils(ComparisonTestCase):
         colors = bokeh_palette_to_palette('Category20', 3)
         self.assertEqual(colors, ['#1f77b4', '#c5b0d5', '#9edae5'])
 
+    def test_bokeh_palette_categorical_reverse(self):
+        colors = bokeh_palette_to_palette('Category20_r', 3)
+        self.assertEqual(colors, ['#1f77b4', '#8c564b', '#9edae5'][::-1])
+
     def test_bokeh_palette_sequential(self):
         colors = bokeh_palette_to_palette('RdBu', 3)
         self.assertEqual(colors, ['#67001f', '#f7f7f7', '#053061'])
 
+    def test_bokeh_palette_uniform_interpolated(self):
+        colors = bokeh_palette_to_palette('Viridis', 4)
+        self.assertEqual(colors, ['#440154', '#30678D', '#35B778', '#FDE724'])
+
     def test_bokeh_palette_perceptually_uniform(self):
         colors = bokeh_palette_to_palette('viridis', 4)
         self.assertEqual(colors, ['#440154', '#30678D', '#35B778', '#FDE724'])
+
+    def test_bokeh_palette_perceptually_uniform_reverse(self):
+        colors = bokeh_palette_to_palette('viridis_r', 4)
+        self.assertEqual(colors, ['#440154', '#30678D', '#35B778', '#FDE724'][::-1])
 
 
         


### PR DESCRIPTION
In the recent colormap consistency PR it was noticed that upper case Magma, Inferno, Viridis, Plasma palettes were being inverted incorrectly. These should not be inverted like many of the other palettes that ship with bokeh. Additionally this PR fixes an issue resampling categorical bokeh palettes.