### PR TITLE
Handle kdims referencing multi-index in dask

### DIFF
--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -96,7 +96,6 @@ class HomogeneousColumnTests(object):
     # all interfaces.
 
     def test_dataset_array_init_hm(self):
-        "Tests support for arrays (homogeneous)"
         dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
                           kdims=['x'], vdims=['x2'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
@@ -106,7 +105,7 @@ class HomogeneousColumnTests(object):
         if pd is None:
             raise SkipTest("Pandas not available")
         dataset = Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
-                          kdims=['x'], vdims=[ 'x2'])
+                          kdims=['x'], vdims=['x2'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
     def test_dataset_dataframe_init_hm_alias(self):

--- a/tests/core/data/testdaskinterface.py
+++ b/tests/core/data/testdaskinterface.py
@@ -1,13 +1,20 @@
+from nose.plugins.attrib import attr
 from unittest import SkipTest
 
+import numpy as np
+
 try:
+    import pandas as pd
     import dask.dataframe as dd
 except:
-    dd = None
+    raise SkipTest("Could not import dask, skipping DaskInterface tests.")
+
+from holoviews.core.data import Dataset
 
 from .testpandasinterface import PandasInterfaceTests
 
 
+@attr(optional=1)
 class DaskDatasetTest(PandasInterfaceTests):
     """
     Test of the pandas DaskDataset interface.
@@ -46,3 +53,15 @@ class DaskDatasetTest(PandasInterfaceTests):
 
     def test_dataset_boolean_index(self):
         raise SkipTest("Not supported")
+
+    def test_dataset_from_multi_index(self):
+        df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
+        ddf = dd.from_pandas(df, 1)
+        ds = Dataset(ddf.groupby(['x', 'y']).mean(), ['x', 'y'])
+        self.assertEqual(ds, Dataset(df, ['x', 'y']))
+    
+    def test_dataset_from_multi_index_tuple_dims(self):
+        df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
+        ddf = dd.from_pandas(df, 1)
+        ds = Dataset(ddf.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
+        self.assertEqual(ds, Dataset(df, [('x', 'X'), ('y', 'Y')]))

--- a/tests/core/data/testpandasinterface.py
+++ b/tests/core/data/testpandasinterface.py
@@ -153,3 +153,13 @@ class PandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
         hmap = HoloMap({0: Scatter(([0, 1], [1, 2]), 'index', 'y'),
                         1: Scatter([(2, 3)], 'index', 'y')}, 'x')
         self.assertEqual(scatters, hmap)
+
+    def test_dataset_from_multi_index(self):
+        df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
+        ds = Dataset(df.groupby(['x', 'y']).mean(), ['x', 'y'])
+        self.assertEqual(ds, Dataset(df, ['x', 'y']))
+
+    def test_dataset_from_multi_index_tuple_dims(self):
+        df = pd.DataFrame({'x': np.arange(10), 'y': np.arange(10), 'z': np.random.rand(10)})
+        ds = Dataset(df.groupby(['x', 'y']).mean(), [('x', 'X'), ('y', 'Y')])
+        self.assertEqual(ds, Dataset(df, [('x', 'X'), ('y', 'Y')]))


### PR DESCRIPTION
Since dask dataframes do not support multi-indexes the current code does not detect when a multi-index is referenced. The only way of checking whether the multi-index exists is to speculatively reset the index (which is almost free when using dask) and check whether the columns exist on the reindexed dataframe. This code now resets the index and uses the reindexed dataframe if the columns are present there (otherwise the validation code will complain about missing columns as before).

- [x] Adds unit tests