### PR TITLE
Fixed plot extent calculation when apply_ranges=False

### DIFF
--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1226,7 +1226,10 @@ class GenericOverlayPlot(GenericElementPlot):
         """
         Iterates over all subplots and collects the extents of each.
         """
-        extents = defaultdict(list)
+        if range_type == 'combined':
+            extents = {'extents': [], 'soft': [], 'hard': [], 'data': []}
+        else:
+            extents = {range_type: []}
         items = overlay.items()
         if self.batched and self.subplots:
             subplot = list(self.subplots.values())[0]
@@ -1253,9 +1256,9 @@ class GenericOverlayPlot(GenericElementPlot):
                 sp_ranges = ranges
             else:
                 sp_ranges = util.match_spec(layer, ranges) if ranges else {}
-            range_types = ('extents', 'soft', 'hard', 'data') if range_type == 'combined' else (range_type,)
-            for rt in range_types:
-                extents[rt].append(subplot.get_extents(layer, sp_ranges, range_type=rt))
+            for rt in extents:
+                extent = subplot.get_extents(layer, sp_ranges, range_type=rt)
+                extents[rt].append(extent)
         return extents
 
 

--- a/tests/plotting/bokeh/testoverlayplot.py
+++ b/tests/plotting/bokeh/testoverlayplot.py
@@ -20,6 +20,11 @@ class TestOverlayPlot(TestBokehPlot):
         legend_labels = [l.label['value'] for l in plot.state.legend[0].items]
         self.assertEqual(legend_labels, ['A', 'B'])
 
+    def test_overlay_apply_ranges_disabled(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options('Curve', apply_ranges=False)
+        plot = bokeh_renderer.get_plot(overlay)
+        self.assertTrue(all(np.isnan(e) for e in plot.get_extents(overlay, {})))
+
     def test_overlay_update_sources(self):
         hmap = HoloMap({i: (Curve(np.arange(i), label='A') *
                             Curve(np.arange(i)*2, label='B'))

--- a/tests/plotting/matplotlib/testoverlayplot.py
+++ b/tests/plotting/matplotlib/testoverlayplot.py
@@ -25,6 +25,11 @@ class TestOverlayPlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(overlay)
         self.assertEqual(len(plot.subplots), 1)
 
+    def test_overlay_apply_ranges_disabled(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options('Curve', apply_ranges=False)
+        plot = mpl_renderer.get_plot(overlay)
+        self.assertTrue(all(np.isnan(e) for e in plot.get_extents(overlay, {})))
+
     def test_overlay_empty_element_extent(self):
         overlay = Curve([]).redim.range(x=(-10, 10)) * Scatter([]).redim.range(y=(-20, 20))
         plot = mpl_renderer.get_plot(overlay)


### PR DESCRIPTION
Fixes small bug in extent calculations for plots with ``apply_ranges=False`` which skip extent calculation.

- [x] Add unit test