### PR TITLE
Fixed issues in notebook plot cleanup

### DIFF
--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -140,7 +140,8 @@ class notebook_extension(extension):
                    'between %r' % p.display_formats)
             display(HTML('<b>Warning</b>: %s' % msg))
 
-        if notebook_extension._loaded == False:
+        loaded = notebook_extension._loaded
+        if loaded == False:
             param_ext.load_ipython_extension(ip, verbose=False)
             load_magics(ip)
             Store.output_settings.initialize(list(Store.renderers.keys()))
@@ -161,8 +162,9 @@ class notebook_extension(extension):
         Renderer.load_nb()
         for r in [r for r in resources if r != 'holoviews']:
             Store.renderers[r].load_nb(inline=p.inline)
-        if hasattr(ip, 'kernel'):
-            Renderer.comm_manager.get_client_comm(self._process_comm_msg,
+
+        if hasattr(ip, 'kernel') and not loaded:
+            Renderer.comm_manager.get_client_comm(notebook_extension._process_comm_msg,
                                                   "hv-extension-comm")
 
         # Create a message for the logo (if shown)


### PR DESCRIPTION
In https://github.com/ioam/holoviews/pull/2500 I added cleanup code that cleans up any artifacts whenever a plot is deleted. In doing so the ``notebook_extension``created a new Comm whenever the extension was executed, which in certain scenarios caused errors. The Comm is now created just once, when the extension is loaded for the first time, and corresponding JS code cleans up the cached Comm when the kernel is restarted.

@jbednar would be helpful if you could test.