### PR TITLE
Fix for empty options method call

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1214,7 +1214,10 @@ class Dimensioned(LabelledData):
             options = {type(self).__name__: kwargs}
 
         from ..util import opts
-        expanded = opts.expand_options(options, backend)
+        if options is None:
+            expanded = {}
+        else:
+            expanded = opts.expand_options(options, backend)
         return self.opts(expanded, backend, clone)
 
 

--- a/tests/core/teststoreoptions.py
+++ b/tests/core/teststoreoptions.py
@@ -7,6 +7,7 @@ from holoviews import Overlay, Curve, Image, HoloMap
 from holoviews.core.options import Store, StoreOptions
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews import plotting              # noqa Register backends
+from holoviews.plotting import mpl          # noqa Register backends
 from nose.plugins.attrib import attr
 
 
@@ -110,3 +111,6 @@ class TestStoreOptionsCall(ComparisonTestCase):
         opts = Store.lookup_options('matplotlib', hmap.last, 'plot')
         self.assertIs(opts.kwargs['xaxis'], None)
 
+
+    def test_holomap_options_empty_no_exception(self):
+        HoloMap({0: Image(np.random.rand(10,10))}).options()


### PR DESCRIPTION
When calling the ``.options`` method without any arguments it would previously be an error. This PR ensures that condition is handled appropriately.