### PR TITLE
Do not sort data in Violin and BoxWhisker plots

### DIFF
--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -7,6 +7,7 @@ import numpy as np
 from bokeh.models import FactorRange, Circle, VBar, HBar
 
 from ...core.dimension import Dimension
+from ...core.ndmapping import sorted_context
 from ...core.util import (basestring, dimension_sanitizer, wrap_tuple,
                           unique_iterator)
 from ...operation.stats import univariate_kde
@@ -121,7 +122,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
 
     def get_data(self, element, ranges, style):
         if element.kdims:
-            groups = element.groupby(element.kdims).data
+            with sorted_context(False):
+                groups = element.groupby(element.kdims).data
         else:
             groups = dict([(element.label, element)])
         vdim = dimension_sanitizer(element.vdims[0].name)
@@ -364,7 +366,8 @@ class ViolinPlot(BoxWhiskerPlot):
 
     def get_data(self, element, ranges, style):
         if element.kdims:
-            groups = element.groupby(element.kdims).data
+            with sorted_context(False):
+                groups = element.groupby(element.kdims).data
         else:
             groups = dict([((element.label,), element)])
 

--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -1,6 +1,7 @@
 import param
 import numpy as np
 
+from ...core.ndmapping import sorted_context
 from .chart import AreaPlot, ChartPlot
 from .path import PolygonPlot
 from .plot import AdjoinedPlot
@@ -64,7 +65,8 @@ class BoxPlot(ChartPlot):
 
 
     def get_data(self, element, ranges, style):
-        groups = element.groupby(element.kdims)
+        with sorted_context(False):
+            groups = element.groupby(element.kdims)
 
         data, labels = [], []
 
@@ -173,7 +175,8 @@ class ViolinPlot(BoxPlot):
         return artists
 
     def get_data(self, element, ranges, style):
-        groups = element.groupby(element.kdims)
+        with sorted_context(False):
+            groups = element.groupby(element.kdims)
 
         data, labels, colors = [], [], []
         elstyle = self.lookup_options(element, 'style')


### PR DESCRIPTION
Stops the Violin and BoxWhisker plots from sorting the data on groupbys which provides a temporary fix for #2792 until we disable sorting on groupbys in general in https://github.com/ioam/holoviews/pull/2803.

- [x] Fixes #2792 
