### PR TITLE
Disabled auto-indexable on Dataset baseclass

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -173,7 +173,7 @@ class Dataset(Element):
 
     # In the 1D case the interfaces should not automatically add x-values
     # to supplied data
-    _auto_indexable_1d = True
+    _auto_indexable_1d = False
 
     # Define a class used to transform Datasets into other Element types
     _conversion_interface = DataConversion

--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -29,6 +29,9 @@ class Chart(Dataset, Element2D):
         The value dimensions of the Chart, usually corresponding to a
         number of dependent variables.""")
 
+    # Enables adding index if 1D array like data is supplied
+    _auto_indexable_1d = True
+
     def __getitem__(self, index):
         sliced = super(Chart, self).__getitem__(index)
         if not isinstance(sliced, Chart):

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -425,7 +425,7 @@ class HeterogeneousColumnTypes(HomogeneousColumnTypes):
                          np.array(['M', 'F']))
 
     def test_dataset_implicit_indexing_init(self):
-        dataset = Dataset(self.ys, kdims=['x'], vdims=['y'])
+        dataset = Scatter(self.ys, kdims=['x'], vdims=['y'])
         self.assertTrue(isinstance(dataset.data, self.data_instance_type))
 
     def test_dataset_tuple_init(self):
@@ -887,20 +887,20 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         self.init_column_data()
 
     def test_dataset_series_construct(self):
-        ds = Dataset(pd.Series([1, 2, 3], name='A'))
-        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
+        ds = Scatter(pd.Series([1, 2, 3], name='A'))
+        self.assertEqual(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_df_construct_autoindex(self):
-        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'test', 'A')
-        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'test', 'A'))
+        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'test', 'A')
+        self.assertEqual(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'test', 'A'))
 
     def test_dataset_df_construct_not_autoindex(self):
-        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'index', 'A')
-        self.assertEqual(ds, Dataset(([1, 2, 3], [1, 2, 3]), 'index', 'A'))
+        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A'], index=[1, 2, 3]), 'index', 'A')
+        self.assertEqual(ds, Scatter(([1, 2, 3], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_single_column_construct(self):
-        ds = Dataset(pd.DataFrame([1, 2, 3], columns=['A']))
-        self.assertEqual(ds, Dataset(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
+        ds = Scatter(pd.DataFrame([1, 2, 3], columns=['A']))
+        self.assertEqual(ds, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'A'))
 
     def test_dataset_df_duplicate_columns_raises(self):
         df = pd.DataFrame(np.random.randint(-100,100, size=(100, 2)), columns=list("AB"))


### PR DESCRIPTION
A while back it seem I accidentally enabled auto-indexing for the Dataset baseclass. The feature was meant as a convenience for 1D Chart types but absolutely should not apply to the baseclass which should accurately represent the underlying data and not fiddle with it. This needs to be called out explicitly in the release notes but should be done immediately since it is a bug and can make it awkward to work with ``Graph`` types which allow passing in a list or array of node indices to define an explicit order. This currently will not work correctly because it will add an index automatically.

- [x] Updated existing tests