### PR TITLE
Split all value dimensions when splitting by path color

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   - conda info -a
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
-  - conda install -c conda-forge filelock iris plotly=2.7 flexx ffmpeg netcdf4=1.3.1 --quiet
+  - conda install -c conda-forge filelock iris plotly=2.7 flexx=0.4.1 ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.4" ]]; then
       conda install python=3.4.3;

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -916,7 +916,7 @@ class PolyDrawCallback(CDSCallback):
                 if scalar:
                     cds.data[dim] = element.dimension_values(d, not scalar)
                 else:
-                    cds.data[dim] = element.split(datatype='array')
+                    cds.data[dim] = [arr[:, 0] for arr in element.split(datatype='array', dimensions=[dim])]
 
 
 class FreehandDrawCallback(PolyDrawCallback):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1093,6 +1093,9 @@ class ColorbarPlot(ElementPlot):
             palette = process_cmap(cmap, ncolors, categorical=categorical)
             if isinstance(self.color_levels, list):
                 palette = color_intervals(palette, self.color_levels, clip=(low, high))
+                if low == high:
+                    idx = np.argmin(np.array(self.color_levels)-low)
+                    low, high = self.color_levels[idx: idx+2]
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)
 
         cmapper = self.handles.get(name)

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1092,10 +1092,7 @@ class ColorbarPlot(ElementPlot):
                                      % (ncolors, len(cmap)))
             palette = process_cmap(cmap, ncolors, categorical=categorical)
             if isinstance(self.color_levels, list):
-                palette = color_intervals(palette, self.color_levels, clip=(low, high))
-                if low == high:
-                    idx = np.argmin(np.array(self.color_levels)-low)
-                    low, high = self.color_levels[idx: idx+2]
+                palette, (low, high) = color_intervals(palette, self.color_levels, clip=(low, high))
         colormapper, opts = self._get_cmapper_opts(low, high, factors, nan_colors)
 
         cmapper = self.handles.get(name)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -62,14 +62,15 @@ class PathPlot(ColorbarPlot):
 
         dim_name = util.dimension_sanitizer(cdim.name)
         if not self.static_source:
-            paths, cvals = [], []
+            paths, vals = [], defaultdict(list)
             for path in element.split(datatype='array'):
                 splits = [0]+list(np.where(np.diff(path[:, cidx])!=0)[0]+1)
                 for (s1, s2) in zip(splits[:-1], splits[1:]):
-                    cvals.append(path[s1, cidx])
+                    for i, vd in enumerate(element.vdims):
+                        vals[util.dimension_sanitizer(vd.name)].append(path[s1, i+2])
                     paths.append(path[s1:s2+1, :2])
             xs, ys = ([path[:, idx] for path in paths] for idx in inds)
-            data = dict(xs=xs, ys=ys, **{dim_name: np.array(cvals)})
+            data = dict(xs=xs, ys=ys, **{d: np.array(vs) for d, vs in vals.items()})
         cmapper = self._get_colormapper(cdim, element, ranges, style)
         mapping['line_color'] = {'field': dim_name, 'transform': cmapper}
         self._get_hover_data(data, element)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -65,6 +65,8 @@ class PathPlot(ColorbarPlot):
             paths, vals = [], {util.dimension_sanitizer(vd.name): [] for vd in element.vdims}
             for path in element.split(datatype='array'):
                 splits = [0]+list(np.where(np.diff(path[:, cidx])!=0)[0]+1)
+                if len(splits) == 1:
+                    splits.append(len(path))
                 for (s1, s2) in zip(splits[:-1], splits[1:]):
                     for i, vd in enumerate(element.vdims):
                         vals[util.dimension_sanitizer(vd.name)].append(path[s1, i+2])

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -62,7 +62,7 @@ class PathPlot(ColorbarPlot):
 
         dim_name = util.dimension_sanitizer(cdim.name)
         if not self.static_source:
-            paths, vals = [], defaultdict(list)
+            paths, vals = [], {util.dimension_sanitizer(vd.name): [] for vd in element.vdims}
             for path in element.split(datatype='array'):
                 splits = [0]+list(np.where(np.diff(path[:, cidx])!=0)[0]+1)
                 for (s1, s2) in zip(splits[:-1], splits[1:]):

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -691,6 +691,9 @@ class ColorbarPlot(ElementPlot):
                 palette = process_cmap(cmap, ncolors, categorical=categorical)
                 if isinstance(self.color_levels, list):
                     palette = color_intervals(palette, self.color_levels, clip=(vmin, vmax))
+                    if vmin == vmax:
+                        idx = np.argmin(np.array(self.color_levels)-vmin)
+                        low, high = self.color_levels[idx: idx+2]
             cmap = mpl_colors.ListedColormap(palette)
         if 'max' in colors: cmap.set_over(**colors['max'])
         if 'min' in colors: cmap.set_under(**colors['min'])

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -690,10 +690,7 @@ class ColorbarPlot(ElementPlot):
             else:
                 palette = process_cmap(cmap, ncolors, categorical=categorical)
                 if isinstance(self.color_levels, list):
-                    palette = color_intervals(palette, self.color_levels, clip=(vmin, vmax))
-                    if vmin == vmax:
-                        idx = np.argmin(np.array(self.color_levels)-vmin)
-                        low, high = self.color_levels[idx: idx+2]
+                    palette, (vmin, vmax) = color_intervals(palette, self.color_levels, clip=(vmin, vmax))
             cmap = mpl_colors.ListedColormap(palette)
         if 'max' in colors: cmap.set_over(**colors['max'])
         if 'min' in colors: cmap.set_under(**colors['min'])

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -36,6 +36,8 @@ class PathPlot(ColorbarPlot):
         paths, cvals = [], []
         for path in element.split(datatype='array'):
             splits = [0]+list(np.where(np.diff(path[:, cidx])!=0)[0]+1)
+            if len(splits) == 1:
+                splits.append(len(path))
             for (s1, s2) in zip(splits[:-1], splits[1:]):
                 cvals.append(path[s1, cidx])
                 paths.append(path[s1:s2+1, :2])

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -805,7 +805,27 @@ def process_cmap(cmap, ncolors=None, provider=None, categorical=False):
 
 def color_intervals(colors, levels, clip=None, N=255):
     """
-    Maps a set of intervals to colors given a fixed color range.
+    Maps the supplied colors into bins defined by the supplied levels.
+    If a clip tuple is defined the bins are clipped to the defined
+    range otherwise the range is computed from the levels and returned.
+
+    Arguments
+    ---------
+    colors: list
+      List of colors (usually hex string or named colors)
+    levels: list or array_like
+      Levels specifying the bins to map the colors to
+    clip: tuple (optional)
+      Lower and upper limits of the color range
+    N: int
+      Number of discrete colors to map the range onto
+
+    Returns
+    -------
+    cmap: list
+      List of colors
+    clip: tuple
+      Lower and upper bounds of the color range
     """
     if len(colors) != len(levels)-1:
         raise ValueError('The number of colors in the colormap '

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -822,7 +822,10 @@ def color_intervals(colors, levels, clip=None, N=255):
         clmin, clmax = clip
         lidx = int(round(N*((clmin-cmin)/interval)))
         uidx = int(round(N*((cmax-clmax)/interval)))
-        cmap = cmap[lidx:N-uidx]
+        uidx = N-uidx
+        if lidx == uidx:
+            uidx = lidx+1
+        cmap = cmap[lidx:uidx]
     return cmap
 
 

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -826,7 +826,10 @@ def color_intervals(colors, levels, clip=None, N=255):
         if lidx == uidx:
             uidx = lidx+1
         cmap = cmap[lidx:uidx]
-    return cmap
+        if clmin == clmax:
+            idx = np.argmin(np.abs(np.array(levels)-clmin))
+            clip = levels[idx: idx+2] if len(levels) > idx+2 else levels[idx-1: idx+1]
+    return cmap, clip
 
 
 def dim_axis_label(dimensions, separator=', '):

--- a/tests/plotting/bokeh/testpathplot.py
+++ b/tests/plotting/bokeh/testpathplot.py
@@ -56,6 +56,20 @@ class TestPathPlot(TestBokehPlot):
         self.assertEqual(len(source.data['ys']), 0)
         self.assertEqual(len(source.data['Intensity']), 0)
 
+    def test_path_colored_and_split_with_extra_vdims(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        color = [0, 0.25, 0.5, 0.75]
+        other = ['A', 'B', 'C', 'D']
+        data = {'x': xs, 'y': ys, 'color': color, 'other': other}
+        path = Path([data], vdims=['color','other']).options(color_index='color')
+        plot = bokeh_renderer.get_plot(path)
+        source = plot.handles['source']
+
+        self.assertEqual(source.data['xs'], [np.array([1, 2]), np.array([2, 3]), np.array([3, 4])])
+        self.assertEqual(source.data['ys'], [np.array([4, 3]), np.array([3, 2]), np.array([2, 1])])
+        self.assertEqual(source.data['other'], np.array(['A', 'B', 'C']))
+        self.assertEqual(source.data['color'], np.array([0, 0.25, 0.5]))
 
 
 class TestPolygonPlot(TestBokehPlot):

--- a/tests/plotting/bokeh/testpathplot.py
+++ b/tests/plotting/bokeh/testpathplot.py
@@ -71,6 +71,38 @@ class TestPathPlot(TestBokehPlot):
         self.assertEqual(source.data['other'], np.array(['A', 'B', 'C']))
         self.assertEqual(source.data['color'], np.array([0, 0.25, 0.5]))
 
+    def test_path_colored_and_split_on_single_value(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        color = [1, 1, 1, 1]
+        data = {'x': xs, 'y': ys, 'color': color}
+        path = Path([data], vdims=['color']).options(color_index='color')
+        plot = bokeh_renderer.get_plot(path)
+        source = plot.handles['source']
+
+        self.assertEqual(source.data['xs'], [np.array([1, 2, 3, 4])])
+        self.assertEqual(source.data['ys'], [np.array([4, 3, 2, 1])])
+        self.assertEqual(source.data['color'], np.array([1]))
+
+    def test_path_colored_by_levels_single_value(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        color = [998, 998, 998, 998]
+        data = {'x': xs, 'y': ys, 'color': color}
+        levels = [0, 38, 73, 95, 110, 130, 156, 999]
+        colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
+        path = Path([data], vdims=['color']).options(color_index='color', color_levels=levels, cmap=colors)
+        plot = bokeh_renderer.get_plot(path)
+        source = plot.handles['source']
+        cmapper = plot.handles['color_mapper']
+
+        self.assertEqual(source.data['xs'], [np.array([1, 2, 3, 4])])
+        self.assertEqual(source.data['ys'], [np.array([4, 3, 2, 1])])
+        self.assertEqual(source.data['color'], np.array([998]))
+        self.assertEqual(cmapper.low, 156)
+        self.assertEqual(cmapper.high, 999)
+        self.assertEqual(cmapper.palette, colors[-1:])
+
 
 class TestPolygonPlot(TestBokehPlot):
 

--- a/tests/plotting/testplotutils.py
+++ b/tests/plotting/testplotutils.py
@@ -568,7 +568,7 @@ class TestBokehPaletteUtils(ComparisonTestCase):
     def test_color_intervals(self):
         levels = [0, 38, 73, 95, 110, 130, 156]  
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20']
-        cmap = color_intervals(colors, levels, N=10)
+        cmap, lims = color_intervals(colors, levels, N=10)
         self.assertEqual(cmap, ['#5ebaff', '#5ebaff', '#00faf4',
                                 '#00faf4', '#ffffcc', '#ffe775',
                                 '#ffc140', '#ff8f20', '#ff8f20'])
@@ -576,9 +576,10 @@ class TestBokehPaletteUtils(ComparisonTestCase):
     def test_color_intervals_clipped(self):
         levels = [0, 38, 73, 95, 110, 130, 156, 999]  
         colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
-        cmap = color_intervals(colors, levels, clip=(10, 90), N=100) 
+        cmap, lims = color_intervals(colors, levels, clip=(10, 90), N=100)
         self.assertEqual(cmap, ['#5ebaff', '#5ebaff', '#5ebaff', '#00faf4', '#00faf4',
                                 '#00faf4', '#00faf4', '#ffffcc'])
+        self.assertEqual(lims, (10, 90))
 
 
 class TestPlotUtils(ComparisonTestCase):


### PR DESCRIPTION
When displaying a path with a varying value dimension used to color each line segment the path is split into little chunks. However previously other value dimensions would not be split in this way which would cause several issues:

1) When enabling hover on the path the CDS would end up with mismatched shapes
2) When enabling a drawing tool on the path the CDS would also end up with mismatching shapes

The solution is to split all value dimensions by default.