### PR TITLE
Grid interface reindex

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -319,7 +319,11 @@ class Dataset(Element):
         converting key dimensions to value dimensions and vice versa.
         """
         if kdims is None:
-            key_dims = [d for d in self.kdims if not vdims or d not in vdims]
+            # If no key dimensions are defined and interface is gridded
+            # drop all scalar key dimensions
+            gridded = self.interface.gridded
+            key_dims = [d for d in self.kdims if (not vdims or d not in vdims)
+                        and not (gridded and len(self.dimension_values(d, expanded=False)) == 1)]
         else:
             key_dims = [self.get_dimension(k, strict=True) for k in kdims]
 

--- a/tests/core/data/testgridinterface.py
+++ b/tests/core/data/testgridinterface.py
@@ -238,6 +238,16 @@ class GridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Interfac
                          datatype=['dictionary'])
         self.assertEqual(ds.ndloc[[0, 1, 2], [1, 2, 3]], sliced)
 
+    def test_reindex_drop_scalars_xs(self):
+        reindexed = self.dataset_grid.ndloc[:, 0].reindex()
+        ds = Dataset((self.grid_ys, self.grid_zs[:, 0]), 'y', 'z')
+        self.assertEqual(reindexed, ds)
+
+    def test_reindex_drop_scalars_ys(self):
+        reindexed = self.dataset_grid.ndloc[0].reindex()
+        ds = Dataset((self.grid_xs, self.grid_zs[0]), 'x', 'z')
+        self.assertEqual(reindexed, ds)
+
 
 
 class DaskGridInterfaceTests(GridInterfaceTests):

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -170,8 +170,8 @@ class DaskXArrayInterfaceTest(XArrayInterfaceTests):
         import dask.array
         self.grid_xs = [0, 1]
         self.grid_ys = [0.1, 0.2, 0.3]
-        self.grid_zs = [[0, 1], [2, 3], [4, 5]]
-        dask_zs = dask.array.from_array(np.array(self.grid_zs), 2)
+        self.grid_zs = np.array([[0, 1], [2, 3], [4, 5]])
+        dask_zs = dask.array.from_array(self.grid_zs, 2)
         self.dataset_grid = self.element((self.grid_xs, self.grid_ys,
                                          dask_zs), kdims=['x', 'y'],
                                         vdims=['z'])


### PR DESCRIPTION
This ensures that GridInterface.reindex has the same behavior as NdMapping.reindex, which is to drop scalar dimensions automatically. Also fixes a bug in ``XArrayInterface.ndloc`` uncovered in the process of writing tests for the new reindex functionality.

- [x] Fixes https://github.com/ioam/holoviews/issues/2362
- [x] Adds unit test