### PR TITLE
Updated and expanded 14-Large_Data.ipynb

### DIFF
--- a/examples/user_guide/14-Large_Data.ipynb
+++ b/examples/user_guide/14-Large_Data.ipynb
@@ -531,22 +531,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,

--- a/examples/user_guide/14-Large_Data.ipynb
+++ b/examples/user_guide/14-Large_Data.ipynb
@@ -4,16 +4,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Working with large data using datashader"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The various plotting backends supported by HoloViews (such as Matplotlib and Bokeh) each have  limitations on the amount of data that is practical to work with, for a variety of reasons.  For instance, Bokeh mirrors your data directly into an HTML page viewable in your browser, which can cause problems when data sizes approach the limited memory available for each web page in your browser.\n",
+    "# Working with large data using Datashader\n",
     "\n",
-    "Luckily, a visualization of even the largest dataset will be constrained by the resolution of your display device, and so one approach to handling such data is to pre-render or rasterize the data into a fixed-size array or image before sending it to the backend.  The [Datashader package](https://github.com/bokeh/datashader) provides a high-performance big-data rasterization pipeline that works seamlessly with HoloViews to support datasets that are orders of magnitude larger than those supported natively by the plotting backends."
+    "The various plotting-library backends supported by HoloViews, such as Matplotlib and Bokeh, each have a variety of limitations on the amount of data that is practical to work with.  Bokeh in particular mirrors your data directly into an HTML page viewable in your browser, which can cause problems when data sizes approach the limited memory available for each web page in current browsers.\n",
+    "\n",
+    "Luckily, a visualization of even the largest dataset will be constrained by the resolution of your display device, and so one approach to handling such data is to pre-render or rasterize the data into a fixed-size array or image *before* sending it to the backend.  The [Datashader](https://github.com/bokeh/datashader) library provides a high-performance big-data server-side rasterization pipeline that works seamlessly with HoloViews to support datasets that are orders of magnitude larger than those supported natively by the plotting-library backends, including millions or billions of points even on ordinary laptops.\n",
+    "\n",
+    "Here, we will see how and when to use Datashader with HoloViews Elements and Containers. For simplicity in this discussion we'll focus on simple synthetic datasets, but the [Datashader docs](http://datashader.org/topics) include a wide variety of real datasets that give a much better idea of the power of using Datashader with HoloViews, and [PyViz.org](http://pyviz.org) shows how to install and work with HoloViews and Datashader together.\n",
+    "\n",
+    "<style>.container { width:100% !important; }</style>"
    ]
   },
   {
@@ -25,9 +24,9 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "import datashader as ds\n",
-    "from holoviews.operation.datashader import aggregate, datashade, dynspread\n",
+    "from holoviews.operation.datashader import datashade, shade, dynspread, rasterize\n",
     "from holoviews.operation import decimate\n",
-    "hv.extension('bokeh')\n",
+    "hv.extension('bokeh','matplotlib')\n",
     "decimate.max_samples=1000\n",
     "dynspread.max_px=20\n",
     "dynspread.threshold=0.5\n",
@@ -69,9 +68,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Supported ``Elements``\n",
+    "# Principles of datashading\n",
     "\n",
-    "As HoloViews elements are fundamentally data containers, not visualizations, you can very quickly declare elements such as ``Points`` or ``Path`` containing datasets that may be as large as the available memory. For instance, this means you can immediately specify a datastructure that you can work with until you try to visualize it directly with either the matplotlib or bokeh plotting extensions as the rendering process may now be prohibitively expensive.\n",
+    "Because HoloViews elements are fundamentally data containers, not visualizations, you can very quickly declare elements such as ``Points`` or ``Path`` containing datasets that may be as large as the full memory available on your machine (or even larger if using Dask dataframes). So even for very large datasets, you can easily  specify a data structure that you can work with for making selections, sampling, aggregations, and so on. However, as soon as you try to visualize it directly with either the matplotlib or bokeh plotting extensions, the rendering process may be prohibitively expensive.\n",
     "\n",
     "Let's start with a simple example we can visualize as normal:"
    ]
@@ -95,12 +94,9 @@
    "source": [
     "These browser-based plots are fully interactive, as you can see if you select the Wheel Zoom or Box Zoom tools and use your scroll wheel or click and drag.  \n",
     "\n",
-    "Because all of the data in these plots gets transferred directly into the web browser, the interactive functionality will be available even on a static export of this figure as a web page. Note that even though the visualization above is not computationally expensive, even with just 1000 points as in the scatterplot above, the plot already suffers from [overplotting](https://anaconda.org/jbednar/plotting_pitfalls), with later points obscuring previously plotted points.  With much larger datasets, these issues will quickly make it impossible to see the true structure of the data.  \n",
+    "Because all of the data in these plots gets transferred directly into the web browser, the interactive functionality will be available even on a static export of this figure as a web page. Note that even though the visualization above is not computationally expensive, even with just 1000 points as in the scatterplot above, the plot already suffers from [overplotting](https://anaconda.org/jbednar/plotting_pitfalls), with later points obscuring previously plotted points.  \n",
     "\n",
-    "\n",
-    "# Datashader operations\n",
-    "\n",
-    "If we tried to visualize the same two elements below which are just larger versions of the same data above, the plots would be nearly unusable even if the browser did not crash:"
+    "With much larger datasets, these issues will quickly make it impossible to see the true structure of the data.  We can easily declare 50X or 1000X larger versions of the same plots above, but if we tried to visualize them they would be nearly unusable even if the brwoser did not crash:"
    ]
   },
   {
@@ -120,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Luckily, because elements are just containers for data and associated metadata, not plots, HoloViews can generate entirely different types of visualizations from the same data structure when appropriate.  For instance, in the plot on the left below you can see the result of applying a `decimate()` operation acting on the `points` object, which will automatically downsample this million-point dataset to at most 1000 points at any time as you zoom in or out:"
+    "Luckily, HoloViews Elements are just containers for data and associated metadata, not plots, so HoloViews can generate entirely different types of visualizations from the same data structure when appropriate.  For instance, in the plot on the left below you can see the result of applying a `decimate()` operation acting on the `points` object, which will automatically downsample this million-point dataset to at most 1000 points at any time as you zoom in or out:"
    ]
   },
   {
@@ -136,11 +132,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Decimating a plot in this way can be useful, but it discards most of the data, yet still suffers from overplotting. If you have Datashader installed, you can instead use the `datashade()` operation to create a dynamic Datashader-based Bokeh plot.  (Here `datashade()` is just a convenient shortcut for the two main steps used in datashader, i.e., `shade(aggregate())`, which can also be invoked separately.) The middle plot above shows the result of using `datashade()` to create a dynamic Datashader-based plot out of an Element with arbitrarily large data.  In the Datashader version, a new image is regenerated automatically on every zoom or pan event, revealing all the data available at that zoom level and avoiding issues with overplotting.\n",
+    "Decimating a plot in this way can be useful, but it discards most of the data, yet still suffers from overplotting. If you have Datashader installed, you can instead use the `datashade()` operation to create a dynamic Datashader-based Bokeh plot. The middle plot above shows the result of using `datashade()` to create a dynamic Datashader-based plot out of an Element with arbitrarily large data.  In the Datashader version, a new image is regenerated automatically on every zoom or pan event, revealing all the data available at that zoom level and avoiding issues with overplotting by dynamically rescaling the colors used.  The same process is used for the line-based data in the Paths plot.\n",
     "\n",
-    "These two Datashader-based plots are similar to the native Bokeh plots above, but instead of making a static Bokeh plot that embeds points or line segments directly into the browser, HoloViews sets up a Bokeh plot with dynamic callbacks that render the data as an RGB image using Datashader instead.  The dynamic re-rendering provides an interactive user experience even though the data itself is never provided directly to the browser.  Of course, because the full data is not in the browser, a static export of this page (e.g. on anaconda.org) will only show the initially rendered version, and will not update with new images when zooming as it will when there is a live Python process available.\n",
+    "These two Datashader-based plots are similar to the native Bokeh plots above, but instead of making a static Bokeh plot that embeds points or line segments directly into the browser, HoloViews sets up a Bokeh plot with dynamic callbacks that render the data as an RGB image using Datashader instead.  The dynamic re-rendering provides an interactive user experience even though the data itself is never provided directly to the browser.  Of course, because the full data is not in the browser, a static export of this page (e.g. on holoviews.org or on anaconda.org) will only show the initially rendered version, and will not update with new images when zooming as it will when there is a live Python process available.\n",
     "\n",
-    "Though you can no longer have a completely interactive exported file, with the Datashader version on a live server you can now change the number of data points from 1000000 to 10000000 or more to see how well your machine will handle larger datasets. It will get a bit slower, but if you have enough memory, it should still be very usable, and should never crash your browser as transferring the whole dataset into your browser would.  If you don't have enough memory, you can instead set up a [Dask](http://dask.pydata.org) dataframe as shown in other Datashader examples, which will provide out of core and/or distributed processing to handle even the largest datasets."
+    "Though you can no longer have a completely interactive exported file, with the Datashader version on a live server you can now change the number of data points from 1000000 to 10000000 or more to see how well your machine will handle larger datasets. It will get a bit slower, but if you have enough memory, it should still be very usable, and should never crash your browser as transferring the whole dataset into your browser would.  If you don't have enough memory, you can instead set up a [Dask](http://dask.pydata.org) dataframe as shown in other Datashader examples, which will provide out-of-core and/or distributed processing to handle even the largest datasets.\n",
+    "\n",
+    "The `datashade()` operation is actually a \"macro\" or shortcut that combines the two main computations done by datashader, namely `shade()` and `rasterize()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rasterize(points).hist() + shade(rasterize(points)) + datashade(points)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In all three of the above plots, `rasterize()` is being called to aggregate the data (a large set of x,y locations) into a rectangular grid, with each grid cell counting up the number of points that fall into it.  In the plot on the left, only `rasterize()` is done, and the resulting numeric array of counts is passed to Bokeh for colormapping.  Bokeh can thenuse dynamic (client-side, browser-based) operations in JavaScript, allowing users to have dynamic control over  even static HTML plots.  For instance, in this case, users can use the Box Select tool and select a range of the histogram shown, dynamically remapping the colors used in the plot to cover the selected range.\n",
+    "\n",
+    "The other two plots should be identical.  In both cases, the numerical array output of `rasterize()` is mapped into RGB colors by Datashader itself, in Python (\"server-side\"), which allows special Datashader computations like the histogram-equalization in the above plots and the \"spreading\" discussed below.  The `shade()` and `datashade()` operations accept a `cmap` argument that lets you control the colormap used, which can be selected to match the HoloViews/Bokeh `cmap` option but is strictly independent of it.  See ``hv.help(rasterize)``,  ``hv.help(shade)``, and ``hv.help(datashade)`` for options that can be selected, and the [Datashader web site](http://datashader.org) for all the details. You can also try the lower-level ``hv.aggregate()`` (for points and lines) and ``hv.regrid()` (for image/raster data) operations, which may provide more control."
    ]
   },
   {
@@ -149,8 +165,6 @@
    "source": [
     "## Spreading\n",
     "\n",
-    "\n",
-    "\n",
     "The Datashader examples above treat points and lines as infinitesimal in width, such that a given point or small bit of line segment appears in at most one pixel. This approach ensures that the overall distribution of the points will be mathematically well founded -- each pixel will scale in value directly by the number of points that fall into it, or by the lines that cross it.\n",
     "\n",
     "However, many monitors are sufficiently high resolution that the resulting point or line can be difficult to see---a single pixel may not actually be visible on its own, and its color may likely be very difficult to make out.  To compensate for this, HoloViews provides access to Datashader's image-based \"spreading\", which makes isolated pixels \"spread\" into adjacent ones for visibility.  There are two varieties of spreading supported:\n",
@@ -158,7 +172,7 @@
     "1. ``spread``: fixed spreading of a certain number of pixels, which is useful if you want to be sure how much spreading is done regardless of the properties of the data.\n",
     "2. ``dynspread``: spreads up to a maximum size as long as it does not exceed a specified fraction of adjacency between pixels.  \n",
     "\n",
-    "Dynamic spreading is typically more useful, because it adjusts depending on how close the datapoints are to each other on screen. You can see the effect of ``dynspread\n",
+    "Dynamic spreading is typically more useful, because it adjusts depending on how close the datapoints are to each other on screen. Both types of spreading require Datashader to do the colormapping (applying `shade`), because they operate on RGB pixels, not data arrays.\n",
     "\n",
     "You can compare the results in the two plots below after zooming in:"
    ]
@@ -252,6 +266,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Here the dummy points are at 0,0 for this dataset, but would need to be at another suitable value for data that is in a different range.\n",
+    "\n",
     "The `hv.NdOverlay` data structure merges all values along that dimension into the same image, (optionally) coloring each point or line to keep the values visibly different.  If you prefer to keep the values completely separate so that every image contains only one value along the `k` dimension, you can put the data into an `hv.HoloMap`, which lets you use indexes to choose a value for that dimension (or for multiple such dimensions).  If you have not indexed into the dimension(s) to choose one location in the multidimensional space, HoloViews will automatically generate slider widgets to allow you to choose such a value interactively:"
    ]
   },
@@ -270,7 +286,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can thus very naturally explore even very large multidimensional datasets.  Note that the static exported version (e.g. on anaconda.org) will only show a single frame, rather than the entire set of frames visible with a live Python server.\n",
+    "You can thus very naturally explore even very large multidimensional datasets.  Note that the static exported version on holoviews.org or anaconda.org will only show a single frame, rather than the entire set of frames visible with a live Python server.\n",
     "\n",
     "\n",
     "## Working with time series"
@@ -280,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``aggregate`` operations."
+    "HoloViews also makes it possible to datashade large timeseries using the ``datashade`` and ``rasterize`` operations:"
    ]
   },
   {
@@ -322,11 +338,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the above plot will look blocky in a static export (such as on anaconda.org), because the exported version is generated without taking the size of the actual plot (using default height and width for Datashader) into account, whereas the live notebook automatically regenerates the plot to match the visible area on the page.\n",
+    "Note that the above plot will look blocky in a static export (such as on anaconda.org), because the exported version is generated without taking the size of the actual plot (using default height and width for Datashader) into account, whereas the live notebook automatically regenerates the plot to match the visible area on the page. The result of all these operations can be laid out, overlaid, selected, and sampled just like any other HoloViews element, letting you work naturally with even very large datasets.\n",
+    "\n",
     "\n",
     "# Hover info\n",
     "\n",
-    "As you can see, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. Luckily, you can still provide hover information that reports properties of a subset of the data in a separate layer (as above), or you can provide information for a spatial region of the plot rather than for specific datapoints.  For instance, in some small rectangle you can provide statistics such as the mean, count, standard deviation, etc:"
+    "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. Luckily, you can still provide hover information that reports properties of a subset of the data in a separate layer (as above), or you can provide information for a spatial region of the plot rather than for specific datapoints.  For instance, in some small rectangle you can provide statistics such as the mean, count, standard deviation, etc:"
    ]
   },
   {
@@ -339,10 +356,10 @@
     "from holoviews.streams import RangeXY\n",
     "\n",
     "fixed_hover = datashade(points, width=400, height=400) * \\\n",
-    "    hv.QuadMesh(aggregate(points, width=10, height=10, dynamic=False))\n",
+    "    hv.QuadMesh(rasterize(points, width=10, height=10, dynamic=False))\n",
     "\n",
     "dynamic_hover = datashade(points, width=400, height=400) * \\\n",
-    "    hv.util.Dynamic(aggregate(points, width=10, height=10, streams=[RangeXY]), operation=hv.QuadMesh)\n",
+    "    hv.util.Dynamic(rasterize(points, width=10, height=10, streams=[RangeXY]), operation=hv.QuadMesh)\n",
     "\n",
     "fixed_hover + dynamic_hover"
    ]
@@ -351,16 +368,185 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above examples, the plot on the left provides hover information at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful.\n",
+    "In the above examples, the plot on the left provides hover information at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful (but requires a live Python server)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Element types supported for Datashading\n",
     "\n",
-    "As you can see, HoloViews exposes the functionality of Datashader, connecting this powerful rasterizer with Bokeh output so you can visualize data of any size in a browser using just a few lines of code. Because Datashader-based HoloViews plots are implemented as HoloViews operations, they support all of the same features as regular HoloViews objects, and can freely be laid out, overlaid, and nested together."
+    "Fundamentally, what datashader does is to rasterize data, i.e., render a representation of it into a regularly gridded rectangular portion of a two-dimensional plane.  Datashader natively supports four basic types of rasterization:\n",
+    "\n",
+    "- **points**: zero-dimensional objects aggregated by position alone, each point covering zero area in the plane and thus falling into exactly one grid cell of the resulting array (if the point is within the bounds being aggregated).\n",
+    "- **line**: polyline/multiline objects (connected series of line segments), with each segment having a fixed length but zero width and crossing each grid cell at most once.\n",
+    "- **trimesh**: irregularly spaced triangular grid, with each triangle covering a portion of the 2D plane and thus potentially crossing multiple grid cells (thus requiring interpolation/upsampling). Depending on the zoom level, a single pixel can also include multiple triangles, which then becomes similar to the `points` case (requiring aggregation/downsampling of all triangles covered by the pixel).\n",
+    "- **raster**: an axis-aligned regularly gridded two-dimensional subregion of the plane, with each grid cell in the source data covering more than one grid cell in the output grid (requiring interpolation/upsampling), or with each grid cell in the output grid including contributions from more than one grid cell in the input grid (requiring aggregation/downsampling).\n",
+    "\n",
+    "Datashader focuses on implementing those four cases very efficiently, and HoloViews in turn can use them to render a very large range of specific types of data: \n",
+    "\n",
+    "### Supported Elements\n",
+    "\n",
+    "- **points**: [`hv.Nodes`](../reference/elements/bokeh/Graph.ipynb), [`hv.Points`](../reference/elements/bokeh/Points.ipynb), [`hv.Scatter`](../reference/elements/bokeh/Scatter.ipynb)\n",
+    "- **line**: [`hv.Curve`](../reference/elements/bokeh/Curve.ipynb), [`hv.Path`](../reference/elements/bokeh/Path.ipynb), [`hv.Graph`](../reference/elements/bokeh/Graph.ipynb), [`hv.EdgePaths`](../reference/elements/bokeh/Graph.ipynb)\n",
+    "- **raster**: [`hv.Image`](../reference/elements/bokeh/Image.ipynb), [`hv.HSV`](../reference/elements/bokeh/HSV.ipynb), [`hv.RGB`](../reference/elements/bokeh/RGB.ipynb)\n",
+    "- **trimesh**: [`hv.QuadMesh`](../reference/elements/bokeh/QuadMesh.ipynb), [`hv.TriMesh`](../reference/elements/bokeh/TriMesh.ipynb)\n",
+    "\n",
+    "Other HoloViews elements *could* be supported, but do not currently have a useful datashaded representation:\n",
+    "\n",
+    "### Elements not yet supported\n",
+    "\n",
+    "- **line**: [`hv.Spikes`](../reference/elements/bokeh/Spikes.ipynb), [`hv.Contours`](../reference/elements/bokeh/Contours.ipynb), [`hv.Spline`](../reference/elements/bokeh/Spline.ipynb), [`hv.VectorField`](../reference/elements/bokeh/VectorField.ipynb)\n",
+    "- **raster**: [`hv.HeatMap`](../reference/elements/bokeh/HeatMap.ipynb), [`hv.Raster`](../reference/elements/bokeh/Raster.ipynb)\n",
+    "- **trimesh**: [`hv.Area`](../reference/elements/bokeh/Area.ipynb), [`hv.Spread`](../reference/elements/bokeh/Spread.ipynb), [`hv.Histogram`](../reference/elements/bokeh/Histogram.ipynb), [`hv.Polygons`](../reference/elements/bokeh/Polygons.ipynb)\n",
+    "\n",
+    "There are also other Elements that are not expected to be useful with datashader because they are isolated annotations, are already summaries or aggregations of other data, have graphical representations that are only meaningful at a certain size, or are text based:\n",
+    "\n",
+    "### Not useful to support\n",
+    "\n",
+    "- annotations: [`hv.Arrow`](../reference/elements/bokeh/Arrow.ipynb), [`hv.Bounds`](../reference/elements/bokeh/Bounds.ipynb), [`hv.Box`](../reference/elements/bokeh/Box.ipynb), [`hv.Ellipse`](../reference/elements/bokeh/Ellipse.ipynb), [`hv.HLine`](../reference/elements/bokeh/HLine.ipynb), [`hv.VLine`](../reference/elements/bokeh/VLine.ipynb), [`hv.Text`](../reference/elements/bokeh/Text.ipynb)\n",
+    "- kdes: [`hv.Distribution`](../reference/elements/bokeh/Distribution.ipynb), [`hv.Bivariate`](../reference/elements/bokeh/Bivariate.ipynb)\n",
+    "- categorical/symbolic: [`hv.BoxWhisker`](../reference/elements/bokeh/BoxWhisker.ipynb), [`hv.Bars`](../reference/elements/bokeh/Bars.ipynb), [`hv.ErrorBars`](../reference/elements/bokeh/ErrorBars.ipynb)\n",
+    "- tables: [`hv.Table`](../reference/elements/bokeh/Table.ipynb), [`hv.ItemTable`](../reference/elements/bokeh/ItemTable.ipynb)\n",
+    "\n",
+    "Examples of each supported Element type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%output backend='matplotlib'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Layout [vspace=0.1 hspace=0.1]\n",
+    "np.random.seed(12)\n",
+    "N=100\n",
+    "pts = [(10*i/N, np.sin(10*i/N)) for i in range(N)]\n",
+    "\n",
+    "x = y = np.linspace(0, 5, int(np.sqrt(N)))\n",
+    "xs,ys = np.meshgrid(x,y)\n",
+    "z = np.sin(xs)*np.cos(ys)\n",
+    "\n",
+    "r = 0.5*np.sin(0.1*xs**2+0.05*ys**2)+0.5\n",
+    "g = 0.5*np.sin(0.02*xs**2+0.2*ys**2)+0.5\n",
+    "b = 0.5*np.sin(0.02*xs**2+0.02*ys**2)+0.5\n",
+    "\n",
+    "opts2 = dict(filled=True, edge_color_index='z')\n",
+    "tri = hv.TriMesh.from_vertices(hv.Points(np.random.randn(N,3), vdims='z')).options(**opts2)\n",
+    "(tri + tri.edgepaths + datashade(tri, aggregator=ds.mean('z')) + datashade(tri.edgepaths)).cols(2)\n",
+    "\n",
+    "shadeable  = [elemtype(pts) for elemtype in [hv.Curve, hv.Scatter, hv.Points]]\n",
+    "shadeable += [hv.Path([pts])]\n",
+    "shadeable += [hv.Image((x,y,z)), hv.QuadMesh((x,y,z))]\n",
+    "shadeable += [hv.Graph(((np.zeros(N), np.arange(N)),))]\n",
+    "shadeable += [tri.edgepaths]\n",
+    "shadeable += [tri]\n",
+    "\n",
+    "rasterizable = [hv.RGB(np.dstack([r,g,b])), hv.HSV(np.dstack([g,b,r]))]\n",
+    "\n",
+    "opts = dict(sublabel_format=\"\", yaxis='bare', xaxis='bare', aspect=1, axiswise=True)\n",
+    "\n",
+    "hv.Layout([dynspread(datashade(e.relabel(e.__class__.name)).options(**opts)) for e in shadeable] + \n",
+    "          [          rasterize(e.relabel(e.__class__.name)).options(**opts)  for e in rasterizable]).cols(6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we called `datashade()` on each Element type, letting Datashader do the full process of rasterization and shading, except that for `RGB` and `HSV` we only called `rasterize()` or else the results would have been converted into a monochrome image.\n",
+    "\n",
+    "For comparison, you can see the corresponding non-datashaded plots (as long as you leave N lower than 10000 unless you have a long time to wait!):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Layout [vspace=0.1 hspace=0.1]\n",
+    "\n",
+    "hv.Layout([e.relabel(e.__class__.name).options(**opts) for e in shadeable + rasterizable]).cols(6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These two examples use Matplotlib, but if they were switched to Bokeh and you had a live server, they would support dynamic re-rendering on zoom and pan so that you could explore the full range of data available (e.g. even very large raster images, networks, paths, point clouds, or meshes).\n",
+    "\n",
+    "\n",
+    "# Container types supported for datashading\n",
+    "\n",
+    "In the above examples `datashade()` was called directly on each Element, but it can also be called on Containers, in which case each Element in the Container will be datashaded separately (for all Container types other than a Layout):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%output backend='matplotlib'\n",
+    "%%opts RGB Overlay NdOverlay GridSpace [sublabel_format=''] \n",
+    "%%opts RGB [aspect=1 yaxis='bare' xaxis='bare'] \n",
+    "%%opts Layout [vspace=0.2 hspace=0.2] TriMesh [filled=False]\n",
+    "\n",
+    "curves = {2:hv.Curve(pts),1:hv.Curve([(x,0.5*y) for x,y in pts])}\n",
+    "\n",
+    "supported = [hv.HoloMap(curves,kdims='size'), hv.Overlay(list(curves.values())), hv.NdOverlay(curves), hv.GridSpace(hv.NdOverlay(curves))]\n",
+    "hv.Layout([datashade(e.relabel(e.__class__.name)) for e in supported]).cols(4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dynspread(datashade(hv.NdLayout(curves)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Performance\n",
+    "\n",
+    "Although HoloViews tries to convert whatever data you have provided into what Datashader itself supports, you will see much better performance if you store your data in a format that Datashader understands already, so that HoloViews can simply pass it down to Datashader without copying or transforming it. For point, line, and trimesh data, Datashader supports Dask and Pandas dataframes, and so those two data sources will be fastest (with Dask Dataframes somewhat faster and also able to make use of distributed computational resources).  For rasters, Datashader supports xarray objects, and so those will be implemented most efficiently. See the [Datashader docs](http://datashader.org) for instructions and examples for dealing with even quite large datasets (in the billions of points) on commodity hardware.  \n",
+    "\n",
+    "The combination of HoloViews and Datashader allows you to work uniformly with data covering a huge range of sizes, trading off the ability to export user-manipulable plots against file size and browser compatibility, and allowing you to render even the largest dataset faithfully. HoloViews makes the full power of Datashader available in just a few lines of code, letting you reveal your data regardless of its size."
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The updated notebook is readable in uncleared form at: https://anaconda.org/jbednar/14-large_data

Adds a section near the front explaining rasterize vs shade vs datashade, a section near the end showing all the supported Element and Container types, a section at the very end discussing performance, and various other cleanups throughout.

@philippjfr, can you please check the section listing the supported types, and see if you agree with the ones I think could eventually be supported (e.g. by making a trimesh-based approximation to Area, etc.), and those that make no sense to support?