### PR TITLE
GridSpace and GridPlot fixes

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1526,15 +1526,17 @@ class GridSpace(UniformNdMapping):
             key = tuple(next(num_keys) if i in dim_inds else next(str_keys)
                         for i in range(self.ndims))
         elif any(not (isinstance(el, slice) or callable(el)) for el in key):
-            index_inds = [idx for idx, el in enumerate(key)
-                         if not isinstance(el, (slice, str))]
-            if len(index_inds):
-                index_ind = index_inds[0]
-                dim_keys = np.array([k[index_ind] for k in self.keys()])
-                snapped_val = dim_keys[np.argmin(np.abs(dim_keys-key[index_ind]))]
+            keys = self.keys()
+            for i, k in enumerate(key):
+                if isinstance(k, slice):
+                    continue
+                dim_keys = np.array([ke[i] for ke in keys])
+                if dim_keys.dtype.kind in 'OSU':
+                    continue
+                snapped_val = dim_keys[np.argmin(np.abs(dim_keys-k))]
                 key = list(key)
-                key[index_ind] = snapped_val
-                key = tuple(key)
+                key[i] = snapped_val
+            key = tuple(key)
         return key
 
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -563,12 +563,13 @@ class GridPlot(CompositePlot, GenericCompositePlot):
         width, height = self.renderer.get_size(plot)
         x_axis, y_axis = None, None
         kwargs = dict(sizing_mode=self.sizing_mode)
+        keys = self.layout.keys(full_grid=True)
         if self.xaxis:
             flip = self.shared_xaxis
             rotation = self.xrotation
             lsize = self._fontsize('xlabel').get('fontsize')
             tsize = self._fontsize('xticks', common=False).get('fontsize')
-            xfactors = list(unique_iterator(self.layout.dimension_values(0)))
+            xfactors = list(unique_iterator([wrap_tuple(k)[0] for k in keys]))
             x_axis = make_axis('x', width, xfactors, self.layout.kdims[0],
                                flip=flip, rotation=rotation, label_size=lsize,
                                tick_size=tsize)
@@ -577,7 +578,7 @@ class GridPlot(CompositePlot, GenericCompositePlot):
             rotation = self.yrotation
             lsize = self._fontsize('ylabel').get('fontsize')
             tsize = self._fontsize('yticks', common=False).get('fontsize')
-            yfactors = list(unique_iterator(self.layout.dimension_values(1)))
+            yfactors = list(unique_iterator([k[1] for k in keys]))
             y_axis = make_axis('y', height, yfactors, self.layout.kdims[1],
                                flip=flip, rotation=rotation, label_size=lsize,
                                tick_size=tsize)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -241,7 +241,7 @@ def make_axis(axis, size, factors, dim, flip=False, rotation=0,
         opts = dict(y_axis_label=axis_label, x_range=ranges2,
                     y_range=ranges, plot_width=width, plot_height=size)
 
-    p = Figure(toolbar_location=None, **opts)
+    p = Figure(toolbar_location=None, tools=[], **opts)
     p.outline_line_alpha = 0
     p.grid.grid_line_alpha = 0
 

--- a/tests/core/testlayouts.py
+++ b/tests/core/testlayouts.py
@@ -187,6 +187,24 @@ class GridTest(CompositeTest):
         grid = GridSpace(zip(keys, vals))
         self.assertEqual(grid.shape, (2,2))
 
+    def test_grid_index_snap(self):
+        vals = [self.view1, self.view2, self.view3, self.view2]
+        keys = [(0,0), (0,1), (1,0), (1,1)]
+        grid = GridSpace(zip(keys, vals))
+        self.assertEqual(grid[0.1, 0.1], self.view1)
+
+    def test_grid_index_strings(self):
+        vals = [self.view1, self.view2, self.view3, self.view2]
+        keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
+        grid = GridSpace(zip(keys, vals))
+        self.assertEqual(grid['B', 1], self.view2)
+
+    def test_grid_index_one_axis(self):
+        vals = [self.view1, self.view2, self.view3, self.view2]
+        keys = [('A', 0), ('B', 1), ('C', 0), ('D', 1)]
+        grid = GridSpace(zip(keys, vals))
+        self.assertEqual(grid[:, 0], GridSpace([(('A', 0), self.view1), (('C', 0), self.view3)]))
+
     def test_gridspace_overlay_element(self):
         items = [(0, self.view1), (1, self.view2), (2, self.view3), (3, self.view2)]
         grid = GridSpace(items, 'X')


### PR DESCRIPTION
Fixes three bugs related to grids:

*  The outer axes label ordering of the grid (which was in some cases wrong)
*  Indexing on a GridSpace with non-numeric keys
* Disable zooming on the GridPlot outer axes