### PR TITLE
Add support to adjust fontsize for zlabels/zticks

### DIFF
--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -185,7 +185,14 @@ class ElementPlot(GenericElementPlot, MPLPlot):
             self._set_axis_ticks(axis.zaxis, zticks, log=self.logz,
                                  rotation=self.zrotation)
 
-        for ax, ax_obj in zip('xy', [axis.xaxis, axis.yaxis]):
+        axes_str = 'xy'
+        axes_list = [axis.xaxis, axis.yaxis]
+
+        if hasattr(axis, 'zaxis'):
+            axes_str += 'z'
+            axes_list.append(axis.zaxis)
+
+        for ax, ax_obj in zip(axes_str, axes_list):
             tick_fontsize = self._fontsize('%sticks' % ax,'labelsize',common=False)
             if tick_fontsize: ax_obj.set_tick_params(**tick_fontsize)
 

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -182,16 +182,16 @@ class DimensionedPlot(Plot):
        unmentioned keys reverts to the default sizes, e.g:
 
           {'ticks':20, 'title':15,
-           'ylabel':5, 'xlabel':5,
+           'ylabel':5, 'xlabel':5, 'zlabel':5,
            'legend':8, 'legend_title':13}
 
-       You can set the fontsize of both 'ylabel' and 'xlabel' together
+       You can set the fontsize of 'zlabel', 'ylabel' and 'xlabel' together
        using the 'labels' key.""")
 
     #Allowed fontsize keys
-    _fontsize_keys = ['xlabel','ylabel', 'labels', 'ticks',
+    _fontsize_keys = ['xlabel','ylabel', 'zlabel', 'labels', 'ticks',
                       'title', 'legend', 'legend_title', 'xticks',
-                      'yticks']
+                      'yticks', 'zticks']
 
     show_title = param.Boolean(default=True, doc="""
         Whether to display the plot title.""")
@@ -330,9 +330,9 @@ class DimensionedPlot(Plot):
 
         if key in self.fontsize:
             return {label:self.fontsize[key]}
-        elif key in ['ylabel', 'xlabel'] and 'labels' in self.fontsize:
+        elif key in ['zlabel', 'ylabel', 'xlabel'] and 'labels' in self.fontsize:
             return {label:self.fontsize['labels']}
-        elif key in ['xticks', 'yticks'] and 'ticks' in self.fontsize:
+        elif key in ['xticks', 'yticks', 'zticks'] and 'ticks' in self.fontsize:
             return {label:self.fontsize['ticks']}
         else:
             return {}


### PR DESCRIPTION
https://github.com/ioam/holoviews/issues/2964

Test zticks/label alone
![image](https://user-images.githubusercontent.com/15331990/44824128-da52ed00-abb8-11e8-8e76-c32151d7e4a3.png)

Test ticks/labels
![image](https://user-images.githubusercontent.com/15331990/44824134-e2129180-abb8-11e8-8c41-c3f8c2827d6a.png)

Test other plots
![image](https://user-images.githubusercontent.com/15331990/44824143-e9399f80-abb8-11e8-9773-5554eb2bfeff.png)
