### PR TITLE
Ensure that Dataset.groupby does not sort by default

### DIFF
--- a/holoviews/core/data/array.py
+++ b/holoviews/core/data/array.py
@@ -8,7 +8,7 @@ import numpy as np
 from .interface import Interface, DataError
 from ..dimension import dimension_name
 from ..element import Element
-from ..ndmapping import NdMapping, item_check
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .. import util
 
 
@@ -183,7 +183,7 @@ class ArrayInterface(Interface):
             grouped_data.append((tuple(group), group_data))
 
         if issubclass(container_type, NdMapping):
-            with item_check(False):
+            with item_check(False), sorted_context(False):
                 return container_type(grouped_data, kdims=dimensions)
         else:
             return container_type(grouped_data)

--- a/holoviews/core/data/dask.py
+++ b/holoviews/core/data/dask.py
@@ -13,7 +13,7 @@ from dask.dataframe import DataFrame, Series
 from .. import util
 from ..dimension import Dimension
 from ..element import Element
-from ..ndmapping import NdMapping, item_check, OrderedDict
+from ..ndmapping import NdMapping, item_check, OrderedDict, sorted_context
 from .interface import Interface
 from .pandas import PandasInterface
 
@@ -174,7 +174,7 @@ class DaskInterface(PandasInterface):
             group = group_type(groupby.get_group(coord), **group_kwargs)
             data.append((coord, group))
         if issubclass(container_type, NdMapping):
-            with item_check(False):
+            with item_check(False), sorted_context(False):
                 return container_type(data, kdims=index_dims)
         else:
             return container_type(data)

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -10,7 +10,7 @@ from .interface import Interface, DataError
 from ..dimension import dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
-from ..ndmapping import NdMapping, item_check
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .. import util
 
 
@@ -270,7 +270,7 @@ class DictInterface(Interface):
             grouped_data.append((unique_key, group_data))
 
         if issubclass(container_type, NdMapping):
-            with item_check(False):
+            with item_check(False), sorted_context(False):
                 return container_type(grouped_data, kdims=dimensions)
         else:
             return container_type(grouped_data)

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -14,7 +14,7 @@ from .interface import Interface, DataError
 from ..dimension import dimension_name
 from ..element import Element
 from ..dimension import OrderedDict as cyODict
-from ..ndmapping import NdMapping, item_check
+from ..ndmapping import NdMapping, item_check, sorted_context
 from .. import util
 
 
@@ -195,7 +195,7 @@ class PandasInterface(Interface):
         data = [(k, group_type(v, **group_kwargs)) for k, v in
                 columns.data.groupby(group_by, sort=False)]
         if issubclass(container_type, NdMapping):
-            with item_check(False):
+            with item_check(False), sorted_context(False):
                 return container_type(data, kdims=index_dims)
         else:
             return container_type(data)

--- a/tests/core/data/base.py
+++ b/tests/core/data/base.py
@@ -586,7 +586,8 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         group2 = {'Age':[12], 'Weight':[10], 'Height':[0.8]}
         grouped = HoloMap([('M', Dataset(group1, kdims=['Age'], vdims=self.vdims)),
                            ('F', Dataset(group2, kdims=['Age'], vdims=self.vdims))],
-                          kdims=['Gender'])
+                          kdims=['Gender'], sort=False)
+        print(grouped.keys())
         self.assertEqual(self.table.groupby(['Gender']), grouped)
 
     def test_dataset_groupby_alias(self):
@@ -596,14 +597,8 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
                                          vdims=self.alias_vdims)),
                            ('F', Dataset(group2, kdims=[('age', 'Age')],
                                          vdims=self.alias_vdims))],
-                          kdims=[('gender', 'Gender')])
+                          kdims=[('gender', 'Gender')], sort=False)
         self.assertEqual(self.alias_table.groupby('Gender'), grouped)
-
-        self.gender, self.age = np.array(['M','M','F']), np.array([10,16,12])
-        self.weight, self.height = np.array([15,18,10]), np.array([0.8,0.6,0.8])
-        self.table = Dataset({'Gender':self.gender, 'Age':self.age,
-                              'Weight':self.weight, 'Height':self.height},
-                             kdims=self.kdims, vdims=self.vdims)
 
     def test_dataset_groupby_second_dim(self):
         group1 = {'Gender':['M'], 'Weight':[15], 'Height':[0.8]}
@@ -612,7 +607,7 @@ class HeterogeneousColumnTests(HomogeneousColumnTests):
         grouped = HoloMap([(10, Dataset(group1, kdims=['Gender'], vdims=self.vdims)),
                            (16, Dataset(group2, kdims=['Gender'], vdims=self.vdims)),
                            (12, Dataset(group3, kdims=['Gender'], vdims=self.vdims))],
-                          kdims=['Age'])
+                          kdims=['Age'], sort=False)
         self.assertEqual(self.table.groupby(['Age']), grouped)
 
     def test_dataset_groupby_dynamic(self):

--- a/tests/core/data/testpandasinterface.py
+++ b/tests/core/data/testpandasinterface.py
@@ -131,7 +131,7 @@ class PandasInterfaceTests(HeterogeneousColumnTests, InterfaceTests):
     def test_multi_dimension_groupby(self):
         x, y, z = list('AB'*10), np.arange(20)%3, np.arange(20)
         ds = Dataset((x, y, z), kdims=['x', 'y'], vdims=['z'],  datatype=[self.datatype])
-        keys = [('A', 0), ('A', 1), ('A', 2), ('B', 0), ('B', 1), ('B', 2)]
+        keys = [('A', 0), ('B', 1), ('A', 2), ('B', 0), ('A', 1), ('B', 2)]
         grouped = ds.groupby(['x', 'y'])
         self.assertEqual(grouped.keys(), keys)
         group = Dataset({'z': [5, 11, 17]}, vdims=['z'])


### PR DESCRIPTION
Seemingly all the tabular data interfaces sorted the groups when applying a groupby, which is not always desirable, and is inconsistent with the gridded interfaces, which already maintain the supplied ordering. It also causes issues like https://github.com/ioam/holoviews/issues/2792, where the user expected the data to stay in the order it was defined in. While I think the previous behavior was incorrect I'm also somewhat wary of changing it right away since it is a definite change in behavior. Any thoughts @jbednar and @jlstevens?

- [x] Fixes https://github.com/ioam/holoviews/issues/2792