### PR TITLE
Fix theme's title

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -10,7 +10,6 @@ from bokeh.models import (HoverTool, Renderer, Range1d, DataRange1d, Title,
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
-from bokeh.themes import built_in_themes
 try:
     from bokeh.models import ColorBar
     from bokeh.models.mappers import LogColorMapper, CategoricalColorMapper

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -355,22 +355,12 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             title = self._format_title(key, separator=' ')
         else:
             title = ''
-
-        theme = self.renderer.theme
-        if theme is not None:
-            if theme in built_in_themes:  # built-in-theme name
-                opts = built_in_themes[theme]._json['attrs']['Title']
-            else:  # theme object
-                opts = theme._json['attrs']['Title']
-            opts['text'] = title
-        else:
-            opts = dict(text=title, text_color='black')
+        opts = dict(text=title)
 
         # this will override theme if not set to the default 12pt
         title_font = self._fontsize('title').get('fontsize')
         if title_font != '12pt':
             opts['text_font_size'] = value(title_font)
-
         return opts
 
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -10,6 +10,7 @@ from bokeh.models import (HoverTool, Renderer, Range1d, DataRange1d, Title,
 from bokeh.models.tickers import Ticker, BasicTicker, FixedTicker, LogTicker
 from bokeh.models.widgets import Panel, Tabs
 from bokeh.models.mappers import LinearColorMapper
+from bokeh.themes import built_in_themes
 try:
     from bokeh.models import ColorBar
     from bokeh.models.mappers import LogColorMapper, CategoricalColorMapper
@@ -355,11 +356,23 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             title = ''
 
-        opts = dict(text=title, text_color='black')
+        theme = self.renderer.theme
+        if theme is not None:
+            if theme in built_in_themes:  # built-in-theme name
+                opts = built_in_themes[theme]._json['attrs']['Title']
+            else:  # theme object
+                opts = theme._json['attrs']['Title']
+            opts['text'] = title
+        else:
+            opts = dict(text=title, text_color='black')
+
+        # this will override theme if not set to the default 12pt
         title_font = self._fontsize('title').get('fontsize')
-        if title_font:
+        if title_font != '12pt':
             opts['text_font_size'] = value(title_font)
+
         return opts
+
 
     def _init_axes(self, plot):
         if self.xaxis is None:

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -63,10 +63,17 @@ if (comm_msg != null) {{
 }}
 """
 
+default_theme = Theme(json={
+    'attrs': {
+        'Title': {'text_color': 'black', 'text_font_size': '12pt'}
+    }
+})
+
 
 class BokehRenderer(Renderer):
 
-    theme = param.ClassSelector(default=None, class_=(Theme, str), allow_None=True, doc="""
+    theme = param.ClassSelector(default=default_theme, class_=(Theme, str),
+                                allow_None=True, doc="""
        The applicable Bokeh Theme object (if any).""")
 
     backend = param.String(default='bokeh', doc="The backend name.")


### PR DESCRIPTION
This should not be merged until bokeh's master is released because `from bokeh.themes import built_in_themes` doesn't exist yet in the latest stable version.

https://github.com/ioam/holoviews/issues/2871
![image](https://user-images.githubusercontent.com/15331990/44947725-7b62c300-adc6-11e8-9522-0c109bde4b2a.png)
![image](https://user-images.githubusercontent.com/15331990/44947727-80277700-adc6-11e8-9ca2-ad9330ce0885.png)
![image](https://user-images.githubusercontent.com/15331990/44947729-86b5ee80-adc6-11e8-88c5-3e29110ca6f7.png)
