### PR TITLE
Fixed handling of categorical colormapping

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1074,7 +1074,7 @@ class ColorbarPlot(ElementPlot):
         if isinstance(cmap, dict) and factors:
             palette = [cmap.get(f, nan_colors.get('NaN', self._default_nan)) for f in factors]
         else:
-            palette = process_cmap(cmap, self.color_levels or ncolors)
+            palette = process_cmap(cmap, self.color_levels or ncolors, categorical=ncolors is not None)
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)
 
         cmapper = self.handles.get(name)

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -520,7 +520,7 @@ class PointPlot(ChartPlot, ColorbarPlot):
             else:
                 categories = np.unique(cs)
                 xsorted = np.argsort(categories)
-                ypos = np.searchsorted(categories[xsorted], cs)
+                ypos = np.searchsorted(categories, cs)
                 style['c'] = xsorted[ypos]
             self._norm_kwargs(element, ranges, style, cdim)
         elif color:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -599,7 +599,10 @@ class ColorbarPlot(ElementPlot):
         clim = opts.pop(prefix+'clims', None)
         values = np.asarray(element.dimension_values(vdim))
         if clim is None:
-            if len(values) and values.dtype.kind in 'uif':
+            if not len(values):
+                clim = (0, 0)
+                categorical = False
+            elif values.dtype.kind in 'uif':
                 clim = ranges[vdim.name] if vdim.name in ranges else element.range(vdim)
                 if self.logz:
                     # Lower clim must be >0 when logz=True
@@ -609,8 +612,10 @@ class ColorbarPlot(ElementPlot):
                         clim = (values[values!=0].min(), clim[1])
                 if self.symmetric:
                     clim = -np.abs(clim).max(), np.abs(clim).max()
+                categorical = False
             else:
                 clim = (0, len(np.unique(values))-1)
+                categorical = True
         if self.logz:
             if self.symmetric:
                 norm = mpl_colors.SymLogNorm(vmin=clim[0], vmax=clim[1],
@@ -663,7 +668,7 @@ class ColorbarPlot(ElementPlot):
                 palette = [cmap.get(f, colors.get('NaN', {'color': self._default_nan})['color'])
                            for f in factors]
             else:
-                palette = process_cmap(cmap, ncolors)
+                palette = process_cmap(cmap, ncolors, categorical=categorical)
             cmap = mpl_colors.ListedColormap(palette)
         if 'max' in colors: cmap.set_over(**colors['max'])
         if 'min' in colors: cmap.set_under(**colors['min'])


### PR DESCRIPTION
In the recent PR to make colormapping consistent across bokeh and matplotlib I adopted the categorical colormapping behavior that was used by matplotlib, which linearly interpolated the colormap. However for categorical values you instead want to cycle through the colors. This PR ensures that when colormapping a categorical dimension with a categorical colormap it cycles through the colors instead of interpolating between the colors.