### PR TITLE
Fixes hover on inverted Histogram

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -328,7 +328,7 @@ class HistogramPlot(ElementPlot):
 
     def get_data(self, element, ranges, style):
         if self.invert_axes:
-            mapping = dict(top='left', bottom='right', left=0, right='top')
+            mapping = dict(top='right', bottom='left', left=0, right='top')
         else:
             mapping = dict(top='top', bottom=0, left='left', right='right')
         if self.static_source:


### PR DESCRIPTION
Very simple fix for Histogram hover, the inversion of top/bottom values on the bars caused bokeh not to correctly perform the hover hit testing.

- [x] Fixes https://github.com/ioam/holoviews/issues/2747