### PR TITLE
Fixed namespace issue in opts utility

### DIFF
--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -85,7 +85,9 @@ class opts(param.ParameterizedFunction):
 
         if isinstance(options, basestring):
             from .parser import OptsSpec
-            options = OptsSpec.parse(options)
+            try:     ns = get_ipython().user_ns
+            except:  ns = globals()
+            options = OptsSpec.parse(options, ns=ns)
 
 
         errmsg = StoreOptions.validation_error_message(options)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -85,7 +85,7 @@ class opts(param.ParameterizedFunction):
 
         if isinstance(options, basestring):
             from .parser import OptsSpec
-            try:     ns = get_ipython().user_ns
+            try:     ns = get_ipython().user_ns  # noqa
             except:  ns = globals()
             options = OptsSpec.parse(options, ns=ns)
 


### PR DESCRIPTION
Simple fix to address #2576.

In the ipython module where the magic is defined, ``self.shell.user_ns`` is used as the namespace passed to the parser which is safe as the entire subpackage assumes you are in an IPython environment. In this PR, the IPython namespace is used if available, otherwise it falls back to ``globals`` which should be fine outside of an IPython context.