### PR TITLE
Added validation for Image bounds

### DIFF
--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -217,7 +217,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
     bounds = param.ClassSelector(class_=BoundingRegion, default=BoundingBox(), doc="""
        The bounding region in sheet coordinates containing the data.""")
 
-    datatype = param.List(default=['grid', 'xarray', 'image', 'cube', 'dataframe', 'dictionary'])
+    datatype = param.List(default=['image', 'grid', 'xarray', 'cube', 'dataframe', 'dictionary'])
 
     group = param.String(default='Image', constant=True)
 

--- a/tests/core/data/testimageinterfaces.py
+++ b/tests/core/data/testimageinterfaces.py
@@ -41,6 +41,10 @@ class ImageInterfaceTest(ComparisonTestCase):
         with self.assertRaises(DataError):
             Image((ys, xs, array))
 
+    def test_bounds_mismatch(self):
+        with self.assertRaises(ValueError):
+            Image((range(10), range(10), np.random.rand(10, 10)), bounds=0.5)
+
     def test_init_data_datetime_xaxis(self):
         start = np.datetime64(dt.datetime.today())
         end = start+np.timedelta64(1, 's')


### PR DESCRIPTION
Previously the Image element would allow passing in bounds which did not match the coordinates that were declared. This adds validation ensuring that if both bounds and coordinates are passed they are appropriately validated.

- [x] Add unit test
- [x] Fixes https://github.com/ioam/holoviews/issues/2605