### PR TITLE
Colormap categories

### DIFF
--- a/doc/user_guide/index.rst
+++ b/doc/user_guide/index.rst
@@ -78,6 +78,9 @@ These guides provide detail about specific additional features in HoloViews:
 * `Styling Plots <Styling_Plots.html>`_
    How to control common styling options including color/style cycles and colormapping.
 
+* `Colormaps <Colormaps.html>`_
+   Overview of colormaps available, including when and how to use each type.
+
 * `Plotting with Bokeh <Plotting_with_Bokeh.html>`_
    Styling options and unique `Bokeh <bokeh.pydata.org>`_ features such as plot tools and using bokeh models directly.
 
@@ -123,6 +126,7 @@ These guides provide detail about specific additional features in HoloViews:
     Working with streaming data <Streaming_Data>
     Creating interactive dashboards <Dashboards>
     Styling Plots <Styling_Plots>
+    Colormaps <Colormaps>
     Plotting with Bokeh <Plotting_with_Bokeh>
     Deploying Bokeh Apps <Deploying_Bokeh_Apps>
     Plotting with matplotlib <Plotting_with_Matplotlib>

--- a/examples/user_guide/Colormaps.ipynb
+++ b/examples/user_guide/Colormaps.ipynb
@@ -60,8 +60,7 @@
     "opts = dict(aspect=6, xaxis=None, yaxis=None, sublabel_format='')\n",
     "\n",
     "def cmap_examples(category,cols=4):\n",
-    "    cms = list(sorted(hv.plotting.util.list_cmaps(category=category,records=True,reverse=False), \n",
-    "                      key=lambda s: s.name.lower()))\n",
+    "    cms = hv.plotting.util.list_cmaps(category=category,records=True,reverse=False)\n",
     "    n = len(cms)*1.0\n",
     "    c=ceil(n/cols) if n>cols else cols\n",
     "    bars = [hv.Image(spacing, ydensity=1, label=\"{0} ({1})\".format(r.name,r.provider)).options(cmap=process_cmap(r.name,provider=r.provider), **opts)\n",
@@ -124,7 +123,11 @@
     "\n",
     "Rainbow-like colormaps convey value primarily through color rather than luminance.  They result in eye-catching plots, but because rainbow colors form a continuous, cyclic spectrum, they can be ambiguous about which values are higher than the others.  Most of them are also highly perceptually non-uniform, with pronounced banding that makes some values easily distinguished from their neighbors, and others wide ranges of values nearly indistinguishable (e.g. the greenish colors in the `gist_rainbow` and `jet` colormaps). \n",
     "\n",
-    "If you do want a rainbow colormap, please consider using one of the two perceptually uniform versions here, either `rainbow` (colorcet), for monotonically increasing values, or `colorwheel`, for cyclic values like angles and longitudes that wrap around to the same value at the end of the range (notice that the lowest and highest colors are both blue for `colorwheel`).\n",
+    "If you do want a rainbow colormap, please consider using one of the three perceptually uniform versions here:\n",
+    "\n",
+    "- `colorwheel` (colorcet): for cyclic values like angles and longitudes that wrap around to the same value at the end of the range (notice that the lowest and highest colors are both blue)\n",
+    "- `rainbow` (colorcet): for monotonically and uniformly increasing values (skips purple region to avoid ordering ambiguity)\n",
+    "- `isolum` (colorcet): for monotonically and uniformly increasing values, but only uses hue changes, with a constant lightness.  Nearly all the other maps are dominated by changes in lightness, which is much more perceptually salient than strict changes in hue as in this map.  Useful as a counterpart and illustration of the role of lightness.\n",
     "\n",
     "Of course, rainbow colormaps have the disadvantage that they are inherently unsuitable for most colorblind viewers, because they require viewers to distinguish between red and green to determine value."
    ]
@@ -180,7 +183,7 @@
    "source": [
     "### Other Sequential colormaps\n",
     "\n",
-    "Other sequential colormaps are included, but are not meant for general use.  Some of these have a very high degree of perceptual non-uniformity, making them very misleading. E.g. the `hot` (matplotlib) colormap includes pronounced banding (with sharp perceptual discontinuities and long stretches of indistinguishable colors); consider using `fire` (colorcet) instead. Others like `gray` largely duplicate maps in the other categories above, and so can cause confusion. The Uniform Sequential maps, or if necessary Mono Sequential, are generally good alternatives to these."
+    "Other sequential colormaps are included, but are not meant for general use.  Some of these have a very high degree of perceptual non-uniformity, making them highly misleading. E.g. the `hot` (matplotlib) colormap includes pronounced banding (with sharp perceptual discontinuities and long stretches of indistinguishable colors); consider using `fire` (colorcet) instead. Others like `gray` largely duplicate maps in the other categories above, and so can cause confusion. The Uniform Sequential maps, or if necessary Mono Sequential, are generally good alternatives to these."
    ]
   },
   {
@@ -198,10 +201,7 @@
    "source": [
     "### Miscellaneous colormaps\n",
     "\n",
-    "There are a variety of other colormaps not fitting into the categories above, mostly of limited usefuless. Notable exceptions that do have important uses:\n",
-    "\n",
-    "- `isolum` (colorcet): perceptually uniform map using only color changes, with a constant luminance.  Nearly all the other maps are dominated by changes in luminance, which is much more perceptually salient than strict changes in hue as in this map.  Useful as a counterpart and illustration of the role of luminance.\n",
-    "- `flag` and `prism` (matplotlib): useful for highlighting local changes in value (details), with no information about global changes in value since the colors repeat."
+    "There are a variety of other colormaps not fitting into the categories above, mostly of limited usefuless. Exceptions include the `flag` and `prism` (matplotlib) colormaps that could be useful for highlighting local changes in value (details), with no information about global changes in value (due to the repeating colors)."
    ]
   },
   {
@@ -217,7 +217,151 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See the [Styling_Plots](Styling_Plots.ipynb) user guide for how these colormaps can be used to control how your data is plotted."
+    "See the [Styling_Plots](Styling_Plots.ipynb) user guide for how these colormaps can be used to control how your data is plotted.\n",
+    "\n",
+    "## Querying and filtering the list of colormaps\n",
+    "\n",
+    "For most purposes, you can just pick one of the colormaps above for a given plot. However, HoloViews is very often used to build applications and dashboards, many of which include a \"colormap\" selection widget. Because there are so many colormaps available, most of which are inappropriate for any specific plot, it's useful to be able to pull up a list of all the colormaps that are suitable for the specific type of plot used in the app.\n",
+    "\n",
+    "To allow such filtering, HoloViews stores the following information about each named colormap:\n",
+    "\n",
+    "- **name**: string name for the colormap\n",
+    "- **category**: Type of map by intended use or purpose ('Uniform Sequential', 'Mono Sequential', 'Other Sequential', 'Diverging', 'Categorical', 'Rainbow', or 'Miscellaneous')\n",
+    "- **provider**: package offering the colormap ('matplotlib', 'bokeh', or 'colorcet')\n",
+    "- **source**: original source or creator of the colormaps ('cet', 'colorbrewer', 'd3', 'bids','misc')\n",
+    "- **bg**: base/background color expected for the map ('light','dark','medium','any')\n",
+    "- **reverse**: whether the colormap name includes `_r` indicating that it is a reverse of a base map (True, False)\n",
+    "\n",
+    "The `hv.plotting.list_cmaps()` function used above can select a subset of the available colormaps by filtering based on the above values:\n",
+    "\n",
+    "```\n",
+    "list_cmaps(provider, records, name, category, source, bg, reverse)\n",
+    "```\n",
+    "\n",
+    "The examples below should make it clear how to use this function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from holoviews.plotting import list_cmaps\n",
+    "def format_list(l):\n",
+    "    print(' '.join(sorted([k for k in l])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All named colormaps provided by `colorcet`, reversed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(provider='colorcet',reverse=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "All non-reversed colormaps provided by `matplotlib` and originating from `d3` that have `20` in their names:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(name='20',source='d3', provider='matplotlib', reverse=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Colormaps provided by Bokeh that are suitable for dark-colored (e.g. black) backgrounds:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(category='Other Sequential', bg='dark'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice how some of these have `_r`, because those two natively start with light values and must be reversed to be suitable on a dark background.  In this case the results for `bg='light'` are the complementary set of colormaps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(category='Other Sequential', bg='light'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "However, `Diverging` colormaps do not change their background color when reversed, and so requesting a light or dark background gives different results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(category='Diverging', bg='dark'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(category='Diverging', bg='light'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the examples above, `list_cmaps` is returning just the colormap name, but if you want to work with the filter information yourself, you can ask that it return the full records as namedtuples instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list_cmaps(category=\"Uniform Sequential\", provider='bokeh', bg='light', records=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You could also consider filtering on the actual values in the colormap, perhaps to ensure that the specific background color you are using is not present in the colormap.  For this you can use the `hv.plotting.process_cmap` function to look up the actual colormap values by name and provider."
    ]
   }
  ],

--- a/examples/user_guide/Colormaps.ipynb
+++ b/examples/user_guide/Colormaps.ipynb
@@ -26,7 +26,7 @@
     "img = hv.Image(np.sin(x)*np.cos(y)+0.1*np.random.rand(400,400), \n",
     "               bounds=(-20,-20,20,20)).options(colorbar=True, xaxis=None, yaxis=None)\n",
     "\n",
-    "img.options(cmap='gray') + img.options(cmap='PiYG') + img.options(cmap='flag') + img.options(cmap='Set1')"
+    "hv.Layout([img.options(cmap=c).relabel(c) for c in ['gray','PiYG','flag','Set1']])"
    ]
   },
   {
@@ -59,11 +59,15 @@
     "spacing = np.linspace(0, 1, 64)[np.newaxis]\n",
     "opts = dict(aspect=6, xaxis=None, yaxis=None, sublabel_format='')\n",
     "\n",
+    "def filter_cmaps(category):\n",
+    "    return hv.plotting.util.list_cmaps(records=True,category=category,reverse=False)\n",
+    "\n",
     "def cmap_examples(category,cols=4):\n",
-    "    cms = hv.plotting.util.list_cmaps(category=category,records=True,reverse=False)\n",
+    "    cms = filter_cmaps(category)\n",
     "    n = len(cms)*1.0\n",
     "    c=ceil(n/cols) if n>cols else cols\n",
-    "    bars = [hv.Image(spacing, ydensity=1, label=\"{0} ({1})\".format(r.name,r.provider)).options(cmap=process_cmap(r.name,provider=r.provider), **opts)\n",
+    "    bars = [hv.Image(spacing, ydensity=1, label=\"{0} ({1})\".format(r.name,r.provider))\\\n",
+    "            .options(cmap=process_cmap(r.name,provider=r.provider), **opts)\n",
     "           for r in cms]\n",
     "    return hv.Layout(bars).options(vspace=0.1, hspace=0.1, transpose=(n>cols)).cols(c)"
    ]
@@ -223,7 +227,7 @@
     "\n",
     "For most purposes, you can just pick one of the colormaps above for a given plot. However, HoloViews is very often used to build applications and dashboards, many of which include a \"colormap\" selection widget. Because there are so many colormaps available, most of which are inappropriate for any specific plot, it's useful to be able to pull up a list of all the colormaps that are suitable for the specific type of plot used in the app.\n",
     "\n",
-    "To allow such filtering, HoloViews stores the following information about each named colormap:\n",
+    "To allow such filtering, HoloViews stores the following information about each named colormap, matched by substring:\n",
     "\n",
     "- **name**: string name for the colormap\n",
     "- **category**: Type of map by intended use or purpose ('Uniform Sequential', 'Mono Sequential', 'Other Sequential', 'Diverging', 'Categorical', 'Rainbow', or 'Miscellaneous')\n",
@@ -320,7 +324,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "However, `Diverging` colormaps do not change their background color when reversed, and so requesting a light or dark background gives different results:"
+    "However, `Diverging` colormaps do not change their background color when reversed, and so requesting a light or dark background gives different maps altogether (depending on their central color):"
    ]
   },
   {
@@ -345,7 +349,23 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the examples above, `list_cmaps` is returning just the colormap name, but if you want to work with the filter information yourself, you can ask that it return the full records as namedtuples instead:"
+    "Matches are done by substring, so all sequential colormaps suitable for `dark` or `any` backgrounds can be obtained with:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_list(list_cmaps(category='Sequential', bg='a'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the examples above, `list_cmaps` is returning just the colormap name, but if you want to work with the filter information yourself to do more complex queries, you can ask that it return the full records as namedtuples instead:"
    ]
   },
   {
@@ -355,6 +375,24 @@
    "outputs": [],
    "source": [
     "list_cmaps(category=\"Uniform Sequential\", provider='bokeh', bg='light', records=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to populating GUI widgets, another way to use this filtering is to systematically evaluate how your plot will look with a variety of different colormaps of the same type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hv.Layout([img.options(cmap=c, colorbar=False, sublabel_format='').relabel(c) \n",
+    "           for c in list_cmaps(category='Diverging', bg='light', reverse=False)])\\\n",
+    "    .options(vspace=0.1, hspace=0.1).cols(7)"
    ]
   },
   {

--- a/examples/user_guide/Colormaps.ipynb
+++ b/examples/user_guide/Colormaps.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "HoloViews supports a wide range of colormaps, each of which allow you to translate numerical data values into visible colors in a plot. Here we will review all the colormaps provided for HoloViews and discuss when and how to use them.\n",
+    "\n",
+    "## Using colormaps\n",
+    "\n",
+    "The [Styling_Plots](Styling_Plots.ipynb) user guide discusses how to specify any of the colormaps discussed here, using the `cmap` style option:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import holoviews as hv\n",
+    "hv.extension('matplotlib')\n",
+    "\n",
+    "ls  = np.linspace(0, 10, 400)\n",
+    "x,y = np.meshgrid(ls, ls)\n",
+    "img = hv.Image(np.sin(x)*np.cos(y)+0.1*np.random.rand(400,400), \n",
+    "               bounds=(-20,-20,20,20)).options(colorbar=True, xaxis=None, yaxis=None)\n",
+    "\n",
+    "img.options(cmap='gray') + img.options(cmap='PiYG') + img.options(cmap='flag') + img.options(cmap='Set1')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, the colormap you choose can dramatically change how your data appears. A well-chosen colormap can help guide the user to notice the features of the data you want to highlight, while a poorly chosen colormap can completely obscure the data and lead to erroneous conclusions. E.g. the low levels of noise present in this data are very difficult to see in A and B, but they completely dominate the plot in C and are visible only at specific (presumably arbitrary) value levels that correspond to color transitions in D. Thus it is important to choose colormaps very carefully!\n",
+    "\n",
+    "Note that the `cmap` style option used above is applied by the underlying plotting library, not by HoloViews itself. In the above example, Matplotlib uses it as the colormap constructs the image, whereas a Bokeh version of the same plot would provide the colormap to the Bokeh JavaScript code running in the local web browser, which allows the user to control the colormap dynamically in some cases.\n",
+    "\n",
+    "Colormaps can also be used with the [Datashader `shade()` operation](14-Large_Data.ipynb), in which the provided `cmap` is applied by Datashader to create an image *before* passing the image to the plotting library, which enables additional Datashader features but disables client-side features like colorbars and dynamic colormapping on display.\n",
+    "\n",
+    "## Available colormaps\n",
+    "\n",
+    "As outlined in [Styling_Plots](Styling_Plots.ipynb), you can easily make your own custom colormaps, but it's quite difficult to ensure that a custom map is designed well, so it's generally best to choose an existing, well-tested colormap. Here we will show the many different types of colormaps available, discussing each category and how to use that type of map. The ones shown here are those that are available by name, if the corresponding provider has been installed. E.g. those labelled \"(bokeh)\" will only be available if Bokeh is installed.\n",
+    "\n",
+    "Most of these colormaps will work best on *either* a light or a dark background, but not both. To faithfully and intuitively represent monotonically increasing values, you will generally want a colormap where the lowest values are similar in tone to the page background, and higher values become more perceptually salient compared to the page background. To let you match the colormap to the page, the maps listed below have a variant suffixed with `_r` (not shown), which is the same map but with the reverse order."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from math import ceil\n",
+    "from holoviews.plotting.util import process_cmap\n",
+    "\n",
+    "colormaps = hv.plotting.list_cmaps()\n",
+    "spacing = np.linspace(0, 1, 64)[np.newaxis]\n",
+    "opts = dict(aspect=6, xaxis=None, yaxis=None, sublabel_format='')\n",
+    "\n",
+    "def cmap_examples(category,cols=4):\n",
+    "    cms = list(sorted(hv.plotting.util.list_cmaps(category=category,records=True,reverse=False), \n",
+    "                      key=lambda s: s.name.lower()))\n",
+    "    n = len(cms)*1.0\n",
+    "    c=ceil(n/cols) if n>cols else cols\n",
+    "    bars = [hv.Image(spacing, ydensity=1, label=\"{0} ({1})\".format(r.name,r.provider)).options(cmap=process_cmap(r.name,provider=r.provider), **opts)\n",
+    "           for r in cms]\n",
+    "    return hv.Layout(bars).options(vspace=0.1, hspace=0.1, transpose=(n>cols)).cols(c)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Perceptually uniform sequential colormaps\n",
+    "\n",
+    "Useful for the typical case of having increasing numeric values that you want to distinguish without bias for any specific value. The colormaps in this category are designed to represent similar distances in value space (e.g. a numerical difference from 0.2 to 0.4, or one from 0.4 to 0.6, with similar differences in what we perceive visually.  \n",
+    "\n",
+    "For detailed discussions of this important issue, see\n",
+    "[Kovesi](https://arxiv.org/abs/1509.03700),\n",
+    "[van der Walt & Smith](https://bids.github.io/colormap), and \n",
+    "[Karpov](http://inversed.ru/Blog_2.htm), who each argue for different color spaces and criteria for evaluating colormaps and thus develop different types of colormaps.  Despite the disagreements over important details, *all* of the maps here will be significantly more uniform than an arbitrary map designed without perceptual criteria, such as those in \"Other Sequential\" below, and thus these colormaps represent good default choices in most cases.\n",
+    "\n",
+    "When choosing one of these, be sure to consider whether you wish your page background to be distinguishable from a color in the colormap. If your data covers the entire plot, then using the background color is fine, but if you need the background color to show through (e.g. to show missing values), then you should avoid maps that include black (`fire`, `magma`, `inferno`, `gray`, `k*`) on a black page or white (`fire`,`gray`) on a white page."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Uniform Sequential')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Diverging colormaps\n",
+    "\n",
+    "Useful to highlight differences from a neutral central value, which is typically chosen to match the page background (e.g. white or yellow when using a white page, or black when using a black page).  \n",
+    "\n",
+    "Most of the diverging maps listed here were *not* developed to match a definition of perceptual uniformity, but those coming from `colorcet` were and should thus be preferred over the rest.\n",
+    "\n",
+    "Some of these colormaps include both red and green, making them ambiguous for people with the most common types of colorblindness, and should thus be avoided where possible."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Diverging')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Rainbow colormaps\n",
+    "\n",
+    "Rainbow-like colormaps convey value primarily through color rather than luminance.  They result in eye-catching plots, but because rainbow colors form a continuous, cyclic spectrum, they can be ambiguous about which values are higher than the others.  Most of them are also highly perceptually non-uniform, with pronounced banding that makes some values easily distinguished from their neighbors, and others wide ranges of values nearly indistinguishable (e.g. the greenish colors in the `gist_rainbow` and `jet` colormaps). \n",
+    "\n",
+    "If you do want a rainbow colormap, please consider using one of the two perceptually uniform versions here, either `rainbow` (colorcet), for monotonically increasing values, or `colorwheel`, for cyclic values like angles and longitudes that wrap around to the same value at the end of the range (notice that the lowest and highest colors are both blue for `colorwheel`).\n",
+    "\n",
+    "Of course, rainbow colormaps have the disadvantage that they are inherently unsuitable for most colorblind viewers, because they require viewers to distinguish between red and green to determine value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Rainbow')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Categorical colormaps\n",
+    "\n",
+    "Primarily useful as color cycles rather than colormaps, i.e. as a list of discrete color values, not continuous color ranges. Will produce discrete banding when used on continuous values, like in a geographic contour plot, but if that effect is desired it's probably better to use `color_levels` with a sequential colormap to be able to control how many levels there are and give them a natural ordering."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Categorical')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mono Sequential colormaps\n",
+    "\n",
+    "Monotonically increasing values that serve the same purpose as [Uniform Sequential](#Perceptually-uniform-sequential-colormaps) (above), but are not specifically constructed to be perceptually uniform. Useful when you want to fit into a particular visual theme or color scheme, or when you want to color entire plots differently from other entire plots (e.g. to provide a visual \"traffic light\" indicator for the entire plot, making some plots stand out relative to others).  If you just need a single colormap, try to select a Uniform Sequential map instead of these."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Mono Sequential')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Other Sequential colormaps\n",
+    "\n",
+    "Other sequential colormaps are included, but are not meant for general use.  Some of these have a very high degree of perceptual non-uniformity, making them very misleading. E.g. the `hot` (matplotlib) colormap includes pronounced banding (with sharp perceptual discontinuities and long stretches of indistinguishable colors); consider using `fire` (colorcet) instead. Others like `gray` largely duplicate maps in the other categories above, and so can cause confusion. The Uniform Sequential maps, or if necessary Mono Sequential, are generally good alternatives to these."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Other Sequential')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Miscellaneous colormaps\n",
+    "\n",
+    "There are a variety of other colormaps not fitting into the categories above, mostly of limited usefuless. Notable exceptions that do have important uses:\n",
+    "\n",
+    "- `isolum` (colorcet): perceptually uniform map using only color changes, with a constant luminance.  Nearly all the other maps are dominated by changes in luminance, which is much more perceptually salient than strict changes in hue as in this map.  Useful as a counterpart and illustration of the role of luminance.\n",
+    "- `flag` and `prism` (matplotlib): useful for highlighting local changes in value (details), with no information about global changes in value since the colors repeat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmap_examples('Miscellaneous')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See the [Styling_Plots](Styling_Plots.ipynb) user guide for how these colormaps can be used to control how your data is plotted."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/user_guide/Styling_Plots.ipynb
+++ b/examples/user_guide/Styling_Plots.ipynb
@@ -73,7 +73,7 @@
    "outputs": [],
    "source": [
     "def format_list(l):\n",
-    "    print(' '.join(sorted([k for k in l if '_r' not in k])))\n",
+    "    print(' '.join(sorted([k for k in l if not k.endswith('_r')])))\n",
     "\n",
     "format_list(hv.Cycle.default_cycles.keys())"
    ]
@@ -130,7 +130,7 @@
    "source": [
     "### Palettes\n",
     "\n",
-    "Palettes are similar to cycles, but treat a set of colors as a continuous colorspace to be sampled at regularly spaced intervals. Again they are made automatically available from existing colormaps:"
+    "Palettes are similar to cycles, but treat a set of colors as a continuous colorspace to be sampled at regularly spaced intervals. Again they are made automatically available from existing colormaps (with `_r` versions also available):"
    ]
   },
   {
@@ -175,13 +175,9 @@
     "Color cycles and styles are useful for categorical plots and when overlaying multiple subsets, but when we want to map data values to a color it is better to use HoloViews' facilities for color mapping. Certain image-like types will apply colormapping automatically; e.g. for ``Image``, ``QuadMesh`` or ``HeatMap`` types the first value dimension is automatically mapped to the color. In other cases the values to colormap can be declared through the ``color_index``, which may reference any dimension by name or by numerical index.\n",
     "\n",
     "\n",
-    "#### Setting a colormap\n",
+    "#### Named colormaps\n",
     "\n",
-    "A HoloViews colormap can take a number of forms. By default, HoloViews will make bokeh Palettes and matplotlib colormaps available to reference by name when the respective backend is imported. It is also possible to declare a colormap as a list of hex or HTML colors.\n",
-    "\n",
-    "##### Named colormaps\n",
-    "\n",
-    "The full list of available named colormaps can be accessed using ``hv.plotting.list_cmaps``. To provide an overview we will create a layout of all available colormaps (except the reversed versions with the ``'_r'`` suffix)."
+    "HoloViews accepts colormaps specified either as an explicit list of hex or HTML colors, as a Matplotlib colormap object, or as the name of a bokeh, matplotlib, and colorcet palettes/colormap (which are available when the respective library is imported).  The named colormaps available are listed here (suppressing the `_r` versions) and illustrated in detail in the separate [Colormaps](Colormaps.ipynb) user guide:"
    ]
   },
   {
@@ -190,13 +186,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%output backend='matplotlib'\n",
-    "colormaps = hv.plotting.list_cmaps()\n",
-    "\n",
-    "spacing = np.linspace(0, 1, 64)[np.newaxis]\n",
-    "opts = dict(aspect=6, xaxis=None, yaxis=None, sublabel_format='')\n",
-    "hv.Layout([hv.Image(spacing, ydensity=1, label=cmap).options(cmap=cmap, **opts)\n",
-    "           for cmap in colormaps if '_r' not in cmap]).options(vspace=0.1, hspace=0.1, transpose=True).cols(15)"
+    "format_list(hv.plotting.list_cmaps())"
    ]
   },
   {
@@ -215,17 +205,15 @@
     "ls = np.linspace(0, 10, 400)\n",
     "xx, yy = np.meshgrid(ls, ls)\n",
     "bounds=(-1,-1,1,1)   # Coordinate system: (left, bottom, top, right)\n",
-    "img = hv.Image(np.sin(xx)*np.cos(yy), bounds=bounds)\n",
+    "img = hv.Image(np.sin(xx)*np.cos(yy), bounds=bounds).options(colorbar=True, width=400)\n",
     "\n",
-    "img.options(cmap='PiYG', colorbar=True, width=400)"
+    "img.options(cmap='PiYG') + img.options(cmap='PiYG_r')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the `cmap` style option discussed here is distinct from the `cmap` argument to the [Datashader `shade()` operation](14-Large_Data.ipynb).  Both the option and the `shade()` argument accept similar specifications for colormapping your data, but the style option discussed here is dynamically applied \"client side\" (in your browser, using JavaScript) while the `shade()` argument uses datashader's Python-based functionality. Here we are focusing only on the client-side colormapping using the `cmap` option.\n",
-    "\n",
     "##### Custom colormaps\n",
     "\n",
     "You can make your own custom colormaps by providing a list of hex colors:"
@@ -260,7 +248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.options(cmap='PiYG', color_levels=10, colorbar=True, width=400)"
+    "img.options(cmap='PiYG', color_levels=5) + img.options(cmap='PiYG', color_levels=11) "
    ]
   },
   {

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -515,8 +515,9 @@ def bokeh_palette_to_palette(cmap, ncolors=None):
         reverse = True
 
     # Some colormaps are inverted compared to matplotlib
-    inverted = not (categorical or cmap.capitalize() in palettes.mpl)
-    reverse = (reverse and not inverted) or inverted
+    inverted = (not categorical and not cmap.capitalize() in palettes.mpl)
+    if inverted:
+        reverse=not reverse
     ncolors = ncolors or 256
 
     # Alias mpl tab cmaps with bokeh Category cmaps
@@ -676,13 +677,13 @@ def list_cmaps(provider=None, records=False, name=None, category=None, source=No
                        elif r.bg=='dark': 
                            r=r._replace(bg='light')
 
-                   if ((    name==None or name in r.name) and
-                       (provider==None or r.provider==provider) and
-                       (category==None or r.category==category) and
-                       (  source==None or r.source==source) and
-                       (      bg==None or r.bg==bg)):
+                   if ((    name is None or     name in r.name) and
+                       (provider is None or provider in r.provider) and
+                       (category is None or category in r.category) and
+                       (  source is None or   source in r.source) and
+                       (      bg is None or       bg in r.bg)):
                        matches.add(r)
-            if not matched and (category==None or category=='Miscellaneous'):
+            if not matched and (category is None or category=='Miscellaneous'):
                 # Return colormaps that exist but are not found in cmap_info
                 # under the 'Miscellaneous' category, with no source or bg
                 r = CMapInfo(aname,provider=avail.provider,category='Miscellaneous',source=None,bg=None)
@@ -692,7 +693,7 @@ def list_cmaps(provider=None, records=False, name=None, category=None, source=No
     if records:
         return list(unique_iterator(sorted(matches, key=lambda r: (r.category,r.bg,r.source,r.name.lower(),r.provider))))
     else:
-        return list(unique_iterator(sorted([r.name for r in matches], key=lambda n:n.lower())))
+        return list(unique_iterator(sorted([rec.name for rec in matches], key=lambda n:n.lower())))
 
 
 register_cmaps('Uniform Sequential', 'matplotlib', 'bids', 'dark',
@@ -707,11 +708,11 @@ register_cmaps('Other Sequential', 'matplotlib', 'misc', 'light',
     ['gist_yarg', 'binary'])
 
 register_cmaps('Other Sequential', 'matplotlib', 'misc', 'dark',
-    ['afmhot', 'gray', 'bone', 'copper', 'gist_gray', 'gist_heat',
+    ['afmhot', 'gray', 'bone', 'gist_gray', 'gist_heat',
      'hot', 'pink'])
 
 register_cmaps('Other Sequential', 'matplotlib', 'misc', 'any',
-    ['spring', 'summer', 'autumn', 'winter', 'cool', 'Wistia'])
+    ['copper', 'spring', 'summer', 'autumn', 'winter', 'cool', 'Wistia'])
 
 register_cmaps('Diverging', 'matplotlib', 'colorbrewer', 'light',
     ['BrBG', 'PiYG', 'PRGn', 'PuOr', 'RdBu', 'RdGy',
@@ -728,10 +729,10 @@ register_cmaps('Categorical', 'matplotlib', 'd3', 'any',
     ['tab10', 'tab20', 'tab20b', 'tab20c'])
 
 register_cmaps('Rainbow', 'matplotlib', 'misc', 'dark',
-    ['brg', 'nipy_spectral', 'gist_ncar'])
+    ['nipy_spectral', 'gist_ncar'])
 
 register_cmaps('Rainbow', 'matplotlib', 'misc', 'any',
-    ['hsv', 'gist_rainbow', 'rainbow', 'jet'])
+    ['brg', 'hsv', 'gist_rainbow', 'rainbow', 'jet'])
 
 register_cmaps('Miscellaneous', 'matplotlib', 'misc', 'dark',
     ['CMRmap', 'cubehelix', 'gist_earth', 'gist_stern',
@@ -741,12 +742,12 @@ register_cmaps('Miscellaneous', 'matplotlib', 'misc', 'any',
     ['flag', 'prism'])
 
 
-register_cmaps('Uniform Sequential', 'colorcet', 'cet', 'light',
-    ['blues'])
-
 register_cmaps('Uniform Sequential', 'colorcet', 'cet', 'dark',
     ['bgyw', 'bgy', 'kbc', 'bmw', 'bmy', 'kgy', 'gray',
-     'dimgray', 'fire', 'kb', 'kg', 'kr'])
+     'dimgray', 'fire'])
+
+register_cmaps('Uniform Sequential', 'colorcet', 'cet', 'any',
+    ['blues', 'kr', 'kg', 'kb'])
 
 register_cmaps('Diverging', 'colorcet', 'cet', 'light',
     ['coolwarm','gwv'])

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1,6 +1,5 @@
 from __future__ import unicode_literals, absolute_import
 
-import sys
 from collections import defaultdict, namedtuple
 
 import traceback

--- a/tests/plotting/testplotutils.py
+++ b/tests/plotting/testplotutils.py
@@ -474,8 +474,20 @@ class TestMPLColormapUtils(ComparisonTestCase):
         self.assertEqual(colors, ['#1f77b4', '#8c564b', '#9edae5'][::-1])
 
     def test_mpl_colormap_sequential(self):
+        colors = mplcmap_to_palette('YlGn', 3)
+        self.assertEqual(colors, ['#ffffe5', '#77c578', '#004529'])
+
+    def test_mpl_colormap_sequential_reverse(self):
+        colors = mplcmap_to_palette('YlGn_r', 3)
+        self.assertEqual(colors, ['#ffffe5', '#78c679', '#004529'][::-1])
+
+    def test_mpl_colormap_diverging(self):
         colors = mplcmap_to_palette('RdBu', 3)
         self.assertEqual(colors, ['#67001f', '#f6f6f6', '#053061'])
+
+    def test_mpl_colormap_diverging_reverse(self):
+        colors = mplcmap_to_palette('RdBu_r', 3)
+        self.assertEqual(colors, ['#67001f', '#f7f6f6', '#053061'][::-1])
 
     def test_mpl_colormap_perceptually_uniform(self):
         colors = mplcmap_to_palette('viridis', 4)
@@ -510,8 +522,20 @@ class TestBokehPaletteUtils(ComparisonTestCase):
         self.assertEqual(colors, ['#1f77b4', '#8c564b', '#9edae5'][::-1])
 
     def test_bokeh_palette_sequential(self):
+        colors = bokeh_palette_to_palette('YlGn', 3)
+        self.assertEqual(colors, ['#ffffe5', '#78c679', '#004529'])
+
+    def test_bokeh_palette_sequential_reverse(self):
+        colors = bokeh_palette_to_palette('YlGn_r', 3)
+        self.assertEqual(colors, ['#ffffe5', '#78c679', '#004529'][::-1])
+
+    def test_bokeh_palette_diverging(self):
         colors = bokeh_palette_to_palette('RdBu', 3)
         self.assertEqual(colors, ['#67001f', '#f7f7f7', '#053061'])
+        
+    def test_bokeh_palette_diverging_reverse(self):
+        colors = bokeh_palette_to_palette('RdBu_r', 3)
+        self.assertEqual(colors, ['#67001f', '#f7f7f7', '#053061'][::-1])
 
     def test_bokeh_palette_uniform_interpolated(self):
         colors = bokeh_palette_to_palette('Viridis', 4)


### PR DESCRIPTION
This PR replaces #2492 (rebasing it on master).  What it mainly adds is the ability to pull out any particular category, provider, or source of colormaps (e.g. `list_cmaps(category='Diverging',provider='bokeh', source='d3'))`, which I think will be very useful when building GUIs.  Usually, only a subset of the types are relevant for any given plot, and it's very painful to list them out by name in an app or dashboard, yet it's also very painful for users to page through long lists of mostly inappropriate colormaps.  I think that this approach will allow a given app or dashboard to select just the subset of colormaps that would be relevant for it much more easily.

Using this facility, I've also created a new [Colormaps user guide](https://anaconda.org/jbednar/colormaps) that breaks down all of the available colormaps by type and explains how and when to use each one.

For any of this to work, I had to list each of the various colormaps provided across backends, declaring their category, etc., because that information is not otherwise available programmatically except for colorcet.  This ended up being less verbose than I expected, but it does encode knowledge about the external backends that we should be aware that we are encoding. Colormaps that are deleted from the packages in the future will simply fail to show up in these lists, and those that are added will appear in the 'Miscellaneous' category until someone adds some other category and source information for them.

Tasks required:

- [x] Fix handling for reversed ('_r') colormaps
- [x] Define a useful default for colormaps not found in the lookup table
- [x] Find a better way to break up the big list of colormaps with big category labels (presumably not possible in the same cell, given the lack of hierarchical layouts?)
- [x] Sort colormaps in the displayed list
- [x] Clean up categorization of Bokeh maps to make sure they end up in the same category as similar Matplotlib maps
- [x] Consider merging list_cmaps with lookup_cmaps, e.g. making the current list_cmaps private and making lookup_cmaps be a superset of its functionality
- [x] There's no obvious way to specify a colormap by provider, and so when providers have matching-named colormaps the example currently shows only one of them, twice; must be fixed.
- [x] Add examples of pulling out categories of colormaps, e.g. for a gui (maybe to pyviz?)
- [x] Allow categorizing by background type as well, to make it simpler for dashboards to select the right set of useful colormaps?
- [x] Consider allowing excluding certain colors (white, black), for the same reason? Decided against, as people can already do that programmatically by searching in the colormap itself.