### PR TITLE
Stripped metadata from bokeh element notebooks

### DIFF
--- a/examples/gallery/demos/bokeh/autompg_violins.ipynb
+++ b/examples/gallery/demos/bokeh/autompg_violins.ipynb
@@ -57,22 +57,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/box_draw_roi_editor.ipynb
+++ b/examples/gallery/demos/bokeh/box_draw_roi_editor.ipynb
@@ -85,22 +85,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/iris_density_grid.ipynb
+++ b/examples/gallery/demos/bokeh/iris_density_grid.ipynb
@@ -61,22 +61,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/iris_grouped_grid.ipynb
+++ b/examples/gallery/demos/bokeh/iris_grouped_grid.ipynb
@@ -62,22 +62,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/irregular_quadmesh.ipynb
+++ b/examples/gallery/demos/bokeh/irregular_quadmesh.ipynb
@@ -61,22 +61,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/nyc_radial_heatmap.ipynb
+++ b/examples/gallery/demos/bokeh/nyc_radial_heatmap.ipynb
@@ -105,22 +105,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/point_draw_triangulate.ipynb
+++ b/examples/gallery/demos/bokeh/point_draw_triangulate.ipynb
@@ -56,22 +56,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/bokeh/route_chord.ipynb
+++ b/examples/gallery/demos/bokeh/route_chord.ipynb
@@ -66,22 +66,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/autompg_violins.ipynb
+++ b/examples/gallery/demos/matplotlib/autompg_violins.ipynb
@@ -58,22 +58,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/iris_density_grid.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_density_grid.ipynb
@@ -61,22 +61,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/iris_grouped_grid.ipynb
+++ b/examples/gallery/demos/matplotlib/iris_grouped_grid.ipynb
@@ -61,22 +61,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/irregular_quadmesh.ipynb
+++ b/examples/gallery/demos/matplotlib/irregular_quadmesh.ipynb
@@ -62,22 +62,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/nyc_radial_heatmap.ipynb
+++ b/examples/gallery/demos/matplotlib/nyc_radial_heatmap.ipynb
@@ -105,22 +105,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/gallery/demos/matplotlib/route_chord.ipynb
+++ b/examples/gallery/demos/matplotlib/route_chord.ipynb
@@ -67,22 +67,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/Div.ipynb
+++ b/examples/reference/elements/bokeh/Div.ipynb
@@ -36,9 +36,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "hv.Div(\"\"\"\n",
@@ -85,22 +83,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/QuadMesh.ipynb
+++ b/examples/reference/elements/bokeh/QuadMesh.ipynb
@@ -164,22 +164,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/RadialHeatMap.ipynb
+++ b/examples/reference/elements/bokeh/RadialHeatMap.ipynb
@@ -103,22 +103,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/bokeh/Violin.ipynb
+++ b/examples/reference/elements/bokeh/Violin.ipynb
@@ -91,22 +91,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/matplotlib/QuadMesh.ipynb
+++ b/examples/reference/elements/matplotlib/QuadMesh.ipynb
@@ -146,22 +146,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/matplotlib/RadialHeatMap.ipynb
+++ b/examples/reference/elements/matplotlib/RadialHeatMap.ipynb
@@ -104,22 +104,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/elements/matplotlib/VectorField.ipynb
+++ b/examples/reference/elements/matplotlib/VectorField.ipynb
@@ -131,7 +131,12 @@
    ]
   }
  ],
- "metadata": {},
+ "metadata": {
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
  "nbformat": 4,
  "nbformat_minor": 2
 }

--- a/examples/reference/elements/matplotlib/Violin.ipynb
+++ b/examples/reference/elements/matplotlib/Violin.ipynb
@@ -90,22 +90,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/features/bokeh/table_hooks_example.ipynb
+++ b/examples/reference/features/bokeh/table_hooks_example.ipynb
@@ -22,9 +22,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "name = ['homepage', 'github', 'chat']\n",
@@ -54,22 +52,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/streams/bokeh/BoxEdit.ipynb
+++ b/examples/reference/streams/bokeh/BoxEdit.ipynb
@@ -105,22 +105,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/streams/bokeh/PointDraw.ipynb
+++ b/examples/reference/streams/bokeh/PointDraw.ipynb
@@ -107,22 +107,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/streams/bokeh/PolyDraw.ipynb
+++ b/examples/reference/streams/bokeh/PolyDraw.ipynb
@@ -109,22 +109,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/reference/streams/bokeh/PolyEdit.ipynb
+++ b/examples/reference/streams/bokeh/PolyEdit.ipynb
@@ -110,22 +110,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/topics/simulation/sri_model.ipynb
+++ b/examples/topics/simulation/sri_model.ipynb
@@ -649,22 +649,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 2",
-   "language": "python",
-   "name": "python2"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 2
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.13"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/user_guide/08-Gridded_Datasets.ipynb
+++ b/examples/user_guide/08-Gridded_Datasets.ipynb
@@ -461,22 +461,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR aims to address #1617.

Here is the script I used:

```bash
#!/bin/bash
jq --indent 1 \
    '
    (.cells[] | select(has("outputs")) | .outputs) = []
    | (.cells[] | select(has("execution_count")) | .execution_count) = null
    | .metadata = {}
    | .cells[].metadata = {}
    ' $1 > /tmp/$(basename $1)
cat /tmp/$(basename $1) > $1
```

Note: This now clears *all* the notebook metadata, unlike the earlier versions of the script. I checked and the notebooks still work correctly.

Here is how I would clear the metadata from a directory:

```
for f in *.ipynb; do  strip_kernel.sh $f; done
```