### PR TITLE
Handle zero ranges correctly in regrid operation

### DIFF
--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -156,14 +156,14 @@ class ImageInterface(GridInterface):
             l, b, r, t = dataset.bounds.lbrt()
             dim2, dim1 = dataset.data.shape[:2]
             xdate, ydate = isinstance(l, util.datetime_types), isinstance(b, util.datetime_types)
-            if l == r:
+            if l == r or dim1 == 0:
                 xlin = np.full((dim1,), l, dtype=('datetime64[us]' if xdate else 'float'))
             elif xdate:
                 xlin = util.date_range(l, r, dim1, dataset._time_unit)
             else:
                 xstep = float(r - l)/dim1
                 xlin = np.linspace(l+(xstep/2.), r-(xstep/2.), dim1)
-            if b == t:
+            if b == t or dim2 == 0:
                 ylin = np.full((dim2,), b, dtype=('datetime64[us]' if ydate else 'float'))
             elif ydate:
                 ylin = util.date_range(b, t, dim2, dataset._time_unit)

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1690,6 +1690,8 @@ def bound_range(vals, density, time_unit='us'):
     assumed to be evenly spaced. Density is rounded to machine precision
     using significant digits reported by sys.float_info.dig.
     """
+    if not len(vals):
+        return(np.nan, np.nan, density, False)
     low, high = vals.min(), vals.max()
     invert = False
     if len(vals) > 1 and vals[0] > vals[1]:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -248,7 +248,10 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         if (data is None
             or (isinstance(data, (list, tuple)) and not data)
             or (isinstance(data, np.ndarray) and data.size == 0)):
-            data = np.zeros((2, 2))
+            data = np.zeros((0, 0))
+            if not xdensity: xdensity = 1
+            if not ydensity: ydensity = 1
+
         if rtol is not None:
             params['rtol'] = rtol
         else:

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -248,7 +248,8 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         if (data is None
             or (isinstance(data, (list, tuple)) and not data)
             or (isinstance(data, np.ndarray) and data.size == 0)):
-            data = np.zeros((0, 0))
+            data = data if isinstance(data, np.ndarray) and data.ndim == 2 else np.zeros((0, 0))
+            bounds = 0
             if not xdensity: xdensity = 1
             if not ydensity: ydensity = 1
 

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -107,6 +107,9 @@ class RGBPlot(RasterPlot):
             b, t = t, b
         dh, dw = t-b, r-l
 
+        if 0 in img.shape:
+            img = np.zeros((1, 1), dtype=np.uint32)
+
         data = dict(image=[img], x=[l], y=[b], dw=[dw], dh=[dh])
         return (data, mapping, style)
 

--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -283,6 +283,15 @@ class DatashaderRegridTests(ComparisonTestCase):
                            dynamic=False)
         self.assertEqual(regridded, img)
 
+    def test_regrid_zero_range(self):
+        ls = np.linspace(0, 10, 200)
+        xx, yy = np.meshgrid(ls, ls)
+        img = Image(np.sin(xx)*np.cos(yy), bounds=(0, 0, 1, 1))
+        regridded = regrid(img, x_range=(-1, -0.5), y_range=(-1, -0.5), dynamic=False)
+        expected = Image(np.zeros((0, 0)), bounds=(0, 0, 0, 0), xdensity=1, ydensity=1)
+        self.assertEqual(regridded, expected)
+
+
 
 @attr(optional=1)
 class DatashaderRasterizeTests(ComparisonTestCase):


### PR DESCRIPTION
While I fixed the zero range handling in the aggregate operation I seemingly did not do it properly in the regrid operation. Additionally this PR allows Images to contain arrays with a (0, 0) shape, which previously required a hack which would instead store a (1, 1) image.

- [x] Fixes https://github.com/ioam/holoviews/issues/2817
- [x] Adds unit test