### PR TITLE
Fixed bug defining callbacks on synced sources

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -347,9 +347,10 @@ class BokehPlot(DimensionedPlot):
                     plots.append(plot)
                 shared_sources.append(new_source)
                 source_cols[id(new_source)] = [c for c in new_source.data]
+        plot_id = self.id if self.top_level else None
         for plot in plots:
             for callback in plot.callbacks:
-                callback.initialize()
+                callback.initialize(plot_id=plot_id)
         self.handles['shared_sources'] = shared_sources
         self.handles['source_cols'] = source_cols
 


### PR DESCRIPTION
After datasources are synced, i.e. shared across a layout any callbacks defined on the datasource is currently not given the correct plot id. When the top level plot syncs the datasources, the callbacks are reinitialized at which point we can directly pass the plot_id to the callback.

- [x] Adds unit test