### PR TITLE
Fixes for handling of curvilinear coordinates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx affine
   - source activate test-environment
   - conda install -c conda-forge filelock iris plotly=2.7 flexx=0.4.1 ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
   - conda update -q conda
   # Useful for debugging any issues with conda
   - conda info -a
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx affine
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION flake8 scipy=1.0.0 numpy freetype nose pandas=0.22.0 jupyter ipython=5.4.1 param matplotlib=2.1.2 xarray networkx
   - source activate test-environment
   - conda install -c conda-forge filelock iris plotly=2.7 flexx=0.4.1 ffmpeg netcdf4=1.3.1 --quiet
   - conda install -c bokeh datashader dask bokeh=0.12.15 selenium

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -266,7 +266,7 @@ class GridInterface(DictInterface):
         slices = []
         for d in data_coords:
             coords = cls.coords(dataset, d)
-            if np.all(coords[1:] < coords[:-1]):
+            if np.all(coords[1:] < coords[:-1]) and not coords.ndim > 1:
                 slices.append(slice(None, None, -1))
                 invert = True
             else:

--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -261,18 +261,6 @@ class GridInterface(DictInterface):
         if data_coords is None:
             data_coords = dataset.dimensions('key', label='name')[::-1]
 
-        # Reorient data
-        invert = False
-        slices = []
-        for d in data_coords:
-            coords = cls.coords(dataset, d)
-            if np.all(coords[1:] < coords[:-1]) and not coords.ndim > 1:
-                slices.append(slice(None, None, -1))
-                invert = True
-            else:
-                slices.append(slice(None))
-        data = data[tuple(slices)] if invert else data
-
         # Transpose data
         dims = [name for name in data_coords
                 if isinstance(cls.coords(dataset, name), array_types)]
@@ -286,6 +274,18 @@ class GridInterface(DictInterface):
             inds = [i - sum([1 for d in dropped if i>=d]) for i in inds]
             if inds:
                 data = data.transpose(inds[::-1])
+
+        # Reorient data
+        invert = False
+        slices = []
+        for d in dataset.kdims[::-1]:
+            coords = cls.coords(dataset, d)
+            if np.all(coords[1:] < coords[:-1]) and not coords.ndim > 1:
+                slices.append(slice(None, None, -1))
+                invert = True
+            else:
+                slices.append(slice(None))
+        data = data[tuple(slices)] if invert else data
 
         # Allow lower dimensional views into data
         if len(dataset.kdims) < 2:

--- a/holoviews/core/data/iris.py
+++ b/holoviews/core/data/iris.py
@@ -153,9 +153,10 @@ class CubeInterface(GridInterface):
 
     @classmethod
     def coords(cls, dataset, dim, ordered=False, expanded=False):
+        dim = dataset.get_dimension(dim, strict=True)
         if expanded:
-            return util.expand_grid_coords(dataset, dim)
-        data = dataset.data.coords(dim)[0].points
+            return util.expand_grid_coords(dataset, dim.name)
+        data = dataset.data.coords(dim.name)[0].points
         if ordered and np.all(data[1:] < data[:-1]):
             data = data[::-1]
         return data

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -268,7 +268,8 @@ class XArrayInterface(GridInterface):
             if edges:
                 data = cls._infer_interval_breaks(data, axis=1)
                 data = cls._infer_interval_breaks(data, axis=0)
-            return data
+
+            return data.values if isinstance(data, xr.DataArray) else data
 
         data = np.atleast_1d(dataset.data[dim].data)
         if ordered and data.shape and np.all(data[1:] < data[:-1]):
@@ -285,7 +286,8 @@ class XArrayInterface(GridInterface):
             data = cls._infer_interval_breaks(data)
         elif not edges and isedges:
             data = np.convolve(data, [0.5, 0.5], 'valid')
-        return data
+
+        return data.values if isinstance(data, xr.DataArray) else data
 
 
     @classmethod

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -113,6 +113,8 @@ class XArrayInterface(GridInterface):
                 data.update({d: np.empty((0,) * ndims) for d in dimensions[ndims:]})
             if not isinstance(data, dict):
                 raise TypeError('XArrayInterface could not interpret data type')
+            data = {d: np.asarray(values) if d in kdims else values
+                    for d, values in data.items()}
             coord_dims = [data[kd.name].ndim for kd in kdims]
             dims = tuple('dim_%d' % i for i in range(max(coord_dims)))[::-1]
             coords = OrderedDict()

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -768,7 +768,12 @@ class QuadMesh(Dataset, Element2D):
         # Generate vertices
         xs = self.interface.coords(self, 0, edges=True)
         ys = self.interface.coords(self, 1, edges=True)
+
         if xs.ndim == 1:
+            if np.all(xs[1:] < xs[:-1]):
+                xs = xs[::-1]
+            if np.all(ys[1:] < ys[:-1]):
+                ys = ys[::-1]
             xs, ys = (np.tile(xs[:, np.newaxis], len(ys)).T,
                       np.tile(ys[:, np.newaxis], len(xs)))
         vertices = (xs.T.flatten(), ys.T.flatten())

--- a/tests/core/data/testgridinterface.py
+++ b/tests/core/data/testgridinterface.py
@@ -48,6 +48,17 @@ class GridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Interfac
             Dataset(pd.DataFrame({'x':self.xs, 'x2':self.xs_2}),
                     kdims=['x'], vdims=['x2'])
 
+    def test_irregular_grid_data_values(self):
+        from affine import Affine
+        transform = Affine(3, 0, 2, 0, -2, -2)
+        nx, ny = 20, 5
+        xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5) * transform
+        zs = np.arange(100).reshape(5, 20)
+        ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
+        self.assertEqual(ds.dimension_values(2, flat=False), zs)
+        self.assertEqual(ds.interface.coords(ds, 'x'), xs)
+        self.assertEqual(ds.interface.coords(ds, 'y'), ys)
+
     def test_dataset_sort_hm(self):
         raise SkipTest("Not supported")
 

--- a/tests/core/data/testgridinterface.py
+++ b/tests/core/data/testgridinterface.py
@@ -49,10 +49,17 @@ class GridInterfaceTests(GriddedInterfaceTests, HomogeneousColumnTests, Interfac
                     kdims=['x'], vdims=['x2'])
 
     def test_irregular_grid_data_values(self):
-        from affine import Affine
-        transform = Affine(3, 0, 2, 0, -2, -2)
         nx, ny = 20, 5
-        xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5) * transform
+        xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5)
+        zs = np.arange(100).reshape(5, 20)
+        ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
+        self.assertEqual(ds.dimension_values(2, flat=False), zs)
+        self.assertEqual(ds.interface.coords(ds, 'x'), xs)
+        self.assertEqual(ds.interface.coords(ds, 'y'), ys)
+
+    def test_irregular_grid_data_values_inverted_y(self):
+        nx, ny = 20, 5
+        xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)*-1+0.5)
         zs = np.arange(100).reshape(5, 20)
         ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
         self.assertEqual(ds.dimension_values(2, flat=False), zs)

--- a/tests/core/data/testirisinterface.py
+++ b/tests/core/data/testirisinterface.py
@@ -190,6 +190,12 @@ class IrisInterfaceTests(GridInterfaceTests):
         cube = Dataset(self.cube)
         self.assertEqual(cube[0, 0], 5)
 
+    def test_irregular_grid_data_values(self):
+        raise SkipTest('Irregular mesh data not supported by IrisInterface')
+
+    def test_irregular_grid_data_values_inverted_y(self):
+        raise SkipTest('Irregular mesh data not supported by IrisInterface')
+
 
 @attr(optional=1)
 class Image_IrisInterfaceTests(Image_ImageInterfaceTests):

--- a/tests/core/data/testxarrayinterface.py
+++ b/tests/core/data/testxarrayinterface.py
@@ -30,18 +30,18 @@ class XArrayInterfaceTests(GridInterfaceTests):
     data_type = xr.Dataset
 
     def get_irregular_dataarray(self, invert_y=True):
-        from affine import Affine
         multiplier = -1 if invert_y else 1
+        x = np.arange(2, 62, 3)
+        y = np.arange(2, 12, 2) * multiplier
         da = xr.DataArray(
             data=[np.arange(100).reshape(5, 20)],
-            coords={'band': [1], 'x': np.arange(2, 62, 3), 'y': np.arange(2, 12, 2) * multiplier},
+            coords=OrderedDict([('band', [1]), ('x', x), ('y', y)]),
             dims=['band', 'y','x'],
             attrs={'transform': (3, 0, 2, 0, -2, -2)})
-        transform = Affine(*da.transform)
-        nx, ny = da.sizes['x'], da.sizes['y']
-        x, y = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5) * transform
-        return da.assign_coords(**{'xc': xr.DataArray(x, dims=('y','x')),
-                                   'yc': xr.DataArray(y, dims=('y','x')),})
+        xs, ys = (np.tile(x[:, np.newaxis], len(y)).T,
+                  np.tile(y[:, np.newaxis], len(x)))
+        return da.assign_coords(**{'xc': xr.DataArray(xs, dims=('y','x')),
+                                   'yc': xr.DataArray(ys, dims=('y','x')),})
 
     def test_xarray_dataset_with_scalar_dim_canonicalize(self):
         xs = [0, 1]
@@ -123,17 +123,6 @@ class XArrayInterfaceTests(GridInterfaceTests):
         dataset = xr.Dataset({'value': darray}, coords=coords)
         ds = Dataset(dataset)
         self.assertEqual(ds.kdims, ['b', 'c', 'a'])
-
-    def test_irregular_grid_data_values(self):
-        from affine import Affine
-        transform = Affine(3, 0, 2, 0, -2, -2)
-        nx, ny = 20, 5
-        xs, ys = np.meshgrid(np.arange(nx)+0.5, np.arange(ny)+0.5) * transform
-        zs = np.arange(100).reshape(5, 20)
-        ds = Dataset((xs, ys, zs), ['x', 'y'], 'z')
-        self.assertEqual(ds.dimension_values(2, flat=False), zs)
-        self.assertEqual(ds.interface.coords(ds, 'x').values, xs)
-        self.assertEqual(ds.interface.coords(ds, 'y').values, ys)
 
     def test_irregular_and_regular_coordinate_inference(self):
         data = self.get_irregular_dataarray()


### PR DESCRIPTION
- [x] Adds support for constructing curvilinear xarray dataset from literals
- [x] Fixes bug where rasterization would flip QuadMesh
- [x] Fixes bug where canonicalization would flip value dimension arrays when curvilinear coordinate arrays are used (this is unnecessary and caused various bugs)