### PR TITLE
Fix misleading example boxplot and change default

### DIFF
--- a/examples/gallery/demos/bokeh/boxplot_chart.ipynb
+++ b/examples/gallery/demos/bokeh/boxplot_chart.ipynb
@@ -37,7 +37,7 @@
     "from bokeh.sampledata.autompg import autompg as df\n",
     "\n",
     "title = \"MPG by Cylinders and Data Source, Colored by Cylinders\"\n",
-    "boxwhisker = hv.BoxWhisker(df, ['cyl', 'origin'], 'mpg', label=title)"
+    "boxwhisker = hv.BoxWhisker(df, ['cyl', 'origin'], 'mpg', label=title).options(color_index=0)"
    ]
   },
   {

--- a/examples/gallery/demos/matplotlib/boxplot_chart.ipynb
+++ b/examples/gallery/demos/matplotlib/boxplot_chart.ipynb
@@ -38,7 +38,7 @@
     "from bokeh.sampledata.autompg import autompg as df\n",
     "\n",
     "title = \"MPG by Cylinders and Data Source, Colored by Cylinders\"\n",
-    "boxwhisker = hv.BoxWhisker(df, ['cyl', 'origin'], 'mpg', label=title)"
+    "boxwhisker = hv.BoxWhisker(df, ['cyl', 'origin'], 'mpg', label=title).options(color_index=0)"
    ]
   },
   {

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -160,7 +160,7 @@ options = Store.options(backend='bokeh')
 
 # Charts
 options.Curve = Options('style', color=Cycle(), line_width=2)
-options.BoxWhisker = Options('style', box_fill_color=Cycle(), whisker_color='black',
+options.BoxWhisker = Options('style', box_fill_color='lightgray', whisker_color='black',
                              box_line_color='black', outlier_color='black')
 options.Scatter = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)
 options.Points = Options('style', color=Cycle(), size=point_size, cmap=dflt_cmap)

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -274,7 +274,7 @@ options.Distribution = Options(
     muted_alpha=0.2
 )
 options.Violin = Options(
-    'style', violin_fill_color=Cycle(), violin_line_color='black',
+    'style', violin_fill_color='lightgray', violin_line_color='black',
     violin_fill_alpha=0.5, stats_color='black', box_color='black',
     median_color='white'
 )


### PR DESCRIPTION
Fixes misleading plot (title says colored by cylinder, but the coloring looks random) https://github.com/ioam/holoviews/issues/2974

Also, changes the default of box and violin's fill color from Cycle() to 'lightgray' because the colors don't really add any value unless there are multiple categories. See https://serialmentor.com/dataviz/color-pitfalls.html Figure 15.3

This has a misleading title
![image](https://user-images.githubusercontent.com/15331990/44948450-5b390100-add2-11e8-99bd-1f46ab315354.png)

This is correct but looks a bit ugly to me
![image](https://user-images.githubusercontent.com/15331990/44948474-fc27bc00-add2-11e8-9008-c7ad7c30bd8a.png)

This looks the cleanest to me
![image](https://user-images.githubusercontent.com/15331990/44948477-047ff700-add3-11e8-8b60-bf5af2503dac.png)

