### PR TITLE
Fixed PlotSelector bug in matplotlib colormapping

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -15,8 +15,9 @@ import param
 
 from ...core import OrderedDict, Dimension, Store
 from ...core.util import match_spec, unique_iterator, basestring, max_range
-from ...element import Raster
+from ...element import Raster, HeatMap
 from ...operation import interpolate_curve
+from ..plot import PlotSelector
 from ..util import compute_sizes, get_sideplot_ranges, get_min_distance
 from .element import ElementPlot, ColorbarPlot, LegendPlot
 from .path  import PathPlot
@@ -407,6 +408,8 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
 
         # Check if plot is colormapped
         plot_type = Store.registry['matplotlib'].get(type(range_item))
+        if isinstance(plot_type, PlotSelector):
+            plot_type = plot_type.get_plot_class(range_item)
         opts = self.lookup_options(range_item, 'plot')
         if plot_type and issubclass(plot_type, ColorbarPlot):
             cidx = opts.options.get('color_index', None)
@@ -415,7 +418,7 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
             cdim = None
 
         # Get colormapping options
-        if isinstance(range_item, Raster) or cdim:
+        if isinstance(range_item, (HeatMap, Raster)) or cdim:
             style = self.lookup_options(range_item, 'style')[self.cyclic_index]
             cmap = cm.get_cmap(style.get('cmap'))
             main_range = style.get('clims', main_range)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -144,11 +144,16 @@ class PlotSelector(object):
 
 
     def __call__(self, obj, **kwargs):
+        plot_class = self.get_plot_class(obj)
+        return plot_class(obj, **kwargs)
+
+
+    def get_plot_class(self, obj):
         key = self.selector(obj)
         if key not in self.plot_classes:
             msg = "Key %s returned by selector not in set: %s"
             raise Exception(msg  % (key, ', '.join(self.plot_classes.keys())))
-        return self.plot_classes[key](obj, **kwargs)
+        return self.plot_classes[key]
 
 
     def __setattr__(self, label, value):


### PR DESCRIPTION
The code that handles adjoined colormapping in matplotlib was not taking into account PlotSelector instances, which are now resolved correctly.

- [x] Fixes a bug mentioned in https://github.com/ioam/holoviews/pull/2629