### PR TITLE
Fixed bug datashading NdOverlay with datetime axis

### DIFF
--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -91,6 +91,26 @@ class DatashaderAggregateTests(ComparisonTestCase):
                          datatype=['xarray'], bounds=bounds, vdims='Count')
         self.assertEqual(img, expected)
 
+    def test_aggregate_ndoverlay_count_cat_datetimes_microsecond_timebase(self):
+        dates = pd.date_range(start="2016-01-01", end="2016-01-03", freq='1D')
+        xstart = np.datetime64('2015-12-31T23:59:59.723518000', 'us')
+        xend = np.datetime64('2016-01-03T00:00:00.276482000', 'us')
+        curve = Curve((dates, [1, 2, 3]))
+        curve2 = Curve((dates, [3, 2, 1]))
+        ndoverlay = NdOverlay({0: curve, 1: curve2}, 'Cat')
+        imgs = aggregate(ndoverlay, aggregator=ds.count_cat('Cat'), width=2, height=2,
+                         x_range=(xstart, xend), dynamic=False)
+        bounds = (np.datetime64('2015-12-31T23:59:59.723518'), 1.0,
+                  np.datetime64('2016-01-03T00:00:00.276482'), 3.0)
+        dates = [np.datetime64('2016-01-01T11:59:59.861759000',),
+                 np.datetime64('2016-01-02T12:00:00.138241000')]
+        expected = Image((dates, [1.5, 2.5], [[1, 0], [0, 2]]),
+                         datatype=['xarray'], bounds=bounds, vdims='Count')
+        expected2 = Image((dates, [1.5, 2.5], [[0, 1], [1, 1]]),
+                         datatype=['xarray'], bounds=bounds, vdims='Count')
+        self.assertEqual(imgs[0], expected)
+        self.assertEqual(imgs[1], expected2)
+
     def test_aggregate_ndoverlay(self):
         ds = Dataset([(0.2, 0.3, 0), (0.4, 0.7, 1), (0, 0.99, 2)], kdims=['x', 'y', 'z'])
         ndoverlay = ds.to(Points, ['x', 'y'], [], 'z').overlay()


### PR DESCRIPTION
The datashading code was not converting coordinates back to datetimes when applied to an NdOverlay. This PR simply ensures the same conversion is applied as in all other cases.

- [x] Fixes https://github.com/ioam/holoviews/issues/2819
- [x] Adds unit test
