### PR TITLE
Ensure PolyDraw data has consistent keys on initialization

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -922,17 +922,12 @@ class PolyDrawCallback(CDSCallback):
                                  empty_value=self.streams[0].empty_value,
                                  renderers=[plot.handles['glyph_renderer']])
         plot.state.tools.append(poly_tool)
-        super(PolyDrawCallback, self).initialize()
 
-    def _process_msg(self, msg):
-        data = super(PolyDrawCallback, self)._process_msg(msg)['data']
-        element = self.plot.current_frame
+        element = plot.current_frame
         x, y = element.dimensions('key', label=True)
-        if 'xs' in data and 'xs' != x:
-            data[x] = data.pop('xs', [])
-        if 'ys' in data and 'ys' != y:
-            data[y] = data.pop('ys', [])
-        return dict(data=data)
+        data = dict(plot.handles['source'].data)
+        for stream in self.streams:
+            stream.update(data=data)
 
 
 class BoxEditCallback(CDSCallback):


### PR DESCRIPTION
Previously the PolyDraw stream renamed the keys in its .data dictionary, but only after initialization. This is inconsistent in two ways, first of all other draw/edit streams give the data consistent keys, such as x0/x1/y0/y1 in the case of ``BoxEdit`` or 'xs' and 'ys' in the case of ``PolyEdit``, while this renamed the keys to match the dimensions. We already offer a ``.element`` property on the stream, which transforms the columns so it's preferable to give the stream.data consistent naming.

- [x] Fixes https://github.com/ioam/holoviews/issues/2650