### PR TITLE
Minor Interface improvements

### DIFF
--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -248,14 +248,18 @@ class Interface(param.Parameterized):
                 k = slice(*k)
             arr = cls.values(dataset, dim)
             if isinstance(k, slice):
-                if k.start is not None:
-                    mask &= k.start <= arr
-                if k.stop is not None:
-                    mask &= arr < k.stop
+                with warnings.catch_warnings():
+                    warnings.filterwarnings('ignore', r'invalid value encountered')
+                    if k.start is not None:
+                        mask &= k.start <= arr
+                    if k.stop is not None:
+                        mask &= arr < k.stop
             elif isinstance(k, (set, list)):
                 iter_slcs = []
                 for ik in k:
-                    iter_slcs.append(arr == ik)
+                    with warnings.catch_warnings():
+                        warnings.filterwarnings('ignore', r'invalid value encountered')
+                        iter_slcs.append(arr == ik)
                 mask &= np.logical_or.reduce(iter_slcs)
             elif callable(k):
                 mask &= k(arr)

--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -1,3 +1,5 @@
+import warnings
+
 import param
 import numpy as np
 

--- a/holoviews/element/__init__.py
+++ b/holoviews/element/__init__.py
@@ -87,6 +87,9 @@ class ElementConversion(DataConversion):
     def vectorfield(self, kdims=None, vdims=None, groupby=None, **kwargs):
         return self(VectorField, kdims, vdims, groupby, **kwargs)
 
+    def violin(self, kdims=None, vdims=None, groupby=None, **kwargs):
+        return self(Violin, kdims, vdims, groupby, **kwargs)
+
 
 Dataset._conversion_interface = ElementConversion
 

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -49,7 +49,7 @@ class rolling(Operation,RollingBase):
         df = df.set_index(xdim).rolling(win_type=self.p.window_type,
                                         **self._roll_kwargs())
         if self.p.window_type is None:
-            rolled = df.apply(self.p.function)
+            rolled = df.apply(self.p.function, raw=True)
         else:
             if self.p.function is np.mean:
                 rolled = df.mean()

--- a/holoviews/operation/timeseries.py
+++ b/holoviews/operation/timeseries.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from ..core import Operation, Element
 from ..core.data import PandasInterface
+from ..core.util import pandas_version
 from ..element import Scatter
 
 
@@ -49,7 +50,8 @@ class rolling(Operation,RollingBase):
         df = df.set_index(xdim).rolling(win_type=self.p.window_type,
                                         **self._roll_kwargs())
         if self.p.window_type is None:
-            rolled = df.apply(self.p.function, raw=True)
+            kwargs = {'raw': True} if pandas_version >= '0.23.0' else {}
+            rolled = df.apply(self.p.function, **kwargs)
         else:
             if self.p.function is np.mean:
                 rolled = df.mean()


### PR DESCRIPTION
Three minor fixes/improvements for data interfaces:

1) Fixed pandas 0.23 deprecation warning in rolling operation
2) Added element conversion method for violin (Fixes https://github.com/ioam/holoviews/issues/2763)
3) Filter warnings for nan/inf comparisons on Interface.select_mask