### PR TITLE
Allow the conversion interface to discover pandas indexes

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -25,8 +25,9 @@ try:
     datatypes = ['dataframe', 'dictionary', 'grid', 'ndelement', 'array']
     DFColumns = PandasInterface
 except ImportError:
-    pass
+    pd = None
 except Exception as e:
+    pd = None
     param.main.warning('Pandas interface failed to import with '
                        'following error: %s' % e)
 
@@ -132,7 +133,15 @@ class DataConversion(object):
             else:
                 selected = self._element
         else:
-            selected = self._element.reindex(groupby+kdims, vdims)
+            if pd and issubclass(self._element.interface, PandasInterface):
+                ds_dims = self._element.dimensions()
+                ds_kdims = [self._element.get_dimension(d) if d in ds_dims else d
+                            for d in groupby+kdims]
+                ds_vdims = [self._element.get_dimension(d) if d in ds_dims else d
+                            for d in vdims]
+                selected = self._element.clone(kdims=ds_kdims, vdims=ds_vdims)
+            else:
+                selected = self._element.reindex(groupby+kdims, vdims)
         params = {'kdims': [selected.get_dimension(kd, strict=True) for kd in kdims],
                   'vdims': [selected.get_dimension(vd, strict=True) for vd in vdims],
                   'label': selected.label}

--- a/tests/core/data/testpandasinterface.py
+++ b/tests/core/data/testpandasinterface.py
@@ -11,6 +11,7 @@ except:
 from holoviews.core.dimension import Dimension
 from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
+from holoviews.core.spaces import HoloMap
 from holoviews.element import Scatter, Points, Distribution
 
 
@@ -140,3 +141,15 @@ class PandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         dataset = Dataset({2: 2, 1: 1, 3: 3}, kdims=['x'], vdims=['y'])
         self.assertEqual(dataset, Dataset([(i, i) for i in range(1, 4)],
                                           kdims=['x'], vdims=['y']))
+
+    def test_dataset_conversion_with_index(self):
+        df = pd.DataFrame({'y': [1, 2, 3]}, index=[0, 1, 2])
+        scatter = Dataset(df).to(Scatter, 'index', 'y')
+        self.assertEqual(scatter, Scatter(([0, 1, 2], [1, 2, 3]), 'index', 'y'))
+
+    def test_dataset_conversion_groupby_with_index(self):
+        df = pd.DataFrame({'y': [1, 2, 3], 'x': [0, 0, 1]}, index=[0, 1, 2])
+        scatters = Dataset(df).to(Scatter, 'index', 'y')
+        hmap = HoloMap({0: Scatter(([0, 1], [1, 2]), 'index', 'y'),
+                        1: Scatter([(2, 3)], 'index', 'y')}, 'x')
+        self.assertEqual(scatters, hmap)


### PR DESCRIPTION
Allows referencing pandas indexes in .to interface even when Dataset does not declare them as dimensions.

- [x] Fixes https://github.com/ioam/holoviews/issues/2717