### PR TITLE
Improved notebook MIME type handling and added cleanup on cell deletion

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -210,7 +210,7 @@ def deephash(obj):
 
 
 # Python3 compatibility
-if sys.version_info.major == 3:
+if sys.version_info.major >= 3:
     basestring = str
     unicode = str
     long = int
@@ -394,6 +394,13 @@ def bytes_to_unicode(value):
     if isinstance(value, bytes):
         return unicode(value.decode('utf-8'))
     return value
+
+
+def get_method_owner(method):
+    """
+    Gets the instance that owns the supplied method
+    """
+    return method.__self__ if sys.version_info.major >= 3 else method.im_self
 
 
 def capitalize_unicode_name(s):

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -252,7 +252,8 @@ class notebook_extension(extension):
     @classmethod
     def _process_comm_msg(cls, msg):
         """
-        Processes global comm messages to process deletions.
+        Processes comm messages to handle global actions such as
+        cleaning up plots.
         """
         if msg['event_type'] == 'delete':
             Renderer._delete_plot(msg['id'])

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -161,6 +161,9 @@ class notebook_extension(extension):
         Renderer.load_nb()
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
+        if hasattr(ip, 'kernel'):
+            Renderer.comm_manager.get_client_comm(self._process_comm_msg,
+                                                  "hv-extension-comm")
 
         # Create a message for the logo (if shown)
         self.load_hvjs(logo=p.logo,
@@ -237,9 +240,6 @@ class notebook_extension(extension):
                                 'plotly_logo': plotly_logo,
                                 'message':     message})
         publish_display_data(data={'text/html': html})
-
-        Renderer.comm_manager.get_client_comm(cls._process_comm_msg,
-                                              "hv-extension-comm")
 
         # Vanilla JS mime type is only consumed by classic notebook
         # Custom mime type is only consumed by JupyterLab

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -238,6 +238,9 @@ class notebook_extension(extension):
                                 'message':     message})
         publish_display_data(data={'text/html': html})
 
+        Renderer.comm_manager.get_client_comm(cls._process_comm_msg,
+                                              "hv-extension-comm")
+
         # Vanilla JS mime type is only consumed by classic notebook
         # Custom mime type is only consumed by JupyterLab
         if JS:
@@ -245,6 +248,14 @@ class notebook_extension(extension):
                 MIME_TYPES['js']           : widgetjs,
                 MIME_TYPES['jlab-hv-load'] : widgetjs
             })
+
+    @classmethod
+    def _process_comm_msg(cls, msg):
+        """
+        Processes global comm messages to process deletions.
+        """
+        if msg['event_type'] == 'delete':
+            Renderer._delete_plot(msg['id'])
 
 
     @param.parameterized.bothmethod

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -52,7 +52,7 @@ class MessageCallback(object):
         self.plot = plot
         self.streams = streams
         if plot.renderer.mode != 'server':
-            self.comm = plot.renderer.comm_manager.get_client_comm(plot, on_msg=self.on_msg)
+            self.comm = plot.renderer.comm_manager.get_client_comm(on_msg=self.on_msg)
         self.source = source
         self.handle_ids = defaultdict(dict)
         self.reset()

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -15,6 +15,7 @@ from ...streams import Stream
 from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
                     GenericElementPlot, GenericOverlayPlot)
 from ..util import attach_streams, displayable, collate
+from .callbacks import Callback
 from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
                    update_shared_sources, empty_plot, decode_bytes,
                    bokeh_version)
@@ -245,6 +246,9 @@ class BokehPlot(DimensionedPlot):
         plots = self.traverse(lambda x: x, [GenericElementPlot])
         for plot in plots:
             for callback in plot.callbacks:
+                callbacks = {k: cb for k, cb in callback._callbacks.items()
+                            if cb is not callback}
+                Callback._callbacks = callbacks
                 for stream in callback.streams:
                     subscribers = [
                         (p, subscriber) for p, subscriber in stream._subscribers

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -243,18 +243,24 @@ class BokehPlot(DimensionedPlot):
 
 
     def cleanup(self):
+        """
+        Cleans up references to the plot after the plot has been
+        deleted. Traverses through all plots cleaning up Callbacks and
+        Stream subscribers.
+        """
         plots = self.traverse(lambda x: x, [GenericElementPlot])
         for plot in plots:
+            streams = list(plot.streams)
             for callback in plot.callbacks:
+                streams += callback.streams
                 callbacks = {k: cb for k, cb in callback._callbacks.items()
                             if cb is not callback}
                 Callback._callbacks = callbacks
-                for stream in callback.streams:
-                    subscribers = [
-                        (p, subscriber) for p, subscriber in stream._subscribers
-                        if get_method_owner(subscriber) not in plots
-                    ]
-                    stream._subscribers = subscribers
+            for stream in set(streams):
+                stream._subscribers = [
+                    (p, subscriber) for p, subscriber in stream._subscribers
+                    if get_method_owner(subscriber) not in plots
+                ]
 
 
     def _fontsize(self, key, label='fontsize', common=True):

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -12,6 +12,7 @@ from bokeh.layouts import widgetbox, row, column
 from ...core import Store, NdMapping, OrderedDict
 from ...core.util import (drop_streams, unique_array, isnumeric,
                           wrap_tuple_streams, unicode)
+from ..renderer import MIME_TYPES
 from ..widgets import NdWidget, SelectionWidget, ScrubberWidget
 from .util import serialize_json
 
@@ -274,7 +275,7 @@ class BokehWidget(NdWidget):
         msg, metadata = self.renderer.components(self.plot, comm=False)
         data = super(BokehWidget, self)._get_data()
         return dict(data, init_html=msg['text/html'],
-                    init_js=msg['application/javascript'],
+                    init_js=msg[MIME_TYPES['js']],
                     plot_id=self.plot.state._id)
 
     def encode_frames(self, frames):

--- a/holoviews/plotting/comms.py
+++ b/holoviews/plotting/comms.py
@@ -57,12 +57,11 @@ class Comm(object):
 
     js_template = ''
 
-    def __init__(self, plot, id=None, on_msg=None):
+    def __init__(self, id=None, on_msg=None):
         """
         Initializes a Comms object
         """
         self.id = id if id else uuid.uuid4().hex
-        self._plot = plot
         self._on_msg = on_msg
         self._comm = None
 
@@ -191,12 +190,12 @@ class JupyterCommJS(JupyterComm):
     </script>
     """
 
-    def __init__(self, plot, id=None, on_msg=None):
+    def __init__(self, id=None, on_msg=None):
         """
         Initializes a Comms object
         """
         from IPython import get_ipython
-        super(JupyterCommJS, self).__init__(plot, id, on_msg)
+        super(JupyterCommJS, self).__init__(id, on_msg)
         self.manager = get_ipython().kernel.comm_manager
         self.manager.register_target(self.id, self._handle_open)
 
@@ -240,14 +239,14 @@ class CommManager(object):
     client_comm = Comm
 
     @classmethod
-    def get_server_comm(cls, plot, on_msg=None, id=None):
-        comm = cls.server_comm(plot, id, on_msg)
+    def get_server_comm(cls, on_msg=None, id=None):
+        comm = cls.server_comm(id, on_msg)
         cls._comms[comm.id] = comm
         return comm
 
     @classmethod
-    def get_client_comm(cls, plot, on_msg=None, id=None):
-        comm = cls.client_comm(plot, id, on_msg)
+    def get_client_comm(cls, on_msg=None, id=None):
+        comm = cls.client_comm(id, on_msg)
         cls._comms[comm.id] = comm
         return comm
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -534,7 +534,7 @@ class DimensionedPlot(Plot):
         """
         comm = None
         if self.dynamic or self.renderer.widget_mode == 'live':
-            comm = self.renderer.comm_manager.get_server_comm(self)
+            comm = self.renderer.comm_manager.get_server_comm()
         return comm
 
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -23,7 +23,7 @@ from ..element import Table
 from .util import (get_dynamic_mode, initialize_unbounded, dim_axis_label,
                    attach_streams, traverse_setter, get_nested_streams,
                    compute_overlayable_zorders, get_plot_frame,
-                   split_dmap_overlay, get_method_owner)
+                   split_dmap_overlay)
 
 
 class Plot(param.Parameterized):
@@ -73,7 +73,7 @@ class Plot(param.Parameterized):
             for stream in set(plot.streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
-                    if get_method_owner(subscriber) not in plots]
+                    if util.get_method_owner(subscriber) not in plots]
 
 
     @property

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -23,7 +23,7 @@ from ..element import Table
 from .util import (get_dynamic_mode, initialize_unbounded, dim_axis_label,
                    attach_streams, traverse_setter, get_nested_streams,
                    compute_overlayable_zorders, get_plot_frame,
-                   split_dmap_overlay)
+                   split_dmap_overlay, get_method_owner)
 
 
 class Plot(param.Parameterized):
@@ -65,8 +65,15 @@ class Plot(param.Parameterized):
 
     def cleanup(self):
         """
-        Allows defining cleanup actions to perform on plot deletion.
+        Cleans up references to the plot on the attached Stream
+        subscribers.
         """
+        plots = self.traverse(lambda x: x, [GenericElementPlot])
+        for plot in plots:
+            for stream in set(plot.streams):
+                stream._subscribers = [
+                    (p, subscriber) for p, subscriber in stream._subscribers
+                    if get_method_owner(subscriber) not in plots]
 
 
     @property

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -63,6 +63,12 @@ class Plot(param.Parameterized):
         raise NotImplementedError
 
 
+    def cleanup(self):
+        """
+        Allows defining cleanup actions to perform on plot deletion.
+        """
+
+
     @property
     def id(self):
         return self.comm.id if self.comm else id(self.state)

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -324,7 +324,7 @@ class Renderer(Exporter):
         data['text/html'] = html
         if js:
             data[MIME_TYPES['js']] = js
-            data[MIME_TYPES['jlab-hv-exec']] = js
+            data[MIME_TYPES['jlab-hv-exec']] = ''
             metadata['id'] = plot_id
         return (data, {MIME_TYPES['jlab-hv-exec']: metadata})
 

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -157,6 +157,9 @@ class Renderer(Exporter):
     # Whether in a notebook context, set when running Renderer.load_nb
     notebook_context = False
 
+    # Plot registry
+    _plots = {}
+
     def __init__(self, **params):
         self.last_plot = None
         super(Renderer, self).__init__(**params)
@@ -326,6 +329,7 @@ class Renderer(Exporter):
             data[MIME_TYPES['js']] = js
             data[MIME_TYPES['jlab-hv-exec']] = ''
             metadata['id'] = plot_id
+            self._plots[plot_id] = plot
         return (data, {MIME_TYPES['jlab-hv-exec']: metadata})
 
 
@@ -593,3 +597,15 @@ class Renderer(Exporter):
         with param.logging_level('ERROR'):
             cls.notebook_context = True
             cls.comm_manager = JupyterCommManager
+
+
+    @classmethod
+    def _delete_plot(cls, plot_id):
+        """
+        Deletes registered plots and calls Plot.cleanup
+        """
+        plot = cls._plots.get(plot_id)
+        if plot is None:
+            return
+        plot.cleanup()
+        del cls._plots[plot_id]

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -140,6 +140,11 @@ class NdWidget(param.Parameterized):
                                                      on_msg=self._process_update)
 
 
+    def cleanup(self):
+        self.plot.cleanup()
+        del NdWidget.widgets[self.id]
+
+
     def _process_update(self, msg):
         if 'content' not in msg:
             raise ValueError('Received widget comm message has no content.')

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -136,8 +136,7 @@ class NdWidget(param.Parameterized):
         self.jinjaEnv = jinja2.Environment(loader=templateLoader)
         if not self.embed:
             comm_manager = self.renderer.comm_manager
-            self.comm = comm_manager.get_client_comm(self.plot,
-                                                     id=self.id+'_client',
+            self.comm = comm_manager.get_client_comm(id=self.id+'_client',
                                                      on_msg=self._process_update)
 
 

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -522,6 +522,8 @@ function init_dropdown(id, plot_id, dim, vals, value, next_vals, labels, next_di
 
 if (window.HoloViews === undefined) {
   window.HoloViews = {}
+} else {
+  delete HoloViews.comms["hv-extension-comm"]
 }
 
 var _namespace = {
@@ -570,6 +572,18 @@ function handleAddOutput(event, handle) {
   }
 }
 
+/**
+ * Handle when an output is cleared or removed
+ */
+
+
+function handleClearOutput(event, handle) {
+  var id = handle.cell.output_area._hv_plot_id;
+  if (id === undefined) { return; }
+    comm = window.HoloViews.comm_manager.get_client_comm("hv-extension-comm", "hv-extension-comm", function () {});
+    comm.send({event_type: 'delete', 'id': id})
+}
+
 function register_renderer(events, OutputArea) {
   function append_mime(data, metadata, element) {
     // create a DOM node to render to
@@ -585,7 +599,10 @@ function register_renderer(events, OutputArea) {
     element.append(toinsert);
     return toinsert
   }
+
   events.on('output_added.OutputArea', handleAddOutput);
+  events.on('clear_output.CodeCell', handleClearOutput);
+  events.on('delete.Cell', handleClearOutput);
 
   OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {
     safe: true,

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -580,8 +580,14 @@ function handleAddOutput(event, handle) {
 function handleClearOutput(event, handle) {
   var id = handle.cell.output_area._hv_plot_id;
   if (id === undefined) { return; }
-    comm = window.HoloViews.comm_manager.get_client_comm("hv-extension-comm", "hv-extension-comm", function () {});
-    comm.send({event_type: 'delete', 'id': id})
+  var comm = window.HoloViews.comm_manager.get_client_comm("hv-extension-comm", "hv-extension-comm", function () {});
+  if (comm !== null) {
+    comm.send({event_type: 'delete', 'id': id});
+  }
+  if ((window.Bokeh !== undefined) & (id in window.Bokeh.index)) {
+    window.Bokeh.index[id].model.document.clear();
+    delete Bokeh.index[id];
+  }
 }
 
 function register_renderer(events, OutputArea) {

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -617,9 +617,12 @@ function register_renderer(events, OutputArea) {
 }
 
 if (window.Jupyter !== undefined) {
-  var events = require('base/js/events');
-  var OutputArea = require('notebook/js/outputarea').OutputArea;
-  if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {
-    register_renderer(events, OutputArea);
+  try {
+    var events = require('base/js/events');
+    var OutputArea = require('notebook/js/outputarea').OutputArea;
+    if (OutputArea.prototype.mime_types().indexOf(EXEC_MIME_TYPE) == -1) {
+      register_renderer(events, OutputArea);
+    }
+  } catch(err) {
   }
 }

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -558,10 +558,10 @@ function render(props, node) {
 /**
  * Handle when a new output is added
  */
-function handleAddOutput(event, handle) {
+function handle_add_output(event, handle) {
   var output_area = handle.output_area;
   var output = handle.output;
-  // limit handleAddOutput to display_data with EXEC_MIME_TYPE content only
+  // limit handle_add_output to display_data with EXEC_MIME_TYPE content only
   if ((output.output_type != "display_data") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
     return
   }
@@ -577,7 +577,7 @@ function handleAddOutput(event, handle) {
  */
 
 
-function handleClearOutput(event, handle) {
+function handle_clear_output(event, handle) {
   var id = handle.cell.output_area._hv_plot_id;
   if (id === undefined) { return; }
   var comm = window.HoloViews.comm_manager.get_client_comm("hv-extension-comm", "hv-extension-comm", function () {});
@@ -606,9 +606,9 @@ function register_renderer(events, OutputArea) {
     return toinsert
   }
 
-  events.on('output_added.OutputArea', handleAddOutput);
-  events.on('clear_output.CodeCell', handleClearOutput);
-  events.on('delete.Cell', handleClearOutput);
+  events.on('output_added.OutputArea', handle_add_output);
+  events.on('clear_output.CodeCell', handle_clear_output);
+  events.on('delete.Cell', handle_clear_output);
 
   OutputArea.prototype.register_mime_type(EXEC_MIME_TYPE, append_mime, {
     safe: true,

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -66,6 +66,14 @@ class TestElementPlot(TestBokehPlot):
         self.assertEqual(source.data['image'][0].mean(), 2)
         self.assertNotIn(source, plot.current_handles)
 
+    def test_stream_cleanup(self):
+        stream = Stream.define(str('Test'), test=1)()
+        dmap = DynamicMap(lambda test: Curve([]), streams=[stream])
+        plot = bokeh_renderer.get_plot(dmap)
+        self.assertTrue(bool(stream._subscribers))
+        plot.cleanup()
+        self.assertFalse(bool(stream._subscribers))
+
     @attr(optional=1)  # Requires Flexx
     def test_element_formatter_xaxis(self):
         def formatter(x):

--- a/tests/plotting/matplotlib/testelementplot.py
+++ b/tests/plotting/matplotlib/testelementplot.py
@@ -1,8 +1,21 @@
 import numpy as np
 
-from holoviews.element import Image
+from holoviews.core.spaces import DynamicMap
+from holoviews.element import Image, Curve
+from holoviews.streams import Stream
 
 from .testplot import TestMPLPlot, mpl_renderer
+
+
+class TestElementPlot(TestMPLPlot):
+
+    def test_stream_cleanup(self):
+        stream = Stream.define(str('Test'), test=1)()
+        dmap = DynamicMap(lambda test: Curve([]), streams=[stream])
+        plot = mpl_renderer.get_plot(dmap)
+        self.assertTrue(bool(stream._subscribers))
+        plot.cleanup()
+        self.assertFalse(bool(stream._subscribers))
 
 
 class TestColorbarPlot(TestMPLPlot):

--- a/tests/plotting/testcomms.py
+++ b/tests/plotting/testcomms.py
@@ -7,10 +7,10 @@ from holoviews.plotting.comms import Comm, JupyterComm
 class TestComm(ComparisonTestCase):
 
     def test_init_comm(self):
-        Comm(None)
+        Comm()
 
     def test_init_comm_id(self):
-        comm = Comm(None, id='Test')
+        comm = Comm(id='Test')
         self.assertEqual(comm.id, 'Test')
 
     def test_decode(self):
@@ -24,14 +24,14 @@ class TestComm(ComparisonTestCase):
             decoded = json.loads(msg)
             self.assertEqual(decoded['msg_type'], "Error")
             self.assertTrue(decoded['traceback'].endswith('Exception: Test'))
-        comm = Comm(None, id='Test', on_msg=raise_error)
+        comm = Comm(id='Test', on_msg=raise_error)
         comm.send = assert_error
         comm._handle_msg({})
 
     def test_handle_message_ready_reply(self):
         def assert_ready(msg):
             self.assertEqual(json.loads(msg), {'msg_type': "Ready", 'content': ''})
-        comm = Comm(None, id='Test')
+        comm = Comm(id='Test')
         comm.send = assert_ready
         comm._handle_msg({})
 
@@ -40,7 +40,7 @@ class TestComm(ComparisonTestCase):
             decoded = json.loads(msg)
             self.assertEqual(decoded, {'msg_type': "Ready", 'content': '',
                                        'comm_id': 'Testing id'})
-        comm = Comm(None, id='Test')
+        comm = Comm(id='Test')
         comm.send = assert_ready
         comm._handle_msg({'comm_id': 'Testing id'})
 
@@ -49,10 +49,10 @@ class TestComm(ComparisonTestCase):
 class TestJupyterComm(ComparisonTestCase):
 
     def test_init_comm(self):
-        JupyterComm(None)
+        JupyterComm()
 
     def test_init_comm_id(self):
-        comm = JupyterComm(None, id='Test')
+        comm = JupyterComm(id='Test')
         self.assertEqual(comm.id, 'Test')
 
     def test_decode(self):
@@ -64,6 +64,6 @@ class TestJupyterComm(ComparisonTestCase):
         def raise_error(msg):
             if msg == 'Error':
                 raise Exception()
-        comm = JupyterComm(None, id='Test', on_msg=raise_error)
+        comm = JupyterComm(id='Test', on_msg=raise_error)
         with self.assertRaises(Exception):
             comm._handle_msg({'content': {'data': 'Error'}})


### PR DESCRIPTION
Currently the ``Renderer`` publishes JS code on two different MIME_TYPEs, one used by the classic notebook (``application/js``) and the other used by the JupyterLab extension (``application/vnd.holoviews_exec.v0+json``). The main issue with this is that all the data is sent both times a) doubling network traffic and b) doubling the size of the notebook.

This PR ensures that the Renderer will now only publish the actual data to the ``application/js`` MIME type. Additionally it adds a MIME handler for the classic notebook which processes the empty ``application/vnd.holoviews_exec.v0+json`` output and replaces it with ``application/js`` output, (which is what the jupyterlab extension was already doing). 

Finally this lays the groundwork to notify Python when a cell is deleted, which will allow us to clean up unused plots and stream callbacks.

- [x] Tested in classic notebook
- [x] Tested in JupyterLab
- [x] Tested in nbconvert export