### PR TITLE
XArray: enable overriding dimension names

### DIFF
--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1812,6 +1812,29 @@ class XArrayDatasetTest(GridDatasetTest):
         dataset_from_ds_rev = Dataset(ds_rev)
         self.assertEqual(dataset_from_da_rev, dataset_from_ds_rev)
 
+    def test_xarray_override_dims(self):
+        import xarray as xr
+        xs = [0.1, 0.2, 0.3]
+        ys = [0, 1]
+        zs = np.array([[0, 1], [2, 3], [4, 5]])
+        da = xr.DataArray(zs, coords=[('x_dim', xs), ('y_dim', ys)], name="data_name", dims=['y_dim', 'x_dim'])
+        da.attrs['long_name'] = "data long name"
+        da.attrs['units'] = "array_unit"
+        da.x_dim.attrs['units'] = "x_unit"
+        da.y_dim.attrs['long_name'] = "y axis long name"
+        ds = Dataset(da, kdims=["x_dim", "y_dim"], vdims=["z_dim"])
+        x_dim = Dimension("x_dim")
+        y_dim = Dimension("y_dim")
+        z_dim = Dimension("z_dim")
+        self.assertEqual(ds.kdims[0], x_dim)
+        self.assertEqual(ds.kdims[1], y_dim)
+        self.assertEqual(ds.vdims[0], z_dim)
+        ds_from_ds = Dataset(da.to_dataset(), kdims=["x_dim", "y_dim"], vdims=["data_name"])
+        self.assertEqual(ds_from_ds.kdims[0], x_dim)
+        self.assertEqual(ds_from_ds.kdims[1], y_dim)
+        data_dim = Dimension("data_name")
+        self.assertEqual(ds_from_ds.vdims[0], data_dim)
+
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"
         raise SkipTest("Not supported")


### PR DESCRIPTION
Referencing issue #2319, I made some small changes so that the automatic extraction of units and labels from Dataset and DataArrays is only done if no key or value dimensions are supplied, respectively. This makes it easy to override labels and units e.g. for a DataArray loaded from a netcdf file.