### PR TITLE
Added support for cftime types

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -18,6 +18,12 @@ from ..element import Element
 from .grid import GridInterface
 from .interface import Interface, DataError
 
+try:
+    import cftime
+    util.datetime_types += (cftime._cftime.DatetimeGregorian,)
+except:
+    pass
+
 
 class XArrayInterface(GridInterface):
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -26,7 +26,7 @@ from ..util import dynamic_update, process_cmap
 from .plot import BokehPlot, TOOLS
 from .util import (mpl_to_bokeh, get_tab_title,  py2js_tickformatter,
                    rgba_tuple, recursive_model_update, glyph_order,
-                   decode_bytes)
+                   decode_bytes, date_to_integer)
 
 property_prefixes = ['selection', 'nonselection', 'muted', 'hover']
 
@@ -528,6 +528,8 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             if util.isfinite(high):
                 updates['end'] = (axis_range.end, high)
             for k, (old, new) in updates.items():
+                if isinstance(new, util.datetime_types):
+                    new = date_to_integer(new)
                 axis_range.update(**{k:new})
                 if streaming:
                     axis_range.trigger(k, old, new)

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -1,4 +1,4 @@
-import re, time, sys
+import re, time, sys, calendar
 from distutils.version import LooseVersion
 from collections import defaultdict
 import datetime as dt
@@ -617,8 +617,8 @@ def date_to_integer(date):
         date = dt64_to_dt(date)
     elif pd and isinstance(date, pd.Timestamp):
         date = date.to_pydatetime()
-    if isinstance(date, (dt.datetime, dt.date)):
-        dt_int = time.mktime(date.timetuple())*1000
+    if hasattr(date, 'timetuple'):
+        dt_int = calendar.timegm(date.timetuple())*1000
     else:
         raise ValueError('Datetime type not recognized')
     return dt_int


### PR DESCRIPTION
This PR adds support for ``cftime`` types which are a custom time type used by xarray for dates that cannot be stored in a datetime64 type. A small example:

```python
ref_date = '0181-01-01'
ds = xr.DataArray([1, 2, 3], dims=['time'],
                  coords={'time': ('time', [1, 2, 3],
                                   {'units': 'days since %s' % ref_date})}
                  ).to_dataset(name='foo')
with xr.set_options(enable_cftimeindex=True):
    ds = xr.decode_cf(ds)
print(ds)
hv_ds = hv.Dataset(ds)
hv_ds.to(hv.Curve)
```

```
<xarray.Dataset>
Dimensions:  (time: 3)
Coordinates:
  * time     (time) object 0181-01-02 00:00:00 0181-01-03 00:00:00 ...
Data variables:
    foo      (time) int64 ...
```

![bokeh_plot](https://user-images.githubusercontent.com/1550771/40522053-d1439324-5fc6-11e8-85fd-e944fdf79c52.png)

This approach seems to work well but there are a questions I have, which @rabernat and @spencerclark hopefully can answer:

1. Which types does it make sense to support, and do they all support conversion to a timetuple? As far as I could tell this is the list of types ``cftime`` provides:

cftime._cftime.Datetime360Day
cftime._cftime.DatetimeGregorian
cftime._cftime.DatetimeJulian
cftime._cftime.DatetimeNoLeap
cftime._cftime.DatetimeProlepticGregorian

2. Secondly in what context can I expect these types to be used? Will they mostly be used by xarray or should I also handle them elsewhere?

- [x] Addresses https://github.com/ioam/holoviews/issues/2709
- [ ] Add unit tests
- [ ] Handle matplotlib
- [ ] Handle datashader (if possible)