### PR TITLE
Fixed mimebundle None handling

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1289,8 +1289,6 @@ class Store(object):
             d, md = hook(obj)
             data.update(d)
             metadata.update(md)
-        if not data:
-            return None
         return data, metadata
 
 

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -158,7 +158,7 @@ def display_hook(fn):
             # Only want to add to the archive for one display hook...
             disabled_suffixes = ['png_display', 'svg_display']
             if not any(fn.__name__.endswith(suffix) for suffix in disabled_suffixes):
-                if type(holoviews.archive) is not FileArchive:
+                if type(holoviews.archive) is not FileArchive and mimebundle is not None:
                     html = mimebundle_to_html(mimebundle)
                     holoviews.archive.add(element, html=html)
             filename = OutputSettings.options['filename']


### PR DESCRIPTION
When we introduced ``_repr_mimebundle_`` we did not correctly handle None returns causing errors.