### PR TITLE
Allow changes to columns in bokeh CDS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray
   - source activate test-environment
-  - conda install -c conda-forge  iris plotly flexx ffmpeg --quiet
+  - conda install -c conda-forge  iris plotly flexx ffmpeg netcdftime --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray
   - source activate test-environment
-  - conda install -c conda-forge  iris plotly flexx ffmpeg netcdftime --quiet
+  - conda install -c conda-forge  iris plotly flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -225,6 +225,18 @@ class BokehPlot(DimensionedPlot):
                     source.data.update(converted_data)
                 else:
                     source.stream(data, stream.length)
+            return
+
+        # Determine if the CDS.data requires a full update or simply needs
+        # to be updated, this is done by determining whether newly added
+        # or not updated columns have the same length
+        new_length = [len(v) for v in data.values() if isinstance(v, (list, np.ndarray))]
+        length = [len(v) for v in source.data.values() if isinstance(v, (list, np.ndarray))]
+        not_updated = [k for k in source.data if k not in data]
+        new = [k for k in data if k not in source.data]
+        if ((not_updated and new_length and any(len(source.data[n]) != new_length[0] for n in not_updated))
+            or (new and length and any(len(data[n]) != length[0] for n in new))):
+            source.data = data
         else:
             source.data.update(data)
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -227,15 +227,13 @@ class BokehPlot(DimensionedPlot):
                     source.stream(data, stream.length)
             return
 
-        # Determine if the CDS.data requires a full update or simply needs
-        # to be updated, this is done by determining whether newly added
-        # or not updated columns have the same length
+        # Determine if the CDS.data requires a full replacement or simply needs
+        # to be updated. A replacement is required if untouched columns
+        # are not the same length as the columns being updated.
+        current_length = [len(v) for v in source.data.values() if isinstance(v, (list, np.ndarray))]
         new_length = [len(v) for v in data.values() if isinstance(v, (list, np.ndarray))]
-        length = [len(v) for v in source.data.values() if isinstance(v, (list, np.ndarray))]
-        not_updated = [k for k in source.data if k not in data]
-        new = [k for k in data if k not in source.data]
-        if ((not_updated and new_length and any(len(source.data[n]) != new_length[0] for n in not_updated))
-            or (new and length and any(len(data[n]) != length[0] for n in new))):
+        untouched = [k for k in source.data if k not in data]
+        if (untouched and current_length and new_length and current_length[0] != new_length[0]):
             source.data = data
         else:
             source.data.update(data)

--- a/holoviews/plotting/bokeh/tabular.py
+++ b/holoviews/plotting/bokeh/tabular.py
@@ -121,4 +121,6 @@ class TablePlot(BokehPlot, GenericElementPlot):
         source = self.handles['source']
         style = self.lookup_options(element, 'style')[self.cyclic_index]
         data, _, style = self.get_data(element, ranges, style)
+        columns = self._get_columns(element, data)
+        self.handles['plot'].columns = columns
         self._update_datasource(source, data)

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -121,6 +121,26 @@ class TestElementPlot(TestBokehPlot):
         self.assertEqual(plot.state.ygrid[0].grid_line_width, 1.5)
         self.assertEqual(plot.state.ygrid[0].bounds, (0.3, 0.7))
 
+    def test_change_cds_columns(self):
+        lengths = {'a': 1, 'b': 2, 'c': 3}
+        curve = DynamicMap(lambda a: Curve(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['a', 'y'])
+        self.assertEqual(plot.state.xaxis[0].axis_label, 'a')
+        plot.update(('b',))
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['b', 'y'])
+        self.assertEqual(plot.state.xaxis[0].axis_label, 'b')
+
+    def test_update_cds_columns(self):
+        curve = DynamicMap(lambda a: Curve(range(10), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['a', 'y'])
+        self.assertEqual(plot.state.xaxis[0].axis_label, 'a')
+        plot.update(('b',))
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['a', 'b', 'y'])
+        self.assertEqual(plot.state.xaxis[0].axis_label, 'b')
+
+
 
 class TestColorbarPlot(TestBokehPlot):
 

--- a/tests/plotting/bokeh/testtabular.py
+++ b/tests/plotting/bokeh/testtabular.py
@@ -2,6 +2,7 @@ from datetime import datetime as dt
 from unittest import SkipTest
 
 from holoviews.core.options import Store
+from holoviews.core.spaces import DynamicMap
 from holoviews.element import Table
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import CDSStream
@@ -62,3 +63,13 @@ class TestBokehTablePlot(ComparisonTestCase):
         plot = bokeh_renderer.get_plot(table)
         self.assertEqual(len(plot.callbacks), 1)
         self.assertIsInstance(plot.callbacks[0], CDSCallback)
+
+    def test_table_change_columns(self):
+        lengths = {'a': 1, 'b': 2, 'c': 3}
+        table = DynamicMap(lambda a: Table(range(lengths[a]), a), kdims=['a']).redim.values(a=['a', 'b', 'c'])
+        plot = bokeh_renderer.get_plot(table)
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['a'])
+        self.assertEqual(plot.handles['plot'].columns[0].title, 'a')
+        plot.update(('b',))
+        self.assertEqual(sorted(plot.handles['source'].data.keys()), ['b'])
+        self.assertEqual(plot.handles['plot'].columns[0].title, 'b')


### PR DESCRIPTION
This PR eliminates a long-standing limitation in updating plots with elements where the dimensions change. Specifically the code that updates a CDS now checks whether the data needs to be replaced completely, which occurs in one of two conditions 1) there is a new column which does not match the length of old columns or 2) there is an old column which is not being updated which does not match the updated columns in length.

Here are some examples of what this allows (note the changes in the axis label and table column header):

![curve_update](https://user-images.githubusercontent.com/1550771/39767337-697a4278-52de-11e8-858a-90dd1658ac9f.gif)
![table_update](https://user-images.githubusercontent.com/1550771/39767340-6b5b4dee-52de-11e8-88d7-d93e74792f06.gif)

Technically we could just always replace the data completely but a) that can be inefficient and b) it breaks ``shared_datasource``. I've double checked shared sources are not affected by this change.