### PR TITLE
Optimize display of large DynamicMap parameter space

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1329,7 +1329,8 @@ def drop_streams(streams, kdims, keys):
     inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
                        if kdim not in stream_params])
     get = itemgetter(*inds)
-    return dims, [get(k) for k in keys]
+    keys = (get(k) for k in keys)
+    return dims, ([wrap_tuple(k) for k in keys] if len(inds) == 1 else list(keys))
 
 
 def itervalues(obj):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from functools import partial
 from contextlib import contextmanager
 from distutils.version import LooseVersion
+from operator import itemgetter
 
 from threading import Thread, Event
 import numpy as np
@@ -1327,9 +1328,8 @@ def drop_streams(streams, kdims, keys):
     stream_params = stream_parameters(streams)
     inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
                        if kdim not in stream_params])
-    values = list(zip(*keys))
-    keys = zip(*[values[i] for i in inds])
-    return dims, list(keys)
+    get = itemgetter(*inds)
+    return dims, [get(k) for k in keys]
 
 
 def itervalues(obj):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -11,7 +11,6 @@ from collections import defaultdict
 from functools import partial
 from contextlib import contextmanager
 from distutils.version import LooseVersion
-from operator import itemgetter
 
 from threading import Thread, Event
 import numpy as np
@@ -1328,7 +1327,7 @@ def drop_streams(streams, kdims, keys):
     stream_params = stream_parameters(streams)
     inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
                        if kdim not in stream_params])
-    get = itemgetter(*inds)
+    get = operator.itemgetter(*inds) # itemgetter used for performance
     keys = (get(k) for k in keys)
     return dims, ([wrap_tuple(k) for k in keys] if len(inds) == 1 else list(keys))
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1327,7 +1327,9 @@ def drop_streams(streams, kdims, keys):
     stream_params = stream_parameters(streams)
     inds, dims = zip(*[(ind, kdim) for ind, kdim in enumerate(kdims)
                        if kdim not in stream_params])
-    return dims, [tuple(wrap_tuple(key)[ind] for ind in inds) for key in keys]
+    values = list(zip(*keys))
+    keys = zip(*[values[i] for i in inds])
+    return dims, list(keys)
 
 
 def itervalues(obj):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -673,11 +673,7 @@ class GenericElementPlot(DimensionedPlot):
         self.top_level = keys is None
         if self.top_level:
             dimensions = self.hmap.kdims
-            values = [d.values for d in dimensions]
-            if dynamic and values and all(values):
-                keys = list(product(*values))
-            else:
-                keys = list(self.hmap.data.keys())
+            keys = list(self.hmap.data.keys())
 
         self.style = self.lookup_options(plot_element, 'style') if style is None else style
         plot_opts = self.lookup_options(plot_element, 'plot').options

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from ...core import OrderedDict, NdMapping
 from ...core.options import Store
+from ...core.ndmapping import item_check
 from ...core.util import (dimension_sanitizer, bytes_to_unicode,
                           unique_array, unicode, isnumeric,
                           wrap_tuple_streams, drop_streams)
@@ -125,8 +126,10 @@ class NdWidget(param.Parameterized):
         else:
             self.renderer = renderer
         # Create mock NdMapping to hold the common dimensions and keys
-        self.mock_obj = NdMapping([(k, None) for k in self.keys],
-                                  kdims=list(self.dimensions), sort=False)
+
+        with item_check(False):
+            self.mock_obj = NdMapping([(k, None) for k in self.keys],
+                                      kdims=list(self.dimensions), sort=False)
 
         NdWidget.widgets[self.id] = self
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -111,9 +111,11 @@ class NdWidget(param.Parameterized):
         for stream in plot.streams:
             if any(k in plot.dimensions for k in stream.contents):
                 streams.append(stream)
+
+        keys = plot.keys[:1] if self.plot.dynamic else plot.keys
         self.dimensions, self.keys = drop_streams(streams,
                                                   plot.dimensions,
-                                                  plot.keys)
+                                                  keys)
         defaults = [kd.default for kd in self.dimensions]
         self.init_key = tuple(v if d is None else d for v, d in
                               zip(self.keys[0], defaults))
@@ -125,11 +127,11 @@ class NdWidget(param.Parameterized):
             self.renderer = Store.renderers[backend]
         else:
             self.renderer = renderer
-        # Create mock NdMapping to hold the common dimensions and keys
 
-        items = [] if self.plot.dynamic else [(k, None) for k in self.keys]
+        # Create mock NdMapping to hold the common dimensions and keys
         with item_check(False):
-            self.mock_obj = NdMapping(items, kdims=list(self.dimensions), sort=False)
+            self.mock_obj = NdMapping([(k, None) for k in self.keys], kdims=list(self.dimensions),
+                                      sort=False)
 
         NdWidget.widgets[self.id] = self
 

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -301,7 +301,10 @@ class SelectionWidget(NdWidget):
     def get_widgets(self):
         # Generate widget data
         widgets, dimensions, init_dim_vals = [], [], []
-        hierarchy = hierarchical(list(self.mock_obj.data.keys()))
+        if self.plot.dynamic:
+            hierarchy = hierarchical(list(self.mock_obj.data.keys()))
+        else:
+            hierarchy = None
         for idx, dim in enumerate(self.mock_obj.kdims):
             # Hide widget if it has 1-to-1 mapping to next widget
             if self.plot.dynamic:

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -127,9 +127,9 @@ class NdWidget(param.Parameterized):
             self.renderer = renderer
         # Create mock NdMapping to hold the common dimensions and keys
 
+        items = [] if self.plot.dynamic else [(k, None) for k in self.keys]
         with item_check(False):
-            self.mock_obj = NdMapping([(k, None) for k in self.keys],
-                                      kdims=list(self.dimensions), sort=False)
+            self.mock_obj = NdMapping(items, kdims=list(self.dimensions), sort=False)
 
         NdWidget.widgets[self.id] = self
 
@@ -302,9 +302,9 @@ class SelectionWidget(NdWidget):
         # Generate widget data
         widgets, dimensions, init_dim_vals = [], [], []
         if self.plot.dynamic:
-            hierarchy = hierarchical(list(self.mock_obj.data.keys()))
-        else:
             hierarchy = None
+        else:
+            hierarchy = hierarchical(list(self.mock_obj.data.keys()))
         for idx, dim in enumerate(self.mock_obj.kdims):
             # Hide widget if it has 1-to-1 mapping to next widget
             if self.plot.dynamic:


### PR DESCRIPTION
As described in https://github.com/ioam/holoviews/issues/2645, a DynamicMap with a large parameter space can be very slow to initialize, this is because we have started to process its keys more consistently but did not take into account the fact that the DynamicMap parameter spaces can be much larger. This now avoids a number of computations that are not necessary and optimized some others:

```python
def test(t, z, cmap, vmin, vmax):
    return hv.Image(np.random.rand(100, 100))
    
dmap = hv.DynamicMap(test, kdims=['t','z', 'cmap', 'vmin','vmax']).redim.values(t=range(10), z=range(10) ,cmap=['viridis','Greys'], vmin=range(100), vmax=range(100,200))
```

This DynamicMap defines a parameter space with 2 million keys, previously this would take 52 seconds to display, with this PR this drops to 0.5 seconds.

![bokeh_plot](https://user-images.githubusercontent.com/1550771/39636307-bd150df2-4fb7-11e8-9e4f-e86b2a6c1b9d.png)


