### PR TITLE
Generalized display function again

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -256,7 +256,7 @@ def display(obj, raw=False, **kwargs):
     elif isinstance(obj, Plot):
         output = render(obj)
     else:
-        output = {'text/plain': repr(obj)}
+        output = obj
 
     if raw:
         return output
@@ -264,7 +264,7 @@ def display(obj, raw=False, **kwargs):
         data, metadata = output
     else:
         data, metadata = output, {}
-    publish_display_data(data, metadata)
+    return IPython.display.display(data, metadata=metadata)
 
 
 def pprint_display(obj):
@@ -287,7 +287,7 @@ def image_display(element, max_frames, fmt):
         return None
     info = process_object(element)
     if info:
-        IPython.display.display(IPython.display.HTML(info))
+        display(IPython.display.HTML(info))
         return
 
     backend = Store.current_backend

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -8,7 +8,7 @@ import os, sys, traceback
 
 import IPython
 from IPython import get_ipython
-from IPython.display import publish_display_data
+from IPython.display import HTML
 
 import holoviews
 from ..core.options import (Store, StoreOptions, SkipRendering,
@@ -49,7 +49,7 @@ def process_object(obj):
 def render(obj, **kwargs):
     info = process_object(obj)
     if info:
-        IPython.display.display(IPython.display.HTML(info))
+        display(HTML(info))
         return
 
     if render_anim is not None:
@@ -178,7 +178,7 @@ def display_hook(fn):
 def element_display(element, max_frames):
     info = process_object(element)
     if info:
-        IPython.display.display(IPython.display.HTML(info))
+        display(HTML(info))
         return
 
     backend = Store.current_backend
@@ -241,6 +241,7 @@ def display(obj, raw_output=False, **kwargs):
     using the IPython display function. If raw is enabled
     the raw HTML is returned instead of displaying it directly.
     """
+    raw = True
     if isinstance(obj, GridSpace):
         with option_state(obj):
             output = grid_display(obj)
@@ -257,6 +258,7 @@ def display(obj, raw_output=False, **kwargs):
         output = render(obj)
     else:
         output = obj
+        raw = kwargs.pop('raw', False)
 
     if raw_output:
         return output
@@ -264,7 +266,7 @@ def display(obj, raw_output=False, **kwargs):
         data, metadata = output
     else:
         data, metadata = output, {}
-    return IPython.display.display(data, metadata=metadata, **kwargs)
+    return IPython.display.display(data, raw=raw, metadata=metadata, **kwargs)
 
 
 def pprint_display(obj):
@@ -287,7 +289,7 @@ def image_display(element, max_frames, fmt):
         return None
     info = process_object(element)
     if info:
-        display(IPython.display.HTML(info))
+        display(HTML(info))
         return
 
     backend = Store.current_backend

--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -235,7 +235,7 @@ def grid_display(grid, max_frames):
     return render(grid)
 
 
-def display(obj, raw=False, **kwargs):
+def display(obj, raw_output=False, **kwargs):
     """
     Renders any HoloViews object to HTML and displays it
     using the IPython display function. If raw is enabled
@@ -258,13 +258,13 @@ def display(obj, raw=False, **kwargs):
     else:
         output = obj
 
-    if raw:
+    if raw_output:
         return output
     elif isinstance(output, tuple):
         data, metadata = output
     else:
         data, metadata = output, {}
-    return IPython.display.display(data, metadata=metadata)
+    return IPython.display.display(data, metadata=metadata, **kwargs)
 
 
 def pprint_display(obj):
@@ -275,7 +275,7 @@ def pprint_display(obj):
     ip = get_ipython()  #  # noqa (in IPython namespace)
     if not ip.display_formatter.formatters['text/plain'].pprint:
         return None
-    return display(obj, raw=True)
+    return display(obj, raw_output=True)
 
 
 def image_display(element, max_frames, fmt):


### PR DESCRIPTION
In the past the ``hv.ipython.display`` function simply extended the IPython version to add support for displaying HoloViews objects. When refactoring the MIME types that generality was lost and non-holoviews objects were simply rendered as their ``repr``, which disrupted various usages of the function inside the extension, e.g. to adjust the ``width`` or display various warnings.

- [x] Fixes https://github.com/ioam/holoviews/issues/2548