### PR TITLE
Switched to parambokeh in Dashboards user guide

### DIFF
--- a/examples/user_guide/16-Dashboards.ipynb
+++ b/examples/user_guide/16-Dashboards.ipynb
@@ -25,7 +25,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the [Data Processing Pipelines section](./13-Data_Pipelines.ipynb) we discovered how to declare a ``DynamicMap`` and control multiple processing steps with the use of custom streams as described in the [Responding to Events](./11-Responding_to_Events.ipynb) guide. Here we will use the same example exploring a dataset of stock timeseries and build a small dashboard using the [``paramNB``](http://paramnb.holoviews.org) library, which allows us to declare easily declare custom widgets and link them to our streams. We will begin by once again declaring our function that loads the stock data:"
+    "In the [Data Processing Pipelines section](./13-Data_Pipelines.ipynb) we discovered how to declare a ``DynamicMap`` and control multiple processing steps with the use of custom streams as described in the [Responding to Events](./11-Responding_to_Events.ipynb) guide. Here we will use the same example exploring a dataset of stock timeseries and build a small dashboard using the [``paramBokeh``](https://ioam.github.io/parambokeh/) library, which allows us to declare easily declare custom widgets and link them to our streams. We will begin by once again declaring our function that loads the stock data:"
    ]
   },
   {
@@ -52,7 +52,7 @@
    "source": [
     "## Building dashboards\n",
     "\n",
-    "Controlling stream events manually from the Python prompt can be a bit cumbersome. However since you can now trigger events from Python we can easily bind any Python based widget framework to the stream. HoloViews itself is based on param and param has various UI toolkits that accompany it and allow you to quickly generate a set of widgets. Here we will use ``paramnb``, which is based on ``ipywidgets`` to control our stream values.\n",
+    "Controlling stream events manually from the Python prompt can be a bit cumbersome. However since you can now trigger events from Python we can easily bind any Python based widget framework to the stream. HoloViews itself is based on param and param has various UI toolkits that accompany it and allow you to quickly generate a set of widgets. Here we will use ``parambokeh``, which is based on bokeh to control our stream values.\n",
     "\n",
     "To do so we will declare a ``StockExplorer`` class which inherits from ``Stream`` and defines two parameters, the ``rolling_window`` as an integer and the ``symbol`` as an ObjectSelector. Additionally we define a view method, which defines the DynamicMap and applies the two operations we have already played with, returning an overlay of the smoothed ``Curve`` and outlier ``Scatter``.\n"
    ]
@@ -64,7 +64,7 @@
    "outputs": [],
    "source": [
     "import param\n",
-    "import paramnb\n",
+    "import parambokeh\n",
     "\n",
     "class StockExplorer(Stream):\n",
     "    \n",
@@ -99,7 +99,7 @@
    "source": [
     "%opts Curve [width=600] {+framewise} Scatter (color='red' marker='triangle')\n",
     "explorer = StockExplorer()\n",
-    "paramnb.Widgets(explorer, continuous_update=True, callback=explorer.event, on_init=True)\n",
+    "parambokeh.Widgets(explorer, continuous_update=True, callback=explorer.event, on_init=True)\n",
     "explorer.view()"
    ]
   },
@@ -130,11 +130,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def render(obj):\n",
+    "def render(obj, view):\n",
     "    renderer = hv.renderer('bokeh')\n",
-    "    plot = renderer.get_plot(obj)\n",
-    "    size = renderer.get_size(plot)\n",
-    "    return renderer._figure_data(plot), size"
+    "    return renderer.get_plot(obj).state"
    ]
   },
   {
@@ -152,7 +150,7 @@
    "source": [
     "class AdvancedStockExplorer(StockExplorer):\n",
     "    \n",
-    "    output = paramnb.view.HTML(renderer=render)\n",
+    "    output = parambokeh.view.Plot(renderer=render)\n",
     "    \n",
     "    variable = param.ObjectSelector(default='adj_close', objects=[c for c in stocks.AAPL.keys() if c!= 'date'])\n",
     "\n",
@@ -170,7 +168,7 @@
    "outputs": [],
    "source": [
     "explorer = AdvancedStockExplorer()\n",
-    "paramnb.Widgets(explorer, continuous_update=True, callback=explorer.event, on_init=True)"
+    "parambokeh.Widgets(explorer, continuous_update=True, callback=explorer.event, on_init=True, view_position='right')"
    ]
   },
   {
@@ -184,7 +182,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see using streams we have bound the widgets to the streams letting us easily control the stream values and making it trivial to define complex dashboards. ``paramNB`` is only one widget framework we could use, we could also use ``paramBokeh`` to use bokeh widgets and deploy the dashboard on bokeh server or manually linked ``ipywidgets`` to our streams. For more information on how to deploy bokeh apps from HoloViews and build dashboards see the [Deploying Bokeh Apps](./Deploying_Bokeh_Apps.ipynb)."
+    "As you can see using streams we have bound the widgets to the streams letting us easily control the stream values and making it trivial to define complex dashboards. ``paramBokeh`` is only one widget framework we could use, we could also use ``paramNB`` to use ipywidgets or simply use ipywidgets. For more information on how to deploy bokeh apps from HoloViews and build dashboards see the [Deploying Bokeh Apps](./Deploying_Bokeh_Apps.ipynb)."
    ]
   }
  ],


### PR DESCRIPTION
Latest versions of ipywidgets are basically broken as far as I can tell and since we aim to switch to paramBokeh more generally I've replaced the usage of paramnb with parambokeh in the Dashboards notebook.