### PR TITLE
Fixed bokeh LayoutPlot bugs

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -876,7 +876,7 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         kwargs = dict(sizing_mode=self.sizing_mode)
         if self.tabs:
             plots = filter_toolboxes([p for t, p in tab_plots])
-            panels = [Panel(child=child, title=title) for title, child in tab_plots]
+            panels = [Panel(child=child, title=t) for t, child in tab_plots]
             layout_plot = Tabs(tabs=panels)
         else:
             plots = layout_padding(plots, self.renderer)

--- a/tests/plotting/bokeh/testlayoutplot.py
+++ b/tests/plotting/bokeh/testlayoutplot.py
@@ -7,7 +7,7 @@ from .testplot import TestBokehPlot, bokeh_renderer
 
 try:
     from bokeh.layouts import Column, Row
-    from bokeh.models import Div, ToolbarBox, GlyphRenderer
+    from bokeh.models import Div, ToolbarBox, GlyphRenderer, Tabs, Panel
     from bokeh.plotting import Figure
 except:
     pass
@@ -155,6 +155,16 @@ class TestLayoutPlot(TestBokehPlot):
             self.assertIsInstance(fig, Figure)
         self.assertEqual([r for r in fig2.renderers if isinstance(r, GlyphRenderer)], [])
 
+    def test_layout_plot_tabs_with_adjoints(self):
+        layout = (Curve([]) + Curve([]).hist()).options(tabs=True)
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertIsInstance(plot.state, Tabs)
+        panel1, panel2 = plot.state.tabs
+        self.assertIsInstance(panel1, Panel)
+        self.assertIsInstance(panel2, Panel)
+        self.assertEqual(panel1.title, 'Curve I')
+        self.assertEqual(panel2.title, 'AdjointLayout I')
+        
     def test_layout_shared_source_synced_update(self):
         hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)
                                     for j in range(4)}, kdims=['A', 'B', 'C', 'D'])

--- a/tests/plotting/bokeh/testlayoutplot.py
+++ b/tests/plotting/bokeh/testlayoutplot.py
@@ -7,7 +7,7 @@ from .testplot import TestBokehPlot, bokeh_renderer
 
 try:
     from bokeh.layouts import Column, Row
-    from bokeh.models import Div, ToolbarBox
+    from bokeh.models import Div, ToolbarBox, GlyphRenderer
     from bokeh.plotting import Figure
 except:
     pass
@@ -130,7 +130,6 @@ class TestLayoutPlot(TestBokehPlot):
         positions = [(0, 0), (0, 1), (1, 0), (2, 0), (3, 0)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
 
-
     def test_empty_adjoint_plot(self):
         adjoint = Curve([0,1,1,2,3]) << Empty() << Curve([0,1,1,0,1])
         plot = bokeh_renderer.get_plot(adjoint)
@@ -142,6 +141,19 @@ class TestLayoutPlot(TestBokehPlot):
         self.assertEqual(row1.children[1].plot_width, 0)
         self.assertEqual(row2.children[1].plot_width, 0)
         self.assertEqual(row2.children[0].plot_height, row2.children[1].plot_height)
+
+    def test_layout_plot_with_adjoints(self):
+        layout = (Curve([]) + Curve([]).hist()).cols(1)
+        plot = bokeh_renderer.get_plot(layout)
+        toolbar, column = plot.state.children
+        self.assertIsInstance(toolbar, ToolbarBox)
+        self.assertIsInstance(column, Column)
+        row1, row2 = column.children
+        fig1, fig2 = row1.children
+        fig3, fig4 = row2.children
+        for fig in (fig1, fig2, fig3, fig4):
+            self.assertIsInstance(fig, Figure)
+        self.assertEqual([r for r in fig2.renderers if isinstance(r, GlyphRenderer)], [])
 
     def test_layout_shared_source_synced_update(self):
         hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)


### PR DESCRIPTION
Turns out that the bokeh LayoutPlot implementation was wrong in all kinds of subtle ways so I've completely rewritten the implementation from scratch. The main issue was that AdjointLayout plots were not correctly positioned on the grid. Secondly when enabling ``tabs`` AdjointLayout plots were split across multiple tabs.

- [x] Fixes https://github.com/ioam/holoviews/issues/1489
- [x] Fixes https://github.com/ioam/holoviews/issues/2568
- [x] Fixes https://github.com/ioam/holoviews/issues/2652
- [x] Adds unit test