### PR TITLE
Suppress warnings about deprecated rcParams in matplotlib>=3.0

### DIFF
--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -17,7 +17,7 @@ from ...core.util import int_to_roman, int_to_alpha, basestring
 from ..plot import (DimensionedPlot, GenericLayoutPlot, GenericCompositePlot,
                     GenericElementPlot)
 from ..util import attach_streams, collate, displayable
-from .util import compute_ratios, fix_aspect
+from .util import compute_ratios, fix_aspect, mpl_version
 
 
 @contextmanager
@@ -25,7 +25,9 @@ def _rc_context(rcparams):
     """
     Context manager that temporarily overrides the pyplot rcParams.
     """
-    old_rcparams = mpl.rcParams.copy()
+    deprecated = ['text.latex.unicode', 'examples.directory']
+    old_rcparams = {k: mpl.rcParams[k] for k in mpl.rcParams.keys()
+                    if mpl_version < '3.0' or k not in deprecated}
     mpl.rcParams.update(rcparams)
     try:
         yield

--- a/holoviews/plotting/mpl/util.py
+++ b/holoviews/plotting/mpl/util.py
@@ -1,9 +1,13 @@
 import re
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
+import matplotlib
 from matplotlib import ticker
 from matplotlib.transforms import Bbox, TransformedBbox, Affine2D
+
+mpl_version = LooseVersion(matplotlib.__version__)  # noqa
 
 from ...core.util import basestring, _getargspec
 from ...element import Raster, RGB


### PR DESCRIPTION
- [x] Fixes https://github.com/ioam/holoviews/issues/2963