### PR TITLE
Fix for matplotlib BoxWhisker and Violin overlays

### DIFF
--- a/holoviews/plotting/mpl/stats.py
+++ b/holoviews/plotting/mpl/stats.py
@@ -86,7 +86,9 @@ class BoxPlot(ChartPlot):
         return (data,), style, {'dimensions': [format_kdims, element.vdims[0]]}
 
     def init_artists(self, ax, plot_args, plot_kwargs):
-        return ax.boxplot(*plot_args, **plot_kwargs)
+        artists = ax.boxplot(*plot_args, **plot_kwargs)
+        artists['artist'] = artists['boxes']
+        return artists
 
     def teardown_handles(self):
         for g in ('whiskers', 'fliers', 'medians', 'boxes', 'caps', 'means'):
@@ -173,6 +175,7 @@ class ViolinPlot(BoxPlot):
         for stat in ['cmedians', 'cmeans', 'cmaxes', 'cmins', 'cbars']:
             if stat in artists:
                 artists[stat].set_edgecolors(stats_color)
+        artists['bodies'] = artists['bodies']
         return artists
 
     def get_data(self, element, ranges, style):

--- a/tests/plotting/matplotlib/testboxwhisker.py
+++ b/tests/plotting/matplotlib/testboxwhisker.py
@@ -1,0 +1,26 @@
+from __future__ import absolute_import
+
+import numpy as np
+
+from holoviews.element import BoxWhisker
+
+from .testplot import TestMPLPlot, mpl_renderer
+
+
+class TestMPLBoxWhiskerPlot(TestMPLPlot):
+
+    def test_boxwhisker_simple(self):
+        values = np.random.rand(100)
+        boxwhisker = BoxWhisker(values)
+        plot = mpl_renderer.get_plot(boxwhisker)
+        data, style, axis_opts = plot.get_data(boxwhisker, {}, {})
+        self.assertEqual(data[0][0], values)
+        self.assertEqual(style['labels'], [''])
+
+    def test_boxwhisker_simple_overlay(self):
+        values = np.random.rand(100)
+        boxwhisker = BoxWhisker(values) * BoxWhisker(values)
+        plot = mpl_renderer.get_plot(boxwhisker)
+        p1, p2 = plot.subplots.values()
+        self.assertEqual(p1.handles['boxes'][0].get_path().vertices,
+                         p2.handles['boxes'][0].get_path().vertices)

--- a/tests/plotting/matplotlib/testviolinplot.py
+++ b/tests/plotting/matplotlib/testviolinplot.py
@@ -18,6 +18,16 @@ class TestMPLViolinPlot(TestMPLPlot):
         self.assertEqual(style['positions'], [0])
         self.assertEqual(style['labels'], [''])
 
+    def test_violin_simple_overlay(self):
+        values = np.random.rand(100)
+        violin = Violin(values) * Violin(values)
+        plot = mpl_renderer.get_plot(violin)
+        p1, p2 = plot.subplots.values()
+        self.assertEqual(p1.handles['boxes'][0].get_path().vertices,
+                         p2.handles['boxes'][0].get_path().vertices)
+        for b1, b2 in zip(p1.handles['bodies'][0].get_paths(), p2.handles['bodies'][0].get_paths()):
+            self.assertEqual(b1.vertices, b2.vertices)
+        
     def test_violin_multi(self):
         violin = Violin((np.random.randint(0, 2, 100), np.random.rand(100)), kdims=['A']).sort()
         r1, r2 = violin.range(1)


### PR DESCRIPTION
The legend code in the matplotlib looks at the artist in the ``handles`` dictionary and tries to hash it in order to generate a unique legend entry for each artist. In the case of BoxWhisker and Violin elements the artist is a dictionary which cannot be hashed. This PR adds each artist to the handles separately ensuring and aliases the 'boxes' and 'bodies' artists to the 'artist' handle, which allows the legend code to correctly process the legend for these elements.

- [x] Fixes https://github.com/ioam/holoviews/issues/2826
- [x] Adds unit tests