### PR TITLE
Use different bokeh Documents in notebook context

### DIFF
--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -8,6 +8,7 @@ from param.parameterized import bothmethod
 import bokeh
 from bokeh.application.handlers import FunctionHandler
 from bokeh.application import Application
+from bokeh.document import Document
 from bokeh.io import curdoc, show as bkshow
 from bokeh.models import Model
 from bokeh.resources import CDN, INLINE
@@ -139,7 +140,8 @@ class BokehRenderer(Renderer):
         Allows supplying a document attach the plot to, useful when
         combining the bokeh model with another plot.
         """
-        doc = curdoc() if doc is None else doc
+        if doc is None:
+            doc = Document() if self_or_cls.notebook_context else curdoc()
         doc.theme = self_or_cls.theme
         plot = super(BokehRenderer, self_or_cls).get_plot(obj, renderer)
         plot.document = doc

--- a/tests/plotting/bokeh/testrenderer.py
+++ b/tests/plotting/bokeh/testrenderer.py
@@ -26,6 +26,7 @@ class BokehRendererTest(ComparisonTestCase):
         self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')
         self.map1 = HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
         self.renderer = BokehRenderer.instance()
+        self.renderer.notebook_context = False
 
     def test_save_html(self):
         bytesio = BytesIO()

--- a/tests/plotting/bokeh/testrenderer.py
+++ b/tests/plotting/bokeh/testrenderer.py
@@ -7,6 +7,7 @@ from nose.plugins.attrib import attr
 import numpy as np
 
 from holoviews import HoloMap, Image, GridSpace, Table, Curve, Store
+from holoviews.plotting import Renderer
 from holoviews.element.comparison import ComparisonTestCase
 
 try:
@@ -26,7 +27,11 @@ class BokehRendererTest(ComparisonTestCase):
         self.image2 = Image(np.array([[1,0],[4,-2]]), label='Image2')
         self.map1 = HoloMap({1:self.image1, 2:self.image2}, label='TestMap')
         self.renderer = BokehRenderer.instance()
-        self.renderer.notebook_context = False
+        self.nbcontext = Renderer.notebook_context 
+        Renderer.notebook_context = False
+
+    def tearDown(self):
+        Renderer.notebook_context = self.nbcontext
 
     def test_save_html(self):
         bytesio = BytesIO()

--- a/tests/plotting/bokeh/testserver.py
+++ b/tests/plotting/bokeh/testserver.py
@@ -4,6 +4,7 @@ from holoviews.core.spaces import DynamicMap
 from holoviews.core.options import Store
 from holoviews.element import Curve, Polygons, Path, HLine
 from holoviews.element.comparison import ComparisonTestCase
+from holoviews.plotting import Renderer
 from holoviews.streams import RangeXY, PlotReset
 
 try:
@@ -30,11 +31,14 @@ class TestBokehServerSetup(ComparisonTestCase):
         if not bokeh_renderer:
             raise SkipTest("Bokeh required to test plot instantiation")
         Store.current_backend = 'bokeh'
+        self.nbcontext = Renderer.notebook_context 
+        Renderer.notebook_context = False
 
     def tearDown(self):
         Store.current_backend = self.previous_backend
         bokeh_renderer.last_plot = None
         Callback._callbacks = {}
+        Renderer.notebook_context = self.nbcontext
 
     def test_render_server_doc_element(self):
         obj = Curve([])


### PR DESCRIPTION
In the notebook all bokeh plots were attached to curdoc(), resulting in references to deleted plots to be kept and causing issues sending updates to multiple plots at once.