### PR TITLE
Allow defining color intervals

### DIFF
--- a/examples/user_guide/Styling_Plots.ipynb
+++ b/examples/user_guide/Styling_Plots.ipynb
@@ -262,6 +262,38 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "##### Custom color intervals\n",
+    "\n",
+    "In addition to a simple integer defining the number of discrete levels, the ``color_levels`` option also allows defining a set of custom intervals. This can be useful for defining a fixed scale, such as the Saffir-Simpson hurricane wind scale. Below we declare the color levels along with a list of colors, declaring the scale. Note that the levels define the intervals to map each color to, so if there are N colors we have to define N+1 levels.\n",
+    "\n",
+    "Having defined the scale we can generate a theoretical hurricane path with wind speed values and use the ``color_levels`` and ``cmap`` to supply the custom color scale:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "levels = [0, 38, 73, 95, 110, 130, 156, 999]  \n",
+    "colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']\n",
+    "\n",
+    "path = [\n",
+    "    (-75.1, 23.1, 0),   (-76.2, 23.8, 0),   (-76.9, 25.4, 0),   (-78.4, 26.1, 39),  (-79.6, 26.2, 39),\n",
+    "    (-80.3, 25.9, 39),  (-82.0, 25.1, 74),  (-83.3, 24.6, 74),  (-84.7, 24.4, 96),  (-85.9, 24.8, 111),\n",
+    "    (-87.7, 25.7, 111), (-89.2, 27.2, 131), (-89.6, 29.3, 156), (-89.6, 30.2, 156), (-89.1, 32.6, 131),\n",
+    "    (-88.0, 35.6, 111), (-85.3, 38.6, 96)\n",
+    "]\n",
+    "\n",
+    "hv.Path([path], vdims='Wind Speed').options(\n",
+    "    color_index='Wind Speed', color_levels=levels, cmap=colors, line_width=8, colorbar=True, width=450\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "#### Setting color ranges\n",
     "\n",
     "For an image-like element, color ranges are determined by the range of the `z` value dimension, and they can thus be controlled using the ``.redim.range`` method with `z`. As an example, let's set some values in the image array to NaN and then set the range to clip the data at 0 and 0.9. By declaring the ``clipping_colors`` option we can control what colors are used for NaN values and for values above and below the defined range:"

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -850,11 +850,11 @@ def color_intervals(colors, levels, clip=None, N=255):
     interval = cmax-cmin
     cmap = []
     for intv, c in zip(intervals, colors):
-        cmap += [c]*int(N*(intv/interval))
+        cmap += [c]*int(round(N*(intv/interval)))
     if clip is not None:
         clmin, clmax = clip
-        lidx = int(N*((clmin-cmin)/interval))
-        uidx = int(N*((cmax-clmax)/interval))
+        lidx = int(round(N*((clmin-cmin)/interval)))
+        uidx = int(round(N*((cmax-clmax)/interval)))
         cmap = cmap[lidx:N-uidx]
     return cmap
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -1,4 +1,4 @@
-from __future__ import unicode_literals, absolute_import
+from __future__ import unicode_literals, absolute_import, division
 
 from collections import defaultdict, namedtuple
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -836,6 +836,29 @@ def process_cmap(cmap, ncolors=None, provider=None, categorical=False):
     return palette
 
 
+def color_intervals(colors, levels, clip=None, N=255):
+    """
+    Maps a set of intervals to colors given a fixed color range.
+    """
+    if len(colors) != len(levels)-1:
+        raise ValueError('The number of colors in the colormap '
+                         'must match the intervals defined in the '
+                         'color_levels, expected %d colors found %d.'
+                         % (ncolors, len(cmap)))
+    intervals = np.diff(levels)
+    cmin, cmax = min(levels), max(levels)
+    interval = cmax-cmin
+    cmap = []
+    for intv, c in zip(intervals, colors):
+        cmap += [c]*int(N*(intv/interval))
+    if clip is not None:
+        clmin, clmax = clip
+        lidx = int(N*((clmin-cmin)/interval))
+        uidx = int(N*((cmax-clmax)/interval))
+        cmap = cmap[lidx:N-uidx]
+    return cmap
+
+
 def dim_axis_label(dimensions, separator=', '):
     """
     Returns an axis label for one or more dimensions.

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -844,7 +844,7 @@ def color_intervals(colors, levels, clip=None, N=255):
         raise ValueError('The number of colors in the colormap '
                          'must match the intervals defined in the '
                          'color_levels, expected %d colors found %d.'
-                         % (ncolors, len(cmap)))
+                         % (N, len(colors)))
     intervals = np.diff(levels)
     cmin, cmax = min(levels), max(levels)
     interval = cmax-cmin

--- a/tests/plotting/testplotutils.py
+++ b/tests/plotting/testplotutils.py
@@ -15,7 +15,7 @@ from holoviews.operation import operation
 from holoviews.plotting.util import (
     compute_overlayable_zorders, get_min_distance, process_cmap,
     initialize_dynamic, split_dmap_overlay, _get_min_distance_numpy,
-    bokeh_palette_to_palette, mplcmap_to_palette)
+    bokeh_palette_to_palette, mplcmap_to_palette, color_intervals)
 from holoviews.streams import PointerX
 
 try:
@@ -565,6 +565,20 @@ class TestBokehPaletteUtils(ComparisonTestCase):
         colors = bokeh_palette_to_palette('viridis_r', 4)
         self.assertEqual(colors, ['#440154', '#30678D', '#35B778', '#FDE724'][::-1])
 
+    def test_color_intervals(self):
+        levels = [0, 38, 73, 95, 110, 130, 156]  
+        colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20']
+        cmap = color_intervals(colors, levels, N=10)
+        self.assertEqual(cmap, ['#5ebaff', '#5ebaff', '#00faf4',
+                                '#00faf4', '#ffffcc', '#ffe775',
+                                '#ffc140', '#ff8f20', '#ff8f20'])
+
+    def test_color_intervals_clipped(self):
+        levels = [0, 38, 73, 95, 110, 130, 156, 999]  
+        colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
+        cmap = color_intervals(colors, levels, clip=(10, 90), N=100) 
+        self.assertEqual(cmap, ['#5ebaff', '#5ebaff', '#5ebaff', '#00faf4', '#00faf4',
+                                '#00faf4', '#00faf4', '#ffffcc'])
 
 
 class TestPlotUtils(ComparisonTestCase):


### PR DESCRIPTION
This PR adds support for defining color intervals via the color_levels option. The ``color_levels`` option now allows defining a list of levels to map each supplied color to.

The example used in the docs is as follows:

```python
levels = [0, 38, 73, 95, 110, 130, 156, 999]  
colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']

path = [
    (-75.1, 23.1, 0),   (-76.2, 23.8, 0),   (-76.9, 25.4, 0),   (-78.4, 26.1, 39),  (-79.6, 26.2, 39),
    (-80.3, 25.9, 39),  (-82.0, 25.1, 74),  (-83.3, 24.6, 74),  (-84.7, 24.4, 96),  (-85.9, 24.8, 111),
    (-87.7, 25.7, 111), (-89.2, 27.2, 131), (-89.6, 29.3, 156), (-89.6, 30.2, 156), (-89.1, 32.6, 131),
    (-88.0, 35.6, 111), (-85.3, 38.6, 96)
]

hv.Path([path], vdims='Wind Speed').options(
    color_index='Wind Speed', color_levels=levels, cmap=colors, line_width=8, colorbar=True, width=450
)
```

![bokeh_plot](https://user-images.githubusercontent.com/1550771/41293181-8b2453b2-6e4c-11e8-88dc-65c56aa216cc.png)
