### PR TITLE
Fixed matplotlib HeatMap extents

### DIFF
--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -55,6 +55,12 @@ class HeatMapPlot(RasterPlot):
         Ticks along y-axis/annulars specified as an integer, explicit list of
         ticks or function. If `None`, no ticks are shown.""")
 
+
+    def get_extents(self, element, ranges):
+        ys, xs = element.gridded.interface.shape(element.gridded, gridded=True)
+        return (0, 0, xs, ys)
+
+
     @classmethod
     def is_radial(cls, heatmap):
         opts = cls.lookup_options(heatmap, 'plot').options
@@ -167,7 +173,8 @@ class HeatMapPlot(RasterPlot):
         shape = data.shape
         style['aspect'] = shape[0]/shape[1]
         style['extent'] = (0, shape[1], 0, shape[0])
-        style['annotations'] = self._annotate_values(element.gridded)
+        if self.show_values:
+            style['annotations'] = self._annotate_values(element.gridded)
         style['origin'] = 'upper'
         vdim = element.vdims[0]
         self._norm_kwargs(element, ranges, style, vdim)

--- a/tests/plotting/matplotlib/testheatmapplot.py
+++ b/tests/plotting/matplotlib/testheatmapplot.py
@@ -15,6 +15,11 @@ class TestLayoutPlot(TestMPLPlot):
         self.assertEqual(artist.get_array().data, arr.T[::-1, ::-1])
         self.assertEqual(artist.get_extent(), (0, 2, 0, 3))
 
+    def test_heatmap_extents(self):
+        hmap = HeatMap([('A', 50, 1), ('B', 2, 2), ('C', 50, 1)])
+        plot = mpl_renderer.get_plot(hmap)
+        self.assertEqual(plot.get_extents(hmap, {}), (0, 0, 3, 2))
+
     def test_heatmap_xmarks_int(self):
         hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(xmarks=2)
         plot = mpl_renderer.get_plot(hmap)


### PR DESCRIPTION
HeatMap extents weren't being set correctly when the values were numeric.

- [x] Adds unit test