### PR TITLE
Fixed bug disabling axis labels with labelled option

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -449,8 +449,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                  for axis, dim in zip(['x', 'y'], dimensions)}
         xlabel, ylabel, zlabel = self._get_axis_labels(dimensions)
         if self.invert_axes: xlabel, ylabel = ylabel, xlabel
-        props['x']['axis_label'] = xlabel
-        props['y']['axis_label'] = ylabel
+        props['x']['axis_label'] = xlabel if 'x' in self.labelled else ''
+        props['y']['axis_label'] = ylabel if 'y' in self.labelled else ''
         recursive_model_update(plot.xaxis[0], props.get('x', {}))
         recursive_model_update(plot.yaxis[0], props.get('y', {}))
 

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -27,7 +27,7 @@ class TestElementPlot(TestBokehPlot):
         curve = Curve([])
         plot = bokeh_renderer.get_plot(curve)
         self.assertTrue(plot.handles['glyph_renderer'].visible)
-        
+
     def test_element_no_xaxis(self):
         curve = Curve(range(10)).opts(plot=dict(xaxis=None))
         plot = bokeh_renderer.get_plot(curve).state
@@ -48,6 +48,24 @@ class TestElementPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.yaxis[0].major_label_orientation, np.pi/2)
 
+    def test_element_labelled_x_disabled(self):
+        curve = Curve(range(10)).options(labelled=['y'])
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.xaxis[0].axis_label, '')
+        self.assertEqual(plot.yaxis[0].axis_label, 'y')
+
+    def test_element_labelled_y_disabled(self):
+        curve = Curve(range(10)).options(labelled=['x'])
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.xaxis[0].axis_label, 'x')
+        self.assertEqual(plot.yaxis[0].axis_label, '')
+
+    def test_element_labelled_both_disabled(self):
+        curve = Curve(range(10)).options(labelled=[])
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.xaxis[0].axis_label, '')
+        self.assertEqual(plot.yaxis[0].axis_label, '')
+        
     def test_static_source_optimization(self):
         global data
         data = np.ones((5, 5))


### PR DESCRIPTION
The ``labelled`` plot option allows disabling axis labels, however in bokeh it is being ignored by the ``_update_plot`` method. This fixes the issue.

- [x] Add unit tests