### PR TITLE
Add support for HTML export after moving to MIME bundle

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -24,7 +24,11 @@ var BokehMethods = {
     }
     var data = this.frames[current];
 	if (data !== undefined) {
-      var doc = HoloViews.plot_index[data.root].model.document;
+      if (data.root in HoloViews.plot_index) {
+        var doc = HoloViews.plot_index[data.root].model.document;
+	  } else {
+        var doc = Bokeh.index[data.root].model.document;
+	  }
       doc.apply_json_patch(data.content);
     }
   },
@@ -37,7 +41,11 @@ var BokehMethods = {
     return HoloViewsWidget.prototype.init_comms.call(this);
   },
   process_msg : function(msg) {
-    var doc = HoloViews.plot_index[this.plot_id].model.document;
+    if (this.plot_id in HoloViews.plot_index) {
+      var doc = HoloViews.plot_index[this.plot_id].model.document;
+	} else {
+      var doc = Bokeh.index[this.plot_id].model.document;
+	}
     if (this.receiver === null) { return }
     var receiver = this.receiver;
     if (msg.buffers.length > 0) {

--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -23,12 +23,12 @@ var BokehMethods = {
       return;
     }
     var data = this.frames[current];
-	if (data !== undefined) {
+    if (data !== undefined) {
       if (data.root in HoloViews.plot_index) {
         var doc = HoloViews.plot_index[data.root].model.document;
-	  } else {
+      } else {
         var doc = Bokeh.index[data.root].model.document;
-	  }
+      }
       doc.apply_json_patch(data.content);
     }
   },
@@ -37,15 +37,15 @@ var BokehMethods = {
       this.receiver = new Bokeh.protocol.Receiver()
     } else {
       this.receiver = null;
-	}
+    }
     return HoloViewsWidget.prototype.init_comms.call(this);
   },
   process_msg : function(msg) {
     if (this.plot_id in HoloViews.plot_index) {
       var doc = HoloViews.plot_index[this.plot_id].model.document;
-	} else {
+    } else {
       var doc = Bokeh.index[this.plot_id].model.document;
-	}
+    }
     if (this.receiver === null) { return }
     var receiver = this.receiver;
     if (msg.buffers.length > 0) {

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -34,15 +34,20 @@ NOTEBOOK_DIV = """
 
 # Following JS block becomes body of the message handler callback
 bokeh_msg_handler = """
-var plot = HoloViews.plot_index["{plot_id}"];
+var plot_id = "{plot_id}";
+if (plot_id in HoloViews.plot_index) {
+  var doc = HoloViews.plot_index[plot_id];
+} else {
+  var doc = Bokeh.index[plot_id];
+}
 
-if ("{plot_id}" in HoloViews.receivers) {{
-  var receiver = HoloViews.receivers["{plot_id}"];
+if (plot_id in HoloViews.receivers) {{
+  var receiver = HoloViews.receivers[plot_id];
 }} else if (Bokeh.protocol === undefined) {{
   return;
 }} else {{
   var receiver = new Bokeh.protocol.Receiver();
-  HoloViews.receivers["{plot_id}"] = receiver;
+  HoloViews.receivers[plot_id] = receiver;
 }}
 
 if (buffers.length > 0) {{

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -70,8 +70,9 @@ static_template = """
 """
 
 embed_js = """
-// Sorry for this hack! See #2574 if you want to be sad
+// Ugly hack - see #2574 for more information
 if (!(document.getElementById('{plot_id}')) && !(document.getElementById('_anim_img{widget_id}'))) {{
+  console.log("Creating DOM nodes dynamically for assumed nbconvert export. To generate clean HTML output set HV_DOC_HTML as an environment variable.")
   var htmlObject = document.createElement('div');
   htmlObject.innerHTML = `{html}`;
   var scriptTags = document.getElementsByTagName('script');

--- a/holoviews/plotting/renderer.py
+++ b/holoviews/plotting/renderer.py
@@ -70,7 +70,8 @@ static_template = """
 """
 
 embed_js = """
-if (!(document.getElementById('{plot_id}')) && !(document.getElementById('_anim_img{element_id}'))) {{
+// Sorry for this hack! See #2574 if you want to be sad
+if (!(document.getElementById('{plot_id}')) && !(document.getElementById('_anim_img{widget_id}'))) {{
   var htmlObject = document.createElement('div');
   htmlObject.innerHTML = `{html}`;
   var scriptTags = document.getElementsByTagName('script');
@@ -318,11 +319,12 @@ class Renderer(Exporter):
         else:
             plot, fmt = self._validate(obj, fmt)
 
+        widget_id = None
         data, metadata = {}, {}
         if isinstance(plot, NdWidget):
             js, html = plot(as_script=True)
             plot_id = plot.plot_id
-            element_id = plot.id
+            widget_id = plot.id
         else:
             html, js = self._figure_data(plot, fmt, as_script=True, **kwargs)
             plot_id = plot.id
@@ -334,10 +336,9 @@ class Renderer(Exporter):
                                                        comm_id=plot.comm.id,
                                                        plot_id=plot_id)
                 js = '\n'.join([js, comm_js])
-            element_id = plot_id
-            html = "<div id='%s' style='display: table; margin: 0 auto;'>%s</div>" % (element_id, html)
+            html = "<div id='%s' style='display: table; margin: 0 auto;'>%s</div>" % (plot_id, html)
         if not os.environ.get('HV_DOC_HTML', False) and js is not None:
-            js = embed_js.format(element_id=element_id, plot_id=plot_id, html=html) + js
+            js = embed_js.format(widget_id=widget_id, plot_id=plot_id, html=html) + js
 
         data['text/html'] = html
         if js:


### PR DESCRIPTION
When we switched to rendering our plots using the ``_repr_mimebundle`` we lost all support for exporting bokeh plots and holoviews widgets to standalone HTML files. This is because nbconvert will only render a single MIME type, whichever is highest in its priority ordering. Since ``application/javascript`` has the highest priority only that gets rendered and doesn't end up finding the HTML tags it's meant to render into.

The only approach I could possible see how to make it work is to dynamically create the HTML DOM nodes that the JS renders into. So this PR adds a bit of JS code to each plot that includes ``application/javascript``, which looks for an existing DOM element with the matching ``element_id`` and if that doesn't exist it dynamically creates it on its own parent node. This means that in the notebook nothing changes but in a static HTML export the DOM nodes are appropriately created.

I have to say I really dislike this approach but it is absolutely the only way I see to make this possible, since I can only publish a single MIME type in the nbconvert output and ``application/javascript`` will always take precedence.