### PR TITLE
Do not expand full DynamicMap cartesian product

### DIFF
--- a/holoviews/core/traversal.py
+++ b/holoviews/core/traversal.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from operator import itemgetter
 
 from .dimension import Dimension
-from .util import merge_dimensions, cartesian_product
+from .util import merge_dimensions
 
 try:
     import itertools.izip as zip
@@ -88,11 +88,6 @@ def unique_dimkeys(obj, default_dim='Frame'):
                                               for i, k in zip(item, padded_key))]
             if not matches:
                 unique_keys.append(padded_key)
-
-    # Add cartesian product of DynamicMap values to keys
-    values = [d.values for d in all_dims]
-    if obj.traverse(lambda x: x, ['DynamicMap']) and values and all(values):
-        unique_keys += list(zip(*cartesian_product(values)))
 
     with item_check(False):
         sorted_keys = NdMapping({key: None for key in unique_keys},

--- a/tests/core/testtraversal.py
+++ b/tests/core/testtraversal.py
@@ -27,27 +27,6 @@ class TestUniqueDimKeys(ComparisonTestCase):
         with self.assertRaisesRegexp(Exception, exception):
             dims, keys = unique_dimkeys(hmap1+hmap2)
 
-    def test_unique_keys_dmap_complete_overlap(self):
-        hmap1 = DynamicMap(lambda x: Curve(range(10)), kdims=['x']).redim.values(x=[1, 2, 3])
-        hmap2 = DynamicMap(lambda x: Curve(range(10)), kdims=['x']).redim.values(x=[1, 2, 3])
-        dims, keys = unique_dimkeys(hmap1+hmap2)
-        self.assertEqual(hmap1.kdims, dims)
-        self.assertEqual(keys, [(i,) for i in range(1, 4)])
-
-    def test_unique_keys_dmap_partial_overlap(self):
-        hmap1 = DynamicMap(lambda x: Curve(range(10)), kdims=['x']).redim.values(x=[1, 2, 3])
-        hmap2 = DynamicMap(lambda x: Curve(range(10)), kdims=['x']).redim.values(x=[1, 2, 3, 4])
-        dims, keys = unique_dimkeys(hmap1+hmap2)
-        self.assertEqual(hmap2.kdims, dims)
-        self.assertEqual(keys, [(i,) for i in range(1, 5)])
-
-    def test_unique_keys_dmap_cartesian_product(self):
-        hmap1 = DynamicMap(lambda x, y: Curve(range(10)), kdims=['x', 'y']).redim.values(x=[1, 2, 3])
-        hmap2 = DynamicMap(lambda x, y: Curve(range(10)), kdims=['x', 'y']).redim.values(y=[1, 2, 3])
-        dims, keys = unique_dimkeys(hmap1+hmap2)
-        self.assertEqual(hmap1.kdims[:1]+hmap2.kdims[1:], dims)
-        self.assertEqual(keys, [(x, y) for x in range(1, 4) for y in range(1, 4)])
-
     def test_unique_keys_no_overlap_dynamicmap_uninitialized(self):
         dmap1 = DynamicMap(lambda A: Curve(range(10)), kdims=['A'])
         dmap2 = DynamicMap(lambda B: Curve(range(10)), kdims=['B'])


### PR DESCRIPTION
I previously removed code that computed the cartesian product of DynamicMap dimension values which is completely infeasible for large parameter spaces. It seems this was still being done for layout plots, I'll have to have another look but afaik I already ensured that the fact that these keys aren't expanded doesn't cause any issues.