### PR TITLE
Dropping gridded data non-scalar coordinates casts datatype 

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -22,7 +22,7 @@ datatypes = ['dictionary', 'grid']
 try:
     import pandas as pd # noqa (Availability import)
     from .pandas import PandasInterface
-    datatypes = ['dataframe', 'dictionary', 'grid', 'ndelement', 'array']
+    datatypes = ['dataframe', 'dictionary', 'grid', 'array']
     DFColumns = PandasInterface
 except ImportError:
     pd = None

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -352,7 +352,6 @@ class Dataset(Element):
         data = self.interface.reindex(self, key_dims, val_dims)
         datatype = self.datatype
         if gridded and dropped:
-            interfaces = [dt for dt in datatype if dt in self.interface.interfaces]
             datatype = [dt for dt in datatype if not self.interface.interfaces[dt].gridded]
         return self.clone(data, kdims=key_dims, vdims=val_dims,
                           new_type=new_type, datatype=datatype)

--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -330,7 +330,7 @@ class Dataset(Element):
         gridded = self.interface.gridded
         scalars = []
         if gridded:
-            coords = [(d, self.interface.coords(self, d)) for d in self.kdims]
+            coords = [(d, self.interface.coords(self, d.name)) for d in self.kdims]
             scalars = [d for d, vs in coords if len(vs) == 1]
 
         if kdims is None:

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -8,7 +8,7 @@ except ImportError:
 import numpy as np
 import pandas as pd
 import dask.dataframe as dd
-from dask.dataframe import DataFrame
+from dask.dataframe import DataFrame, Series
 
 from .. import util
 from ..dimension import Dimension
@@ -37,7 +37,7 @@ class DaskInterface(PandasInterface):
        some functions applied with aggregate and reduce will not work.
     """
 
-    types = (DataFrame,)
+    types = (DataFrame, Series)
 
     datatype = 'dask'
 

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -1081,3 +1081,8 @@ class GriddedInterfaceTests(object):
         agg = ds.aggregate('x', np.mean, np.std)
         example = Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
         self.assertEqual(agg, example)
+
+    def test_reindex_2d_grid_to_1d(self):
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.dataset_grid):
+            ds = self.dataset_grid.reindex(kdims=['x'])
+        self.assertEqual(ds, Dataset(self.dataset_grid.columns(), 'x', 'z'))

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -1081,8 +1081,3 @@ class GriddedInterfaceTests(object):
         agg = ds.aggregate('x', np.mean, np.std)
         example = Dataset((range(5), array.mean(axis=0), array.std(axis=0)), 'x', ['z', 'z_std'])
         self.assertEqual(agg, example)
-
-    def test_reindex_2d_grid_to_1d(self):
-        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.dataset_grid):
-            ds = self.dataset_grid.reindex(kdims=['x'])
-        self.assertEqual(ds, Dataset(self.dataset_grid.columns(), 'x', 'z'))

--- a/tests/core/data/testgridinterface.py
+++ b/tests/core/data/testgridinterface.py
@@ -248,6 +248,12 @@ class GridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Interfac
         ds = Dataset((self.grid_xs, self.grid_zs[0]), 'x', 'z')
         self.assertEqual(reindexed, ds)
 
+    def test_reindex_2d_grid_to_1d(self):
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], self.dataset_grid):
+            ds = self.dataset_grid.reindex(kdims=['x'])
+        with DatatypeContext([self.datatype, 'dictionary' , 'dataframe'], Dataset):
+            self.assertEqual(ds, Dataset(self.dataset_grid.columns(), 'x', 'z'))
+
 
 
 class DaskGridInterfaceTests(GridInterfaceTests):


### PR DESCRIPTION
Currently when dropping non-scalar gridded data dimensions it still attempts to maintain the datatype, which can cause issues due to duplicate coordinates. This PR cleans up the detection of scalar coordinates (i.e. key dimensions) and ensures that if a non-scalar dimension is dropped the data is cast from a gridded to a tabular datatype.

- [x] Adds unit test