### PR TITLE
Fix dynamic ScrubberWidget and add throttling

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1550,6 +1550,26 @@ def cartesian_product(arrays, flat=True, copy=False):
     return tuple(arr.copy() if copy else arr for arr in arrays)
 
 
+def cross_index(values, index):
+    """
+    Allows efficiently indexing into a cartesian product without
+    expanding it. The values should be defined as a list of iterables
+    making up the cartesian product and a linear index, returning
+    the cross product of the values at the supplied index.
+    """
+    lengths = [len(v) for v in values][::-1]
+    partials = [np.product(lengths[:i]) for i in range(1, len(values)+1)][::-1]
+    length = partials.pop(0)
+    if index >= length:
+        raise ValueError('Index out of bounds')
+    indexes = []
+    for p in partials:
+        indexes.append(index//p)
+        index -= indexes[-1] * p
+    indexes.append(index%lengths[0])
+    return tuple(v[i] for v, i in zip(values, indexes))
+
+
 def arglexsort(arrays):
     """
     Returns the indices of the lexicographical sorting

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1557,16 +1557,17 @@ def cross_index(values, index):
     making up the cartesian product and a linear index, returning
     the cross product of the values at the supplied index.
     """
-    lengths = [len(v) for v in values][::-1]
-    partials = [np.product(lengths[:i]) for i in range(1, len(values)+1)][::-1]
-    length = partials.pop(0)
+    lengths = [len(v) for v in values]
+    length = np.product(lengths)
     if index >= length:
-        raise ValueError('Index out of bounds')
+        raise IndexError('Index %d out of bounds for cross-product of size %d'
+                         % (index, length))
     indexes = []
-    for p in partials:
+    for i in range(1, len(values))[::-1]:
+        p = np.product(lengths[-i:])
         indexes.append(index//p)
         index -= indexes[-1] * p
-    indexes.append(index%lengths[0])
+    indexes.append(index)
     return tuple(v[i] for v, i in zip(values, indexes))
 
 

--- a/holoviews/plotting/widgets/widgets.js
+++ b/holoviews/plotting/widgets/widgets.js
@@ -201,13 +201,19 @@ ScrubberWidget.prototype.set_frame = function(frame){
     return
   }
   widget.value = this.current_frame;
-  if(this.cached) {
-    this.update(frame)
-  } else {
+  if (this.dynamic || !this.cached) {
+    if ((this.time !== undefined) && ((this.wait) && ((this.time + 10000) > Date.now()))) {
+      this.queue.push(frame);
+      return
+    }
+    this.queue = [];
+    this.time = Date.now();
+    this.wait = true;
     this.dynamic_update(frame)
+  } else {
+    this.update(frame)
   }
 }
-
 
 ScrubberWidget.prototype.get_loop_state = function(){
   var button_group = document[this.loop_select_id].state;

--- a/tests/core/testutils.py
+++ b/tests/core/testutils.py
@@ -4,11 +4,12 @@ Unit tests of the helper functions in core.utils
 """
 import sys, math
 import unittest
-from unittest import SkipTest
-
 import datetime
-import numpy as np
+from unittest import SkipTest
+from itertools import product
 from collections import OrderedDict
+
+import numpy as np
 try:
     import pandas as pd
 except:
@@ -17,7 +18,7 @@ except:
 from holoviews.core.util import (
     sanitize_identifier_fn, find_range, max_range, wrap_tuple_streams,
     deephash, merge_dimensions, get_path, make_path_unique, compute_density,
-    date_range, dt_to_int, compute_edges, isfinite
+    date_range, dt_to_int, compute_edges, isfinite, cross_index
 )
 from holoviews import Dimension, Element
 from holoviews.streams import PointerXY
@@ -731,3 +732,42 @@ class TestComputeEdges(ComparisonTestCase):
     def test_uneven_edges(self):
         self.assertEqual(compute_edges(self.array3),
                          np.array([0.5, 1.5, 3.0, 5.0]))
+
+
+class TestCrossIndex(ComparisonTestCase):
+
+    def setUp(self):
+        self.values1 = ['A', 'B', 'C']
+        self.values2 = [1, 2, 3, 4]
+        self.values3 = ['?', '!']
+        self.values4 = ['x']
+
+    def test_cross_index_full_product(self):
+        values = [self.values1, self.values2, self.values3, self.values4]
+        cross_product = list(product(*values))
+        for i, p in enumerate(cross_product):
+            self.assertEqual(cross_index(values, i), p)
+
+    def test_cross_index_depth_1(self):
+        values = [self.values1]
+        cross_product = list(product(*values))
+        for i, p in enumerate(cross_product):
+            self.assertEqual(cross_index(values, i), p)
+
+    def test_cross_index_depth_2(self):
+        values = [self.values1, self.values2]
+        cross_product = list(product(*values))
+        for i, p in enumerate(cross_product):
+            self.assertEqual(cross_index(values, i), p)
+
+    def test_cross_index_depth_3(self):
+        values = [self.values1, self.values2, self.values3]
+        cross_product = list(product(*values))
+        for i, p in enumerate(cross_product):
+            self.assertEqual(cross_index(values, i), p)
+    
+    def test_cross_index_large(self):
+        values = [[chr(65+i) for i in range(26)], list(range(500)),
+                  [chr(97+i) for i in range(26)], [chr(48+i) for i in range(10)]]
+        self.assertEqual(cross_index(values, 50001), ('A', 192, 'i', '1'))
+        self.assertEqual(cross_index(values, 500001), ('D', 423, 'c', '1'))


### PR DESCRIPTION
Fixes two issues with the ScrubberWidget:

1. A few releases ago we added the ability to use the ScrubberWidget on a DynamicMap as long all  its dimensions define ``values``, however for this to work the plots had to expand the values into their cross-product. We subsequently reverted the expansion change because it was very slow and expensive for large cross products but did not disable the scrubber. This PR ensures that this works even without expanding the whole cross-product.

2. This PR adds throttling to the ScrubberWidget by using the same approach used by the selection widgets.

- [x] Fixes https://github.com/ioam/holoviews/issues/2571