### PR TITLE
Fixed inverted QuadMesh bug

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -177,8 +177,9 @@ class QuadMeshPlot(ColorbarPlot):
                 data[x] = np.array(xc)
                 data[y] = np.array(yc)
         else:
-            xc, yc = (element.interface.coords(element, x, edges=True),
-                      element.interface.coords(element, y, edges=True))
+            xc, yc = (element.interface.coords(element, x, edges=True, ordered=True),
+                      element.interface.coords(element, y, edges=True, ordered=True))
+            
             x0, y0 = cartesian_product([xc[:-1], yc[:-1]], copy=True)
             x1, y1 = cartesian_product([xc[1:], yc[1:]], copy=True)
             zvals = zdata.flatten() if self.invert_axes else zdata.T.flatten()

--- a/tests/plotting/bokeh/testquadmeshplot.py
+++ b/tests/plotting/bokeh/testquadmeshplot.py
@@ -36,3 +36,15 @@ class TestQuadMeshPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(qmesh)
         self.assertIsInstance(plot.handles['colorbar'], ColorBar)
         self.assertIs(plot.handles['colorbar'].color_mapper, plot.handles['color_mapper'])
+
+    def test_quadmesh_inverted_coords(self):
+        xs = [0, 1, 2]
+        ys = [2, 1, 0]
+        qmesh = QuadMesh((xs, ys, np.random.rand(3, 3)))
+        plot = bokeh_renderer.get_plot(qmesh)
+        source = plot.handles['source']
+        self.assertEqual(source.data['z'], qmesh.dimension_values(2, flat=False).T.flatten())
+        self.assertEqual(source.data['left'], np.array([-0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 1.5, 1.5, 1.5]))
+        self.assertEqual(source.data['right'], np.array([0.5, 0.5, 0.5, 1.5, 1.5, 1.5, 2.5, 2.5, 2.5]))
+        self.assertEqual(source.data['top'], np.array([0.5, 1.5, 2.5, 0.5, 1.5, 2.5, 0.5, 1.5, 2.5]))
+        self.assertEqual(source.data['bottom'], np.array([-0.5, 0.5, 1.5, -0.5, 0.5, 1.5, -0.5, 0.5, 1.5]))


### PR DESCRIPTION
As reported in a HoloPlot issue the coordinates in a QuadMesh are not correctly ordered causing the plot to be inverted. This is a simple fix to use the ordered coordinates. 

- [x] Fixes https://github.com/pyviz/holoplot/issues/23