### PR TITLE
Added matplotlib SideAreaPlot

### DIFF
--- a/holoviews/plotting/mpl/__init__.py
+++ b/holoviews/plotting/mpl/__init__.py
@@ -191,6 +191,7 @@ Store.register({Curve: CurvePlot,
 
 
 MPLPlot.sideplots.update({Histogram: SideHistogramPlot,
+                          Area: SideAreaPlot,
                           GridSpace: GridPlot,
                           Spikes: SideSpikesPlot,
                           BoxWhisker: SideBoxPlot})

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -201,6 +201,29 @@ class AreaPlot(ChartPlot):
 
 
 
+class SideAreaPlot(AdjoinedPlot, AreaPlot):
+
+    bgcolor = param.Parameter(default=(1, 1, 1, 0), doc="""
+        Make plot background invisible.""")
+
+    border_size = param.Number(default=0, doc="""
+        The size of the border expressed as a fraction of the main plot.""")
+
+    xaxis = param.ObjectSelector(default='bare',
+                                 objects=['top', 'bottom', 'bare', 'top-bare',
+                                          'bottom-bare', None], doc="""
+        Whether and where to display the xaxis, bare options allow suppressing
+        all axis labels including ticks and xlabel. Valid options are 'top',
+        'bottom', 'bare', 'top-bare' and 'bottom-bare'.""")
+
+    yaxis = param.ObjectSelector(default='bare',
+                                 objects=['left', 'right', 'bare', 'left-bare',
+                                          'right-bare', None], doc="""
+        Whether and where to display the yaxis, bare options allow suppressing
+        all axis labels including ticks and ylabel. Valid options are 'left',
+        'right', 'bare' 'left-bare' and 'right-bare'.""")
+
+
 
 class SpreadPlot(AreaPlot):
     """


### PR DESCRIPTION
Improves adjoined Distribution plots by reducing their axis offset, e.g.:

![image](https://user-images.githubusercontent.com/1550771/42106917-8e0e3226-7bcd-11e8-8ab2-d91aeb45084b.png)
