### PR TITLE
Fixed bug adding dimension to XArrayInterface

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -462,8 +462,9 @@ class XArrayInterface(GridInterface):
         if not vdim:
             raise Exception("Cannot add key dimension to a dense representation.")
         dim = dimension.name if isinstance(dimension, Dimension) else dimension
-        arr = xr.DataArray(values, coords=dataset.data.coords, name=dim,
-                           dims=dataset.data.indexes)
+        coords = {d.name: cls.coords(dataset, d.name) for d in dataset.kdims}
+        arr = xr.DataArray(values, coords=coords, name=dim,
+                           dims=tuple(d.name for d in dataset.kdims[::-1]))
         return dataset.data.assign(**{dim: arr})
 
 

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -1075,3 +1075,10 @@ class GriddedInterfaceTests(object):
         values = np.sin(XS)
         sampled = Dataset((xs, ys, values), ['x', 'y'], 'z').sample(y=0)
         self.assertEqual(sampled, Curve((xs, values[0]), vdims='z'))
+
+    def test_aggregate_2d_with_spreadfn(self):
+        array = np.random.rand(10, 5)
+        ds = Dataset((range(5), range(10), array), ['x', 'y'], 'z')
+        agg = ds.aggregate('x', np.mean, np.std)
+        example = Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
+        self.assertEqual(agg, example)

--- a/tests/core/data/testirisinterface.py
+++ b/tests/core/data/testirisinterface.py
@@ -74,6 +74,9 @@ class IrisInterfaceTests(GridInterfaceTests):
     def test_dataset_2D_aggregate_partial_hm_alias(self):
         raise SkipTest("Not supported")
 
+    def test_aggregate_2d_with_spreadfn(self):
+        raise SkipTest("Not supported")
+
     def test_dataset_sample_hm(self):
         raise SkipTest("Not supported")
 


### PR DESCRIPTION
The XArrayInterface.add_dimension method was assuming that the underlying xarray Dataset dimension ordering would be the same as the dimensions on the hv.Dataset, which does not have to be the case. This PR ensures that the dimensions are declared in the correct order.

- [x] https://github.com/ioam/holoviews/issues/2752
- [x] Adds unit tests