### PR TITLE
Add exception to the error message printed from DynamicMap

### DIFF
--- a/examples/user_guide/03-Customizing_Plots.ipynb
+++ b/examples/user_guide/03-Customizing_Plots.ipynb
@@ -287,7 +287,7 @@
     "    plot:  {interpolation: 'steps-mid'}\n",
     "```\n",
     "\n",
-    "The reason HoloViews does not encourage the use of yaml is that yaml to literals and cannot express richer objects that can be used in options such as ``Cycle`` or ``Palette``."
+    "The reason HoloViews does not encourage the use of yaml is that yaml is limited to literals and cannot express richer objects that can be used in options such as ``Cycle`` or ``Palette``."
    ]
   },
   {
@@ -339,7 +339,7 @@
     "\n",
     "#### ``%%opts``\n",
     "\n",
-    "As shown in the examples above, customizes a particular HoloViws output displayed in a code cell. This application is not global and persists for that object which means settings stay in place if the object is re-displayed. Only accepts the string specification format. All cell magics need to appear *above* any code in the cells they are used in and cannot be used if there is no code in the cell. Only accepts the string specification syntax.\n",
+    "As shown in the examples above, customizes a particular HoloViews output displayed in a code cell. This application is not global and persists for that object which means settings stay in place if the object is re-displayed. Only accepts the string specification format. All cell magics need to appear *above* any code in the cells they are used in and cannot be used if there is no code in the cell. Only accepts the string specification syntax. Only applied to the output of the cell when it is displayed by IPython, and thus will not apply to objects exported or displayed using a separate mechanism before the cell completes, and does not affect objects created but not displayed in the output of the cell.\n",
     "\n",
     "#### ``%opts``\n",
     "\n",

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -576,15 +576,15 @@ class Callable(param.Parameterized):
             # KeyError is caught separately because it is used to signal
             # invalid keys on DynamicMap and should not warn
             raise
-        except:
+        except Exception as e:
             posstr = ', '.join(['%r' % el for el in self.args]) if self.args else ''
             kwstr = ', '.join('%s=%r' % (k,v) for k,v in self.kwargs.items())
             argstr = ', '.join([el for el in [posstr, kwstr] if el])
-            message = ("Exception raised in callable '{name}' of type '{ctype}'.\n"
+            message = ("Exception \"{e}\" raised in callable '{name}' of type '{ctype}'.\n"
                        "Invoked as {name}({argstr})")
             self.warning(message.format(name=self.name,
                                         ctype = type(self.callable).__name__,
-                                        argstr=argstr))
+                                        argstr=argstr, e=repr(e)))
             raise
 
         if hashed_key is not None:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -582,9 +582,7 @@ class Callable(param.Parameterized):
             argstr = ', '.join([el for el in [posstr, kwstr] if el])
             message = ("Callable raised \"{e}\".\n"
                        "Invoked as {name}({argstr})")
-            self.warning(message.format(name=self.name,
-                                        ctype = type(self.callable).__name__,
-                                        argstr=argstr, e=repr(e)))
+            self.warning(message.format(name=self.name, argstr=argstr, e=repr(e)))
             raise
 
         if hashed_key is not None:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -580,7 +580,7 @@ class Callable(param.Parameterized):
             posstr = ', '.join(['%r' % el for el in self.args]) if self.args else ''
             kwstr = ', '.join('%s=%r' % (k,v) for k,v in self.kwargs.items())
             argstr = ', '.join([el for el in [posstr, kwstr] if el])
-            message = ("Exception \"{e}\" raised in callable '{name}' of type '{ctype}'.\n"
+            message = ("Callable raised \"{e}\".\n"
                        "Invoked as {name}({argstr})")
             self.warning(message.format(name=self.name,
                                         ctype = type(self.callable).__name__,


### PR DESCRIPTION
RIght now, if an error is raised in a DynamicMap, we get a warning, but it doesn't indicate anything about what the problem was:

```
import holoviews as hv, datashader as ds, pandas as pd, dask.dataframe as dd
from holoviews.operation.datashader import datashade, rasterize, dynspread
hv.extension('bokeh')
df = dd.read_parquet('../data/nyc_taxi_wide.parq').persist()
points = hv.Points(df, ['dropoff_x', 'dropoff_y'], 'dropoff_hour')
rasterize(points, aggregator=ds.last('dropoff_hour'))
```

```
WARNING:root:dynamic_operation: Exception raised in callable 'dynamic_operation' of type 'function'.
Invoked as dynamic_operation(height=400, scale=1.0, width=400, x_range=None, y_range=None)
```

It's quite unclear what a user is meant to do in this case.  With this change, the type and text of the exception will be shown, letting the user know what to do:

```
WARNING:root:dynamic_operation: Exception "NotImplementedError('last is currently implemented only for rasters',)" raised in callable 'dynamic_operation' of type 'function'.
Invoked as dynamic_operation(height=400, scale=1.0, width=400, x_range=None, y_range=None)
```

I don't think we want to show a full backtrace in this case, because there may be many such errors raised dynamically at different points of a DynamicMap's lifetime, but at least knowing the error is vastly better than just guessing...