### PR TITLE
Pinned to param 1.6.1 or greater

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -16,12 +16,12 @@ build:
 requirements:
   build:
     - python
-    - param >=1.6.0,<2.0
+    - param >=1.6.1,<2.0
     - numpy
     - setuptools
   run:
     - python
-    - param >=1.6.0,<2.0
+    - param >=1.6.1,<2.0
     - numpy
     - matplotlib>=2.1
     - bokeh >=0.12.15,<=0.12.16

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 
 setup_args = {}
-install_requires = ['param>=1.6.0,<2.0', 'numpy>=1.0']
+install_requires = ['param>=1.6.1,<2.0', 'numpy>=1.0']
 extras_require = {}
 
 # Notebook dependencies of IPython 3


### PR DESCRIPTION
This will make sure the latest version of ``Version`` is used which is friendlier when using ``python setup.py develop`` (among other relatively minor, but useful changes).