### PR TITLE
Fixed bugs using groupby on transposed gridded data

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -527,6 +527,7 @@ class Dataset(Element):
             kdims = [self.get_dimension(d) for d in group_dims]
             group_kwargs = dict(util.get_param_values(self), kdims=kdims)
             group_kwargs.update(kwargs)
+            kdims = group_kwargs['kdims']
             drop_dim = len(kdims) != len(group_kwargs['kdims'])
             def load_subset(*args):
                 constraint = dict(zip(dim_names, args))
@@ -534,7 +535,7 @@ class Dataset(Element):
                 if np.isscalar(group):
                     return group_type(([group],), group=self.group,
                                       label=self.label, vdims=self.vdims)
-                data = group.reindex(group_dims)
+                data = group.reindex(kdims)
                 if drop_dim and self.interface.gridded:
                     data = data.columns()
                 return group_type(data, **group_kwargs)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -523,12 +523,11 @@ class Dataset(Element):
         dim_names = [d.name for d in dimensions]
 
         if dynamic:
-            group_dims = [d.name for d in self.kdims if d not in dimensions]
-            kdims = [self.get_dimension(d) for d in group_dims]
+            group_dims = [kd for kd in self.kdims if kd not in dimensions]
+            kdims = [self.get_dimension(d) for d in kwargs.pop('kdims', group_dims)]
+            drop_dim = len(group_dims) != len(kdims)
             group_kwargs = dict(util.get_param_values(self), kdims=kdims)
             group_kwargs.update(kwargs)
-            kdims = group_kwargs['kdims']
-            drop_dim = len(kdims) != len(group_kwargs['kdims'])
             def load_subset(*args):
                 constraint = dict(zip(dim_names, args))
                 group = self.select(**constraint)

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -346,6 +346,8 @@ class GridInterface(DictInterface):
 
         # Find all the keys along supplied dimensions
         keys = [cls.coords(dataset, d.name) for d in dimensions]
+        transpose = [dataset.ndims-dataset.kdims.index(kd) for kd in kdims]
+        transpose += [i for i in range(dataset.ndims) if i not in transpose]
 
         # Iterate over the unique entries applying selection masks
         grouped_data = []
@@ -363,7 +365,8 @@ class GridInterface(DictInterface):
                     group_data[dim] = np.atleast_1d(v)
             elif not drop_dim:
                 for vdim in dataset.vdims:
-                    group_data[vdim.name] = np.squeeze(group_data[vdim.name])
+                    data = group_data[vdim.name].transpose(transpose)
+                    group_data[vdim.name] = np.squeeze(data)
             group_data = group_type(group_data, **group_kwargs)
             grouped_data.append((tuple(unique_key), group_data))
 

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1309,6 +1309,18 @@ class GridTests(object):
         self.assertEqual(self.dataset_grid_inv.dimension_values(2, flat=False),
                          expanded_zs)
 
+    def test_dataset_groupby_with_transposed_dimensions(self):
+        dat = np.zeros((3,5,7))
+        dataset = Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
+        grouped = dataset.groupby('z', kdims=['y', 'x'])
+        self.assertEqual(grouped.last.dimension_values(2, flat=False), dat[:, :, -1].T)
+
+    def test_dataset_dynamic_groupby_with_transposed_dimensions(self):
+        dat = np.zeros((3,5,7))
+        dataset = Dataset((range(7), range(5), range(3), dat), ['z','x','y'], 'value')
+        grouped = dataset.groupby('z', kdims=['y', 'x'], dynamic=True)
+        self.assertEqual(grouped[2].dimension_values(2, flat=False), dat[:, :, -1].T)
+
 
 
 class GridDatasetTest(GridTests, HomogeneousColumnTypes, ComparisonTestCase):
@@ -1908,3 +1920,9 @@ class RasterDatasetTest(GridTests, ComparisonTestCase):
                               [ 0.06925999,  0.05800389,  0.05620127]])
         self.assertEqual(dataset.dimension_values('z', flat=False),
                          canonical)
+
+    def test_dataset_groupby_with_transposed_dimensions(self):
+        raise SkipTest('Image interface does not support multi-dimensional data.')
+
+    def test_dataset_dynamic_groupby_with_transposed_dimensions(self):
+        raise SkipTest('Image interface does not support multi-dimensional data.')


### PR DESCRIPTION
When using ``.to`` or ``.groupby`` to group a dataset by one or more dimensions it is possible to reorder the dimensions by passing explicit kdims in. This works fine for xarray datasets but when transposing gridded data in the dictionary format the underlying data actually needs to be transposed appropriately, otherwise it raises an error about mismatching shapes.

- [x] Add unit tests