### PR TITLE
Graph.from_networkx method now extract node and edge attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
   - conda install -c conda-forge  iris plotly flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium

--- a/tests/element/testgraphelement.py
+++ b/tests/element/testgraphelement.py
@@ -157,7 +157,17 @@ class GraphTests(ComparisonTestCase):
         graph = Graph.from_networkx(FG, nx.circular_layout)
         self.assertEqual(graph.dimension_values('weight'), np.array([0.125, 0.75, 1.2, 0.375]))
 
-
+    @attr(optional=1)
+    def test_from_networkx_only_nodes(self):
+        try:
+            import networkx as nx
+        except:
+            raise SkipTest('Test requires networkx to be installed')
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
+        graph = Graph.from_networkx(G, nx.circular_layout)
+        self.assertEqual(graph.nodes.dimension_values(2), np.array([1, 2, 3]))
+        
 class ChordTests(ComparisonTestCase):
 
     def setUp(self):

--- a/tests/element/testgraphelement.py
+++ b/tests/element/testgraphelement.py
@@ -2,6 +2,7 @@
 Unit tests of Graph Element.
 """
 from unittest import SkipTest
+from nose.plugins.attrib import attr
 
 import numpy as np
 from holoviews.core.data import Dataset
@@ -128,6 +129,33 @@ class GraphTests(ComparisonTestCase):
         self.assertEqual(redimmed.nodes, graph.nodes.redim(x='x2', y='y2'))
         self.assertEqual(redimmed.edgepaths, graph.edgepaths.redim(x='x2', y='y2'))
 
+    @attr(optional=1)
+    def test_from_networkx_with_node_attrs(self):
+        try:
+            import networkx as nx
+        except:
+            raise SkipTest('Test requires networkx to be installed')
+        G = nx.karate_club_graph()
+        graph = Graph.from_networkx(G, nx.circular_layout)
+        clubs = np.array([
+            'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Mr. Hi',
+            'Mr. Hi', 'Mr. Hi', 'Mr. Hi', 'Officer', 'Mr. Hi', 'Mr. Hi',
+            'Mr. Hi', 'Mr. Hi', 'Officer', 'Officer', 'Mr. Hi', 'Mr. Hi',
+            'Officer', 'Mr. Hi', 'Officer', 'Mr. Hi', 'Officer', 'Officer',
+            'Officer', 'Officer', 'Officer', 'Officer', 'Officer', 'Officer',
+            'Officer', 'Officer', 'Officer', 'Officer'])
+        self.assertEqual(graph.nodes.dimension_values('club'), clubs)
+
+    @attr(optional=1)
+    def test_from_networkx_with_edge_attrs(self):
+        try:
+            import networkx as nx
+        except:
+            raise SkipTest('Test requires networkx to be installed')
+        FG = nx.Graph()
+        FG.add_weighted_edges_from([(1,2,0.125), (1,3,0.75), (2,4,1.2), (3,4,0.375)])
+        graph = Graph.from_networkx(FG, nx.circular_layout)
+        self.assertEqual(graph.dimension_values('weight'), np.array([0.125, 0.75, 1.2, 0.375]))
 
 
 class ChordTests(ComparisonTestCase):


### PR DESCRIPTION
This PR will allow the Graph.from_networkx method to extract any attributes defined on the nodes and edges and also fixes a bug when trying to plot a Graph with no edges (i.e. only nodes).

- [x] Addresses https://github.com/ioam/holoviews/issues/2696
- [x] Fixes https://github.com/ioam/holoviews/issues/2711
- [x] Add unit tests