### PR TITLE
Fix issue with value dimensions on PolyDraw stream

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -894,24 +894,25 @@ class PolyDrawCallback(CDSCallback):
                                  renderers=[plot.handles['glyph_renderer']],
                                  **kwargs)
         plot.state.tools.append(poly_tool)
+        self._update_cds_vdims()
+        super(PolyDrawCallback, self).initialize(plot_id)
 
+    def _update_cds_vdims(self):
         # Add any value dimensions not already in the CDS data
         # ensuring the element can be reconstituted in entirety
         element = self.plot.current_frame
-        source = plot.handles['cds']
+        cds = self.plot.handles['cds']
         for d in element.vdims:
             scalar = element.interface.isscalar(element, d)
             dim = dimension_sanitizer(d.name)
-            if dim not in source.data:
+            if dim not in cds.data:
                 if scalar:
-                    source.data[dim] = element.dimension_values(d, not scalar)
+                    cds.data[dim] = element.dimension_values(d, not scalar)
                 else:
-                    source.data[dim] = element.split(datatype='array')
-
-        super(PolyDrawCallback, self).initialize(plot_id)
+                    cds.data[dim] = element.split(datatype='array')
 
 
-class FreehandDrawCallback(CDSCallback):
+class FreehandDrawCallback(PolyDrawCallback):
 
     def initialize(self, plot_id=None):
         try:
@@ -927,7 +928,8 @@ class FreehandDrawCallback(CDSCallback):
             renderers=[plot.handles['glyph_renderer']],
         )
         plot.state.tools.append(poly_tool)
-        super(FreehandDrawCallback, self).initialize(plot_id)
+        self._update_cds_vdims()
+        CDSCallback.initialize(self, plot_id)
 
 
 class BoxEditCallback(CDSCallback):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -894,6 +894,20 @@ class PolyDrawCallback(CDSCallback):
                                  renderers=[plot.handles['glyph_renderer']],
                                  **kwargs)
         plot.state.tools.append(poly_tool)
+
+        # Add any value dimensions not already in the CDS data
+        # ensuring the element can be reconstituted in entirety
+        element = self.plot.current_frame
+        source = plot.handles['cds']
+        for d in element.vdims:
+            scalar = element.interface.isscalar(element, d)
+            dim = dimension_sanitizer(d.name)
+            if dim not in source.data:
+                if scalar:
+                    source.data[dim] = element.dimension_values(d, not scalar)
+                else:
+                    source.data[dim] = element.split(datatype='array')
+
         super(PolyDrawCallback, self).initialize(plot_id)
 
 

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -990,7 +990,7 @@ class BoxEditCallback(CDSCallback):
         return {'data': {'x0': x0s, 'x1': x1s, 'y0': y0s, 'y1': y1s}}
 
 
-class PolyEditCallback(CDSCallback):
+class PolyEditCallback(PolyDrawCallback):
 
     def initialize(self, plot_id=None):
         try:
@@ -1009,7 +1009,8 @@ class PolyEditCallback(CDSCallback):
             vertex_tool = PolyEditTool(vertex_renderer=r1)
             plot.state.tools.append(vertex_tool)
         vertex_tool.renderers.append(plot.handles['glyph_renderer'])
-        super(PolyEditCallback, self).initialize(plot_id)
+        self._update_cds_vdims()
+        CDSCallback.initialize(self, plot_id)
 
 
 

--- a/tests/plotting/bokeh/testcallbacks.py
+++ b/tests/plotting/bokeh/testcallbacks.py
@@ -196,6 +196,18 @@ class TestEditToolCallbacks(ComparisonTestCase):
                             {'x': [3, 4, 5], 'y': [3, 4, 5], 'A': 2}], vdims=['A'])
         self.assertEqual(poly_draw.element, element)
 
+    def test_poly_draw_callback_with_vdims_no_color_index(self):
+        polys = Polygons([{'x': [0, 2, 4], 'y': [0, 2, 0], 'A': 1}], vdims=['A']).options(color_index=None)
+        poly_draw = PolyDraw(source=polys)
+        plot = bokeh_server_renderer.get_plot(polys)
+        self.assertIsInstance(plot.callbacks[0], PolyDrawCallback)
+        callback = plot.callbacks[0]
+        data = {'x': [[1, 2, 3], [3, 4, 5]], 'y': [[1, 2, 3], [3, 4, 5]], 'A': [1, 2]}
+        callback.on_msg({'data': data})
+        element = Polygons([{'x': [1, 2, 3], 'y': [1, 2, 3], 'A': 1},
+                            {'x': [3, 4, 5], 'y': [3, 4, 5], 'A': 2}], vdims=['A'])
+        self.assertEqual(poly_draw.element, element)
+
     def test_box_edit_callback(self):
         boxes = Polygons([Box(0, 0, 1)])
         box_edit = BoxEdit(source=boxes)


### PR DESCRIPTION
This PR addresses issues when attaching a Polygons/Path element which contains value dimensions to a PolyDrawTool. The issue arises because value dimensions are only added to the CDS when they are actually needed but the drawing streams expects the data to be in the data it receives. This PR simply ensures that the stream itself adds any missing dimensions to the CDS.

- [x] Fixes bug in PolyDraw stream on element with value dimensions
- [x] Adds unit tests