### PR TITLE
Replace display hooks with mimebundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython>5.4.0 param matplotlib=2.1.2 xarray
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray
   - source activate test-environment
   - conda install -c conda-forge  iris plotly flexx ffmpeg --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.14 selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=4.2.0 param matplotlib=2.1.2 xarray
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython>5.4.0 param matplotlib=2.1.2 xarray
   - source activate test-environment
   - conda install -c conda-forge  iris plotly flexx ffmpeg --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.14 selenium

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - bokeh>=0.12.14,<=0.12.15
     - jupyter
     - notebook
-    - ipython
+    - ipython>=5.4.0
 
 test:
   imports:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -6,7 +6,6 @@ baseclass for classes that accept Dimension values.
 from __future__ import unicode_literals
 import re
 import datetime as dt
-import inspect
 from operator import itemgetter
 
 import numpy as np
@@ -1226,25 +1225,7 @@ class Dimensioned(LabelledData):
         hooks.  The output of all registered display_hooks is then
         combined and returned.
         """
-        class_hierarchy = inspect.getmro(type(self))
-        hooks = []
-        for cls in class_hierarchy:
-            if cls in Store.display_hooks:
-                hooks += Store.display_hooks[cls]
-
-        data, metadata = {}, {}
-        for hook in hooks:
-            out = hook(self)
-            if out is None:
-                continue
-            elif isinstance(out, tuple):
-                d, md = out
-            else:
-                d, md = out, {}
-            data.update(d)
-            metadata.update(md)
-        return data, metadata
-
+        return Store.render(self)
 
 
 class ViewableElement(Dimensioned):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -6,6 +6,7 @@ baseclass for classes that accept Dimension values.
 from __future__ import unicode_literals
 import re
 import datetime as dt
+import inspect
 from operator import itemgetter
 
 import numpy as np
@@ -1216,6 +1217,33 @@ class Dimensioned(LabelledData):
         from ..util import opts
         expanded = opts.expand_options(options, backend)
         return self.opts(expanded, backend, clone)
+
+
+    def _repr_mimebundle_(self, include=None, exclude=None):
+        """
+        Resolves the class hierarchy for the class rendering the
+        object using any display hooks registered on Store.display
+        hooks.  The output of all registered display_hooks is then
+        combined and returned.
+        """
+        class_hierarchy = inspect.getmro(type(self))
+        hooks = []
+        for cls in class_hierarchy:
+            if cls in Store.display_hooks:
+                hooks += Store.display_hooks[cls]
+
+        data, metadata = {}, {}
+        for hook in hooks:
+            out = hook(self)
+            if out is None:
+                continue
+            elif isinstance(out, tuple):
+                d, md = out
+            else:
+                d, md = out, {}
+            data.update(d)
+            metadata.update(md)
+        return data, metadata
 
 
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -35,6 +35,7 @@ Store:
 import pickle
 import traceback
 import difflib
+import inspect
 from contextlib import contextmanager
 from collections import OrderedDict, defaultdict
 
@@ -1035,7 +1036,7 @@ class Store(object):
     display_formats = ['html']
 
     # A mapping from Dimensioned type to display hook
-    display_hooks = defaultdict(list)
+    _display_hooks = defaultdict(dict)
 
     # Once register_plotting_classes is called, this OptionTree is
     # populated for the given backend.
@@ -1256,6 +1257,39 @@ class Store(object):
 
             name = view_class.__name__
             cls._options[backend][name] = opt_groups
+
+
+    @classmethod
+    def set_display_hook(cls, group, objtype, hook):
+        """
+        Specify a display hook that will be applied to objects of type
+        objtype. The group specifies the set to which the display hook
+        belongs, allowing the Store to compute the precedence within
+        each group.
+        """
+        cls._display_hooks[group][objtype] = hook
+
+
+    @classmethod
+    def render(cls, obj):
+        """
+        Using any display hooks that have been registered, render the
+        object to a dictionary of MIME types and metadata information.
+        """
+        class_hierarchy = inspect.getmro(type(obj))
+        hooks = []
+        for _, type_hooks in cls._display_hooks.items():
+            for cls in class_hierarchy:
+                if cls in type_hooks:
+                    hooks.append(type_hooks[cls])
+                    break
+
+        data, metadata = {}, {}
+        for hook in hooks:
+            d, md = hook(obj)
+            data.update(d)
+            metadata.update(md)
+        return data, metadata
 
 
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1034,6 +1034,9 @@ class Store(object):
     # IPython Notebook or a GUI application)
     display_formats = ['html']
 
+    # A mapping from Dimensioned type to display hook
+    display_hooks = defaultdict(list)
+
     # Once register_plotting_classes is called, this OptionTree is
     # populated for the given backend.
     _options = {}

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1289,6 +1289,8 @@ class Store(object):
             d, md = hook(obj)
             data.update(d)
             metadata.update(md)
+        if not data:
+            return None
         return data, metadata
 
 

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -7,6 +7,7 @@ import holoviews
 from param import ipython as param_ext
 from IPython.display import HTML, publish_display_data
 
+from ..core.dimension import LabelledData
 from ..core.tree import AttrTree
 from ..core.options import Store
 from ..element.comparison import ComparisonTestCase
@@ -14,7 +15,7 @@ from ..util import extension
 from ..plotting.renderer import Renderer, MIME_TYPES
 from .magics import load_magics
 from .display_hooks import display  # noqa (API import)
-from .display_hooks import set_display_hooks
+from .display_hooks import pprint_display, png_display, svg_display
 
 
 AttrTree._disabled_prefixes = ['_repr_','_ipython_canary_method_should_not_exist']
@@ -145,7 +146,9 @@ class notebook_extension(extension):
             param_ext.load_ipython_extension(ip, verbose=False)
             load_magics(ip)
             Store.output_settings.initialize(list(Store.renderers.keys()))
-            set_display_hooks(ip)
+            Store.set_display_hook('html+js', LabelledData, pprint_display)
+            Store.set_display_hook('png', LabelledData, png_display)
+            Store.set_display_hook('svg', LabelledData, svg_display)
             notebook_extension._loaded = True
 
         css = ''

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -11,12 +11,12 @@ from IPython import get_ipython
 from IPython.display import publish_display_data
 
 import holoviews
-from holoviews.plotting import Plot
 from ..core.options import (Store, StoreOptions, SkipRendering,
                             AbbreviatedException)
-from ..core import (Dimensioned, ViewableElement, UniformNdMapping,
-                    HoloMap, AdjointLayout, NdLayout, GridSpace, Layout,
-                    CompositeOverlay, DynamicMap)
+from ..core import (
+    Dimensioned, ViewableElement, HoloMap, AdjointLayout, NdLayout,
+    GridSpace, Layout, CompositeOverlay, DynamicMap
+)
 from ..core.traversal import unique_dimkeys
 from ..core.io import FileArchive
 from ..util.settings import OutputSettings

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -14,8 +14,8 @@ import holoviews
 from ..core.options import (Store, StoreOptions, SkipRendering,
                             AbbreviatedException)
 from ..core import (
-    Dimensioned, ViewableElement, HoloMap, AdjointLayout, NdLayout,
-    GridSpace, Layout, CompositeOverlay, DynamicMap
+    ViewableElement, HoloMap, AdjointLayout, NdLayout, GridSpace,
+    Layout, CompositeOverlay, DynamicMap
 )
 from ..core.traversal import unique_dimkeys
 from ..core.io import FileArchive
@@ -82,20 +82,20 @@ def first_frame(obj):
     "Only display the first frame of an animated plot"
     plot, renderer, fmt = single_frame_plot(obj)
     plot.update(0)
-    return renderer.components(plot, fmt)
+    return {'text/html': renderer.html(plot, fmt)}
 
 def middle_frame(obj):
     "Only display the (approximately) middle frame of an animated plot"
     plot, renderer, fmt = single_frame_plot(obj)
     middle_frame = int(len(plot) / 2)
     plot.update(middle_frame)
-    return renderer.components(plot, fmt)
+    return {'text/html': renderer.html(plot, fmt)}
 
 def last_frame(obj):
     "Only display the last frame of an animated plot"
     plot, renderer, fmt = single_frame_plot(obj)
     plot.update(len(plot))
-    return renderer.components(plot, fmt)
+    return {'text/html': renderer.html(plot, fmt)}
 
 #===============#
 # Display hooks #

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -149,7 +149,7 @@ def display_hook(fn):
     def wrapped(element):
         global FULL_TRACEBACK
         if Store.current_backend is None:
-            return
+            return {}, {}
 
         try:
             max_frames = OutputSettings.options['max_frames']

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -569,7 +569,7 @@ function handle_add_output(event, handle) {
   var id = output.metadata[EXEC_MIME_TYPE]["id"];
   var toinsert = output_area.element.find("." + CLASS_NAME.split(' ')[0]);
   if (id !== undefined) {
-	toinsert[0].children[0].innerHTML = output.data[HTML_MIME_TYPE];
+    toinsert[0].children[0].innerHTML = output.data[HTML_MIME_TYPE];
     toinsert[0].children[1].textContent = output.data[JS_MIME_TYPE];
     output_area._hv_plot_id = id;
     HoloViews.plot_index[id] = output_area;

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -561,12 +561,16 @@ function handle_add_output(event, handle) {
   var output_area = handle.output_area;
   var output = handle.output;
   // limit handle_add_output to display_data with EXEC_MIME_TYPE content only
-  if ((output.output_type != "display_data") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
+  if ((output.output_type != "execute_result") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
     return
   }
+  var id = output.metadata[EXEC_MIME_TYPE]["id"];
   var toinsert = output_area.element.find("." + CLASS_NAME.split(' ')[0]);
-  if (output.metadata[EXEC_MIME_TYPE]["id"] !== undefined) {
-    var id = output.metadata[EXEC_MIME_TYPE]["id"];
+  if (id !== undefined) {
+    var hv_div = document.createElement("div");
+	// TODO: Add .addClass('output_subarea output_html rendered_html')
+    hv_div.innerHTML = output.data[HTML_MIME_TYPE];
+	toinsert[0].append(hv_div);
     toinsert[0].firstChild.textContent = output.data[JS_MIME_TYPE];
     output_area._hv_plot_id = id;
     HoloViews.plot_index[id] = output_area;

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -550,7 +550,9 @@ var CLASS_NAME = 'output';
  * Render data to the DOM node
  */
 function render(props, node) {
+  var div = document.createElement("div");
   var script = document.createElement("script");
+  node.appendChild(div);
   node.appendChild(script);
 }
 
@@ -567,11 +569,8 @@ function handle_add_output(event, handle) {
   var id = output.metadata[EXEC_MIME_TYPE]["id"];
   var toinsert = output_area.element.find("." + CLASS_NAME.split(' ')[0]);
   if (id !== undefined) {
-    var hv_div = document.createElement("div");
-	// TODO: Add .addClass('output_subarea output_html rendered_html')
-    hv_div.innerHTML = output.data[HTML_MIME_TYPE];
-	toinsert[0].append(hv_div);
-    toinsert[0].firstChild.textContent = output.data[JS_MIME_TYPE];
+	toinsert[0].children[0].innerHTML = output.data[HTML_MIME_TYPE];
+    toinsert[0].children[1].textContent = output.data[JS_MIME_TYPE];
     output_area._hv_plot_id = id;
     HoloViews.plot_index[id] = output_area;
   }

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -562,8 +562,7 @@ function render(props, node) {
 function handle_add_output(event, handle) {
   var output_area = handle.output_area;
   var output = handle.output;
-  // limit handle_add_output to display_data with EXEC_MIME_TYPE content only
-  if ((output.output_type != "execute_result") || (!output.data.hasOwnProperty(EXEC_MIME_TYPE))) {
+  if (!output.data.hasOwnProperty(EXEC_MIME_TYPE)) {
     return
   }
   var id = output.metadata[EXEC_MIME_TYPE]["id"];


### PR DESCRIPTION
This PR is an initial attempt at replacing the IPython display hooks with a ``_repr_mimebundle_`` method. There is still a bit of cleanup to do but this seems to work.
 
- [x] Fixes https://github.com/ioam/holoviews/issues/2462