### PR TITLE
Implement grid concatenation and standardize datatype casting

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -68,13 +68,15 @@ from .. import util
 
 def concat(datasets, datatype=None):
     """
-    Concatenates multiple datasets wrapped in an NdMapping type
-    along all of its dimensions. Before concatenation all datasets
-    are cast to the same datatype. For columnar data concatenation
-    adds the columns for the dimensions being concatenated along
-    and then concatenates all the old and new columns. For gridded
-    data a new axis is created for each dimension being concatenated
-    along and then hierarchically concatenates along each dimension.
+    Concatenates multiple datasets wrapped in an NdMapping type along
+    all of its dimensions. Before concatenation all datasets are cast
+    to the same datatype, which may be explicitly defined or
+    implicitly derived from the first datatype that is
+    encountered. For columnar data concatenation adds the columns for
+    the dimensions being concatenated along and then concatenates all
+    the old and new columns. For gridded data a new axis is created
+    for each dimension being concatenated along and then
+    hierarchically concatenates along each dimension.
 
     Signature
     ---------

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -84,26 +84,7 @@ def concat(datasets, datatype=None):
 
     Returns: Dataset
     """
-    if isinstance(datasets, NdMapping):
-        dimensions = datasets.kdims
-        datasets = datasets.data
-    if isinstance(datasets, (dict, OrderedDict)):
-        datasets = datasets.items()
-    keys, datasets = zip(*datasets)
-    template = datasets[0]
-    datatype = datatype or template.interface.datatype
-
-    # Handle non-general datatypes by casting to general type
-    if datatype == 'array':
-        datatype = default_datatype
-    elif datatype == 'image':
-        datatype = 'grid'
-
-    datasets = template.interface.cast(datasets, datatype)
-    template = datasets[0]
-    data = list(zip(keys, datasets))
-    concat_data = template.interface.concat(data, dimensions, vdims=template.vdims)
-    return template.clone(concat_data, kdims=dimensions+template.kdims, new_type=Dataset)
+    return Interface.concatenate(datasets, datatype)
 
 
 class DataConversion(object):

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -61,7 +61,7 @@ if 'array' not in datatypes:
 
 from ..dimension import Dimension, process_dimensions
 from ..element import Element
-from ..ndmapping import OrderedDict, NdMapping
+from ..ndmapping import OrderedDict
 from ..spaces import HoloMap, DynamicMap
 from .. import util
 

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -92,6 +92,13 @@ def concat(datasets, datatype=None):
     keys, datasets = zip(*datasets)
     template = datasets[0]
     datatype = datatype or template.interface.datatype
+
+    # Handle non-general datatypes by casting to general type
+    if datatype == 'array':
+        datatype = default_datatype
+    elif datatype == 'image':
+        datatype = 'grid'
+
     datasets = template.interface.cast(datasets, datatype)
     template = datasets[0]
     data = list(zip(keys, datasets))

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -293,7 +293,7 @@ class Dataset(Element):
             dimensions = dict(kdims=dims)
 
         if issubclass(self.interface, ArrayInterface) and np.asarray(dim_val).dtype != self.data.dtype:
-            element = self.clone(datatype=['pandas', 'dictionary'])
+            element = self.clone(datatype=[default_datatype])
             data = element.interface.add_dimension(element, dimension, dim_pos, dim_val, vdim)
         else:
             data = self.interface.add_dimension(self, dimension, dim_pos, dim_val, vdim)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -17,12 +17,14 @@ from .grid import GridInterface
 from .multipath import MultiInterface         # noqa (API import)
 from .image import ImageInterface             # noqa (API import)
 
+default_datatype = 'dictionary'
 datatypes = ['dictionary', 'grid']
 
 try:
     import pandas as pd # noqa (Availability import)
     from .pandas import PandasInterface
-    datatypes = ['dataframe', 'dictionary', 'grid', 'array']
+    default_datatype = 'dataframe'
+    datatypes = ['dataframe', 'dictionary', 'grid']
     DFColumns = PandasInterface
 except ImportError:
     pd = None

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 try:
     import itertools.izip as zip
 except ImportError:
@@ -105,9 +106,11 @@ class ArrayInterface(Interface):
 
 
     @classmethod
-    def concat(cls, dataset_objs):
-        cast_objs = cls.cast(dataset_objs)
-        return np.concatenate([col.data for col in cast_objs])
+    def concat(cls, datasets, dimensions, vdims):
+        from . import default_datatype
+        keys, datasets = zip(*datasets)
+        datasets = cls.cast(datasets, default_datatype)
+        return datasets[0].interface.concat(list(zip(keys, datasets)), dimensions)
 
 
     @classmethod

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 try:
     import itertools.izip as zip
 except ImportError:

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -106,14 +106,6 @@ class ArrayInterface(Interface):
 
 
     @classmethod
-    def concat(cls, datasets, dimensions, vdims):
-        from . import default_datatype
-        keys, datasets = zip(*datasets)
-        datasets = cls.cast(datasets, default_datatype)
-        return datasets[0].interface.concat(list(zip(keys, datasets)), dimensions)
-
-
-    @classmethod
     def sort(cls, dataset, by=[], reverse=False):
         data = dataset.data
         if len(by) == 1:

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -244,9 +244,15 @@ class DaskInterface(PandasInterface):
         return data
 
     @classmethod
-    def concat(cls, columns_objs):
-        cast_objs = cls.cast(columns_objs)
-        return dd.concat([col.data for col in cast_objs])
+    def concat(cls, datasets, dimensions, vdims):
+        dataframes = []
+        for key, ds in datasets:
+            data = ds.data.copy()
+            for d, k in zip(dimensions, key):
+                data[d.name] = k
+            dataframes.append(data)
+        template = datasets[0][1]
+        return dd.concat(dataframes)
 
     @classmethod
     def dframe(cls, columns, dimensions):

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -251,7 +251,6 @@ class DaskInterface(PandasInterface):
             for d, k in zip(dimensions, key):
                 data[d.name] = k
             dataframes.append(data)
-        template = datasets[0][1]
         return dd.concat(dataframes)
 
     @classmethod

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -138,7 +138,10 @@ class DictInterface(Interface):
         key = list(data.keys())[0]
 
         if len(data[key]) == 1 and key in dataset.vdims:
-            return data[key][0]
+            scalar = data[key][0]
+            return scalar.compute() if hasattr(scalar, 'compute') else scalar
+        return data
+
 
     @classmethod
     def isscalar(cls, dataset, dim):

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -117,6 +117,7 @@ class GridInterface(DictInterface):
                             'actual shape: %s' % (vdim, valid_shape, shape), cls)
         return data, {'kdims':kdims, 'vdims':vdims}, {}
 
+
     @classmethod
     def concat(cls, datasets, dimensions, vdims):
         from . import Dataset

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -150,7 +150,8 @@ class GridInterface(DictInterface):
 
     @classmethod
     def isscalar(cls, dataset, dim):
-        return np.unique(cls.values(dataset, dim, expanded=False)) == 1
+        values = cls.values(dataset, dim, expanded=False)
+        return values.shape in ((), (1,)) or len(np.unique(values)) == 1
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -139,6 +139,12 @@ class GridInterface(DictInterface):
         new_data[dim.name] = np.array(values)
         for vdim in vdims:
             arrays = [grid[vdim.name] for grid in grids]
+            shapes = set(arr.shape for arr in arrays)
+            if len(shapes) > 1:
+                raise DataError('When concatenating gridded data the shape '
+                                'of arrays must match. %s found that arrays '
+                                'along the %s dimension do not match.' %
+                                (cls.__name__, vdim.name))
             stack = np.stack if any(is_dask(arr) for arr in arrays) else da.stack
             new_data[vdim.name] = stack(arrays, -1)
         return new_data

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -115,7 +115,6 @@ class Interface(param.Parameterized):
         with the given cast_type (if specified).
         """
         datatype = datatype or cls.datatype
-        interfaces = list(util.unique_iterator((d.interface for d in datasets)))
         cast = []
         for ds in datasets:
             if cast_type is not None or ds.interface.datatype != datatype:
@@ -302,7 +301,7 @@ class Interface(param.Parameterized):
         """
         Utility function to concatenate an NdMapping of Dataset objects.
         """
-        from . import Dataset
+        from . import Dataset, default_datatype
         if isinstance(datasets, NdMapping):
             dimensions = datasets.kdims
             datasets = datasets.data

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -118,7 +118,7 @@ class Interface(param.Parameterized):
         interfaces = list(util.unique_iterator((d.interface for d in datasets)))
         cast = []
         for ds in datasets:
-            if cast_type is not None or ds.interface.datatype in datatype:
+            if cast_type is not None or ds.interface.datatype != datatype:
                 ds = ds.clone(ds, datatype=[datatype], new_type=cast_type)
             cast.append(ds)
         return cast

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -297,11 +297,12 @@ class Interface(param.Parameterized):
                 return column[0], column[-1]
 
     @classmethod
-    def concatenate(cls, datasets, datatype=None):
+    def concatenate(cls, datasets, datatype=None, new_type=None):
         """
         Utility function to concatenate an NdMapping of Dataset objects.
         """
         from . import Dataset, default_datatype
+        new_type = new_type or Dataset
         if isinstance(datasets, NdMapping):
             dimensions = datasets.kdims
             datasets = datasets.data
@@ -324,7 +325,7 @@ class Interface(param.Parameterized):
         template = datasets[0]
         data = list(zip(keys, datasets)) if keys else datasets
         concat_data = template.interface.concat(data, dimensions, vdims=template.vdims)
-        return template.clone(concat_data, kdims=dimensions+template.kdims, new_type=Dataset)
+        return template.clone(concat_data, kdims=dimensions+template.kdims, new_type=new_type)
 
     @classmethod
     def reduce(cls, dataset, reduce_dims, function, **kwargs):

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -4,8 +4,9 @@ import datetime
 from itertools import product
 
 import iris
-from iris.coords import AuxCoord
+from iris.coords import DimCoord
 from iris.cube import CubeList
+from iris.experimental.equalise_cubes import equalise_attributes
 from iris.util import guess_coord_axis
 
 import numpy as np
@@ -240,9 +241,11 @@ class CubeInterface(GridInterface):
         cubes = []
         for c, cube in datasets.items():
             cube = cube.copy()
-            cube.add_aux_coord(AuxCoord([c], var_name=dim.name))
+            cube.add_aux_coord(DimCoord([c], var_name=dim.name))
             cubes.append(cube)
-        return CubeList(cubes).merge()[0]
+        cubes = CubeList(cubes)
+        equalise_attributes(cubes)
+        return cubes.merge_cube()
 
 
     @classmethod
@@ -275,7 +278,7 @@ class CubeInterface(GridInterface):
         """
         Returns the total number of samples in the dataset.
         """
-        return np.product([len(d.points) for d in dataset.data.coords()])
+        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)])
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -4,6 +4,8 @@ import datetime
 from itertools import product
 
 import iris
+from iris.coords import AuxCoord
+from iris.cube import CubeList
 from iris.util import guess_coord_axis
 
 import numpy as np
@@ -229,6 +231,18 @@ class CubeInterface(GridInterface):
                 return container_type(data, kdims=dims)
         else:
             return container_type(data)
+
+    @classmethod
+    def concat_dim(cls, datasets, dim, vdims):
+        """
+        Concatenates datasets along one dimension
+        """
+        cubes = []
+        for c, cube in datasets.items():
+            cube = cube.copy()
+            cube.add_aux_coord(AuxCoord([c], var_name=dim.name))
+            cubes.append(cube)
+        return CubeList(cubes).merge()[0]
 
 
     @classmethod

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -169,9 +169,14 @@ class PandasInterface(Interface):
 
 
     @classmethod
-    def concat(cls, columns_objs):
-        cast_objs = cls.cast(columns_objs)
-        return pd.concat([col.data for col in cast_objs])
+    def concat(cls, datasets, dimensions, vdims):
+        dataframes = []
+        for key, ds in datasets:
+            data = ds.data.copy()
+            for d, k in zip(dimensions, key):
+                data[d.name] = k
+            dataframes.append(data)
+        return pd.concat(dataframes)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -360,13 +360,10 @@ class XArrayInterface(GridInterface):
         else:
             return dataset.data.isel(**isel)
 
-
     @classmethod
-    def concat(cls, dataset_objs):
-        #cast_objs = cls.cast(dataset_objs)
-        # Reimplement concat to automatically add dimensions
-        # once multi-dimensional concat has been added to xarray.
-        return xr.concat([col.data for col in dataset_objs], dim='concat_dim')
+    def concat_dim(cls, datasets, dim, vdims):
+        return xr.concat([ds.assign_coords(**{dim.name: c}) for c, ds in datasets.items()],
+                         dim=dim.name)
 
     @classmethod
     def redim(cls, dataset, dimensions):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -429,15 +429,8 @@ class MultiDimensionalMapping(Dimensioned):
 
     def table(self, datatype=None, **kwargs):
         "Creates a table from the stored keys and data."
-        if datatype is None:
-            datatype = ['dataframe' if pd else 'dictionary']
-
-        tables = []
-        for key, value in self.data.items():
-            value = value.table(datatype=datatype, **kwargs)
-            for idx, (dim, val) in enumerate(zip(self.kdims, key)):
-                value = value.add_dimension(dim, idx, val)
-            tables.append(value)
+        new_data = [(key, value.table(datatype=datatype, **kwargs)) for key, value in self.data.items()]
+        tables = self.clone(tables, shared_data=False)
         return value.interface.concatenate(tables)
 
 

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -13,7 +13,7 @@ import param
 from . import util
 from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement
 from .util import (unique_iterator, sanitize_identifier, dimension_sort,
-                   basestring, wrap_tuple, process_ellipses, get_ndmapping_label, pd)
+                   basestring, wrap_tuple, process_ellipses, get_ndmapping_label)
 
 
 class item_check(object):
@@ -429,9 +429,11 @@ class MultiDimensionalMapping(Dimensioned):
 
     def table(self, datatype=None, **kwargs):
         "Creates a table from the stored keys and data."
-        new_data = [(key, value.table(datatype=datatype, **kwargs)) for key, value in self.data.items()]
-        tables = self.clone(tables, shared_data=False)
-        return value.interface.concatenate(tables)
+        from .data.interface import Interface
+        new_data = [(key, value.table(datatype=datatype, **kwargs))
+                    for key, value in self.data.items()]
+        tables = self.clone(new_data)
+        return Interface.concatenate(tables)
 
 
     def dframe(self):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -430,10 +430,11 @@ class MultiDimensionalMapping(Dimensioned):
     def table(self, datatype=None, **kwargs):
         "Creates a table from the stored keys and data."
         from .data.interface import Interface
+        from ..element.tabular import Table
         new_data = [(key, value.table(datatype=datatype, **kwargs))
                     for key, value in self.data.items()]
         tables = self.clone(new_data)
-        return Interface.concatenate(tables)
+        return Interface.concatenate(tables, new_type=Table)
 
 
     def dframe(self):

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1431,7 +1431,6 @@ def unpack_group(group, getter):
         if hasattr(obj, 'kdims'):
             yield (key, obj)
         else:
-            obj = tuple(v)
             yield (wrap_tuple(key), obj)
 
 
@@ -1532,7 +1531,7 @@ class ndmapping_groupby(param.ParameterizedFunction):
         selects = get_unique_keys(ndmapping, dimensions)
         selects = group_select(list(selects))
         groups = [(k, group_type((v.reindex(idims) if hasattr(v, 'kdims')
-                                  else [((), (v,))]), **kwargs))
+                                  else [((), v)]), **kwargs))
                   for k, v in iterative_select(ndmapping, dim_names, selects)]
         return container_type(groups, kdims=dimensions)
 

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -189,7 +189,7 @@ class categorical_aggregate2d(Operation):
             data[vdim.name] = values
         dtype = default_datatype
         dense_data = Dataset(data, kdims=obj.kdims, vdims=obj.vdims, datatype=[dtype])
-        concat_data = obj.interface.concatenate([dense_data, obj], datatype=[dtype])
+        concat_data = obj.interface.concatenate([dense_data, obj], datatype=dtype)
         reindexed = concat_data.reindex([xdim, ydim], vdims)
         if not reindexed:
             agg = reindexed

--- a/holoviews/element/util.py
+++ b/holoviews/element/util.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from ..core import Dataset, OrderedDict
 from ..core.boundingregion import BoundingBox
+from ..core.data import default_datatype
 from ..core.operation import Operation
 from ..core.sheetcoords import Slice
 from ..core.util import (is_nan, sort_topologically, one_to_one,
@@ -186,7 +187,7 @@ class categorical_aggregate2d(Operation):
             values = np.empty(nsamples)
             values[:] = np.NaN
             data[vdim.name] = values
-        dtype = 'dataframe' if pd else 'dictionary'
+        dtype = default_datatype
         dense_data = Dataset(data, kdims=obj.kdims, vdims=obj.vdims, datatype=[dtype])
         concat_data = obj.interface.concatenate([dense_data, obj], datatype=[dtype])
         reindexed = concat_data.reindex([xdim, ydim], vdims)

--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -11,7 +11,7 @@ from param import _is_number
 
 from ..core import (Operation, NdOverlay, Overlay, GridMatrix,
                     HoloMap, Dataset, Element, Collator, Dimension)
-from ..core.data import ArrayInterface, DictInterface
+from ..core.data import ArrayInterface, DictInterface, default_datatype
 from ..core.util import (group_sanitizer, label_sanitizer, pd,
                          basestring, datetime_types, isfinite, dt_to_int)
 from ..element.chart import Histogram, Scatter
@@ -792,10 +792,7 @@ class gridmatrix(param.ParameterizedFunction):
         # Creates a unified Dataset.data attribute
         # to draw the data from
         if isinstance(element.data, np.ndarray):
-            if 'dataframe' in Dataset.datatype:
-                el_data = element.table('dataframe')
-            else:
-                el_data = element.table('dictionary')
+            el_data = element.table(default_datatype)
         else:
             el_data = element.data
 
@@ -818,7 +815,7 @@ class gridmatrix(param.ParameterizedFunction):
                 if p.diagonal_type is not None:
                     if p.diagonal_type._auto_indexable_1d:
                         el = p.diagonal_type(el_data, kdims=[d1], vdims=[d2],
-                                             datatype=['dataframe', 'dictionary'])
+                                             datatype=[default_datatype])
                     else:
                         values = element.dimension_values(d1)
                         el = p.diagonal_type(values, kdims=[d1])
@@ -830,7 +827,7 @@ class gridmatrix(param.ParameterizedFunction):
             else:
                 kdims, vdims = ([d1, d2], []) if len(p.chart_type.kdims) == 2 else (d1, d2)
                 el = p.chart_type(el_data, kdims=kdims, vdims=vdims,
-                                  datatype=['dataframe', 'dictionary'])
+                                  datatype=[default_datatype])
             data[(d1.name, d2.name)] = el
         return data
 

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -9,6 +9,8 @@ from unittest import SkipTest
 import numpy as np
 
 from holoviews import Dataset, HoloMap, Dimension
+from holoviews.core.data import concat
+from holoviews.core.data.interface import DataError
 from holoviews.element import Scatter, Curve
 from holoviews.element.comparison import ComparisonTestCase 
 
@@ -1081,3 +1083,23 @@ class GriddedInterfaceTests(object):
         agg = ds.aggregate('x', np.mean, np.std)
         example = Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
         self.assertEqual(agg, example)
+
+    def test_concat_grid_3d(self):
+        array = np.random.rand(4, 5, 3, 2)
+        orig = Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
+        hmap = HoloMap({(i, j): self.element((range(5), range(4), array[:, :, j, i]), ['x', 'y'], 'z')
+                        for i in range(2) for j in range(3)}, ['A', 'B'])
+        ds = concat(hmap)
+        self.assertEqual(ds, orig)
+
+    def test_concat_grid_3d_shape_mismatch(self):
+        ds1 = Dataset(([0, 1], [1, 2, 3], np.random.rand(3, 2)), ['x', 'y'], 'z')
+        ds2 = Dataset(([0, 1, 2], [1, 2], np.random.rand(2, 3)), ['x', 'y'], 'z')
+        hmap = HoloMap({1: ds1, 2: ds2})
+        with self.assertRaises(DataError):
+            concat(hmap)
+
+    def test_grid_3d_groupby_concat_roundtrip(self):
+        array = np.random.rand(4, 5, 3, 2)
+        orig = Dataset((range(2), range(3), range(5), range(4), array), ['A', 'B', 'x', 'y'], 'z')
+        self.assertEqual(concat(orig.groupby(['A', 'B'])), orig)

--- a/tests/core/data/testirisinterface.py
+++ b/tests/core/data/testirisinterface.py
@@ -6,11 +6,13 @@ import numpy as np
 try:
     import iris
     from iris.tests.stock import lat_lon_cube
+    from iris.exceptions import MergeError
 except ImportError:
     raise SkipTest("Could not import iris, skipping IrisInterface tests.")
 
-from holoviews.core.data import Dataset
+from holoviews.core.data import Dataset, concat
 from holoviews.core.data.iris import coord_to_dimension
+from holoviews.core.spaces import HoloMap
 from holoviews.element import Image
 
 from .testimageinterface import Image_ImageInterfaceTests
@@ -29,6 +31,15 @@ class IrisInterfaceTests(GridInterfaceTests):
     def init_data(self):
         self.cube = lat_lon_cube()
         self.epsilon = 0.01
+
+    def test_concat_grid_3d_shape_mismatch(self):
+        arr1 = np.random.rand(3, 2)
+        arr2 = np.random.rand(2, 3)
+        ds1 = Dataset(([0, 1], [1, 2, 3], arr1), ['x', 'y'], 'z')
+        ds2 = Dataset(([0, 1, 2], [1, 2], arr2), ['x', 'y'], 'z')
+        hmap = HoloMap({1: ds1, 2: ds2})
+        with self.assertRaises(MergeError):
+            concat(hmap)
 
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -9,8 +9,9 @@ try:
 except:
     raise SkipTest("Could not import xarray, skipping XArrayInterface tests.")
 
-from holoviews.core.data import Dataset
+from holoviews.core.data import Dataset, concat
 from holoviews.core.dimension import Dimension
+from holoviews.core.spaces import HoloMap
 from holoviews.element import Image, RGB, HSV
 
 from .testimageinterface import (
@@ -108,6 +109,18 @@ class XArrayInterfaceTests(GridInterfaceTests):
         dataset = xr.Dataset({'value': darray}, coords=coords)
         ds = Dataset(dataset)
         self.assertEqual(ds.kdims, ['b', 'c', 'a'])
+
+    def test_concat_grid_3d_shape_mismatch(self):
+        arr1 = np.random.rand(3, 2)
+        arr2 = np.random.rand(2, 3)
+        ds1 = Dataset(([0, 1], [1, 2, 3], arr1), ['x', 'y'], 'z')
+        ds2 = Dataset(([0, 1, 2], [1, 2], arr2), ['x', 'y'], 'z')
+        hmap = HoloMap({1: ds1, 2: ds2})
+        arr = np.full((3, 3, 2), np.NaN)
+        arr[:, :2, 0] = arr1
+        arr[:2, :, 1] = arr2
+        ds = Dataset(([1, 2], [0, 1, 2], [1, 2, 3], arr), ['Default', 'x', 'y'], 'z')
+        self.assertEqual(concat(hmap), ds)
 
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"


### PR DESCRIPTION
This PR has two main aims:

1) Standardize and simplify how casting between different datatypes works
2) Implement concatenation for all datatypes

Before this PR was applied past both casting and concatenation were limited to columnar data formats, which meant that certain operations could not be applied to gridded data, e.g. a HoloMap collapse. Having a dedicated concat implementation for both columnar and gridded data also allows much more efficient concatenation than what is currently in use by methods like ``.table`` and ``.dframe`` and will generalize them so that we can eventually replace the column specific ``.table`` implementation with a general one that returns a dataset of arbitrary type.

Implementing concatenation along HoloMap dimensions also means that Dataset.groupby operations are now reversible and fixes HoloMap.collapse.

- [x] Fixes https://github.com/ioam/holoviews/issues/1417
- [x] Adds unit tests