### PR TITLE
Handle non-finite range in datashader operations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
-  - conda install -c conda-forge filelock iris plotly flexx ffmpeg netcdf4=1.3.1 --quiet
+  - conda install -c conda-forge filelock iris plotly=2.7 flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -155,12 +155,17 @@ class ImageInterface(GridInterface):
         if dim_idx in [0, 1]:
             l, b, r, t = dataset.bounds.lbrt()
             dim2, dim1 = dataset.data.shape[:2]
-            if isinstance(l, util.datetime_types):
+            xdate, ydate = isinstance(l, util.datetime_types), isinstance(b, util.datetime_types)
+            if l == r:
+                xlin = np.full((dim1,), l, dtype=('datetime64[us]' if xdate else 'float'))
+            elif xdate:
                 xlin = util.date_range(l, r, dim1, dataset._time_unit)
             else:
                 xstep = float(r - l)/dim1
                 xlin = np.linspace(l+(xstep/2.), r-(xstep/2.), dim1)
-            if isinstance(b, util.datetime_types):
+            if b == t:
+                ylin = np.full((dim2,), b, dtype=('datetime64[us]' if ydate else 'float'))
+            elif ydate:
                 ylin = util.date_range(b, t, dim2, dataset._time_unit)
             else:
                 ystep = float(t - b)/dim2

--- a/holoviews/operation/datashader.py
+++ b/holoviews/operation/datashader.py
@@ -144,11 +144,9 @@ class ResamplingOperation(LinkableOperation):
             xstart, xend = dt_to_int(xstart, 'ns'), dt_to_int(xend, 'ns')
             xtype = 'datetime'
         elif not np.isfinite(xstart) and not np.isfinite(xend):
+            xstart, xend = 0, 0
             if element.get_dimension_type(x) in datetime_types:
-                xstart, xend = 0, 10000
                 xtype = 'datetime'
-            else:
-                xstart, xend = 0, 1
         x_range = (xstart, xend)
 
         ytype = 'numeric'
@@ -156,11 +154,9 @@ class ResamplingOperation(LinkableOperation):
             ystart, yend = dt_to_int(ystart, 'ns'), dt_to_int(yend, 'ns')
             ytype = 'datetime'
         elif not np.isfinite(ystart) and not np.isfinite(yend):
+            ystart, yend = 0, 0
             if element.get_dimension_type(y) in datetime_types:
-                ystart, yend = 0, 10000
                 ytype = 'datetime'
-            else:
-                ystart, yend = 0, 1
         y_range = (ystart, yend)
 
         # Compute highest allowed sampling density


### PR DESCRIPTION
Non-finite ranges in the datashader operation were being given special treatment by defining a fake range. This is incompatible with the bounds and density validation so just like the zero-range case it will now actually use an empty range.

Additionally this PR adds support for zero-ranges to the ImageInterface.