### PR TITLE
Address loop bug in CDSStream on bokeh server

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -811,6 +811,7 @@ class CDSCallback(Callback):
             stream.update(data=self.plot_handles['source'].data)
 
     def _process_msg(self, msg):
+        msg['data'] = dict(msg['data'])
         for col, values in msg['data'].items():
             if isinstance(values, dict):
                 items = sorted([(int(k), v) for k, v in values.items()])


### PR DESCRIPTION
Fixes an issue when using a CDSStream, or any of the drawing tool streams which are subclasses, on bokeh  server. Previously the data dictionary was modified in place which meant it would continuously trigger new events causing an endless loop, by making a copy of the dict we avoid triggering events.

Since we still don't have a way of testing bokeh server apps this can be merged without tests for now.