### PR TITLE
Cleaned up Dimension casting and name lookup

### DIFF
--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -6,7 +6,7 @@ except ImportError:
 import numpy as np
 
 from .interface import Interface, DataError
-from ..dimension import Dimension
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check
 from .. import util
@@ -29,8 +29,7 @@ class ArrayInterface(Interface):
         if vdims is None:
             vdims = eltype.vdims
 
-        dimensions = [d.name if isinstance(d, Dimension) else
-                      d for d in kdims + vdims]
+        dimensions = [dimension_name(d) for d in kdims + vdims]
         if ((isinstance(data, dict) or util.is_dataframe(data)) and
             all(d in data for d in dimensions)):
             dataset = [d if isinstance(d, np.ndarray) else np.asarray(data[d]) for d in dimensions]

--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -6,7 +6,7 @@ except ImportError:
 import numpy as np
 
 from .interface import Interface, DataError
-from ..dimension import Dimension, dimension_name
+from ..dimension import dimension_name
 from ..element import Element
 from ..ndmapping import NdMapping, item_check
 from .. import util

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -7,7 +7,7 @@ except ImportError:
 import numpy as np
 
 from .interface import Interface, DataError
-from ..dimension import Dimension
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check
@@ -40,8 +40,7 @@ class DictInterface(Interface):
         if vdims is None:
             vdims = eltype.vdims
 
-        dimensions = [d.name if isinstance(d, Dimension) else
-                      d for d in kdims + vdims]
+        dimensions = [dimension_name(d) for d in kdims + vdims]
         if isinstance(data, tuple):
             data = {d: v for d, v in zip(dimensions, data)}
         elif util.is_dataframe(data) and all(d in data for d in dimensions):
@@ -170,7 +169,7 @@ class DictInterface(Interface):
 
     @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
-        dim = dimension.name if isinstance(dimension, Dimension) else dimension
+        dim = dimension_name(dimension)
         data = list(dataset.data.items())
         data.insert(dim_pos, (dim, values))
         return OrderedDict(data)

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -7,7 +7,7 @@ except ImportError:
 import numpy as np
 
 from .interface import Interface, DataError
-from ..dimension import Dimension, dimension_name
+from ..dimension import dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -22,7 +22,7 @@ def is_dask(array):
 
 from .dictionary import DictInterface
 from .interface import Interface, DataError
-from ..dimension import Dimension
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check, sorted_context
@@ -64,8 +64,7 @@ class GridInterface(DictInterface):
                              'one value dimension.')
 
         ndims = len(kdims)
-        dimensions = [d.name if isinstance(d, Dimension) else
-                      d for d in kdims + vdims]
+        dimensions = [dimension_name(d) for d in kdims+vdims]
         if isinstance(data, tuple):
             data = {d: v for d, v in zip(dimensions, data)}
         elif isinstance(data, list) and data == []:
@@ -88,14 +87,14 @@ class GridInterface(DictInterface):
                             'dictionary or tuple')
 
         for dim in kdims+vdims:
-            name = dim.name if isinstance(dim, Dimension) else dim
+            name = dimension_name(dim)
             if name not in data:
                 raise ValueError("Values for dimension %s not found" % dim)
             if not isinstance(data[name], array_types):
                 data[name] = np.array(data[name])
 
-        kdim_names = [d.name if isinstance(d, Dimension) else d for d in kdims]
-        vdim_names = [d.name if isinstance(d, Dimension) else d for d in vdims]
+        kdim_names = [dimension_name(d) for d in kdims]
+        vdim_names = [dimension_name(d) for d in vdims]
         expected = tuple([len(data[kd]) for kd in kdim_names])
         irregular_shape = data[kdim_names[0]].shape if kdim_names else ()
         valid_shape = irregular_shape if len(irregular_shape) > 1 else expected[::-1]
@@ -152,7 +151,7 @@ class GridInterface(DictInterface):
 
     @classmethod
     def irregular(cls, dataset, dim):
-        return dataset.data[dim.name if isinstance(dim, Dimension) else dim].ndim > 1
+        return dataset.data[dimension_name(dim)].ndim > 1
 
 
     @classmethod
@@ -571,7 +570,7 @@ class GridInterface(DictInterface):
 
     @classmethod
     def aggregate(cls, dataset, kdims, function, **kwargs):
-        kdims = [kd.name if isinstance(kd, Dimension) else kd for kd in kdims]
+        kdims = [dimension_name(kd) for kd in kdims]
         data = {kdim: dataset.data[kdim] for kdim in kdims}
         axes = tuple(dataset.ndims-dataset.get_dimension_index(kdim)-1
                      for kdim in dataset.kdims if kdim not in kdims)
@@ -618,7 +617,7 @@ class GridInterface(DictInterface):
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         if not vdim:
             raise Exception("Cannot add key dimension to a dense representation.")
-        dim = dimension.name if isinstance(dimension, Dimension) else dimension
+        dim = dimension_name(dimension)
         return dict(dataset.data, **{dim: values})
 
 

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -22,7 +22,7 @@ def is_dask(array):
 
 from .dictionary import DictInterface
 from .interface import Interface, DataError
-from ..dimension import Dimension, dimension_name
+from ..dimension import dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check, sorted_context

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..boundingregion import BoundingBox
-from ..dimension import Dimension, dimension_name
+from ..dimension import dimension_name
 from ..element import Element
 from ..ndmapping import  NdMapping, item_check
 from ..sheetcoords import Slice, SheetCoordinateSystem

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..boundingregion import BoundingBox
-from ..dimension import Dimension
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..ndmapping import  NdMapping, item_check
 from ..sheetcoords import Slice, SheetCoordinateSystem
@@ -28,8 +28,7 @@ class ImageInterface(GridInterface):
             vdims = eltype.vdims
 
         kwargs = {}
-        dimensions = [d.name if isinstance(d, Dimension) else
-                      d for d in kdims + vdims]
+        dimensions = [dimension_name(d) for d in kdims + vdims]
         if isinstance(data, tuple):
             data = dict(zip(dimensions, data))
         if isinstance(data, dict):
@@ -277,7 +276,7 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def aggregate(cls, dataset, kdims, function, **kwargs):
-        kdims = [kd.name if isinstance(kd, Dimension) else kd for kd in kdims]
+        kdims = [dimension_name(kd) for kd in kdims]
         axes = tuple(dataset.ndims-dataset.get_dimension_index(kdim)-1
                      for kdim in dataset.kdims if kdim not in kdims)
 

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -86,7 +86,11 @@ class CubeInterface(GridInterface):
             ndims = len(kdim_names)
             vdim = as_dimension(vdims[0])
             vdims = [vdim]
-            if isinstance(data, tuple):
+            if isinstance(data, np.ndarray):
+                if data.ndim != 2 or data.shape[1] != 2 or len(kdims) != 1:
+                    raise ValueError('Iris interface could not interpret array data.')
+                data = {kdims[0].name: data[:, 0], vdim.name: data[:, 1]}
+            elif isinstance(data, tuple):
                 value_array = data[-1]
                 data = {d: vals for d, vals in zip(kdim_names + [vdim.name], data)}
             elif isinstance(data, list) and data == []:

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from .interface import Interface, DataError
 from .grid import GridInterface
-from ..dimension import Dimension, as_dimension
+from ..dimension import Dimension, asdim
 from ..element import Element
 from ..ndmapping import (NdMapping, item_check, sorted_context)
 from ..spaces import HoloMap
@@ -74,7 +74,7 @@ class CubeInterface(GridInterface):
     @classmethod
     def init(cls, eltype, data, kdims, vdims):
         if kdims:
-            kdims = [as_dimension(kd) for kd in kdims]
+            kdims = [asdim(kd) for kd in kdims]
             kdim_names = [kd.name for kd in kdims]
         else:
             kdims = eltype.kdims
@@ -84,7 +84,7 @@ class CubeInterface(GridInterface):
             if vdims is None:
                 vdims = eltype.vdims
             ndims = len(kdim_names)
-            vdim = as_dimension(vdims[0])
+            vdim = asdim(vdims[0])
             vdims = [vdim]
             if isinstance(data, np.ndarray):
                 if data.ndim != 2 or data.shape[1] != 2 or len(kdims) != 1:

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from .interface import Interface, DataError
-from ..dimension import Dimension, dimension_name
+from ..dimension import dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from .interface import Interface, DataError
-from ..dimension import Dimension
+from ..dimension import Dimension, dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
 from ..ndmapping import NdMapping, item_check
@@ -64,7 +64,7 @@ class PandasInterface(Interface):
 
             # Handle reset of index if kdims reference index by name
             for kd in kdims:
-                if isinstance(kd, Dimension): kd = kd.name
+                kd = dimension_name(kd)
                 if kd in data.columns:
                     continue
                 if any(kd == ('index' if name is None else name)
@@ -76,13 +76,13 @@ class PandasInterface(Interface):
                                 "must be strings not integers.", cls)
 
             if kdims:
-                kdim = kdims[0].name if isinstance(kdims[0], Dimension) else kdims[0]
+                kdim = dimension_name(kdims[0])
                 if eltype._auto_indexable_1d and ncols == 1 and kdim not in data.columns:
                     data = data.copy()
                     data.insert(0, kdim, np.arange(len(data)))
 
             for d in kdims+vdims:
-                if isinstance(d, Dimension): d = d.name
+                d = dimension_name(d)
                 if len([c for c in data.columns if c == d]) > 1:
                     raise DataError('Dimensions may not reference duplicated DataFrame '
                                     'columns (found duplicate %r columns). If you want to plot '
@@ -93,8 +93,7 @@ class PandasInterface(Interface):
             # Then use defined data type
             kdims = kdims if kdims else kdim_param.default
             vdims = vdims if vdims else vdim_param.default
-            columns = [d.name if isinstance(d, Dimension) else d
-                       for d in kdims+vdims]
+            columns = [dimension_name(d) for d in kdims+vdims]
 
             if isinstance(data, dict) and all(c in data for c in columns):
                 data = cyODict(((d, data[d]) for d in columns))

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -12,7 +12,7 @@ except ImportError:
     dask = None
 
 from .. import util
-from ..dimension import Dimension, as_dimension, dimension_name
+from ..dimension import Dimension, asdim, dimension_name
 from ..ndmapping import NdMapping, item_check, sorted_context
 from ..element import Element
 from .grid import GridInterface
@@ -99,8 +99,8 @@ class XArrayInterface(GridInterface):
                 kdims = kdim_param.default
             if vdims is None:
                 vdims = vdim_param.default
-            kdims = [as_dimension(kd) for kd in kdims]
-            vdims = [as_dimension(vd) for vd in vdims]
+            kdims = [asdim(kd) for kd in kdims]
+            vdims = [asdim(vd) for vd in vdims]
             if isinstance(data, np.ndarray) and data.ndim == 2 and data.shape[1] == len(kdims+vdims):
                 data = tuple(data)
             if isinstance(data, tuple):
@@ -136,8 +136,8 @@ class XArrayInterface(GridInterface):
                         if c not in kdims and set(data[c].dims) == set(virtual_dims):
                             kdims.append(c)
                 kdims = [retrieve_unit_and_label(kd) for kd in kdims]
-            vdims = [as_dimension(vd) for vd in vdims]
-            kdims = [as_dimension(kd) for kd in kdims]
+            vdims = [asdim(vd) for vd in vdims]
+            kdims = [asdim(kd) for kd in kdims]
 
         not_found = []
         for d in kdims:

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -101,6 +101,8 @@ class XArrayInterface(GridInterface):
                 vdims = vdim_param.default
             kdims = [as_dimension(kd) for kd in kdims]
             vdims = [as_dimension(vd) for vd in vdims]
+            if isinstance(data, np.ndarray) and data.ndim == 2 and data.shape[1] == len(kdims+vdims):
+                data = tuple(data)
             if isinstance(data, tuple):
                 data = {d.name: vals for d, vals in zip(kdims + vdims, data)}
             elif isinstance(data, list) and data == []:

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -67,10 +67,13 @@ def dimension_name(dimension):
         return dimension[0]
     elif isinstance(dimension, dict):
         return dimension['name']
+    elif dimension is None:
+        return None
     else:
         raise ValueError('%s type could not be interpreted as Dimension. '
                          'Dimensions must be declared as a string, tuple, '
-                         'dictionary or Dimension type.')
+                         'dictionary or Dimension type.'
+                         % type(dimension).__name__)
 
 
 def process_dimensions(kdims, vdims):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -41,7 +41,7 @@ def param_aliases(d):
     return d
 
 
-def as_dimension(dimension):
+def asdim(dimension):
     """
     Converts tuple, dict and basestring types to Dimension and leaves
     Dimension types untouched.
@@ -97,7 +97,7 @@ def process_dimensions(kdims, vdims):
                 raise ValueError('Dimensions must be defined as a tuple, '
                                  'string, dictionary or Dimension instance, '
                                  'found a %s type.' % type(dim).__name__)
-        dimensions[group] = [as_dimension(d) for d in dims]
+        dimensions[group] = [asdim(d) for d in dims]
     return dimensions
 
 

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import param
 
-from .dimension import Dimension, Dimensioned, ViewableElement
+from .dimension import Dimension, Dimensioned, ViewableElement, as_dimension
 from .layout import Composable, Layout, NdLayout
 from .ndmapping import OrderedDict, NdMapping
 from .overlay import Overlayable, NdOverlay, CompositeOverlay
@@ -396,7 +396,7 @@ class Collator(NdMapping):
         if isinstance(item, self.merge_type):
             new_item = item.clone(cdims=constant_keys)
             for dim, val in dim_vals:
-                dim = dim if isinstance(dim, Dimension) else Dimension(dim)
+                dim = as_dimension(dim)
                 if dim not in new_item.kdims:
                     new_item = new_item.add_dimension(dim, 0, val)
         elif isinstance(item, self._nest_order[self.merge_type]):

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import param
 
-from .dimension import Dimension, Dimensioned, ViewableElement, as_dimension
+from .dimension import Dimensioned, ViewableElement, as_dimension
 from .layout import Composable, Layout, NdLayout
 from .ndmapping import OrderedDict, NdMapping
 from .overlay import Overlayable, NdOverlay, CompositeOverlay

--- a/holoviews/core/element.py
+++ b/holoviews/core/element.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import param
 
-from .dimension import Dimensioned, ViewableElement, as_dimension
+from .dimension import Dimensioned, ViewableElement, asdim
 from .layout import Composable, Layout, NdLayout
 from .ndmapping import OrderedDict, NdMapping
 from .overlay import Overlayable, NdOverlay, CompositeOverlay
@@ -396,7 +396,7 @@ class Collator(NdMapping):
         if isinstance(item, self.merge_type):
             new_item = item.clone(cdims=constant_keys)
             for dim, val in dim_vals:
-                dim = as_dimension(dim)
+                dim = asdim(dim)
                 if dim not in new_item.kdims:
                     new_item = new_item.add_dimension(dim, 0, val)
         elif isinstance(item, self._nest_order[self.merge_type]):

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -11,7 +11,7 @@ import numpy as np
 import param
 
 from . import util
-from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement
+from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement, as_dimension
 from .util import (unique_iterator, sanitize_identifier, dimension_sort,
                    basestring, wrap_tuple, process_ellipses, get_ndmapping_label)
 
@@ -285,8 +285,7 @@ class MultiDimensionalMapping(Dimensioned):
         in the key dimensions and a key value scalar or sequence of
         the same length as the existing keys.
         """
-        if not isinstance(dimension, Dimension):
-            dimension = Dimension(dimension)
+        dimension = as_dimension(dimension)
 
         if dimension in self.dimensions():
             raise Exception('{dim} dimension already defined'.format(dim=dimension.name))

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -11,7 +11,7 @@ import numpy as np
 import param
 
 from . import util
-from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement, as_dimension
+from .dimension import OrderedDict, Dimension, Dimensioned, ViewableElement, asdim
 from .util import (unique_iterator, sanitize_identifier, dimension_sort,
                    basestring, wrap_tuple, process_ellipses, get_ndmapping_label)
 
@@ -285,7 +285,7 @@ class MultiDimensionalMapping(Dimensioned):
         in the key dimensions and a key value scalar or sequence of
         the same length as the existing keys.
         """
-        dimension = as_dimension(dimension)
+        dimension = asdim(dimension)
 
         if dimension in self.dimensions():
             raise Exception('{dim} dimension already defined'.format(dim=dimension.name))

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -14,8 +14,9 @@ each collection of paths.
 import numpy as np
 
 import param
-from ..core import Dimension, Element2D, Dataset
+from ..core import Element2D, Dataset
 from ..core.data import MultiInterface
+from ..core.dimension import Dimension, as_dimension
 from ..core.util import disable_constant
 
 
@@ -150,8 +151,7 @@ class Contours(Path):
         super(Contours, self).__init__(data, kdims=kdims, **params)
         if params.get('level') is not None:
             with disable_constant(self):
-                self.vdims = [d if isinstance(d, Dimension) else Dimension(d)
-                              for d in vdims]
+                self.vdims = [as_dimension(d) for d in vdims]
         else:
             all_scalar = all(self.interface.isscalar(self, vdim) for vdim in self.vdims)
             if not all_scalar:

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -16,7 +16,7 @@ import numpy as np
 import param
 from ..core import Element2D, Dataset
 from ..core.data import MultiInterface
-from ..core.dimension import Dimension, as_dimension
+from ..core.dimension import Dimension, asdim
 from ..core.util import disable_constant
 
 
@@ -151,7 +151,7 @@ class Contours(Path):
         super(Contours, self).__init__(data, kdims=kdims, **params)
         if params.get('level') is not None:
             with disable_constant(self):
-                self.vdims = [as_dimension(d) for d in vdims]
+                self.vdims = [asdim(d) for d in vdims]
         else:
             all_scalar = all(self.interface.isscalar(self, vdim) for vdim in self.vdims)
             if not all_scalar:

--- a/holoviews/element/tabular.py
+++ b/holoviews/element/tabular.py
@@ -2,7 +2,8 @@ import numpy as np
 
 import param
 
-from ..core import OrderedDict, Dimension, Element, Dataset, Tabular
+from ..core import OrderedDict, Element, Dataset, Tabular
+from ..core.dimension import Dimension, dimension_name
 
 
 class ItemTable(Element):
@@ -48,8 +49,7 @@ class ItemTable(Element):
             data = OrderedDict(list(data)) # Python 3
         if not 'vdims' in params:
             params['vdims'] = list(data.keys())
-        str_keys = OrderedDict((k.name if isinstance(k, Dimension)
-                                else k ,v) for (k,v) in data.items())
+        str_keys = OrderedDict((dimension_name(k), v) for (k,v) in data.items())
         super(ItemTable, self).__init__(str_keys, **params)
 
 
@@ -127,8 +127,7 @@ class ItemTable(Element):
         Generates a Pandas dframe from the ItemTable.
         """
         from pandas import DataFrame
-        return DataFrame({(k.name if isinstance(k, Dimension)
-                           else k): [v] for k, v in self.data.items()})
+        return DataFrame({dimension_name(k): [v] for k, v in self.data.items()})
 
 
     def table(self, datatype=None):

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -102,6 +102,11 @@ class HomogeneousColumnTests(object):
                           kdims=['x'], vdims=['x2'])
         self.assertTrue(isinstance(dataset.data, self.data_type))
 
+    def test_dataset_array_init_hm_tuple_dims(self):
+        dataset = Dataset(np.column_stack([self.xs, self.xs_2]),
+                          kdims=[('x', 'X')], vdims=[('x2', 'X2')])
+        self.assertTrue(isinstance(dataset.data, self.data_type))
+
     def test_dataset_dataframe_init_hm(self):
         "Tests support for homogeneous DataFrames"
         if pd is None:


### PR DESCRIPTION
The code is currently littered with ``isinstance(dim, Dimension)`` checks, which is not optimal because it's duplicative but more importantly because it does not check for the full range of valid dimension specs which include tuples and dictionaries. This PR adds two utilities one to cast Dimension-like objects to Dimensions if it isn't already one and the other that looks up the name on Dimensions or Dimension-like objects. It then uses these utilities throughout the code.

- [x] Adds unit test