### PR TITLE
Deal with clashing style and plot options

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -660,7 +660,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
        Index of the dimension in the supplied Bars
        Element, which will stacked.""")
 
-    style_opts = line_properties + fill_properties + ['width', 'cmap']
+    style_opts = line_properties + fill_properties + ['width', 'bar_width', 'cmap']
 
     _plot_methods = dict(single=('vbar', 'hbar'))
 
@@ -768,10 +768,10 @@ class BarPlot(ColorbarPlot, LegendPlot):
             tops.append(top)
         return bottoms, tops
 
+
     def _glyph_properties(self, *args):
         props = super(BarPlot, self)._glyph_properties(*args)
-        del props['width']
-        return props
+        return {k: v for k, v in props.items() if k not in ['width', 'bar_width']}
 
 
     def _add_color_data(self, ds, ranges, style, cdim, data, mapping, factors, colors):
@@ -822,7 +822,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
             self.color_index = color_dim.name
 
         # Define style information
-        width = style.get('width', 1)
+        width = style.get('bar_width', style.get('width', 1))
         cmap = style.get('cmap')
         hover = any(t == 'hover' or isinstance(t, HoverTool)
                     for t in self.tools+self.default_tools)

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -226,7 +226,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
     style_opts = (['xmarks_' + p for p in line_properties] + \
                   ['ymarks_' + p for p in line_properties] + \
                   ['annular_' + p for p in fill_properties + line_properties] + \
-                  ['ticks_' + p for p in text_properties] + ['width', 'cmap'])
+                  ['ticks_' + p for p in text_properties] + ['cmap'])
 
     def __init__(self, *args, **kwargs):
         super(RadialHeatMapPlot, self).__init__(*args, **kwargs)

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -71,9 +71,10 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
     _style_groups = {'rect': 'whisker', 'segment': 'whisker',
                      'vbar': 'box', 'hbar': 'box', 'circle': 'outlier'}
 
-    style_opts = (['whisker_'+p for p in line_properties] +\
-                  ['box_'+p for p in fill_properties+line_properties] +\
-                  ['outlier_'+p for p in fill_properties+line_properties] + ['width', 'cmap'])
+    style_opts = (['whisker_'+p for p in line_properties] +
+                  ['box_'+p for p in fill_properties+line_properties] +
+                  ['outlier_'+p for p in fill_properties+line_properties] +
+                  ['width', 'box_width', 'cmap'])
 
     _stream_data = False # Plot does not support streaming data
 
@@ -132,7 +133,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         out_data = defaultdict(list, {'index': [], vdim: []})
 
         # Define glyph-data mapping
-        width = style.get('width', 0.7)
+        width = style.get('box_width', style.get('width', 0.7))
         if self.invert_axes:
             vbar_map = {'y': 'index', 'left': 'top', 'right': 'bottom', 'height': width}
             seg_map = {'y0': 'x0', 'y1': 'x1', 'x0': 'y0', 'x1': 'y1'}

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -261,7 +261,7 @@ if config.style_17:
 else:
     options.Spline = Options('style', edgecolor=Cycle())
 
-options.Arrow = Options('style', color='k', linewidth=2)
+options.Arrow = Options('style', color='k', linewidth=2, fontsize=13)
 # Paths
 options.Contours = Options('style', color=Cycle(), cmap='viridis')
 options.Contours = Options('plot', show_legend=True)

--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -261,8 +261,7 @@ if config.style_17:
 else:
     options.Spline = Options('style', edgecolor=Cycle())
 
-options.Text = Options('style', fontsize=13)
-options.Arrow = Options('style', color='k', linewidth=2, fontsize=13)
+options.Arrow = Options('style', color='k', linewidth=2)
 # Paths
 options.Contours = Options('style', color=Cycle(), cmap='viridis')
 options.Contours = Options('plot', show_legend=True)

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -155,7 +155,7 @@ class ArrowPlot(AnnotationPlot):
     "Draw an arrow using the information supplied to the Arrow annotation"
 
     _arrow_style_opts = ['alpha', 'color', 'lw', 'linewidth', 'visible']
-    _text_style_opts = TextPlot.style_opts
+    _text_style_opts = TextPlot.style_opts + ['textsize', 'fontsize']
 
     style_opts = sorted(set(_arrow_style_opts + _text_style_opts))
 
@@ -170,6 +170,8 @@ class ArrowPlot(AnnotationPlot):
             xytext = (0, points if direction=='v' else -points)
         elif direction in ['>', '<']:
             xytext = (points if direction=='<' else -points, 0)
+        if 'textsize' in textopts:
+            textopts['fontsize'] = textopts.pop('textsize')
         return [axis.annotate(text, xy=(x, y), textcoords='offset points',
                               xytext=xytext, ha="center", va="center",
                               arrowprops=arrowprops, **textopts)]

--- a/holoviews/plotting/mpl/annotation.py
+++ b/holoviews/plotting/mpl/annotation.py
@@ -73,9 +73,7 @@ class HLinePlot(AnnotationPlot):
 class TextPlot(AnnotationPlot):
     "Draw the Text annotation object"
 
-    style_opts = ['alpha', 'color', 'family', 'weight', 'rotation',
-                  'horizontalalignment', 'verticalalignment', 'fontsize',
-                  'visible']
+    style_opts = ['alpha', 'color', 'family', 'weight', 'visible']
 
     def draw_annotation(self, axis, data, opts):
         (x,y, text, fontsize,

--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -49,7 +49,7 @@ class CurvePlot(ElementPlot):
 
     graph_obj = go.Scatter
 
-    style_opts = ['color', 'dash', 'width']
+    style_opts = ['color', 'dash', 'width', 'line_width']
 
     def graph_options(self, element, ranges):
         if 'steps' in self.interpolation:
@@ -57,6 +57,8 @@ class CurvePlot(ElementPlot):
         opts = super(CurvePlot, self).graph_options(element, ranges)
         opts['mode'] = 'lines'
         style = self.style[self.cyclic_index]
+        if 'line_width' in style:
+            style['width'] = style.pop('line_width')
         opts['line'] = style
         return opts
 
@@ -83,6 +85,8 @@ class ErrorBarsPlot(ElementPlot):
         pos_error = element.dimension_values(pos_idx)
 
         style = self.style[self.cyclic_index]
+        if 'line_width' in style:
+            style['width'] = style.pop('line_width')
         error_y = dict(type='data', array=pos_error,
                        arrayminus=neg_error, visible=True, **style)
         return (), dict(x=element.dimension_values(0),

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -131,7 +131,7 @@ class opts(param.ParameterizedFunction):
             for opt, value in options.items():
                 found = False
                 valid_options = []
-                for g, group_opts in obj_options.groups.items():
+                for g, group_opts in sorted(obj_options.groups.items()):
                     if opt in group_opts.allowed_keywords:
                         expanded[objspec][g][opt] = value
                         found = True

--- a/tests/plotting/__init__.py
+++ b/tests/plotting/__init__.py
@@ -1,0 +1,18 @@
+from itertools import combinations
+
+from holoviews.core.options import Store
+
+
+def option_intersections(backend):
+    intersections = []
+    options = Store.options(backend)
+    for k, opts in options.items():
+        if len(k) > 1: continue
+        eltype = k[0]
+        valid_options = {k: set(o.allowed_keywords)
+                         for k, o in opts.groups.items()}
+        for g1, g2 in combinations(['plot', 'style', 'norm'], 2):
+            intersection = valid_options[g1] & valid_options[g2]
+            if intersection:
+                intersections.append((k, intersection))
+    return intersections

--- a/tests/plotting/__init__.py
+++ b/tests/plotting/__init__.py
@@ -6,9 +6,8 @@ from holoviews.core.options import Store
 def option_intersections(backend):
     intersections = []
     options = Store.options(backend)
-    for k, opts in options.items():
+    for k, opts in sorted(options.items()):
         if len(k) > 1: continue
-        eltype = k[0]
         valid_options = {k: set(o.allowed_keywords)
                          for k, o in opts.groups.items()}
         for g1, g2 in combinations(['plot', 'style', 'norm'], 2):

--- a/tests/plotting/bokeh/testplot.py
+++ b/tests/plotting/bokeh/testplot.py
@@ -15,6 +15,17 @@ try:
 except:
     bokeh_renderer = None
 
+from .. import option_intersections
+
+
+class TestPlotDefinitions(ComparisonTestCase):
+
+    known_clashes = [(('Bars',), {'width'}), (('BoxWhisker',), {'width'})]
+
+    def test_bokeh_option_definitions(self):
+        # Check option definitions do not introduce new clashes
+        self.assertEqual(option_intersections('bokeh'), self.known_clashes)
+
 
 class TestBokehPlot(ComparisonTestCase):
 

--- a/tests/plotting/matplotlib/testplot.py
+++ b/tests/plotting/matplotlib/testplot.py
@@ -10,6 +10,14 @@ try:
 except:
     mpl_renderer = None
 
+from .. import option_intersections
+
+
+class TestPlotDefinitions(ComparisonTestCase):
+
+    def test_matplotlib_plot_definitions(self):
+        self.assertEqual(option_intersections('matplotlib'), [])
+
 
 class TestMPLPlot(ComparisonTestCase):
 

--- a/tests/plotting/matplotlib/testplot.py
+++ b/tests/plotting/matplotlib/testplot.py
@@ -15,8 +15,10 @@ from .. import option_intersections
 
 class TestPlotDefinitions(ComparisonTestCase):
 
+    known_clashes = [(('Arrow',), {'fontsize'})]
+
     def test_matplotlib_plot_definitions(self):
-        self.assertEqual(option_intersections('matplotlib'), [])
+        self.assertEqual(option_intersections('matplotlib'), self.known_clashes)
 
 
 class TestMPLPlot(ComparisonTestCase):

--- a/tests/plotting/plotly/testplot.py
+++ b/tests/plotting/plotly/testplot.py
@@ -16,6 +16,17 @@ try:
 except:
     plotly_renderer = None
 
+from .. import option_intersections
+
+
+class TestPlotDefinitions(ComparisonTestCase):
+
+    known_clashes = [(('Curve',), {'width'}), (('ErrorBars',), {'width'})]
+
+    def test_plotly_option_definitions(self):
+        # Check option definitions do not introduce new clashes
+        self.assertEqual(option_intersections('plotly'), self.known_clashes)
+
 
 @attr(optional=1)
 class TestPlotlyPlotInstantiation(ComparisonTestCase):


### PR DESCRIPTION
A number of options exist both as plot and style, which results in issues when using ``.options``. The clashing options are listed in https://github.com/ioam/holoviews/issues/2411 

- [x] Fixes https://github.com/ioam/holoviews/issues/2599
- [x] Fixes https://github.com/ioam/holoviews/issues/2411
- [x] Adds unit tests to avoid future option clashes