### PR TITLE
Fixed bug rendering gif using mpl

### DIFF
--- a/holoviews/plotting/mpl/renderer.py
+++ b/holoviews/plotting/mpl/renderer.py
@@ -244,7 +244,7 @@ class MPLRenderer(Renderer):
         if not hasattr(anim, '_encoded_video'):
             with NamedTemporaryFile(suffix='.%s' % fmt) as f:
                 anim.save(f.name, writer=writer, **anim_kwargs)
-                video = open(f.name, "rb").read()
+                video = f.read()
         return video
 
 


### PR DESCRIPTION
Fixes an annoying bug that's been causing tests to fail about 80% of the time recently. Not sure why or how it worked sometimes but the previous approach was definitely wrong.