### PR TITLE
Fix for shared_datasource

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -509,6 +509,8 @@ def update_shared_sources(f):
         shared_sources = self.handles.get('shared_sources', [])
         for source in shared_sources:
             source.data.clear()
+            if self.document and self.document._held_events:
+                self.document._held_events = self.document._held_events[:-1]
 
         ret = f(self, *args, **kwargs)
 


### PR DESCRIPTION
When plotting something with a ``shared_source`` in bokeh the ColumnDataSource updates need to be coordinated otherwise bokeh will generate very ugly warnings. However the code that coordinates these changes clears the datasource, which wasn't an issue when we were computing events ourselves, however ever since we started using bokeh protocols the clearing event was sent to bokeh triggering errors. This PR pops the clearing event from the document so that bokeh never sees it.