### PR TITLE
Correctly check if hover data should be added

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -2,8 +2,7 @@ from collections import defaultdict
 
 import numpy as np
 import param
-from bokeh.models import (CategoricalColorMapper, CustomJS, HoverTool,
-                          Whisker, Range1d)
+from bokeh.models import CategoricalColorMapper, CustomJS, Whisker, Range1d
 from bokeh.models.tools import BoxSelectTool
 from bokeh.transform import jitter
 
@@ -125,7 +124,7 @@ class PointPlot(LegendPlot, ColorbarPlot):
             for k, v in sdata.items():
                 data[k].append(v)
 
-            if any(isinstance(t, HoverTool) for t in self.state.tools):
+            if 'hover' in self.handles:
                 for dim, k in zip(element.dimensions(), key):
                     sanitized = dimension_sanitizer(dim.name)
                     data[sanitized].append([k]*nvals)
@@ -605,7 +604,7 @@ class SpikesPlot(ColorbarPlot):
             mapping['color'] = {'field': cdim.name,
                                 'transform': cmapper}
 
-        if any(isinstance(t, HoverTool) for t in self.state.tools) and not self.static_source:
+        if 'hover' in self.handles and not self.static_source:
             for d in dims:
                 data[dimension_sanitizer(d)] = element.dimension_values(d)
 
@@ -824,8 +823,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         # Define style information
         width = style.get('bar_width', style.get('width', 1))
         cmap = style.get('cmap')
-        hover = any(t == 'hover' or isinstance(t, HoverTool)
-                    for t in self.tools+self.default_tools)
+        hover = 'hover' in self.handles
 
         # Group by stack or group dim if necessary
         if group_dim is None:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -188,7 +188,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         Initializes hover data based on Element dimension values.
         If empty initializes with no data.
         """
-        if not any(isinstance(t, HoverTool) for t in self.state.tools) or self.static_source:
+        if 'hover' not in self.handles or self.static_source:
             return
 
         for d in (dimensions or element.dimensions()):

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -2,9 +2,8 @@ from collections import defaultdict
 
 import param
 import numpy as np
-from bokeh.models import HoverTool, ColumnDataSource
 from bokeh.models import (StaticLayoutProvider, NodesAndLinkedEdges,
-                          EdgesAndLinkedNodes, Patches, Bezier)
+                          EdgesAndLinkedNodes, Patches, Bezier, ColumnDataSource)
 
 from ...core.data import Dataset
 from ...core.util import (basestring, dimension_sanitizer, unique_array,
@@ -200,7 +199,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             edge_mapping.update(pmapping)
 
         # Get hover data
-        if any(isinstance(t, HoverTool) for t in self.state.tools):
+        if 'hover' in self.handles:
             if self.inspection_policy == 'nodes':
                 index_dim = element.nodes.get_dimension(2)
                 point_data['index_hover'] = [index_dim.pprint_value(v) for v in element.nodes.dimension_values(2)]

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -1,7 +1,7 @@
 import param
 import numpy as np
 
-from bokeh.models import HoverTool, Span
+from bokeh.models import Span
 from bokeh.models.glyphs import AnnularWedge
 
 from ...core.util import is_nan, dimension_sanitizer
@@ -90,7 +90,7 @@ class HeatMapPlot(ColorbarPlot):
             yvals = [ydim.pprint_value(yv) for yv in yvals]
         data = {x: xvals, y: yvals, 'zvalues': zvals}
 
-        if any(isinstance(t, HoverTool) for t in self.state.tools) and not self.static_source:
+        if 'hover' in self.handles and not self.static_source:
             for vdim in element.vdims:
                 sanitized = dimension_sanitizer(vdim.name)
                 data[sanitized] = ['-' if is_nan(v) else vdim.pprint_value(v)
@@ -533,7 +533,7 @@ class RadialHeatMapPlot(CompositeElementPlot, ColorbarPlot):
                         "outer_radius": outer_radius,
                         z: zvals, x: xvals, y: yvals}
 
-        if any(isinstance(t, HoverTool) for t in self.state.tools):
+        if 'hover' in self.handles:
             for vdim in element.vdims:
                 sanitized = dimension_sanitizer(vdim.name)
                 values = ['-' if is_nan(v) else vdim.pprint_value(v)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -3,8 +3,6 @@ from collections import defaultdict
 import param
 import numpy as np
 
-from bokeh.models import HoverTool
-
 from ...core import util
 from .element import ColorbarPlot, LegendPlot, line_properties, fill_properties
 from .util import expand_batched_style
@@ -39,7 +37,7 @@ class PathPlot(ColorbarPlot):
         """
         Initializes hover data based on Element dimension values.
         """
-        if not any(isinstance(t, HoverTool) for t in self.state.tools) or self.static_source:
+        if 'hover' not in self.handles or self.static_source:
             return
 
         for k, v in self.overlay_dims.items():
@@ -129,7 +127,7 @@ class ContourPlot(LegendPlot, PathPlot):
         Initializes hover data based on Element dimension values.
         If empty initializes with no data.
         """
-        if not any(isinstance(t, HoverTool) for t in self.state.tools) or self.static_source:
+        if 'hover' not in self.handles or self.static_source:
             return
 
         for d in element.vdims:

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -1,7 +1,6 @@
 import numpy as np
 import param
 
-from bokeh.models import HoverTool
 from ...core.util import cartesian_product, dimension_sanitizer
 from ...element import Raster, RGB, HSV
 from .element import ElementPlot, ColorbarPlot, line_properties, fill_properties
@@ -170,7 +169,7 @@ class QuadMeshPlot(ColorbarPlot):
             zvals = zdata.flatten() if self.invert_axes else zdata.T.flatten()
             data = {'left': x0, 'right': x1, dimension_sanitizer(z.name): zvals,
                     'bottom': y0, 'top': y1}
-            if any(isinstance(t, HoverTool) for t in self.state.tools) and not self.static_source:
+            if 'hover' in self.handles and not self.static_source:
                 data[dimension_sanitizer(x.name)] = element.dimension_values(x)
                 data[dimension_sanitizer(y.name)] = element.dimension_values(y)
         return data, mapping, style

--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -1,7 +1,7 @@
 import param
 import numpy as np
 
-from bokeh.models import Patches, HoverTool
+from bokeh.models import Patches
 
 from ...core.data import Dataset
 from ...core.util import basestring, max_range, dimension_sanitizer
@@ -124,7 +124,7 @@ class SankeyPlot(GraphPlot):
         """
         Replace edge start and end hover data with label_index data.
         """
-        if not (self.inspection_policy == 'edges' and any(isinstance(t, HoverTool) for t in self.state.tools)):
+        if not (self.inspection_policy == 'edges' and 'hover' in self.handles):
             return
         lidx = element.nodes.get_dimension(self.label_index)
         src, tgt = [dimension_sanitizer(kd.name) for kd in element.kdims[:2]]

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -4,7 +4,7 @@ from functools import partial
 import param
 import numpy as np
 
-from bokeh.models import FactorRange, HoverTool, Circle, VBar, HBar
+from bokeh.models import FactorRange, Circle, VBar, HBar
 
 from ...core.dimension import Dimension
 from ...core.util import (basestring, dimension_sanitizer, wrap_tuple,
@@ -162,7 +162,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                     label = label[0]
             else:
                 label = key
-            hover = any(isinstance(t, HoverTool) for t in self.state.tools)
+            hover = 'hover' in self.handles
 
             # Add color factor
             if cidx is not None and cidx<element.ndims:


### PR DESCRIPTION
This PR addresses a class of bugs in the bokeh backend where the data required to display hover information for the element was added if any subplot of the overlay enabled hover information even if the hover for a particular element was not actually displayed. Rather than checking if the bokeh plot object has a HoverTool, it now checks whether the hover tool has been added to the holoviews plot handles, which is the correct way of checking whether hover was enabled.