### PR TITLE
Add update_display_data event handler

### DIFF
--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -596,9 +596,20 @@ function handle_clear_output(event, handle) {
   }
 }
 
+/**
+ * Handle kernel restart event
+ */
 function handle_kernel_cleanup(event, handle) {
   delete HoloViews.comms["hv-extension-comm"];
   window.HoloViews.plot_index = {}
+}
+
+/**
+ * Handle update_display_data messages
+ */
+function handle_update_output(event, handle) {
+  handle_clear_output(event, {cell: {output_area: handle.output_area}})
+  handle_add_output(event, handle)
 }
 
 function register_renderer(events, OutputArea) {
@@ -617,7 +628,8 @@ function register_renderer(events, OutputArea) {
     return toinsert
   }
 
-  events.on('output_added.OutputArea', handle_add_output);
+  events.on('output_added.OutputArea', handle_add_output);	
+  events.on('output_updated.OutputArea', handle_update_output);
   events.on('clear_output.CodeCell', handle_clear_output);
   events.on('delete.Cell', handle_clear_output);
   events.on('kernel_ready.Kernel', handle_kernel_cleanup);


### PR DESCRIPTION
This PR makes it possible to update existing plotting output using Jupyter ``update_display_data`` messages. While we no longer aim to support or work much with paramnb, this will provide a much cleaner mechanism than it currently uses and can be used more generally to replace displayed plots in the notebook, e.g.:

```python
curve = hv.Curve(np.random.rand(100))
handle = hv.ipython.display(curve, display_id='A')
```

Can be updated with:

```python
scatter = hv.Scatter(curve)
handle.update(scatter)
```

Note: depends on https://github.com/jupyter/notebook/pull/3560, which ~~should be merged soon~~ is now merged and will make it into the imminent 5.5 release, but this approach is already supported by our JupyterLab extension.