### PR TITLE
Add support for looping edges in Chords element

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -581,7 +581,7 @@ class layout_chords(Operation):
             matrix[s, t] += v
 
         # Compute weighted angular slice for each connection
-        weights_of_areas = (matrix.sum(axis=0) + matrix.sum(axis=1)) - matrix.diagonal()
+        weights_of_areas = (matrix.sum(axis=0) + matrix.sum(axis=1))
         areas_in_radians = (weights_of_areas / weights_of_areas.sum()) * (2 * np.pi)
 
         # We add a zero in the begging for the cumulative sum
@@ -608,9 +608,11 @@ class layout_chords(Operation):
         empty = np.array([[np.NaN, np.NaN]])
         paths = []
         for i in range(len(element)):
-            src_area, tgt_area = all_areas[src_idx[i]], all_areas[tgt_idx[i]]
+            sidx, tidx = src_idx[i], tgt_idx[i]
+            src_area, tgt_area = all_areas[sidx], all_areas[tidx]
+            n_conns = matrix[sidx, tidx]
             subpaths = []
-            for _ in range(int(values[i])):
+            for _ in range(int(n_conns)):
                 if not src_area or not tgt_area:
                     continue
                 x0, y0 = src_area.pop()
@@ -625,7 +627,7 @@ class layout_chords(Operation):
             if subpaths:
                 paths.append(np.concatenate(subpaths))
             else:
-                paths.append(np.array([]))
+                paths.append(np.empty((0, 2)))
 
         # Construct Chord element from components
         if nodes_el:

--- a/tests/element/testgraphelement.py
+++ b/tests/element/testgraphelement.py
@@ -155,6 +155,14 @@ class ChordTests(ComparisonTestCase):
         self.assertEqual(chord.nodes, Nodes(nodes))
         self.assertEqual(chord.array(), np.array(self.simplices))
 
+    def test_chord_constructor_self_reference(self):
+        chord = Chord([('A', 'B', 2), ('B', 'A', 3), ('A', 'A', 2)])
+        nodes = np.array(
+            [[-0.5, 0.866025, 0],
+             [0.5, -0.866025, 1]]
+        ) 
+        self.assertEqual(chord.nodes, Nodes(nodes))
+
 
 
 class TriMeshTests(ComparisonTestCase):


### PR DESCRIPTION
The operation that lays out the Chord paths did not take into account nodes connected to themselves. This PR ensures these no longer cause errors and are displayed as looping arcs.

- [x] Fixes https://github.com/ioam/holoviews/issues/2581