### PR TITLE
WIP: Demo unpickling of pre-namespace parameterized objects.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
+  - conda remove --force param && pip install --upgrade https://github.com/ioam/param/archive/unpickling_no_namespace.zip
   - conda install -c conda-forge filelock iris plotly=2.7 flexx ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -754,7 +754,6 @@ class LabelledData(param.Parameterized):
         When unpickled, restore the saved style and plotting options
         to ViewableElement.options.
         """
-        self.param.self = self # TODO: super's setstate not called?
         d = param_aliases(d)
         try:
             load_options = Store.load_counter_offset is not None
@@ -781,7 +780,7 @@ class LabelledData(param.Parameterized):
         except:
             self.warning("Could not unpickle custom style information.")
         self.__dict__.update(d)
-
+        self.param.self = self # TODO: super's setstate not called?
 
 
 class Dimensioned(LabelledData):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -754,6 +754,7 @@ class LabelledData(param.Parameterized):
         When unpickled, restore the saved style and plotting options
         to ViewableElement.options.
         """
+        self.param.self = self # TODO: super's setstate not called?
         d = param_aliases(d)
         try:
             load_options = Store.load_counter_offset is not None

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -780,7 +780,9 @@ class LabelledData(param.Parameterized):
         except:
             self.warning("Could not unpickle custom style information.")
         self.__dict__.update(d)
-        self.param.self = self # TODO: super's setstate not called?
+        # TODO: super's setstate not called?
+        if "param" not in self.__dict__:
+            self.param = type(self.param)(self.__class__, self=self)
 
 
 class Dimensioned(LabelledData):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -782,7 +782,7 @@ class LabelledData(param.Parameterized):
         self.__dict__.update(d)
         # TODO: super's setstate not called?
         if "param" not in self.__dict__:
-            self.param = type(self.param)(self.__class__, self=self)
+            self.__dict__["param"] = type(self.param)(self.__class__, self=self)
 
 
 class Dimensioned(LabelledData):


### PR DESCRIPTION
WIP to see what changes are required to get hv data tests to pass. (The alternative would be updating the hv reference data.)

Explanation (copied from #2903)...

On unpickling, the recently added param namespace object is not being set up correctly from the state in the pickle (of the old param). Specifically, the param object's self isn't set (so is None). That of course leads to various problems (e.g. get_param_values(), used in hv's comparisons, reports the class's values rather than the instance's values).

To test that idea out, I thought it'd be a one line fix in Parameterized.setstate to set self on the param object, but one or more hv things (e.g. LabelledData) appear to have their own independent state handling for pickle, and don't use Parameterized's, so I need to discuss if that's deliberate or an oversight.

I also need to see what param's current policy is regarding backwards compatibility of pickles (and consider if that's how it should be). I used to make pickle loading backwards compatible with old pickles when param was part of topographica, but not sure if I ever moved any of that stuff to param itself, or what's happened since then...