### PR TITLE
Ignore non-referenced data in dictionary format

### DIFF
--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -101,7 +101,7 @@ class DictInterface(Interface):
                     if not np.isscalar(vals) and not vals.ndim == 1 and d in dimensions:
                         raise ValueError('DictInterface expects data for each column to be flat.')
                     unpacked.append((d, vals))
-            if not cls.expanded([d[1] for d in unpacked if not np.isscalar(d[1])]):
+            if not cls.expanded([vs for d, vs in unpacked if d in dimensions and not np.isscalar(vs)]):
                 raise ValueError('DictInterface expects data to be of uniform shape.')
             if isinstance(data, odict_types):
                 data.update(unpacked)
@@ -158,7 +158,8 @@ class DictInterface(Interface):
 
     @classmethod
     def length(cls, dataset):
-        lengths = [len(vals) for vals in dataset.data.values() if not np.isscalar(vals)]
+        lengths = [len(vals) for d, vals in dataset.data.items()
+                   if d in dataset.dimensions() and not np.isscalar(vals)]
         return max(lengths) if lengths else 1
 
     @classmethod

--- a/tests/core/data/testdictinterface.py
+++ b/tests/core/data/testdictinterface.py
@@ -29,3 +29,10 @@ class DictDatasetTest(HeterogeneousColumnTests, ScalarColumnTests, InterfaceTest
         ds = Dataset({('x', 'y'): []}, kdims=['x', 'y'])
         ds2 = Dataset({'x': [], 'y': []}, kdims=['x', 'y'])
         self.assertEqual(ds, ds2)
+
+    def test_dataset_ignore_non_dimensions(self):
+        ds = Dataset({'x': [0, 1], 'y': [1, 2], 'ignore_scalar': 1,
+                      'ignore_array': np.array([2, 3]), 'ignore_None': None},
+                     kdims=['x', 'y'])
+        ds2 = Dataset({'x': [0, 1], 'y': [1, 2]}, kdims=['x', 'y'])
+        self.assertEqual(ds, ds2)


### PR DESCRIPTION
Turns out I hadn't correctly caught everything in https://github.com/ioam/holoviews/pull/2855. This PR further ensures nothing attempts to use dictionary keys that have not been referenced as a dimension.