### PR TITLE
Fix shape and length reporting of gridded interfaces for Python 3.6 on Win 64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 "param<1.7" matplotlib=2.1.2 xarray networkx
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
   - conda install -c conda-forge filelock iris plotly=2.7 flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 "param<1.7" matplotlib=2.1.2 xarray networkx
   - source activate test-environment
   - conda install -c conda-forge filelock iris plotly=2.7 flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -180,7 +180,7 @@ class GridInterface(DictInterface):
         if gridded:
             return shape
         else:
-            return (np.product(shape), len(dataset.dimensions()))
+            return (np.product(shape,dtype=np.intp), len(dataset.dimensions()))
 
 
     @classmethod

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -180,7 +180,7 @@ class GridInterface(DictInterface):
         if gridded:
             return shape
         else:
-            return (np.product(shape,dtype=np.intp), len(dataset.dimensions()))
+            return (np.product(shape, dtype=np.intp), len(dataset.dimensions()))
 
 
     @classmethod

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -79,7 +79,7 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product(dataset.data.shape[:2],dtype=np.intp)
+        return np.product(dataset.data.shape[:2], dtype=np.intp)
 
 
     @classmethod

--- a/holoviews/core/data/image.py
+++ b/holoviews/core/data/image.py
@@ -79,7 +79,7 @@ class ImageInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product(dataset.data.shape[:2])
+        return np.product(dataset.data.shape[:2],dtype=np.intp)
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -280,7 +280,7 @@ class CubeInterface(GridInterface):
         """
         Returns the total number of samples in the dataset.
         """
-        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)],dtype=np.intp)
+        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)], dtype=np.intp)
 
 
     @classmethod

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -280,7 +280,7 @@ class CubeInterface(GridInterface):
         """
         Returns the total number of samples in the dataset.
         """
-        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)])
+        return np.product([len(d.points) for d in dataset.data.coords(dim_coords=True)],dtype=np.intp)
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -443,7 +443,7 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product([len(dataset.data[d.name]) for d in dataset.kdims])
+        return np.product([len(dataset.data[d.name]) for d in dataset.kdims],dtype=np.intp)
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -50,7 +50,7 @@ class XArrayInterface(GridInterface):
         if gridded:
             return shape
         else:
-            return (np.product(shape,dtype=np.intp), len(dataset.dimensions()))
+            return (np.product(shape, dtype=np.intp), len(dataset.dimensions()))
 
 
     @classmethod
@@ -443,7 +443,7 @@ class XArrayInterface(GridInterface):
 
     @classmethod
     def length(cls, dataset):
-        return np.product([len(dataset.data[d.name]) for d in dataset.kdims],dtype=np.intp)
+        return np.product([len(dataset.data[d.name]) for d in dataset.kdims], dtype=np.intp)
 
     @classmethod
     def dframe(cls, dataset, dimensions):

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -50,7 +50,7 @@ class XArrayInterface(GridInterface):
         if gridded:
             return shape
         else:
-            return (np.product(shape), len(dataset.dimensions()))
+            return (np.product(shape,dtype=np.intp), len(dataset.dimensions()))
 
 
     @classmethod


### PR DESCRIPTION
Part of #2895 (this PR just covers grid-based interfaces).

I used the below test files to check these changes. After switching to pyctdev and getting windows tests, these tests could be included in hv's test suite (but presumably re-written into class-based unit tests, which would reduce some boilerplate overlap). (Note for the future: the tests are intentionally set up to work on a machine with less than 4GB ram, for travis/appveyor.)

test_grid.py:
```python
import numpy as np, holoviews as hv
shape = (100, 1+np.iinfo(np.int32).max//100)
img = hv.Image( (range(shape[1]), range(shape[0]), np.empty(shape,dtype=np.uint8)), datatype=['grid'])
img = img.clone(datatype=['grid'])

print(shape, img.shape, type(img.shape[0]))
s = shape[0]*shape[1]

grid_shape = img.interface.shape(img)
# fails because Grid.shape() is wrong
assert grid_shape[0] == s, "%s != %s"%(grid_shape[0],s)
```

test_image.py:
```python
import numpy as np, holoviews as hv
shape = (100, 1+np.iinfo(np.int32).max//100)
img = hv.Image(np.ndarray(shape,dtype=np.uint8))


print(shape, img.data.shape, type(img.data.shape[0]), img.shape, type(img.shape[0]))
s = shape[0]*shape[1]

length = img.interface.length(img)
# fails because Image.length() is wrong
assert length==s, "%s != %s"%(length,s)
assert img.shape[0]==s, "%s != %s"%(img.shape[0],s)
```

test_iris.py:
```python
import numpy as np, holoviews as hv
shape = (100, 1+np.iinfo(np.int32).max//100)
img = hv.Image( (range(shape[1]), range(shape[0]), np.empty(shape,dtype=np.uint8)), datatype=['grid'])
img = img.clone(datatype=['cube'])

print(shape, img.data.shape, type(img.data.shape[0]), img.shape, type(img.shape[0]))
s = shape[0]*shape[1]

# fails because CubeInterface.length() is wrong
assert img.shape[0]==s, "%s != %s"%(img.shape[0],s)
```

test_xarray.py:
```python
import numpy as np, holoviews as hv
shape = (100, 1+np.iinfo(np.int32).max//100)
img = hv.Image( (range(shape[1]), range(shape[0]), np.empty(shape,dtype=np.uint8)), datatype=['grid'])
img = img.clone(datatype=['xarray'])

print(shape, img.shape, type(img.shape[0]))
s = shape[0]*shape[1]

# fails because XArrayInterface.shape() is wrong
assert img.shape[0]==s, "%s != %s"%(img.shape[0],s)
# fails because XArrayInterface.length() is wrong
assert img.interface.length(img)==img.shape[0] # TODO verify that definition of length is right
```

