### PR TITLE
Handle empty datasource updates when streaming

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -193,8 +193,9 @@ class BokehPlot(DimensionedPlot):
         Update datasource with data for a new frame.
         """
         data = {k: decode_bytes(vs) for k, vs in data.items()}
+        empty = all(len(v) == 0 for v in data.values())
         if (self.streaming and self.streaming[0].data is self.current_frame.data
-            and self._stream_data):
+            and self._stream_data and not empty):
             stream = self.streaming[0]
             if stream._triggering:
                 data = {k: v[-stream._chunk_length:] for k, v in data.items()}


### PR DESCRIPTION
When streaming data using Buffer we provide a ``Buffer.clear`` method which clears all the existing data however it seems the ColumnDataSource updating code wasn't appropriately detecting whether the data was cleared. This PR ensures that when all the data is cleared the CDS is cleared as well.