### PR TITLE
Assign int index of coords if no coords in xarray object

### DIFF
--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -121,6 +121,8 @@ class XArrayInterface(GridInterface):
                 arrays[vdim.name] = arr
             data = xr.Dataset(arrays)
         else:
+            if not data.coords:
+                data = data.assign_coords(**{k: range(v) for k, v in data.dims.items()})
             if vdims is None:
                 vdims = list(data.data_vars.keys())
                 vdims = [retrieve_unit_and_label(vd) for vd in vdims]

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -204,7 +204,7 @@ class DaskXArrayInterfaceTest(XArrayInterfaceTests):
         self.dataset_grid_inv = self.element((self.grid_xs[::-1], self.grid_ys[::-1],
                                              dask_zs), kdims=['x', 'y'],
                                             vdims=['z'])
-        
+
     def test_xarray_dataset_with_scalar_dim_canonicalize(self):
         import dask.array
         xs = [0, 1]
@@ -262,6 +262,31 @@ class Image_XArrayInterfaceTests(Image_ImageInterfaceTests):
         img = Image(array)[1:3]
         self.assertEqual(img['z'], Image(array.sel(x=slice(1, 3)))['z'])
 
+    def test_dataarray_with_no_coords(self):
+        expected_xs = list(range(2))
+        expected_ys = list(range(3))
+        zs = np.arange(6).reshape(2, 3)
+        xrarr = xr.DataArray(zs, dims=('x','y'))
+
+        img = Image(xrarr)
+        self.assertTrue(all(img.data.x == expected_xs))
+        self.assertTrue(all(img.data.y == expected_ys))
+
+        img = Image(xrarr, kdims=['x', 'y'])
+        self.assertTrue(all(img.data.x == expected_xs))
+        self.assertTrue(all(img.data.y == expected_ys))
+
+    def test_dataarray_with_some_coords(self):
+        xs = [4.2, 1]
+        expected_ys = list(range(3))
+        zs = np.arange(6).reshape(2, 3)
+        xrarr = xr.DataArray(zs, dims=('x','y'), coords={'x': xs})
+
+        with self.assertRaises(ValueError):
+            img = Image(xrarr)
+
+        with self.assertRaises(ValueError):
+            img = Image(xrarr, kdims=['x', 'y'])
 
 
 @attr(optional=1)

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -278,15 +278,14 @@ class Image_XArrayInterfaceTests(Image_ImageInterfaceTests):
 
     def test_dataarray_with_some_coords(self):
         xs = [4.2, 1]
-        expected_ys = list(range(3))
         zs = np.arange(6).reshape(2, 3)
         xrarr = xr.DataArray(zs, dims=('x','y'), coords={'x': xs})
 
         with self.assertRaises(ValueError):
-            img = Image(xrarr)
+            Image(xrarr)
 
         with self.assertRaises(ValueError):
-            img = Image(xrarr, kdims=['x', 'y'])
+            Image(xrarr, kdims=['x', 'y'])
 
 
 @attr(optional=1)


### PR DESCRIPTION
I am not sure exactly how this should work if there is one set of coords specified but not another. But this is a start at least following on the ideas here: https://github.com/ioam/holoviews/pull/2579#issuecomment-417344368