### PR TITLE
Add ability to mute legend entries by default

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -724,7 +724,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             self.handles['xaxis'] = plot.xaxis[0]
             self.handles['x_range'] = plot.x_range
-            self.handles['y_axis'] = plot.yaxis[0]
+            self.handles['yaxis'] = plot.yaxis[0]
             self.handles['y_range'] = plot.y_range
         self.handles['plot'] = plot
 
@@ -1181,6 +1181,9 @@ class LegendPlot(ElementPlot):
         options. The predefined options may be customized in the
         legend_specs class attribute.""")
 
+    legend_muted = param.Boolean(default=False, doc="""
+        Controls whether the legend entries are muted by default.""")
+
     legend_offset = param.NumericTuple(default=(0, 0), doc="""
         If legend is placed outside the axis, this determines the
         (width, height) offset in pixels from the original position.""")
@@ -1217,6 +1220,13 @@ class LegendPlot(ElementPlot):
             else:
                 legend.location = pos
 
+            # Apply muting
+            for leg in plot.legend:
+                for item in leg.items:
+                    for r in item.renderers:
+                        r.muted = self.legend_muted
+
+
 
 class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
@@ -1235,7 +1245,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'yticks', 'xrotation', 'yrotation', 'lod',
                           'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title_format', 'legend_position', 'legend_offset',
-                          'legend_cols', 'gridstyle']
+                          'legend_cols', 'gridstyle', 'legend_muted']
 
     def _process_legend(self):
         plot = self.handles['plot']
@@ -1311,6 +1321,12 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             legend.plot = None
             legend.location = self.legend_offset
             plot.add_layout(legend, pos)
+
+        # Apply muting
+        for leg in plot.legend:
+            for item in leg.items:
+                for r in item.renderers:
+                    r.muted = self.legend_muted
 
 
     def _init_tools(self, element, callbacks=[]):

--- a/tests/plotting/bokeh/testelementplot.py
+++ b/tests/plotting/bokeh/testelementplot.py
@@ -2,7 +2,7 @@ from nose.plugins.attrib import attr
 
 import numpy as np
 
-from holoviews.core import Dimension, DynamicMap
+from holoviews.core import Dimension, DynamicMap, NdOverlay
 from holoviews.element import Curve, Image, Scatter, Labels
 from holoviews.streams import Stream
 from holoviews.plotting.util import process_cmap
@@ -193,3 +193,16 @@ class TestOverlayPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(overlay)
         self.assertEqual(plot.state.xgrid[0].grid_line_color, 'blue')
         self.assertEqual(plot.state.xgrid[0].grid_line_width, 2)
+
+    def test_ndoverlay_legend_muted(self):
+        overlay = NdOverlay({i: Curve(np.random.randn(10).cumsum()) for i in range(5)}).options(legend_muted=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        for sp in plot.subplots.values():
+            self.assertTrue(sp.handles['glyph_renderer'].muted)
+
+    def test_overlay_legend_muted(self):
+        overlay = (Curve(np.random.randn(10).cumsum(), label='A') *
+                   Curve(np.random.randn(10).cumsum(), label='B')).options(legend_muted=True)
+        plot = bokeh_renderer.get_plot(overlay)
+        for sp in plot.subplots.values():
+            self.assertTrue(sp.handles['glyph_renderer'].muted)


### PR DESCRIPTION
Adds a ``legend_muted`` plot option which mutes the legend entries by default.

- [x] Implements https://github.com/ioam/holoviews/issues/2742