### PR TITLE
Fixed bug initializing empty data in combined dictionary format

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -89,11 +89,15 @@ class DictInterface(Interface):
             for d, vals in data.items():
                 if isinstance(d, tuple):
                     vals = np.asarray(vals)
-                    if not vals.ndim == 2 and vals.shape[1] == len(d):
+                    if vals.shape == (0,):
+                        for sd in d:
+                            unpacked.append((sd, np.array([], dtype=vals.dtype)))
+                    elif not vals.ndim == 2 and vals.shape[1] == len(d):
                         raise ValueError("Values for %s dimensions did not have "
                                          "the expected shape.")
-                    for i, sd in enumerate(d):
-                        unpacked.append((sd, vals[:, i]))
+                    else:
+                        for i, sd in enumerate(d):
+                            unpacked.append((sd, vals[:, i]))
                 else:
                     vals = vals if np.isscalar(vals) else np.asarray(vals)
                     if not np.isscalar(vals) and not vals.ndim == 1:

--- a/tests/core/data/testdataset.py
+++ b/tests/core/data/testdataset.py
@@ -1077,6 +1077,11 @@ class DictDatasetTest(HeterogeneousColumnTypes, ScalarColumnTypes, ComparisonTes
         for d in 'xy':
             self.assertEqual(dataset.dimension_values(d).dtype, np.float64)
 
+    def test_dataset_empty_combined_dimension(self):
+        ds = Dataset({('x', 'y'): []}, kdims=['x', 'y'])
+        ds2 = Dataset({'x': [], 'y': []}, kdims=['x', 'y'])
+        self.assertEqual(ds, ds2)
+
 
 class GridTests(object):
     """


### PR DESCRIPTION
The DictInterface allows combining two columns into one array, however when this array is empty it currently fails and raises an error. This PR ensures that this works:

```python
Dataset({('x', 'y'): []}, kdims=['x', 'y'])
```

- [x] Adds unit test