### PR TITLE
Sort dynamic dimension values in widget constructor

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -807,8 +807,13 @@ class DynamicMap(HoloMap):
         for kdim in self.kdims:
             if str(kdim) in stream_params:
                 key.append(None)
+            elif kdim.default:
+                key.append(kdim.default)
             elif kdim.values:
-                key.append(kdim.values[0])
+                if all(util.isnumeric(v) for v in kdim.values):
+                    key.append(sorted(kdim.values)[0])
+                else:
+                    key.append(kdim.values[0])
             elif kdim.range[0] is not None:
                 key.append(kdim.range[0])
             else:

--- a/holoviews/plotting/widgets/__init__.py
+++ b/holoviews/plotting/widgets/__init__.py
@@ -129,9 +129,14 @@ class NdWidget(param.Parameterized):
             self.renderer = renderer
 
         # Create mock NdMapping to hold the common dimensions and keys
+        sorted_dims = []
+        for dim in self.dimensions:
+            if dim.values and all(isnumeric(v) for v in dim.values):
+                dim = dim.clone(values=sorted(dim.values))
+            sorted_dims.append(dim)
         with item_check(False):
-            self.mock_obj = NdMapping([(k, None) for k in self.keys], kdims=list(self.dimensions),
-                                      sort=False)
+            self.mock_obj = NdMapping([(k, None) for k in self.keys],
+                                      kdims=sorted_dims, sort=False)
 
         NdWidget.widgets[self.id] = self
 
@@ -386,7 +391,7 @@ class SelectionWidget(NdWidget):
                 # Widgets currently detect dynamic mode by type
                 # this value representation is now redundant
                 # and should be removed in a refactor
-                values = sorted(dim.values)
+                values = dim.values
                 dim_vals = {i: i for i, v in enumerate(values)}
                 widget_type = 'slider'
                 value_labels = escape_list(escape_vals([dim.pprint_value(v)

--- a/tests/plotting/bokeh/testwidgets.py
+++ b/tests/plotting/bokeh/testwidgets.py
@@ -373,3 +373,25 @@ class TestSelectionWidget(ComparisonTestCase):
         hmap = HoloMap({chr(65+i): Curve([1, 2, 3]) for i in range(10)}, dim)
         with self.assertRaises(ValueError):
             bokeh_renderer.get_widget(hmap, 'widgets').get_widgets()
+
+    def test_dynamicmap_default_value_slider_plot_initialization(self):
+        dims = [Dimension('N', default=5, range=(0, 10))]
+        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        widgets = bokeh_renderer.get_widget(dmap, 'widgets')
+        widgets.get_widgets()
+        self.assertEqual(widgets.plot.current_key, (5,))
+
+    def test_dynamicmap_unsorted_numeric_values_slider_plot_initialization(self):
+        dims = [Dimension('N', values=[10, 5, 0])]
+        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        widgets = bokeh_renderer.get_widget(dmap, 'widgets')
+        widgets.get_widgets()
+        self.assertEqual(widgets.plot.current_key, (0,))
+
+    def test_dynamicmap_unsorted_numeric_values_slider_plot_update(self):
+        dims = [Dimension('N', values=[10, 5, 0])]
+        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        widgets = bokeh_renderer.get_widget(dmap, 'widgets')
+        widgets.get_widgets()
+        widgets.update((2,))
+        self.assertEqual(widgets.plot.current_key, (10,))

--- a/tests/plotting/testplotutils.py
+++ b/tests/plotting/testplotutils.py
@@ -5,7 +5,7 @@ from nose.plugins.attrib import attr
 
 import numpy as np
 
-from holoviews import NdOverlay, Overlay
+from holoviews import NdOverlay, Overlay, Dimension
 from holoviews.core.spaces import DynamicMap, HoloMap
 from holoviews.core.options import Store, Cycle
 from holoviews.element.comparison import ComparisonTestCase
@@ -321,6 +321,22 @@ class TestOverlayableZorders(ComparisonTestCase):
         self.assertNotIn(area2, sources[0])
         self.assertNotIn(curve_redim, sources[2])
         self.assertNotIn(curve, sources[2])
+
+
+class TestInitializeDynamic(ComparisonTestCase):
+
+    def test_dynamicmap_default_initializes(self):
+        dims = [Dimension('N', default=5, range=(0, 10))]
+        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        initialize_dynamic(dmap)
+        self.assertEqual(dmap.keys(), [5])
+
+    def test_dynamicmap_numeric_values_initializes(self):
+        dims = [Dimension('N', values=[10, 5, 0])]
+        dmap = DynamicMap(lambda N: Curve([1, N, 5]), kdims=dims)
+        initialize_dynamic(dmap)
+        self.assertEqual(dmap.keys(), [0])
+
 
 
 class TestSplitDynamicMapOverlay(ComparisonTestCase):


### PR DESCRIPTION
Fixes two separate bugs caused by Dimension.values potentially being unsorted while the slider widget always expects sorted values.

- [x] Fixes https://github.com/ioam/holoviews/issues/2641
- [x] Added unit tests