### PR TITLE
Minor fixes to examples and docs

### DIFF
--- a/examples/gallery/apps/bokeh/nytaxi_hover.py
+++ b/examples/gallery/apps/bokeh/nytaxi_hover.py
@@ -12,37 +12,34 @@ Once this CSV is placed in a data/ subfolder, you can run this app with:
   bokeh serve --show nytaxi_hover.py
 
 """
+import numpy as np
 import holoviews as hv
-import geoviews as gv
 import dask.dataframe as dd
-import cartopy.crs as ccrs
 
 from holoviews.operation.datashader import aggregate
 
 hv.extension('bokeh')
 
 # Set plot and style options
-hv.util.opts('Image [width=800 height=400 shared_axes=False logz=True] {+axiswise} ')
+hv.util.opts('Image [width=800 height=400 shared_axes=False logz=True xaxis=None yaxis=None] {+axiswise} ')
 hv.util.opts("HLine VLine (color='white' line_width=1) Layout [shared_axes=False] ")
 hv.util.opts("Curve [xaxis=None yaxis=None show_grid=False, show_frame=False] (color='orangered') {+framewise}")
 
 # Read the CSV file
-df = dd.read_csv('data/nyc_taxi.csv',usecols=['pickup_x', 'pickup_y'])
+df = dd.read_parquet('/Users/philippjfr/development/pyviz/data/nyc_taxi_50k.parq')
 df = df.persist()
 
-# Reproject points from Mercator to PlateCarree (latitude/longitude)
-points = gv.Points(df, kdims=['pickup_x', 'pickup_y'], vdims=[], crs=ccrs.GOOGLE_MERCATOR)
-projected = gv.operation.project_points(points, projection=ccrs.PlateCarree())
-projected = projected.redim(pickup_x='lon', pickup_y='lat')
+# Declare points
+points = hv.Points(df, kdims=['pickup_x', 'pickup_y'], vdims=[])
 
 # Use datashader to rasterize and linked streams for interactivity
-agg = aggregate(projected, link_inputs=True, x_sampling=0.0001, y_sampling=0.0001)
-pointerx = hv.streams.PointerX(x=-74, source=projected)
-pointery = hv.streams.PointerY(y=40.8,  source=projected)
+agg = aggregate(points, link_inputs=True, x_sampling=0.0001, y_sampling=0.0001)
+pointerx = hv.streams.PointerX(x=np.mean(points.range('pickup_x')), source=points)
+pointery = hv.streams.PointerY(y=np.mean(points.range('pickup_y')), source=points)
 vline = hv.DynamicMap(lambda x: hv.VLine(x), streams=[pointerx])
 hline = hv.DynamicMap(lambda y: hv.HLine(y), streams=[pointery])
 
-sampled = hv.util.Dynamic(agg, operation=lambda obj, x: obj.sample(lon=x),
+sampled = hv.util.Dynamic(agg, operation=lambda obj, x: obj.sample(pickup_x=x),
                           streams=[pointerx], link_inputs=False)
 
 hvobj = ((agg * hline * vline) << sampled.opts(plot={'Curve': dict(width=100)}))

--- a/examples/reference/elements/matplotlib/Scatter.ipynb
+++ b/examples/reference/elements/matplotlib/Scatter.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Scatter (color='k' marker='s' size=10)\n",
+    "%%opts Scatter (color='k' marker='s' s=10)\n",
     "np.random.seed(42)\n",
     "coords = [(i, np.random.random()) for i in range(20)]\n",
     "hv.Scatter(coords)"
@@ -56,7 +56,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Scatter (color='k' marker='s' size=10)\n",
+    "%%opts Scatter (color='k' marker='s' s=10)\n",
     "hv.Scatter(coords)[0:12] + hv.Scatter(coords)[12:20]"
    ]
   },

--- a/holoviews/plotting/mpl/plot.py
+++ b/holoviews/plotting/mpl/plot.py
@@ -147,8 +147,8 @@ class MPLPlot(DimensionedPlot):
         self.handles['axis'] = axis
 
         if self.final_hooks and self.finalize_hooks:
-            self.warning('Set either final_hooks or deprecated '
-                         'finalize_hooks, not both.')
+            self.warning('Set either finalize_hooks or deprecated '
+                         'final_hooks, not both.')
         self.finalize_hooks = self.final_hooks
         self.handles['bbox_extra_artists'] = []
 


### PR DESCRIPTION
- Fix "size" option that may have been accepted by some Matplotlib versions, but is supposed to be "s" as far as I know
- Clarify that we decided that "finalize_hooks" was the correct spelling, and that "final_hooks" is the deprecated spelling, even though we all prefer "final_hooks", because "finalize_hooks" has been accepted by both bokeh and mpl backends for many releases while "final_hooks" is only accepted by the mpl backend.