### PR TITLE
Add support for Tool.renderers == 'auto'

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -652,6 +652,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         hover = self.handles.get('hover')
         if hover is None:
             return
+        if hover.renderers == 'auto':
+            hover.renderers = []
         hover.renderers.append(renderer)
 
         # If datetime column is in the data replace hover formatter
@@ -1343,7 +1345,9 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 tooltips = ()
             tool = self.handles['hover_tools'].get(tooltips)
             if tool:
-                renderers = tool.renderers+hover.renderers
+                tool_renderers = [] if tool.renderers == 'auto' else tool.renderers
+                hover_renderers = [] if hover.renderers == 'auto' else hover.renderers
+                renderers = tool_renderers + hover_renderers
                 tool.renderers = list(util.unique_iterator(renderers))
             if 'hover' not in self.handles:
                 self.handles['hover'] = tool

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -295,6 +295,8 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                 setattr(renderer.edge_renderer, glyph_type+'glyph', new_glyph)
         self.handles[self.edge_glyph+'_glyph'] = renderer.edge_renderer.glyph
         if 'hover' in self.handles:
+            if self.handles['hover'].renderers == 'auto':
+                self.handles['hover'].renderers = []
             self.handles['hover'].renderers.append(renderer)
 
 


### PR DESCRIPTION
In the upcoming bokeh 0.12.16 some tools may now have ``Tool.renderers == 'auto'``, something that is not handled by the current code. This PR ensures that if the renderers are set to 'auto' HoloViews will explicitly override that.