### PR TITLE
Added workaround for dask interface select issue

### DIFF
--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -92,9 +92,12 @@ class DaskInterface(PandasInterface):
             series = dataset.data[alias]
             if isinstance(k, slice):
                 if k.start is not None:
-                    masks.append(k.start <= series)
+                    # Workaround for dask issue #3392
+                    kval = util.numpy_scalar_to_python(k.start)
+                    masks.append(kval <= series)
                 if k.stop is not None:
-                    masks.append(series < k.stop)
+                    kval = util.numpy_scalar_to_python(k.stop)
+                    masks.append(series < kval)
             elif isinstance(k, (set, list)):
                 iter_slc = None
                 for ik in k:

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1649,3 +1649,15 @@ def mimebundle_to_html(bundle):
         js = data['application/javascript']
         html += '\n<script type="application/javascript">{js}</script>'.format(js=js)
     return html
+
+
+def numpy_scalar_to_python(scalar):
+    """
+    Converts a NumPy scalar to a regular python type.
+    """
+    scalar_type = type(scalar)
+    if np.issubclass_(scalar_type, np.float_):
+        return float(scalar)
+    elif np.issubclass_(scalar_type, np.int_):
+        return int(scalar)
+    return scalar


### PR DESCRIPTION
Workaround for a dask bug when performing comparisons between a NumPy scalar and a dask Series (reported in https://github.com/dask/dask/issues/3392).

- [x] Fixes https://github.com/ioam/holoviews/issues/2555
