### PR TITLE
Support datetimes in histogram operation

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -204,7 +204,7 @@ class GridInterface(DictInterface):
         if edges and not isedges:
             data = cls._infer_interval_breaks(data)
         elif not edges and isedges:
-            data = np.convolve(data, [0.5, 0.5], 'valid')
+            data = data[:-1] + np.diff(data)/2.
         return data
 
 

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1675,6 +1675,13 @@ def dt_to_int(value, time_unit='us'):
     """
     Converts a datetime type to an integer with the supplied time unit.
     """
+    if pd:
+        if isinstance(value, pd.Period):
+            value = value.to_timestamp()
+        if isinstance(value, pd.Timestamp):
+            value = value.to_pydatetime()
+        value = np.datetime64(value)
+
     if isinstance(value, np.datetime64):
         value = np.datetime64(value, 'ns')
         if time_unit == 'ns':
@@ -1685,9 +1692,8 @@ def dt_to_int(value, time_unit='us'):
         tscale = 1000.
     else:
         tscale = 1./np.timedelta64(1, time_unit).tolist().total_seconds()
-    if pd and isinstance(value, pd.Timestamp):
-        value = value.to_pydatetime()
-    elif isinstance(value, np.datetime64):
+
+    if isinstance(value, np.datetime64):
         value = value.tolist()
     if isinstance(value, (int, long)):
         # Handle special case of nanosecond precision which cannot be

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -261,8 +261,8 @@ class HistogramPlot(ChartPlot):
 
         # Get plot ranges and values
         dims = hist.dimensions()[:2]
-        edges, hvals, widths, lims, datetime = self._process_hist(hist)
-        if datetime and not dims[0].value_format:
+        edges, hvals, widths, lims, isdatetime = self._process_hist(hist)
+        if isdatetime and not dims[0].value_format:
             dt_format = Dimension.type_formatters[np.datetime64]
             dims[0] = dims[0](value_format=DateFormatter(dt_format))
 
@@ -297,13 +297,13 @@ class HistogramPlot(ChartPlot):
         hist_vals = np.array(values)
         xlim = hist.range(0)
         ylim = hist.range(1)
-        datetime = False
+        isdatetime = False
         if edges.dtype.kind == 'M' or isinstance(edges[0], datetime_types):
             edges = date2num([v.tolist() if isinstance(v, np.datetime64) else v for v in edges])
             xlim = date2num([v.tolist() if isinstance(v, np.datetime64) else v for v in xlim])
-            datetime = True
+            isdatetime = True
         widths = np.diff(edges)
-        return edges[:-1], hist_vals, widths, xlim+ylim, datetime
+        return edges[:-1], hist_vals, widths, xlim+ylim, isdatetime
 
 
     def _compute_ticks(self, element, edges, widths, lims):
@@ -370,7 +370,7 @@ class HistogramPlot(ChartPlot):
 
     def update_handles(self, key, axis, element, ranges, style):
         # Process values, axes and style
-        edges, hvals, widths, lims, datetime = self._process_hist(element)
+        edges, hvals, widths, lims, _ = self._process_hist(element)
 
         ticks = self._compute_ticks(element, edges, widths, lims)
         ax_settings = self._process_axsettings(element, lims, ticks)
@@ -394,12 +394,12 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         """
         Subclassed to offset histogram by defined amount.
         """
-        edges, hvals, widths, lims, datetime = super(SideHistogramPlot, self)._process_hist(hist)
+        edges, hvals, widths, lims, isdatetime = super(SideHistogramPlot, self)._process_hist(hist)
         offset = self.offset * lims[3]
         hvals *= 1-self.offset
         hvals += offset
         lims = lims[0:3] + (lims[3] + offset,)
-        return edges, hvals, widths, lims, datetime
+        return edges, hvals, widths, lims, isdatetime
 
 
     def _update_artists(self, n, element, edges, hvals, widths, lims, ranges):

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -14,7 +14,9 @@ mpl_version = LooseVersion(mpl.__version__)
 import param
 
 from ...core import OrderedDict, Dimension, Store
-from ...core.util import match_spec, unique_iterator, basestring, max_range, isfinite
+from ...core.util import (
+    match_spec, unique_iterator, basestring, max_range, isfinite, datetime_types
+)
 from ...element import Raster, HeatMap
 from ...operation import interpolate_curve
 from ..plot import PlotSelector
@@ -258,7 +260,11 @@ class HistogramPlot(ChartPlot):
         el_ranges = match_spec(hist, ranges)
 
         # Get plot ranges and values
-        edges, hvals, widths, lims = self._process_hist(hist)
+        dims = hist.dimensions()[:2]
+        edges, hvals, widths, lims, datetime = self._process_hist(hist)
+        if datetime and not dims[0].value_format:
+            dt_format = Dimension.type_formatters[np.datetime64]
+            dims[0] = dims[0](value_format=DateFormatter(dt_format))
 
         style = self.style[self.cyclic_index]
         if self.invert_axes:
@@ -275,6 +281,7 @@ class HistogramPlot(ChartPlot):
 
         ticks = self._compute_ticks(hist, edges, widths, lims)
         ax_settings = self._process_axsettings(hist, lims, ticks)
+        ax_settings['dimensions'] = dims
 
         return self._finalize_axis(self.keys[-1], ranges=el_ranges, element=hist, **ax_settings)
 
@@ -288,9 +295,15 @@ class HistogramPlot(ChartPlot):
         edges = hist.interface.coords(hist, x, edges=True)
         values = hist.dimension_values(1)
         hist_vals = np.array(values)
+        xlim = hist.range(0)
+        ylim = hist.range(1)
+        datetime = False
+        if edges.dtype.kind == 'M' or isinstance(edges[0], datetime_types):
+            edges = date2num([v.tolist() if isinstance(v, np.datetime64) else v for v in edges])
+            xlim = date2num([v.tolist() if isinstance(v, np.datetime64) else v for v in xlim])
+            datetime = True
         widths = np.diff(edges)
-        lims = hist.range(0) + hist.range(1)
-        return edges[:-1], hist_vals, widths, lims
+        return edges[:-1], hist_vals, widths, xlim+ylim, datetime
 
 
     def _compute_ticks(self, element, edges, widths, lims):
@@ -381,12 +394,12 @@ class SideHistogramPlot(AdjoinedPlot, HistogramPlot):
         """
         Subclassed to offset histogram by defined amount.
         """
-        edges, hvals, widths, lims = super(SideHistogramPlot, self)._process_hist(hist)
+        edges, hvals, widths, lims, datetime = super(SideHistogramPlot, self)._process_hist(hist)
         offset = self.offset * lims[3]
         hvals *= 1-self.offset
         hvals += offset
         lims = lims[0:3] + (lims[3] + offset,)
-        return edges, hvals, widths, lims
+        return edges, hvals, widths, lims, datetime
 
 
     def _update_artists(self, n, element, edges, hvals, widths, lims, ranges):

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -370,7 +370,7 @@ class HistogramPlot(ChartPlot):
 
     def update_handles(self, key, axis, element, ranges, style):
         # Process values, axes and style
-        edges, hvals, widths, lims = self._process_hist(element)
+        edges, hvals, widths, lims, datetime = self._process_hist(element)
 
         ticks = self._compute_ticks(element, edges, widths, lims)
         ax_settings = self._process_axsettings(element, lims, ticks)

--- a/tests/core/data/testbinneddatasets.py
+++ b/tests/core/data/testbinneddatasets.py
@@ -145,7 +145,8 @@ class Binned2DTest(ComparisonTestCase):
 
     def test_groupby_xdim(self):
         grouped = self.dataset2d.groupby('x', group_type=Dataset)
-        holomap = HoloMap({self.xs[i:i+2].mean(): Dataset((self.ys, self.zs[:, i]), 'y', 'z')
+        holomap = HoloMap({(self.xs[i]+np.diff(self.xs[i:i+2])/2.)[0]:
+                           Dataset((self.ys, self.zs[:, i]), 'y', 'z')
                            for i in range(3)}, kdims=['x'])
         self.assertEqual(grouped, holomap)
 

--- a/tests/operation/testoperation.py
+++ b/tests/operation/testoperation.py
@@ -1,9 +1,12 @@
+import datetime as dt
+
 import numpy as np
 from nose.plugins.attrib import attr
 
 from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
                        Contours, Polygons, Points, Histogram, Curve, Area,
-                       QuadMesh)
+                       QuadMesh, Dataset)
+from holoviews.core.util import pd
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.element import (operation, transform, threshold,
                                          gradient, contours, histogram,
@@ -136,6 +139,40 @@ class OperationTests(ComparisonTestCase):
         #  default Element label, change back before comparing.
         op_hist = op_hist.redim(x_frequency='Frequency')
         hist = Histogram(([3, 3, 4], [0, 3, 6, 9]))
+        self.assertEqual(op_hist, hist)
+
+    def test_histogram_operation_datetime(self):
+        dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
+        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        hist_data = {'Date': np.array(['2017-01-01T00:00:00.000000', '2017-01-01T17:59:59.999999',
+                                       '2017-01-02T12:00:00.000000', '2017-01-03T06:00:00.000000',
+                                       '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
+                     'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
+                                                   3.85802469e-18])}
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
+        self.assertEqual(op_hist, hist)
+
+    def test_histogram_operation_datetime64(self):
+        dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)]).astype('M')
+        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        hist_data = {'Date': np.array(['2017-01-01T00:00:00.000000', '2017-01-01T17:59:59.999999',
+                                       '2017-01-02T12:00:00.000000', '2017-01-03T06:00:00.000000',
+                                       '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
+                     'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
+                                                   3.85802469e-18])}
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
+        self.assertEqual(op_hist, hist)
+
+    @attr(optional=1) # Requires matplotlib
+    def test_histogram_operation_pd_period(self):
+        dates = pd.date_range('2017-01-01', '2017-01-04', freq='D').to_period('D')
+        op_hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        hist_data = {'Date': np.array(['2017-01-01T00:00:00.000000', '2017-01-01T17:59:59.999999',
+                                       '2017-01-02T12:00:00.000000', '2017-01-03T06:00:00.000000',
+                                       '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
+                     'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
+                                                   3.85802469e-18])}
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_weighted(self):

--- a/tests/plotting/bokeh/testhistogramplot.py
+++ b/tests/plotting/bokeh/testhistogramplot.py
@@ -1,6 +1,11 @@
+import datetime as dt
+
 import numpy as np
 
-from holoviews.element import Image, Points
+from holoviews.element import Image, Points, Dataset
+from holoviews.operation import histogram
+
+from bokeh.models import DatetimeAxis
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -47,3 +52,23 @@ class TestSideHistogramPlot(TestBokehPlot):
         self.assertIs(main_plot.handles['color_mapper'],
                       top_plot.handles['color_mapper'])
         self.assertEqual(main_plot.handles['color_dim'], img.vdims[0])
+
+    def test_histogram_datetime64_plot(self):
+        dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
+        hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        plot = bokeh_renderer.get_plot(hist)
+        source = plot.handles['source']
+        data = {'top': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18, 3.85802469e-18]),
+                'left': np.array(['2017-01-01T00:00:00.000000', '2017-01-01T17:59:59.999999',
+                                  '2017-01-02T12:00:00.000000', '2017-01-03T06:00:00.000000'],
+                                 dtype='datetime64[us]'),
+                'right': np.array(['2017-01-01T17:59:59.999999', '2017-01-02T12:00:00.000000',
+                                   '2017-01-03T06:00:00.000000', '2017-01-04T00:00:00.000000'],
+                                  dtype='datetime64[us]')}
+        for k, v in data.items():
+            self.assertEqual(source.data[k], v)
+        xaxis = plot.handles['xaxis']
+        range_x = plot.handles['x_range']
+        self.assertIsInstance(xaxis, DatetimeAxis)
+        self.assertEqual(range_x.start, np.datetime64('2017-01-01T00:00:00.000000', 'us'))
+        self.assertEqual(range_x.end, np.datetime64('2017-01-04T00:00:00.000000', 'us'))

--- a/tests/plotting/matplotlib/testhistogramplot.py
+++ b/tests/plotting/matplotlib/testhistogramplot.py
@@ -1,0 +1,20 @@
+import datetime as dt
+
+import numpy as np
+
+from holoviews.element import Dataset
+from holoviews.operation import histogram
+
+from .testplot import TestMPLPlot, mpl_renderer
+
+
+class TestCurvePlot(TestMPLPlot):
+
+    def test_histogram_datetime64_plot(self):
+        dates = np.array([dt.datetime(2017, 1, i) for i in range(1, 5)])
+        hist = histogram(Dataset(dates, 'Date'), num_bins=4)
+        plot = mpl_renderer.get_plot(hist)
+        artist = plot.handles['artist']
+        ax = plot.handles['axis']
+        self.assertEqual(ax.get_xlim(), (736330.0, 736333.0))
+        self.assertEqual([p.get_x() for p in artist.patches], [736330.0, 736330.75, 736331.5, 736332.25])


### PR DESCRIPTION
This PR makes it possible to generate a histogram from datetime data as requested in https://github.com/ioam/holoviews/issues/2713 and https://github.com/pyviz/holoplot/issues/12. This is consistent with ``plt.hist`` which also handle datetimes and can be useful to determine the sampling frequency of a dataset.

- [x] Implements https://github.com/ioam/holoviews/issues/2713
- [x] Adds unit tests