### PR TITLE
Avoid making clone in DynamicMap.options method if requested

### DIFF
--- a/tests/core/testdimensioned.py
+++ b/tests/core/testdimensioned.py
@@ -1,8 +1,8 @@
-from holoviews.core.dimension import Dimensioned
+from holoviews.core.element import ViewableElement
 from holoviews.core.options import Store, Keywords, Options, OptionTree
 from ..utils import LoggingComparisonTestCase
 
-class TestObj(Dimensioned):
+class TestObj(ViewableElement):
     pass
 
 

--- a/tests/core/testdynamic.py
+++ b/tests/core/testdynamic.py
@@ -5,12 +5,14 @@ import time
 import numpy as np
 from holoviews import Dimension, NdLayout, GridSpace, Layout
 from holoviews.core.spaces import DynamicMap, HoloMap, Callable
+from holoviews.core.options import Store
 from holoviews.element import Image, Scatter, Curve, Text, Points
 from holoviews.operation import histogram
 from holoviews.streams import Stream, PointerXY, PointerX, PointerY, RangeX, Buffer
 from holoviews.util import Dynamic
 from holoviews.element.comparison import ComparisonTestCase
 
+from .testdimensioned import CustomBackendTestCase, TestObj
 
 XY = Stream.define('XY', x=0,y=0)
 
@@ -242,6 +244,23 @@ class DynamicMapMethods(ComparisonTestCase):
         self.assertEqual(ndlayout[0][()], Scatter([(0, 0)]))
         self.assertEqual(ndlayout[1][()], Scatter([(1, 1)]))
         self.assertEqual(ndlayout[2][()], Scatter([(2, 2)]))
+
+
+
+class DynamicMapOptionsTests(CustomBackendTestCase):
+
+    def test_dynamic_options(self):
+        dmap = DynamicMap(lambda X: TestObj(None), kdims=['X']).redim.range(X=(0,10))
+        dmap = dmap.options(plot_opt1='red')
+        opts = Store.lookup_options('backend_1', dmap[0], 'plot')
+        self.assertEqual(opts.options, {'plot_opt1': 'red'})
+    
+    def test_dynamic_options_no_clone(self):
+        dmap = DynamicMap(lambda X: TestObj(None), kdims=['X']).redim.range(X=(0,10))
+        dmap.options(plot_opt1='red', clone=False)
+        opts = Store.lookup_options('backend_1', dmap[0], 'plot')
+        self.assertEqual(opts.options, {'plot_opt1': 'red'})
+
 
 
 class DynamicMapUnboundedProperty(ComparisonTestCase):


### PR DESCRIPTION
This is a tricky issue, we recently added the ability to use ``.options`` without making a clone, which has worked out great and is used quite frequently (at least by me) since it is very convenient when working with an element that is a stream source. However the ``DynamicMap.options`` method still made clones even when ``clone=False`` was set, this is because our general approach to applying any operation to a DynamicMap is to wrap the DynamicMap in another DynamicMap either by writing a wrapping callback or by using the ``Dynamic`` utility. In this particular case we have to make an exception and wrap the user supplied callback function directly without wrapping the DynamicMap. It's not ideal and doesn't fit the model we use elsewhere but it's the only way to avoid inconsistencies like the one raised in https://github.com/ioam/holoviews/issues/2698.