### PR TITLE
Fixed incorrect options specification

### DIFF
--- a/examples/user_guide/03-Customizing_Plots.ipynb
+++ b/examples/user_guide/03-Customizing_Plots.ipynb
@@ -356,7 +356,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Overlay([hv.Curve((xs, np.sin(xs)**(i+1))).opts(style=dict(color=color, alpha=i+1/3.0)) \n",
+    "hv.Overlay([hv.Curve((xs, np.sin(xs)**(i+1))).opts(style=dict(color=color, alpha=(i+1)/3.0)) \n",
     "            for (i, color) in enumerate(['red','green','blue'])])"
    ]
   },


### PR DESCRIPTION
Fixes this issue where the alpha value ended up greater than one:

![image](https://user-images.githubusercontent.com/890576/38638482-fe392eac-3d93-11e8-9773-dd35e1b2977e.png)
