### PR TITLE
Restored old xarray coord order inference behavior

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -127,9 +127,10 @@ class XArrayInterface(GridInterface):
                 vdims = [retrieve_unit_and_label(vd) for vd in vdims]
             if kdims is None:
                 xrdims = list(data.dims)
+                xrcoords = list(data.coords)
                 kdims = [name for name in data.indexes.keys()
                          if isinstance(data[name].data, np.ndarray)]
-                kdims = sorted(kdims, key=lambda x: (xrdims.index(x) if x in xrdims else float('inf'), x))
+                kdims = sorted(kdims, key=lambda x: (xrcoords.index(x) if x in xrcoords else float('inf'), x))
                 if set(xrdims) != set(kdims):
                     virtual_dims = [xd for xd in xrdims if xd not in kdims]
                     for c in data.coords:

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1850,6 +1850,15 @@ class XArrayDatasetTest(GridDatasetTest):
         data_dim = Dimension("data_name")
         self.assertEqual(ds_from_ds.vdims[0], data_dim)
 
+    def test_xarray_coord_ordering(self):
+        import xarray as xr
+        data = np.zeros((3,4,5))
+        coords = OrderedDict([('b', range(3)), ('c', range(4)), ('a', range(5))])
+        darray = xr.DataArray(data, coords=coords, dims=['b', 'c', 'a'])
+        dataset = xr.Dataset({'value': darray}, coords=coords)
+        ds = Dataset(dataset)
+        self.assertEqual(ds.kdims, ['b', 'c', 'a'])
+
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"
         raise SkipTest("Not supported")


### PR DESCRIPTION
In 1.10.0 the code that infers the coordinate order from an XArray Dataset changed, unintentionally changing the behavior. This PR restores the old behavior. 

- [x] Fixes regression described in https://github.com/ioam/holoviews/issues/2577
- [x] Adds unit test