### PR TITLE
Use robust isfinite utility throughout

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -810,20 +810,6 @@ def find_range(values, soft_range=[]):
             return (None, None)
 
 
-def is_finite(value):
-    """
-    Safe check whether a value is finite, only None, NaN and inf
-    values are considered non-finite and allows checking all types not
-    restricted to numeric types.
-    """
-    if value is None:
-        return False
-    try:
-        return np.isfinite(value)
-    except:
-        return True
-
-
 def max_range(ranges, combined=True):
     """
     Computes the maximal lower and upper bounds from a list bounds.
@@ -882,8 +868,8 @@ def dimension_range(lower, upper, hard_range, soft_range, padding=None, log=Fals
     lower, upper = range_pad(lower, upper, padding, log)
     lower, upper = max_range([(lower, upper), soft_range])
     dmin, dmax = hard_range
-    lower = lower if dmin is None or not np.isfinite(dmin) else dmin
-    upper = upper if dmax is None or not np.isfinite(dmax) else dmax
+    lower = lower if dmin is None or not isfinite(dmin) else dmin
+    upper = upper if dmax is None or not isfinite(dmax) else dmax
     return lower, upper
 
 

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -284,7 +284,7 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         l, b, r, t = bounds.lbrt()
         xdensity = xdensity if xdensity else util.compute_density(l, r, dim1, self._time_unit)
         ydensity = ydensity if ydensity else util.compute_density(b, t, dim2, self._time_unit)
-        if not np.isfinite(xdensity) or not np.isfinite(ydensity):
+        if not util.isfinite(xdensity) or not util.isfinite(ydensity):
             raise ValueError('Density along Image axes could not be determined. '
                              'If the data contains only one coordinate along the '
                              'x- or y-axis ensure you declare the bounds and/or '

--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -102,7 +102,7 @@ class univariate_kde(Operation):
             bin_range = (bin_range[0]-0.5, bin_range[1]+0.5)
 
         element_type = Area if self.p.filled else Curve
-        data = data[np.isfinite(data)] if len(data) else []
+        data = data[isfinite(data)] if len(data) else []
         if len(data) > 1:
             try:
                 kde = stats.gaussian_kde(data)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -491,6 +491,8 @@ class SpreadPlot(ElementPlot):
         Splits area plots at nans and returns x- and y-coordinates for
         each area separated by nans.
         """
+        xnan = np.array([np.datetime64('nat') if xs.dtype.kind == 'M' else np.nan])
+        ynan = np.array([np.datetime64('nat') if lower.dtype.kind == 'M' else np.nan])
         split = np.where(~isfinite(xs) | ~isfinite(lower) | ~isfinite(upper))[0]
         xvals = np.split(xs, split)
         lower = np.split(lower, split)
@@ -501,10 +503,12 @@ class SpreadPlot(ElementPlot):
                 x, l, u = x[1:], l[1:], u[1:]
             if not len(x):
                 continue
-            band_x += [np.append(x, x[::-1]), np.array([np.nan])]
-            band_y += [np.append(l, u[::-1]), np.array([np.nan])]
+            band_x += [np.append(x, x[::-1]), xnan]
+            band_y += [np.append(l, u[::-1]), ynan]
         if len(band_x):
-            return np.concatenate(band_x[:-1]), np.concatenate(band_y[:-1])
+            xs = np.concatenate(band_x[:-1])
+            ys = np.concatenate(band_y[:-1])
+            return xs, ys
         return [], []
 
     def get_data(self, element, ranges, style):

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -491,7 +491,7 @@ class SpreadPlot(ElementPlot):
         Splits area plots at nans and returns x- and y-coordinates for
         each area separated by nans.
         """
-        split = np.where(np.isnan(xs) | np.isnan(lower) | np.isnan(upper))[0]
+        split = np.where(~isfinite(xs) | ~isfinite(lower) | ~isfinite(upper))[0]
         xvals = np.split(xs, split)
         lower = np.split(lower, split)
         upper = np.split(upper, split)

--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -1,7 +1,7 @@
 import numpy as np
 import param
 
-from ...core.util import cartesian_product, dimension_sanitizer
+from ...core.util import cartesian_product, dimension_sanitizer, isfinite
 from ...element import Raster, RGB, HSV
 from .element import ElementPlot, ColorbarPlot, line_properties, fill_properties
 from .util import mpl_to_bokeh, colormesh, bokeh_version
@@ -168,7 +168,7 @@ class QuadMeshPlot(ColorbarPlot):
             xc, yc = [], []
             for xs, ys, zval in zip(X, Y, zvals):
                 xs, ys = xs[:-1], ys[:-1]
-                if np.isfinite(zval) and all(np.isfinite(xs)) and all(np.isfinite(ys)):
+                if isfinite(zval) and all(isfinite(xs)) and all(isfinite(ys)):
                     XS.append(list(xs))
                     YS.append(list(ys))
                     mask.append(True)

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -9,7 +9,7 @@ from bokeh.models import FactorRange, Circle, VBar, HBar
 from ...core.dimension import Dimension
 from ...core.ndmapping import sorted_context
 from ...core.util import (basestring, dimension_sanitizer, wrap_tuple,
-                          unique_iterator)
+                          unique_iterator, isfinite)
 from ...operation.stats import univariate_kde
 from .chart import AreaPlot
 from .element import (CompositeElementPlot, ColorbarPlot, LegendPlot,
@@ -171,7 +171,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
 
             # Compute statistics
             vals = g.dimension_values(g.vdims[0])
-            vals = vals[np.isfinite(vals)]
+            vals = vals[isfinite(vals)]
             if len(vals):
                 q1, q2, q3 = (np.percentile(vals, q=q)
                               for q in range(25, 100, 25))
@@ -321,7 +321,7 @@ class ViolinPlot(BoxWhiskerPlot):
             el = el.clone(vdims=[vdim])
         kde = univariate_kde(el, dimension=vdim, **kwargs)
         xs, ys = (kde.dimension_values(i) for i in range(2))
-        mask = np.isfinite(ys) & (ys>0) # Mask out non-finite and zero values
+        mask = isfinite(ys) & (ys>0) # Mask out non-finite and zero values
         xs, ys = xs[mask], ys[mask]
         ys = (ys/ys.max())*(self.violin_width/2.) if len(ys) else []
         ys = [key+(sign*y,) for sign, vs in ((-1, ys), (1, ys[::-1])) for y in vs]
@@ -330,7 +330,7 @@ class ViolinPlot(BoxWhiskerPlot):
 
         bars, segments, scatter = defaultdict(list), defaultdict(list), {}
         values = el.dimension_values(vdim)
-        values = values[np.isfinite(values)]
+        values = values[isfinite(values)]
         if not len(values):
             pass
         elif self.inner == 'quartiles':

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -14,7 +14,7 @@ from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
 from ..core.options import Cycle
 from ..core.spaces import get_nested_streams
 from ..core.util import (match_spec, wrap_tuple, basestring, get_overlay_spec,
-                         unique_iterator, closest_match, is_number)
+                         unique_iterator, closest_match, is_number, isfinite)
 from ..streams import LinkedStream
 
 def displayable(obj):
@@ -399,8 +399,8 @@ def get_sideplot_ranges(plot, element, main, ranges):
 
 def within_range(range1, range2):
     """Checks whether range1 is within the range specified by range2."""
-    range1 = [r if np.isfinite(r) else None for r in range1]
-    range2 = [r if np.isfinite(r) else None for r in range2]
+    range1 = [r if isfinite(r) else None for r in range1]
+    range2 = [r if isfinite(r) else None for r in range2]
     return ((range1[0] is None or range2[0] is None or range1[0] >= range2[0]) and
             (range1[1] is None or range2[1] is None or range1[1] <= range2[1]))
 

--- a/tests/core/testutils.py
+++ b/tests/core/testutils.py
@@ -18,7 +18,8 @@ except:
 from holoviews.core.util import (
     sanitize_identifier_fn, find_range, max_range, wrap_tuple_streams,
     deephash, merge_dimensions, get_path, make_path_unique, compute_density,
-    date_range, dt_to_int, compute_edges, isfinite, cross_index, closest_match
+    date_range, dt_to_int, compute_edges, isfinite, cross_index, closest_match,
+    dimension_range
 )
 from holoviews import Dimension, Element
 from holoviews.streams import PointerXY
@@ -403,6 +404,28 @@ class TestFindRange(unittest.TestCase):
 
     def test_soft_range(self):
         self.assertEqual(find_range(self.float_vals, soft_range=(np.NaN, 100)), (-0.1424, 100))
+
+
+class TestDimensionRange(unittest.TestCase):
+    """
+    Tests for dimension_range function.
+    """
+
+    def setUp(self):
+        self.date_range = (np.datetime64(datetime.datetime(2017, 1, 1)),
+                           np.datetime64(datetime.datetime(2017, 1, 2)))
+        self.date_range2 = (np.datetime64(datetime.datetime(2016, 12, 31)),
+                            np.datetime64(datetime.datetime(2017, 1, 3)))
+
+    def test_dimension_range_date_hard_range(self):
+        drange = dimension_range(self.date_range2[0], self.date_range2[1],
+                                 self.date_range, (None, None))
+        self.assertEqual(drange, self.date_range)
+
+    def test_dimension_range_date_soft_range(self):
+        drange = dimension_range(self.date_range[0], self.date_range[1],
+                                 (None, None), self.date_range2)
+        self.assertEqual(drange, self.date_range2)
 
 
 class TestMaxRange(unittest.TestCase):

--- a/tests/plotting/bokeh/testareaplot.py
+++ b/tests/plotting/bokeh/testareaplot.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import numpy as np
 
 from holoviews.element import Area
@@ -22,6 +24,28 @@ class TestAreaPlot(TestBokehPlot):
         cds = plot.handles['cds']
         self.assertEqual(cds.data['x'], [])
         self.assertEqual(cds.data['y'], [])
+
+    def test_area_datetime_nat(self):
+        values = [(np.datetime64(dt.datetime(2017, 1, i)), i) for i in range(1, 4)]
+        values.append((np.datetime64('nat'), np.nan))
+        values += [(np.datetime64(dt.datetime(2017, 1, i)), i) for i in range(4, 6)]
+        area = Area(values)
+        plot = bokeh_renderer.get_plot(area)
+        cds = plot.handles['cds']
+        xs = np.array([
+            '2017-01-01T00:00:00.000000000', '2017-01-02T00:00:00.000000000',
+            '2017-01-03T00:00:00.000000000', '2017-01-03T00:00:00.000000000',
+            '2017-01-02T00:00:00.000000000', '2017-01-01T00:00:00.000000000',
+            'NaT', '2017-01-04T00:00:00.000000000',
+            '2017-01-05T00:00:00.000000000', '2017-01-05T00:00:00.000000000',
+            '2017-01-04T00:00:00.000000000'
+        ], dtype='datetime64[ns]')
+
+        ys = np.array([
+            0.,  0.,  0.,  3.,  2.,  1., np.nan,  0.,  0.,  5.,  4.
+        ])
+        self.assertEqual(cds.data['x'], xs)
+        self.assertEqual(cds.data['y'], ys)
 
     def test_area_padding_square(self):
         area = Area([(1, 1), (2, 2), (3, 3)]).options(padding=0.1)


### PR DESCRIPTION
We use np.isfinite in many places across the code, however the numpy version of this function is not robust to many different types which is why we created the ``hv.core.util.isfinite`` utility. Unfortunately this is not yet used everywhere throughout the code, leading to bugs like https://github.com/ioam/holoviews/issues/3044 and https://github.com/ioam/holoviews/issues/3040

- [x] Add unit tests