### PR TITLE
Improve handling of zero range datashader aggregations

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -660,7 +660,7 @@ class GridInterface(DictInterface):
             expanded = cls.irregular(dataset, dimension)
             column = cls.coords(dataset, dimension, expanded=expanded, edges=True)
         else:
-            column = cls.values(dataset, dimension, flat=False)
+            column = cls.values(dataset, dimension, expanded=False, flat=False)
         if column.dtype.kind == 'M':
             dmin, dmax = column.min(), column.max()
             if da and isinstance(column, da.Array):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -183,7 +183,10 @@ class XArrayInterface(GridInterface):
             dmin, dmax = np.nanmin(data), np.nanmax(data)
         else:
             data = dataset.data[dim]
-            dmin, dmax = data.min().data, data.max().data
+            if len(data):
+                dmin, dmax = data.min().data, data.max().data
+            else:
+                dmin, dmax = np.NaN, np.NaN
         if dask and isinstance(dmin, dask.array.Array):
             dmin, dmax = dask.array.compute(dmin, dmax)
         dmin = dmin if np.isscalar(dmin) else dmin.item()

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -685,7 +685,7 @@ class trimesh_rasterize(aggregate):
         else:
             x, y = element.kdims
         info = self._get_sampling(element, x, y)
-        (x_range, y_range), _, (width, height), (xtype, ytype) = info
+        (x_range, y_range), (xs, ys), (width, height), (xtype, ytype) = info
 
         agg = self.p.aggregator
         if not (element.vdims or element.nodes.vdims):
@@ -707,7 +707,8 @@ class trimesh_rasterize(aggregate):
         if width == 0 or height == 0:
             if width == 0: params['xdensity'] = 1
             if height == 0: params['ydensity'] = 1
-            return Image([], **params)
+            bounds = (x_range[0], y_range[0], x_range[1], y_range[1])
+            return Image((xs, ys, np.zeros((height, width))), bounds=bounds, **params)
 
         simplices = precomputed['simplices']
         pts = precomputed['vertices']

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -459,7 +459,7 @@ class aggregate(AggregationOperation):
         params['vdims'] = vdims
 
         if x is None or y is None or width == 0 or height == 0:
-            xarray = xr.DataArray(np.full((height, width), np.NaN, dtype=np.float32),
+            xarray = xr.DataArray(np.full((height, width), np.NaN),
                                   dims=['y', 'x'], coords={'x': xs, 'y': ys})
             if width == 0:
                 params['xdensity'] = 1
@@ -472,7 +472,7 @@ class aggregate(AggregationOperation):
                 return NdOverlay({v: el for v in vals}, dim)
             return el
         elif not len(data):
-            xarray = xr.DataArray(np.full((height, width), np.NaN, dtype=np.float32),
+            xarray = xr.DataArray(np.full((height, width), np.NaN),
                                   dims=[y.name, x.name], coords={x.name: xs, y.name: ys})
             return self.p.element_type(xarray, **params)
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -62,6 +62,9 @@ class RasterPlot(ColorbarPlot):
             b, t = t, b
         dh, dw = t-b, r-l
 
+        if 0 in img.shape:
+            img = np.array([[np.NaN]])
+
         data = dict(image=[img], x=[l], y=[b], dw=[dw], dh=[dh])
         return (data, mapping, style)
 

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -122,6 +122,16 @@ class XArrayInterfaceTests(GridInterfaceTests):
         ds = Dataset(([1, 2], [0, 1, 2], [1, 2, 3], arr), ['Default', 'x', 'y'], 'z')
         self.assertEqual(concat(hmap), ds)
 
+    def test_zero_sized_coordinates_range(self):
+        da = xr.DataArray(np.empty((2, 0)), dims=('y', 'x'), coords={'x': [], 'y': [0 ,1]}, name='A')
+        ds = Dataset(da)
+        x0, x1 = ds.range('x')
+        self.assertTrue(np.isnan(x0))
+        self.assertTrue(np.isnan(x1))
+        z0, z1 = ds.range('A')
+        self.assertTrue(np.isnan(z0))
+        self.assertTrue(np.isnan(z1))
+
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"
         raise SkipTest("Not supported")

--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -34,7 +34,7 @@ class DatashaderAggregateTests(ComparisonTestCase):
     def test_aggregate_zero_range_points(self):
         p = Points([(0, 0), (1, 1)])
         agg = rasterize(p, x_range=(0, 0), y_range=(0, 1), expand=False, dynamic=False)
-        img = Image(([], [0.25, 0.75], np.zeros((2, 0))), bounds=(0, 0, 0, 1), xdensity=1)
+        img = Image(([], [0.25, 0.75], np.zeros((2, 0))), bounds=(0, 0, 0, 1), xdensity=1, vdims=['Count'])
         self.assertEqual(agg, img)
 
     def test_aggregate_points_target(self):
@@ -60,6 +60,18 @@ class DatashaderAggregateTests(ComparisonTestCase):
         expected = NdOverlay({'A': Image((xs, ys, [[1, 0], [0, 0]]), vdims='z Count'),
                               'B': Image((xs, ys, [[0, 0], [1, 0]]), vdims='z Count'),
                               'C': Image((xs, ys, [[0, 0], [1, 0]]), vdims='z Count')},
+                             kdims=['z'])
+        self.assertEqual(img, expected)
+
+    def test_aggregate_points_categorical_zero_range(self):
+        points = Points([(0.2, 0.3, 'A'), (0.4, 0.7, 'B'), (0, 0.99, 'C')], vdims='z')
+        img = aggregate(points, dynamic=False,  x_range=(0, 0), y_range=(0, 1),
+                        aggregator=ds.count_cat('z'))
+        xs, ys = [], [0.25, 0.75]
+        params = dict(bounds=(0, 0, 0, 1), xdensity=1)
+        expected = NdOverlay({'A': Image((xs, ys, np.zeros((2, 0))), vdims='z Count', **params),
+                              'B': Image((xs, ys, np.zeros((2, 0))), vdims='z Count', **params),
+                              'C': Image((xs, ys, np.zeros((2, 0))), vdims='z Count', **params)},
                              kdims=['z'])
         self.assertEqual(img, expected)
 

--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -291,6 +291,15 @@ class DatashaderRasterizeTests(ComparisonTestCase):
                       bounds=(0, 0, 1, 1), vdims='Count')
         self.assertEqual(img, image)
 
+    def test_rasterize_trimesh_no_vdims_zero_range(self):
+        simplices = [(0, 1, 2), (3, 2, 1)]
+        vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]
+        trimesh = TriMesh((simplices, vertices))
+        img = rasterize(trimesh, height=2, x_range=(0, 0), dynamic=False)
+        image = Image(([], [0.25, 0.75], np.zeros((2, 0))),
+                      bounds=(0, 0, 0, 1), xdensity=1, vdims='Count')
+        self.assertEqual(img, image)
+
     def test_rasterize_trimesh(self):
         simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
         vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]
@@ -298,6 +307,15 @@ class DatashaderRasterizeTests(ComparisonTestCase):
         img = rasterize(trimesh, width=3, height=3, dynamic=False)
         image = Image(np.array([[1.5, 1.5, np.NaN], [0.5, 1.5, np.NaN], [np.NaN, np.NaN, np.NaN]]),
                       bounds=(0, 0, 1, 1))
+        self.assertEqual(img, image)
+
+    def test_rasterize_trimesh_zero_range(self):
+        simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
+        vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]
+        trimesh = TriMesh((simplices, vertices), vdims=['z'])
+        img = rasterize(trimesh, x_range=(0, 0), height=2, dynamic=False)
+        image = Image(([], [0.25, 0.75], np.zeros((2, 0))),
+                      bounds=(0, 0, 0, 1), xdensity=1)
         self.assertEqual(img, image)
 
     def test_rasterize_trimesh_vertex_vdims(self):

--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -31,6 +31,12 @@ class DatashaderAggregateTests(ComparisonTestCase):
                          vdims=['Count'])
         self.assertEqual(img, expected)
 
+    def test_aggregate_zero_range_points(self):
+        p = Points([(0, 0), (1, 1)])
+        agg = rasterize(p, x_range=(0, 0), y_range=(0, 1), expand=False, dynamic=False)
+        img = Image(([], [0.25, 0.75], np.zeros((2, 0))), bounds=(0, 0, 0, 1), xdensity=1)
+        self.assertEqual(agg, img)
+
     def test_aggregate_points_target(self):
         points = Points([(0.2, 0.3), (0.4, 0.7), (0, 0.99)])
         expected = Image(([0.25, 0.75], [0.25, 0.75], [[1, 0], [2, 0]]),


### PR DESCRIPTION
Ensures datashader aggregation on zero-range data is handled correctly. Previously there were some workarounds that did one of two things:

1. If the range was zero-width then it was padded by an arbitrary factor of 0.5
2. If the width or height were 0 then it would simply increase it to 1

Both were only workarounds and led to unexpected behavior so the operations now return Images with zero sized arrays. This is also related to https://github.com/bokeh/datashader/pull/612 but doesn't require it since the operations are doing all the guarding against the bad cases that datashader doesn't handle correctly.

- [x] Fixes https://github.com/ioam/holoviews/issues/2817
- [x] Adds unit tests