### PR TITLE
Add functionality to stream from parameterized objects and methods

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -604,7 +604,7 @@ class Generator(Callable):
 
     @property
     def argspec(self):
-        return ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
+        return inspect.ArgSpec(args=[], varargs=None, keywords=None, defaults=None)
 
     def __call__(self):
         try:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -742,7 +742,8 @@ class DynamicMap(HoloMap):
         streams = (streams or [])
 
         # If callback is a parameterized method and watch is disabled add as stream
-        if util.is_param_method(callback) and params.get('watch', True):
+        param_watch_support = util.param_version >= '1.8.0'
+        if util.is_param_method(callback) and params.get('watch', param_watch_support):
             streams.append(callback)
 
         if isinstance(callback, types.GeneratorType):
@@ -760,12 +761,12 @@ class DynamicMap(HoloMap):
         parameterizeds = [s.parameterized for s in streams if isinstance(s, ParamStream)]
         for s in streams:
             if not isinstance(s, Stream):
-                if isinstance(s, param.Parameterized):
+                if isinstance(s, param.Parameterized) and param_watch_support:
                     if s not in parameterizeds:
                         s = ParamStream(s)
                     else:
                         continue
-                elif util.is_param_method(s):
+                elif util.is_param_method(s) and param_watch_support:
                     if not hasattr(s, "_dinfo") or util.get_method_owner(s) in parameterizeds:
                         continue
                     else:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -17,7 +17,7 @@ from .layout import Layout, AdjointLayout, NdLayout, Empty
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream, ParamStream
+from ..streams import Stream, Params, ParamMethod
 
 
 
@@ -758,19 +758,19 @@ class DynamicMap(HoloMap):
 
         # Validate streams by ensuring parameterized objects and methods are wrapped in ParamStream
         valid, invalid = [], []
-        parameterizeds = [s.parameterized for s in streams if isinstance(s, ParamStream)]
+        parameterizeds = [s.parameterized for s in streams if isinstance(s, Params)]
         for s in streams:
             if not isinstance(s, Stream):
                 if isinstance(s, param.Parameterized) and param_watch_support:
                     if s not in parameterizeds:
-                        s = ParamStream(s)
+                        s = Params(s)
                     else:
                         continue
                 elif util.is_param_method(s) and param_watch_support:
                     if not hasattr(s, "_dinfo") or util.get_method_owner(s) in parameterizeds:
                         continue
                     else:
-                        s = ParamStream(s)
+                        s = ParamMethod(s)
                 else:
                     invalid.append(s)
                     continue

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -17,7 +17,7 @@ from .layout import Layout, AdjointLayout, NdLayout, Empty
 from .ndmapping import UniformNdMapping, NdMapping, item_check
 from .overlay import Overlay, CompositeOverlay, NdOverlay, Overlayable
 from .options import Store, StoreOptions
-from ..streams import Stream, Params, ParamMethod
+from ..streams import Stream
 
 
 
@@ -756,27 +756,7 @@ class DynamicMap(HoloMap):
                          'and no longer needs to be specified.')
             del params['sampled']
 
-        # Validate streams by ensuring parameterized objects and methods are wrapped in ParamStream
-        valid, invalid = [], []
-        parameterizeds = [s.parameterized for s in streams if isinstance(s, Params)]
-        for s in streams:
-            if not isinstance(s, Stream):
-                if isinstance(s, param.Parameterized) and param_watch_support:
-                    if s not in parameterizeds:
-                        s = Params(s)
-                    else:
-                        continue
-                elif util.is_param_method(s) and param_watch_support:
-                    if not hasattr(s, "_dinfo") or util.get_method_owner(s) in parameterizeds:
-                        continue
-                    else:
-                        s = ParamMethod(s)
-                else:
-                    invalid.append(s)
-                    continue
-            valid.append(s)
-        
-
+        valid, invalid = Stream._process_streams(streams)
         if invalid:
             msg = ('The supplied streams list contains objects that '
                    'are not Stream instances: {objs}')

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1263,18 +1263,6 @@ def get_param_values(data):
     return params
 
 
-def get_method_owner(meth):
-    """
-    Returns the instance owning the supplied instancemethod or
-    the class owning the supplied classmethod.
-    """
-    if inspect.ismethod(meth):
-        if sys.version_info < (3,0):
-            return meth.im_class if meth.im_self is None else meth.im_self
-        else:
-            return meth.__self__
-
-
 def is_param_method(obj):
     """
     Whether the object is a method on a parameterized object.

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -1263,6 +1263,25 @@ def get_param_values(data):
     return params
 
 
+def get_method_owner(meth):
+    """
+    Returns the instance owning the supplied instancemethod or
+    the class owning the supplied classmethod.
+    """
+    if inspect.ismethod(meth):
+        if sys.version_info < (3,0):
+            return meth.im_class if meth.im_self is None else meth.im_self
+        else:
+            return meth.__self__
+
+
+def is_param_method(obj):
+    """
+    Whether the object is a method on a parameterized object.
+    """
+    return inspect.ismethod(obj) and isinstance(get_method_owner(obj), param.Parameterized)
+
+
 @contextmanager
 def disable_constant(parameterized):
     """

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -38,6 +38,7 @@ except AttributeError:
     get_keywords = operator.attrgetter('keywords')
 
 numpy_version = LooseVersion(np.__version__)
+param_version = LooseVersion(param.__version__)
 
 datetime_types = (np.datetime64, dt.datetime, dt.date)
 timedelta_types = (np.timedelta64, dt.timedelta,)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1048,7 +1048,7 @@ class ParameterizedStream(Stream):
             parameters=parameters, **params
         )
         for p in self.parameters:
-            self.parameterized.param.watch(p, fn=self._listener)
+            self.parameterized.param.watch(self._listener, p)
 
     def _listener(self, change):
         self.trigger([self])

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -1030,9 +1030,11 @@ class ParameterizedStream(Stream):
     object.
     """
 
-    parameterized = param.ClassSelector(class_=param.Parameterized)
+    parameterized = param.ClassSelector(class_=param.Parameterized, constant=True, doc="""
+        Parameterized instance to watch for parameter changes.""")
 
-    parameters = param.List([])
+    parameters = param.List([], constant=True, doc="""
+        Parameters on the parameterized to watch.""")
 
     def __init__(self, parameterized, parameters=None, **params):
         self.is_method = util.is_param_method(parameterized)

--- a/tests/teststreams.py
+++ b/tests/teststreams.py
@@ -305,6 +305,7 @@ class TestParameterRenaming(ComparisonTestCase):
         self.assertEquals(reenabled.contents, {'foo':0, 'y':0})
 
 
+        
 class TestPlotSizeTransform(ComparisonTestCase):
 
     def test_plotsize_initial_contents_1(self):


### PR DESCRIPTION
Requires https://github.com/ioam/param/pull/253 to work

- [x] Adds ability to directly stream from methods decorated with ``param.depends``
- [x] Adds ability from parameterized classes
- [x] DynamicMap allows declaring whether to dependencies on parameterized method
- [ ] Add unit test
- [ ] Update docs