### PR TITLE
Fix layout titles

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -23,10 +23,10 @@ from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
 
 from bokeh.layouts import gridplot
 from bokeh.plotting.helpers import _known_tools as known_tools
-try:
-    from bokeh.themes import built_in_themes
-except ImportError:
+if bokeh_version < '0.13.0':
     built_in_themes = {}
+else:
+    from bokeh.themes import built_in_themes
 
 TOOLS = {name: tool if isinstance(tool, basestring) else type(tool())
          for name, tool in known_tools.items()}

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -23,7 +23,8 @@ from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
 
 from bokeh.layouts import gridplot
 from bokeh.plotting.helpers import _known_tools as known_tools
-if bokeh_version < '0.13.0':
+from holoviews.plotting.bokeh.util import bokeh_version
+if bokeh_version <= '0.13.0':
     built_in_themes = {}
 else:
     from bokeh.themes import built_in_themes

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -23,11 +23,7 @@ from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
 
 from bokeh.layouts import gridplot
 from bokeh.plotting.helpers import _known_tools as known_tools
-from holoviews.plotting.bokeh.util import bokeh_version
-if bokeh_version <= '0.13.0':
-    built_in_themes = {}
-else:
-    from bokeh.themes import built_in_themes
+from holoviews.plotting.bokeh.util import theme_attr_json
 
 TOOLS = {name: tool if isinstance(tool, basestring) else type(tool())
          for name, tool in known_tools.items()}
@@ -376,18 +372,12 @@ class CompositePlot(BokehPlot):
         if not title:
             return title_div
 
-        try:
-            title_json = (built_in_themes[self.renderer.theme]
-                          ._json['attrs'].get('Title', {}))
-        except KeyError:
-            title_json = {}
-
+        title_json = theme_attr_json(self.renderer.theme, 'Title')
         color = title_json.get('text_color', None)
         font = title_json.get('text_font', 'Arial')
         fontstyle = title_json.get('text_font_style', 'bold')
-
         fontsize = self._fontsize('title')['fontsize']
-        if fontsize == '15pt':
+        if fontsize == '15pt':  # if default
             fontsize = title_json.get('text_font_size', '15pt')
             if 'em' in fontsize:
                 # it's smaller than it shosuld be so add 0.25

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -23,6 +23,11 @@ from bokeh.layouts import WidgetBox, Row, Column
 from bokeh.models import Model, ToolbarBox, FactorRange, Range1d, Plot, Spacer, CustomJS
 from bokeh.models.widgets import DataTable, Tabs, Div
 from bokeh.plotting import Figure
+from bokeh.themes.theme import Theme
+if bokeh_version <= '0.13.0':
+    built_in_themes = {}
+else:
+    from bokeh.themes import built_in_themes
 
 try:
     from bkcharts import Chart
@@ -660,3 +665,12 @@ def colormesh(X, Y):
     X = np.column_stack([X1, X2, X3, X4, X1])
     Y = np.column_stack([Y1, Y2, Y3, Y4, Y1])
     return X, Y
+
+
+def theme_attr_json(theme, attr):
+    if isinstance(theme, str) and theme in built_in_themes:
+        return built_in_themes[theme]._json['attrs'].get(attr, {})
+    elif isinstance(theme, Theme):
+        return theme._json['attrs'].get(attr, {})
+    else:
+        return {}

--- a/holoviews/tests/plotting/bokeh/testgridplot.py
+++ b/holoviews/tests/plotting/bokeh/testgridplot.py
@@ -23,7 +23,8 @@ class TestGridPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(grid)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
-        text = "<span style='font-size: 16pt'><b>X: 0</b></font>"
+        text = ('<span style="color:black;font-family:Arial;'
+                'font-style:bold;font-weight:bold;font-size:16pt">X: 0</span>')
         self.assertEqual(title.text, text)
 
     def test_grid_title_update(self):
@@ -34,7 +35,8 @@ class TestGridPlot(TestBokehPlot):
         plot.update(1)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
-        text = "<span style='font-size: 16pt'><b>X: 1</b></font>"
+        text = ('<span style="color:black;font-family:Arial;'
+                'font-style:bold;font-weight:bold;font-size:16pt">X: 1</span>')
         self.assertEqual(title.text, text)
 
     def test_gridmatrix_overlaid_batched(self):

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -34,7 +34,8 @@ class TestLayoutPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(hmap1+hmap2)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
-        text = "<span style='font-size: 16pt'><b>Default: 0</b></font>"
+        text = ('<span style="color:black;font-family:Arial;font-style:bold;'
+                'font-weight:bold;font-size:12pt">Default: 0</span>')
         self.assertEqual(title.text, text)
 
     def test_layout_title_fontsize(self):
@@ -44,7 +45,8 @@ class TestLayoutPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(layout)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
-        text = "<span style='font-size: 12pt'><b>Default: 0</b></font>"
+        text = ('<span style="color:black;font-family:Arial;font-style:bold;'
+                'font-weight:bold;font-size:12pt">Default: 0</span>')
         self.assertEqual(title.text, text)
 
     def test_layout_title_show_title_false(self):
@@ -61,7 +63,8 @@ class TestLayoutPlot(TestBokehPlot):
         plot.update(1)
         title = plot.handles['title']
         self.assertIsInstance(title, Div)
-        text = "<span style='font-size: 16pt'><b>Default: 1</b></font>"
+        text = ('<span style="color:black;font-family:Arial;font-style:bold;'
+                'font-weight:bold;font-size:12pt">Default: 1</span>')
         self.assertEqual(title.text, text)
 
     def test_layout_gridspaces(self):
@@ -164,7 +167,7 @@ class TestLayoutPlot(TestBokehPlot):
         self.assertIsInstance(panel2, Panel)
         self.assertEqual(panel1.title, 'Curve I')
         self.assertEqual(panel2.title, 'AdjointLayout I')
-        
+
     def test_layout_shared_source_synced_update(self):
         hmap = HoloMap({i: Dataset({chr(65+j): np.random.rand(i+2)
                                     for j in range(4)}, kdims=['A', 'B', 'C', 'D'])


### PR DESCRIPTION
https://github.com/ioam/holoviews/issues/3039

```
r.theme = 'caliber'  # with theme
hv.Curve([0, 1, 2])  # single no label
(hv.Curve([0, 1, 2]) * hv.Curve([4, 5, 6]))  # overlay no title
(hv.Curve([0, 1, 2]) * hv.Curve([4, 5, 6])).relabel('This title')  # labeled overlay
(hv.Curve([0, 1, 2]) + hv.Curve([4, 5, 6]))  # layout no title
(hv.Curve([0, 1, 2]) + hv.Curve([4, 5, 6])).relabel('This title')  # labeled layout
```
![image](https://user-images.githubusercontent.com/15331990/46389996-52b23f80-c68a-11e8-907f-a78dcdd78d82.png)
![image](https://user-images.githubusercontent.com/15331990/46390001-58a82080-c68a-11e8-8f32-d75a1f254e64.png)

```
import holoviews as hv
hv.extension('bokeh')
r = hv.renderer('bokeh')
# ensure other plots still work without a theme
hv.Curve([0, 1, 2])  # single no label
(hv.Curve([0, 1, 2]) * hv.Curve([4, 5, 6]))  # overlay no title
(hv.Curve([0, 1, 2]) * hv.Curve([4, 5, 6])).relabel('This title')  # labeled overlay
(hv.Curve([0, 1, 2]) + hv.Curve([4, 5, 6]))  # layout no title
(hv.Curve([0, 1, 2]) + hv.Curve([4, 5, 6])).relabel('This title')  # labeled layout
```
![image](https://user-images.githubusercontent.com/15331990/46389976-34e4da80-c68a-11e8-9808-2c1609bd797e.png)
![image](https://user-images.githubusercontent.com/15331990/46389982-3d3d1580-c68a-11e8-89a0-45a4747a4e5a.png)



Works for other layouts too:
Without theme:
![image](https://user-images.githubusercontent.com/15331990/46390055-af155f00-c68a-11e8-8774-0683e37f6950.png)

With:
![image](https://user-images.githubusercontent.com/15331990/46390038-9442ea80-c68a-11e8-80a5-b7c01a0ce815.png)

