### PR TITLE
Use HoloViews.plot_index to track bokeh models

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -24,7 +24,7 @@ var BokehMethods = {
     }
     var data = this.frames[current];
 	if (data !== undefined) {
-      var doc = Bokeh.index[data.root].model.document;
+      var doc = HoloViews.plot_index[data.root].model.document;
       doc.apply_json_patch(data.content);
     }
   },
@@ -37,7 +37,7 @@ var BokehMethods = {
     return HoloViewsWidget.prototype.init_comms.call(this);
   },
   process_msg : function(msg) {
-    var doc = Bokeh.index[this.plot_id].model.document;
+    var doc = HoloViews.plot_index[this.plot_id].model.document;
     if (this.receiver === null) { return }
     var receiver = this.receiver;
     if (msg.buffers.length > 0) {

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -569,7 +569,11 @@ function handle_add_output(event, handle) {
     var id = output.metadata[EXEC_MIME_TYPE]["id"];
     toinsert[0].firstChild.textContent = output.data[JS_MIME_TYPE];
     output_area._hv_plot_id = id;
-    HoloViews.plot_index[id] = output_area;
+    if ((window.Bokeh !== undefined) && (id in Bokeh.index)) {
+      HoloViews.plot_index[id] = Bokeh.index[id];
+    } else {
+      HoloViews.plot_index[id] = null;
+    }
   }
 }
 


### PR DESCRIPTION
In a recent PR I added a ``HoloViews.plot_index`` which did little more than keep track of the ids of plots that were displayed. Since then I've found another issue related to the ``Bokeh.index``, which is bokeh's way of keeping track of the root models. The problem with ``Bokeh.index`` is that it is reset every time the extension is loaded (nothing we can do about that), which ends up breaking HoloMaps because they require access to the root model. This PR simply uses the ``HoloViews.plot_index`` to mirror the ``Bokeh.index``, which means that HoloMaps will continue  working even when the extension is reloaded.