### PR TITLE
Ensure all tabular interfaces treat empty list equally

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -98,6 +98,8 @@ class PandasInterface(Interface):
 
             if isinstance(data, dict) and all(c in data for c in columns):
                 data = cyODict(((d, data[d]) for d in columns))
+            elif isinstance(data, list) and len(data) == 0:
+                data = {c: np.array([]) for c in columns}
             elif isinstance(data, (list, dict)) and data in ([], {}):
                 data = None
             elif (isinstance(data, dict) and not all(d in data for d in columns) and

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -850,6 +850,11 @@ class ArrayDatasetTest(HomogeneousColumnTypes, ComparisonTestCase):
         self.data_instance_type = np.ndarray
         self.init_column_data()
 
+    def test_dataset_empty_list_init_dtypes(self):
+        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        for d in 'xy':
+            self.assertEqual(dataset.dimension_values(d).dtype, np.float64)
+
     def test_dataset_simple_dict_sorted(self):
         dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],
@@ -885,6 +890,11 @@ class DFDatasetTest(HeterogeneousColumnTypes, ComparisonTestCase):
         Dataset.datatype = [self.datatype]
         self.data_instance_type = pd.DataFrame
         self.init_column_data()
+
+    def test_dataset_empty_list_init_dtypes(self):
+        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        for d in 'xy':
+            self.assertEqual(dataset.dimension_values(d).dtype, np.float64)
 
     def test_dataset_series_construct(self):
         ds = Scatter(pd.Series([1, 2, 3], name='A'))
@@ -1061,6 +1071,11 @@ class DictDatasetTest(HeterogeneousColumnTypes, ScalarColumnTypes, ComparisonTes
         dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
+
+    def test_dataset_empty_list_init_dtypes(self):
+        dataset = Dataset([], kdims=['x'], vdims=['y'])
+        for d in 'xy':
+            self.assertEqual(dataset.dimension_values(d).dtype, np.float64)
 
 
 class GridTests(object):


### PR DESCRIPTION
This PR ensures that all tabular interfaces treat an empty list equally generating data columns of float64 types. Previously the pandas interface would interpret an empty list as 'object' type data which is inconsistent with other interfaces and caused issues in some of our examples (specifically the Tap example in the Custom Interactions user guide).