### PR TITLE
Fixed bug inverting matplotlib heatmap

### DIFF
--- a/holoviews/element/comparison.py
+++ b/holoviews/element/comparison.py
@@ -115,7 +115,8 @@ class Comparison(ComparisonInterface):
         cls.equality_type_funcs[OrderedDict] =  cls.compare_dictionaries
 
         # Numpy array comparison
-        cls.equality_type_funcs[np.ndarray] =   cls.compare_arrays
+        cls.equality_type_funcs[np.ndarray]          = cls.compare_arrays
+        cls.equality_type_funcs[np.ma.masked_array]  = cls.compare_arrays
 
         # Pandas dataframe comparison
         if pd:

--- a/holoviews/plotting/mpl/heatmap.py
+++ b/holoviews/plotting/mpl/heatmap.py
@@ -170,8 +170,7 @@ class HeatMapPlot(RasterPlot):
         data = np.flipud(element.gridded.dimension_values(2, flat=False))
         data = np.ma.array(data, mask=np.logical_not(np.isfinite(data)))
         if self.invert_axes: data = data.T[::-1, ::-1]
-        if self.invert_xaxis: data = data[:, ::-1]
-        if self.invert_yaxis: data = data[::-1]
+
         shape = data.shape
         style['aspect'] = shape[0]/shape[1]
         style['extent'] = (0, shape[1], 0, shape[0])

--- a/tests/plotting/matplotlib/testheatmapplot.py
+++ b/tests/plotting/matplotlib/testheatmapplot.py
@@ -55,3 +55,19 @@ class TestHeatMapPlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(hmap)
         for marker, pos in zip(plot.handles['ymarks'], (0, 1)):
             self.assertEqual(marker.get_ydata(), [pos, pos])
+
+    def test_heatmap_invert_xaxis(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(invert_xaxis=True)
+        plot = mpl_renderer.get_plot(hmap)
+        array = plot.handles['artist'].get_array()
+        expected = np.array([[np.NaN, 2.], [1., np.NaN]])
+        masked = np.ma.array(expected, mask=np.logical_not(np.isfinite(expected)))
+        self.assertEqual(array, masked)
+
+    def test_heatmap_invert_yaxis(self):
+        hmap = HeatMap([('A',1, 1), ('B', 2, 2)]).options(invert_yaxis=True)
+        plot = mpl_renderer.get_plot(hmap)
+        array = plot.handles['artist'].get_array()
+        expected = np.array([[np.NaN, 2.], [1., np.NaN]])
+        masked = np.ma.array(expected, mask=np.logical_not(np.isfinite(expected)))
+        self.assertEqual(array, masked)


### PR DESCRIPTION
Matplotlib handles inverting the data automatically if an axis is inverted which means that the code to invert the HeatMap data was actually undoing the inversion.

- [x] Fixed https://github.com/ioam/holoviews/issues/2633