### PR TITLE
Allowing use of upcoming 0.12.16 bokeh release

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - param >=1.6.0,<2.0
     - numpy
     - matplotlib>=2.1
-    - bokeh>=0.12.14,<=0.12.15
+    - bokeh>=0.12.14,<=0.12.16
     - jupyter
     - notebook
     - ipython>=5.4.0


### PR DESCRIPTION
Simple update to how bokeh is pinned in the meta.yaml.