### PR TITLE
Do not sort by default when concatenating pandas data

### DIFF
--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -175,7 +175,8 @@ class PandasInterface(Interface):
             for d, k in zip(dimensions, key):
                 data[d.name] = k
             dataframes.append(data)
-        return pd.concat(dataframes)
+        kwargs = dict(sort=False) if util.pandas_version >= '0.23.0' else {}
+        return pd.concat(dataframes, **kwargs)
 
 
     @classmethod


### PR DESCRIPTION
Avoids very large futurewarning when concatenating pandas datasets.