### PR TITLE
Ensured Callback plot_id matches top-level

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -184,7 +184,7 @@ class CustomJSCallback(MessageCallback):
             comm_status.event_buffer = [];
         }}
 
-        function on_msg(msg){{
+        function on_msg(msg) {{
           // Receives acknowledgement from Python, processing event
           // and unblocking Comm if event queue empty
           msg = JSON.parse(msg.content.data);
@@ -290,10 +290,11 @@ class CustomJSCallback(MessageCallback):
         attributes back to python.
         """
         # Generate callback JS code to get all the requested data
+        plot_id = self.plot.id if self.plot.top_level else 'PLACEHOLDER_PLOT_ID'
         self_callback = self.js_callback.format(comm_id=self.comm.id,
                                                 timeout=self.timeout,
                                                 debounce=self.debounce,
-                                                plot_id=self.plot.state._id)
+                                                plot_id=plot_id)
 
         attributes = self.attributes_js(self.attributes)
         conditions = ["%s" % cond for cond in self.skip]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1404,6 +1404,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         self.drawn = True
         self.handles['plots'] = plots
 
+        self._update_callbacks(self.handles['plot'])
         if 'plot' in self.handles and not self.tabs:
             plot = self.handles['plot']
             self.handles['xaxis'] = plot.xaxis[0]


### PR DESCRIPTION
The recent changes to Comms mean that it is now necessary to use the plot id to establish a Comm in JupyterLab. In bokeh this plot id is synonymous with the ID of the root-level bokeh model. In a composite plot the individual ElementPlots do not have access to the root level model because it isn't created until a later point. This PR inserts a placeholder into the callbacks CustomJS code, which the composite plot (i.e. LayoutPlot or GridPlot) replaces with the actual id once it is known.

- [x] Fixes https://github.com/ioam/holoviews/issues/2510