### PR TITLE
Nested legend

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -765,7 +765,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             else:
                 if isinstance(subplot, OverlayPlot):
                     legend_data += subplot.handles.get('legend_data', {}).items()
-                if element.label and handle:
+                elif element.label and handle:
                     legend_data.append((handle, element.label))
         all_handles, all_labels = list(zip(*legend_data)) if legend_data else ([], [])
         data = OrderedDict()

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -754,7 +754,8 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
             element = overlay.data.get(key, False)
             if not subplot.show_legend or not element: continue
             title = ', '.join([d.name for d in dimensions])
-            handle = subplot.handles.get('artist', False)
+            handle = subplot.traverse(lambda p: p.handles['artist'],
+                                      [lambda p: 'artist' in p.handles])
             if isinstance(overlay, NdOverlay):
                 key = (dim.pprint_value(k) for k, dim in zip(key, dimensions))
                 label = ','.join([str(k) + dim.unit if dim.unit else str(k) for dim, k in

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -876,7 +876,7 @@ class GenericOverlayPlot(GenericElementPlot):
 
     _passed_handles = []
 
-    def __init__(self, overlay, ranges=None, batched=True, keys=None, **params):
+    def __init__(self, overlay, ranges=None, batched=True, keys=None, group_counter=None, **params):
         if 'projection' not in params:
             params['projection'] = self._get_projection(overlay)
 
@@ -886,7 +886,7 @@ class GenericOverlayPlot(GenericElementPlot):
         # Apply data collapse
         self.hmap = self._apply_compositor(self.hmap, ranges, self.keys)
         self.map_lengths = Counter()
-        self.group_counter = Counter()
+        self.group_counter = Counter() if group_counter is None else group_counter
         self.zoffset = 0
         self.subplots = self._create_subplots(ranges)
         self.traverse(lambda x: setattr(x, 'comm', self.comm))
@@ -999,7 +999,9 @@ class GenericOverlayPlot(GenericElementPlot):
         self.group_counter[group_key] += 1
         group_length = self.map_lengths[group_key]
 
-        if not isinstance(plottype, PlotSelector) and issubclass(plottype, GenericOverlayPlot):
+        if issubclass(plottype, GenericOverlayPlot):
+            opts['group_counter'] = self.group_counter
+        elif not isinstance(plottype, PlotSelector) and issubclass(plottype, GenericOverlayPlot):
             opts['show_legend'] = self.show_legend
             if not any(len(frame) for frame in obj):
                 self.warning('%s is empty and will be skipped during plotting'

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -973,6 +973,8 @@ class GenericOverlayPlot(GenericElementPlot):
         opts = {'overlaid': overlay_type}
         if self.hmap.type == Overlay:
             style_key = (obj.type.__name__,) + key
+            if self.overlay_dims:
+                opts['overlay_dims'] = self.overlay_dims
         else:
             if not isinstance(key, tuple): key = (key,)
             style_key = group_fn(obj) + key
@@ -999,9 +1001,8 @@ class GenericOverlayPlot(GenericElementPlot):
         self.group_counter[group_key] += 1
         group_length = self.map_lengths[group_key]
 
-        if issubclass(plottype, GenericOverlayPlot):
+        if not isinstance(plottype, PlotSelector) and issubclass(plottype, GenericOverlayPlot):
             opts['group_counter'] = self.group_counter
-        elif not isinstance(plottype, PlotSelector) and issubclass(plottype, GenericOverlayPlot):
             opts['show_legend'] = self.show_legend
             if not any(len(frame) for frame in obj):
                 self.warning('%s is empty and will be skipped during plotting'


### PR DESCRIPTION
This PR ensures that nested Nd(Overlays) generate a legend. Previously nesting Overlays inside an NdOverlay would mean two things:

1) The styling group_counter would be reset inside the nested OverlayPlot meaning that color cycles would not work.
2) The topmost legend plot would not find matplotlib artists nested further down and the bokeh version would not pass its dimensions down to the individual elementplots meaning that no legend would be generated.

```python
%%opts Spread (alpha=0.1) Path [show_legend=True]

d = {}
for i in range(1, 5):
    xs = np.linspace(0, 1)
    ys = xs**2 / i + 5 * i
    d[i] = hv.Path((xs, ys), kdims=['X', 'Y']) * hv.Spread((xs, ys, 2))
hv.NdOverlay(d)
```

<img width="304" alt="screen shot 2018-06-01 at 1 27 20 pm" src="https://user-images.githubusercontent.com/1550771/40840658-8b62b644-659f-11e8-82ff-fe96578f5e2a.png">

![image](https://user-images.githubusercontent.com/1550771/40840633-6eafbaba-659f-11e8-9b5b-b56bacb56483.png)

- [x] Fixes https://github.com/ioam/holoviews/issues/2754