### PR TITLE
Fixes for cleanup of LayoutPlots

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -271,19 +271,23 @@ class BokehPlot(DimensionedPlot):
         deleted. Traverses through all plots cleaning up Callbacks and
         Stream subscribers.
         """
-        plots = self.traverse(lambda x: x, [GenericElementPlot])
+        plots = self.traverse(lambda x: x, [BokehPlot])
         for plot in plots:
+            if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
+                continue
             streams = list(plot.streams)
-            for callback in plot.callbacks:
-                streams += callback.streams
-                callbacks = {k: cb for k, cb in callback._callbacks.items()
-                            if cb is not callback}
-                Callback._callbacks = callbacks
             for stream in set(streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if get_method_owner(subscriber) not in plots
                 ]
+            if not isinstance(plot, GenericElementPlot):
+                continue
+            for callback in plot.callbacks:
+                streams += callback.streams
+                callbacks = {k: cb for k, cb in callback._callbacks.items()
+                            if cb is not callback}
+                Callback._callbacks = callbacks
 
 
     def _fontsize(self, key, label='fontsize', common=True):

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -33,7 +33,7 @@ NOTEBOOK_DIV = """
 
 # Following JS block becomes body of the message handler callback
 bokeh_msg_handler = """
-var plot = Bokeh.index["{plot_id}"];
+var plot = HoloViews.plot_index["{plot_id}"];
 
 if ("{plot_id}" in HoloViews.receivers) {{
   var receiver = HoloViews.receivers["{plot_id}"];

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -68,8 +68,10 @@ class Plot(param.Parameterized):
         Cleans up references to the plot on the attached Stream
         subscribers.
         """
-        plots = self.traverse(lambda x: x, [GenericElementPlot])
+        plots = self.traverse(lambda x: x, [Plot])
         for plot in plots:
+            if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
+                continue
             for stream in set(plot.streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers


### PR DESCRIPTION
The plot cleanup code was not correctly cleaning up LayoutPlots which caused events to be sent to non-existent plots on the JS side.