### PR TITLE
Fixed bokeh gridstyle option in Overlays

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -454,11 +454,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         recursive_model_update(plot.xaxis[0], props.get('x', {}))
         recursive_model_update(plot.yaxis[0], props.get('y', {}))
 
-        if not self.overlaid:
-            if plot.title:
-                plot.title.update(**self._title_properties(key, plot, element))
-            else:
-                plot.title = Title(**self._title_properties(key, plot, element))
+        if plot.title:
+            plot.title.update(**self._title_properties(key, plot, element))
+        else:
+            plot.title = Title(**self._title_properties(key, plot, element))
+
         if not self.show_grid:
             plot.xgrid.grid_line_color = None
             plot.ygrid.grid_line_color = None
@@ -1217,7 +1217,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'yticks', 'xrotation', 'yrotation', 'lod',
                           'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title_format', 'legend_position', 'legend_offset',
-                          'legend_cols']
+                          'legend_cols', 'gridstyle']
 
     def _process_legend(self):
         plot = self.handles['plot']

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -3,7 +3,7 @@ from nose.plugins.attrib import attr
 import numpy as np
 
 from holoviews.core import Dimension, DynamicMap
-from holoviews.element import Curve, Image
+from holoviews.element import Curve, Image, Scatter, Labels
 from holoviews.streams import Stream
 
 from .testplot import TestBokehPlot, bokeh_renderer
@@ -182,3 +182,11 @@ class TestOverlayPlot(TestBokehPlot):
         overlay = Curve([]) * Curve([]).options(projection='custom')
         plot = bokeh_renderer.get_plot(overlay)
         self.assertEqual([p.projection for p in plot.subplots.values()], ['custom', 'custom'])
+
+    def test_overlay_gridstyle_applies(self):
+        grid_style = {'grid_line_color': 'blue', 'grid_line_width': 2}
+        overlay = (Scatter([(10,10)]).options(gridstyle=grid_style, show_grid=True, size=20)
+                   * Labels([(10, 10, 'A')]))
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertEqual(plot.state.xgrid[0].grid_line_color, 'blue')
+        self.assertEqual(plot.state.xgrid[0].grid_line_width, 2)


### PR DESCRIPTION
Fixed application of gridstyles in Overlays by declaring it as an option to be propagated.

- [x] Fixes https://github.com/ioam/holoviews/issues/2764
- [x] Adds unit test