### PR TITLE
DictInterface only validates referenced columns

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -98,7 +98,7 @@ class DictInterface(Interface):
                             unpacked.append((sd, vals[:, i]))
                 else:
                     vals = vals if np.isscalar(vals) else np.asarray(vals)
-                    if not np.isscalar(vals) and not vals.ndim == 1:
+                    if not np.isscalar(vals) and not vals.ndim == 1 and d in dimensions:
                         raise ValueError('DictInterface expects data for each column to be flat.')
                     unpacked.append((d, vals))
             if not cls.expanded([d[1] for d in unpacked if not np.isscalar(d[1])]):


### PR DESCRIPTION
Disables validation for columns which are not referenced as a dimension in the DictInterface. It can be useful to store other data in the dictionary and validation should not prevent non-standard data from being stored when HoloViews will just ignore that data anyway.