### PR TITLE
Fixed unreferenced variable in matplotlib colormapping

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -616,6 +616,9 @@ class ColorbarPlot(ElementPlot):
             else:
                 clim = (0, len(np.unique(values))-1)
                 categorical = True
+        else:
+            categorical = values.dtype.kind not in 'uif'
+
         if self.logz:
             if self.symmetric:
                 norm = mpl_colors.SymLogNorm(vmin=clim[0], vmax=clim[1],

--- a/tests/plotting/matplotlib/testelementplot.py
+++ b/tests/plotting/matplotlib/testelementplot.py
@@ -32,6 +32,12 @@ class TestColorbarPlot(TestMPLPlot):
         artist = plot.handles['artist']
         self.assertEqual(artist.get_clim(), (-3, 3))
 
+    def test_colormapper_clims(self):
+        img = Image(np.array([[0, 1], [2, 3]])).options(clims=(0, 4))
+        plot = mpl_renderer.get_plot(img)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_clim(), (0, 4))
+        
     def test_colormapper_color_levels(self):
         img = Image(np.array([[0, 1], [2, 3]])).options(color_levels=5)
         plot = mpl_renderer.get_plot(img)


### PR DESCRIPTION
Fixes bug when clims is passed to a colormapped matplotlib plot and the ``categorical`` variable is then not defined.

- [x] Added unit test