### PR TITLE
Ensure MultiInterface.add_dimension works on array interface

### DIFF
--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -263,9 +263,14 @@ class MultiInterface(Interface):
             raise ValueError('Added dimension values must be scalar or '
                              'match the length of the data.')
         new_data = []
-        ds = cls._inner_dataset_template(dataset)
+        template = cls._inner_dataset_template(dataset)
+        array_type = template.interface.datatype == 'array'
         for d, v in zip(dataset.data, values):
-            ds.data = d
+            template.data = d
+            if array_type:
+                ds = template.clone(template.columns())
+            else:
+                ds = template
             new_data.append(ds.interface.add_dimension(ds, dimension, dim_pos, v, vdim))
         return new_data
 

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -257,11 +257,14 @@ class MultiInterface(Interface):
 
     @classmethod
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
-        if values is None or np.isscalar(values):
+        if not len(dataset.data):
+            return dataset.data
+        elif values is None or np.isscalar(values):
             values = [values]*len(dataset.data)
         elif not len(values) == len(dataset.data):
             raise ValueError('Added dimension values must be scalar or '
                              'match the length of the data.')
+
         new_data = []
         template = cls._inner_dataset_template(dataset)
         array_type = template.interface.datatype == 'array'

--- a/tests/core/data/testmultiinterface.py
+++ b/tests/core/data/testmultiinterface.py
@@ -55,6 +55,13 @@ class MultiInterfaceTest(ComparisonTestCase):
         for i, ds in enumerate(mds.split()):
             self.assertEqual(ds, Path(arrays[i], kdims=['x', 'y'], datatype=['dask']))
 
+    def test_multi_array_dataset_add_dimension_scalar(self):
+        arrays = [np.column_stack([np.arange(i, i+2), np.arange(i, i+2)]) for i in range(2)]
+        mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular']).add_dimension('A', 0, 'Scalar', True)
+        for i, ds in enumerate(mds.split()):
+            self.assertEqual(ds, Path({('x', 'y'): arrays[i], 'A': 'Scalar'}, ['x', 'y'],
+                                      'A', datatype=['dictionary']))
+            
     def test_multi_dict_dataset_add_dimension_scalar(self):
         arrays = [{'x': np.arange(i, i+2), 'y': np.arange(i, i+2)} for i in range(2)]
         mds = Path(arrays, kdims=['x', 'y'], datatype=['multitabular']).add_dimension('A', 0, 'Scalar', True)


### PR DESCRIPTION
Since the ArrayInterface does not support arbitrary types the MultiInterface.add_dimension method now converts the data to dictionary types when adding dimensions.