### PR TITLE
Fixed PlotReset stream parameter

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -750,7 +750,7 @@ class PlotReset(LinkedStream):
     A stream signalling when a plot reset event has been triggered.
     """
 
-    reset = param.Boolean(default=False, constant=True, doc="""
+    resetting = param.Boolean(default=False, constant=True, doc="""
         Whether a reset event is being signalled.""")
 
     def __init__(self, *args, **params):


### PR DESCRIPTION
The reset parameter on the PlotReset stream was shadowing the reset method on Streams, causing errors when the parameter was reset to None on transient events.