### PR TITLE
Support Plot in ipython display function

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -20,6 +20,7 @@ from ..core import (
 from ..core.traversal import unique_dimkeys
 from ..core.io import FileArchive
 from ..core.util import mimebundle_to_html
+from ..plotting import Plot
 from ..util.settings import OutputSettings
 from .magics import OptsMagic, OutputMagic
 
@@ -252,6 +253,8 @@ def display(obj, raw=False, **kwargs):
     elif isinstance(obj, (HoloMap, DynamicMap)):
         with option_state(obj):
             output = map_display(obj)
+    elif isinstance(obj, Plot):
+        output = render(obj)
     else:
         output = {'text/plain': repr(obj)}
 


### PR DESCRIPTION
In the past we allowed Plot objects to display themselves, this was a bad idea. For easier debugging I therefore suggest we instead support it in the ipython ``display`` function.