### PR TITLE
OverlayPlot passes projection to subplots

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1025,6 +1025,7 @@ class GenericOverlayPlot(GenericElementPlot):
                         fontsize=self.fontsize, streams=streams,
                         renderer=self.renderer, adjoined=self.adjoined,
                         stream_sources=self.stream_sources,
+                        projection=self.projection,
                         zorder=zorder, **passed_handles)
         return plottype(obj, **plotopts)
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -879,6 +879,9 @@ class GenericOverlayPlot(GenericElementPlot):
     _passed_handles = []
 
     def __init__(self, overlay, ranges=None, batched=True, keys=None, **params):
+        if 'projection' not in params:
+            params['projection'] = self._get_projection(overlay)
+
         super(GenericOverlayPlot, self).__init__(overlay, ranges=ranges, keys=keys,
                                                  batched=batched, **params)
 

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -169,3 +169,16 @@ class TestColorbarPlot(TestBokehPlot):
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low_color, 'red')
         self.assertEqual(cmapper.high_color, 'blue')
+
+
+class TestOverlayPlot(TestBokehPlot):
+
+    def test_overlay_projection_clashing(self):
+        overlay = Curve([]).options(projection='polar') * Curve([]).options(projection='custom')
+        with self.assertRaises(Exception):
+            bokeh_renderer.get_plot(overlay)
+
+    def test_overlay_projection_propagates(self):
+        overlay = Curve([]) * Curve([]).options(projection='custom')
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual([p.projection for p in plot.subplots.values()], ['custom', 'custom'])


### PR DESCRIPTION
Very simple change which ensures that an OverlayPlot forwards the projection to all subplots. This was not needed for matplotlib since the OverlayPlot (or Layout/GridPlot) creates the axis with the appropriate projection but is needed for bokeh where each plot needs to know its projection independently.

- [x] Adds unit tests