### PR TITLE
Fix for non-categorical discrete color levels in bokeh

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1080,6 +1080,7 @@ class ColorbarPlot(ElementPlot):
         if isinstance(cmap, dict) and factors:
             palette = [cmap.get(f, nan_colors.get('NaN', self._default_nan)) for f in factors]
         else:
+            categorical = ncolors is not None
             if isinstance(self.color_levels, int):
                 ncolors = self.color_levels
             elif isinstance(self.color_levels, list):
@@ -1089,7 +1090,7 @@ class ColorbarPlot(ElementPlot):
                                      'must match the intervals defined in the '
                                      'color_levels, expected %d colors found %d.'
                                      % (ncolors, len(cmap)))
-            palette = process_cmap(cmap, ncolors, categorical=ncolors is not None)
+            palette = process_cmap(cmap, ncolors, categorical=categorical)
             if isinstance(self.color_levels, list):
                 palette = color_intervals(palette, self.color_levels, clip=(low, high))
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -5,6 +5,7 @@ import numpy as np
 from holoviews.core import Dimension, DynamicMap
 from holoviews.element import Curve, Image, Scatter, Labels
 from holoviews.streams import Stream
+from holoviews.plotting.util import process_cmap
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -150,12 +151,14 @@ class TestColorbarPlot(TestBokehPlot):
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low, -3)
         self.assertEqual(cmapper.high, 3)
-
+     
     def test_colormapper_color_levels(self):
-        img = Image(np.array([[0, 1], [2, 3]])).options(color_levels=5)
+        cmap = process_cmap('viridis', provider='bokeh')
+        img = Image(np.array([[0, 1], [2, 3]])).options(color_levels=5, cmap=cmap)
         plot = bokeh_renderer.get_plot(img)
         cmapper = plot.handles['color_mapper']
         self.assertEqual(len(cmapper.palette), 5)
+        self.assertEqual(cmapper.palette, ['#440154', '#440255', '#440357', '#450558', '#45065A'])
 
     def test_colormapper_transparent_nan(self):
         img = Image(np.array([[0, 1], [2, 3]])).options(clipping_colors={'NaN': 'transparent'})


### PR DESCRIPTION
Fixes bug that was introduced in the recent PR to support color intervals. Also improves the unit test to ensure it would have caught this regression.