### PR TITLE
Move DynamicMap unbounded error onto Renderer

### DIFF
--- a/holoviews/ipython/display_hooks.py
+++ b/holoviews/ipython/display_hooks.py
@@ -191,14 +191,6 @@ def element_display(element, max_frames):
 @display_hook
 def map_display(vmap, max_frames):
     if not isinstance(vmap, (HoloMap, DynamicMap)): return None
-    if  isinstance(vmap, DynamicMap) and vmap.unbounded:
-        dims = ', '.join('%r' % dim for dim in  vmap.unbounded)
-        msg = ('DynamicMap cannot be displayed without explicit indexing '
-               'as {dims} dimension(s) are unbounded. '
-               '\nSet dimensions bounds with the DynamicMap redim.range '
-               'or redim.values methods.')
-        sys.stderr.write(msg.format(dims=dims))
-        return None
 
     if len(vmap) == 0 and not isinstance(vmap, DynamicMap):
         return None


### PR DESCRIPTION
The validation for unbounded DynamicMaps previously lived inside the display hooks which meant that when working on bokeh server it did not raise a reasonable error message. This moves the validation onto the Renderer which ensures that it is properly validated in and outside the notebook.

- [x] Fixes https://github.com/ioam/holoviews/issues/2309