### PR TITLE
Improve Params stream handling

### DIFF
--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -609,7 +609,6 @@ class Params(Stream):
         return mapping
 
     def _listener(self, *events):
-        params = self.parameterized.params()
         self._memoize = not any(e.type == 'triggered' for e in events)
         self.trigger([self])
         self._memoize = True

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -597,7 +597,7 @@ class Params(Stream):
         super(Params, self).__init__(parameterized=parameterized, parameters=parameters, **params)
         self._memoize = True
         if watch:
-            self.parameterized.param.watch(self._listener, self.parameters)
+            self.parameterized.param.watch(self._watcher, self.parameters)
 
     def _validate_rename(self, mapping):
         for k, v in mapping.items():
@@ -608,7 +608,7 @@ class Params(Stream):
                                'stream parameter of the same name' % v)
         return mapping
 
-    def _listener(self, *events):
+    def _watcher(self, *events):
         self._memoize = not any(e.type == 'triggered' for e in events)
         self.trigger([self])
         self._memoize = True

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -595,9 +595,9 @@ class Params(Stream):
         if parameters is None:
             parameters = [p for p in parameterized.params() if p != 'name']
         super(Params, self).__init__(parameterized=parameterized, parameters=parameters, **params)
+        self._memoize = True
         if watch:
-            for p in self.parameters:
-                self.parameterized.param.watch(self._listener, p)
+            self.parameterized.param.watch(self._listener, self.parameters)
 
     def _validate_rename(self, mapping):
         for k, v in mapping.items():
@@ -608,8 +608,22 @@ class Params(Stream):
                                'stream parameter of the same name' % v)
         return mapping
 
-    def _listener(self, change):
+    def _listener(self, *changes):
+        params = self.parameterized.params()
+        self._memoize = not any(isinstance(params[c.name], param.Action) for c in changes)
         self.trigger([self])
+        self._memoize = True
+
+    @property
+    def hashkey(self):
+        if self._memoize:
+            return {p: v for p, v in self.parameterized.get_param_values()
+                    if p in self.parameters}
+        else:
+            return {'hash': uuid.uuid4().hex}
+
+    def reset(self):
+        pass
 
     def update(self, **kwargs):
         for k, v in kwargs.items():
@@ -641,10 +655,6 @@ class ParamMethod(Params):
         if not parameters:
             parameters = [p.name for p in parameterized.param.params_depended_on(method.__name__)]
         super(ParamMethod, self).__init__(parameterized, parameters, watch, **params)
-
-    @property
-    def hashkey(self):
-        return {'hash': Params.contents.fget(self)}
 
     @property
     def contents(self):

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -608,9 +608,9 @@ class Params(Stream):
                                'stream parameter of the same name' % v)
         return mapping
 
-    def _listener(self, *changes):
+    def _listener(self, *events):
         params = self.parameterized.params()
-        self._memoize = not any(isinstance(params[c.name], param.Action) for c in changes)
+        self._memoize = not any(e.type == 'triggered' for e in events)
         self.trigger([self])
         self._memoize = True
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -348,7 +348,11 @@ class Dynamic(param.ParameterizedFunction):
     to a DynamicMap.
 
     Any supplied kwargs will be passed to the callable and any streams
-    will be instantiated on the returned DynamicMap.
+    will be instantiated on the returned DynamicMap. If the supplied
+    operation is a method on a parameterized object which was
+    decorated with parameter dependencies Dynamic will automatically
+    create a stream to watch the parameter changes. This default
+    behavior may be disabled by setting watch=False.
     """
 
     operation = param.Callable(default=lambda x: x, doc="""
@@ -374,9 +378,10 @@ class Dynamic(param.ParameterizedFunction):
         List of streams to attach to the returned DynamicMap""")
 
     def __call__(self, map_obj, **params):
+        watch = params.pop('watch', True)
         self.p = param.ParamOverrides(self, params)
         callback = self._dynamic_operation(map_obj)
-        streams = self._get_streams(map_obj)
+        streams = self._get_streams(map_obj, watch)
         if isinstance(map_obj, DynamicMap):
             dmap = map_obj.clone(callback=callback, shared_data=self.p.shared_data,
                                  streams=streams)
@@ -385,7 +390,7 @@ class Dynamic(param.ParameterizedFunction):
         return dmap
 
 
-    def _get_streams(self, map_obj):
+    def _get_streams(self, map_obj, watch=True):
         """
         Generates a list of streams to attach to the returned DynamicMap.
         If the input is a DynamicMap any streams that are supplying values
@@ -411,7 +416,7 @@ class Dynamic(param.ParameterizedFunction):
             streams = list(util.unique_iterator(streams + dim_streams))
 
         # If callback is a parameterized method and watch is disabled add as stream
-        param_watch_support = util.param_version >= '1.8.0'
+        param_watch_support = util.param_version >= '1.8.0' and watch
         if util.is_param_method(self.p.operation) and param_watch_support:
             streams.append(self.p.operation)
         valid, invalid = Stream._process_streams(streams)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -409,7 +409,17 @@ class Dynamic(param.ParameterizedFunction):
         if isinstance(map_obj, DynamicMap):
             dim_streams = util.dimensioned_streams(map_obj)
             streams = list(util.unique_iterator(streams + dim_streams))
-        return streams
+
+        # If callback is a parameterized method and watch is disabled add as stream
+        param_watch_support = util.param_version >= '1.8.0'
+        if util.is_param_method(self.p.operation) and param_watch_support:
+            streams.append(self.p.operation)
+        valid, invalid = Stream._process_streams(streams)
+        if invalid:
+            msg = ('The supplied streams list contains objects that '
+                   'are not Stream instances: {objs}')
+            raise TypeError(msg.format(objs = ', '.join('%r' % el for el in invalid)))
+        return valid
 
 
     def _process(self, element, key=None):


### PR DESCRIPTION
This PR makes twofold improvements for Params streams:

* First of all it improves hashing on Params streams, disabling memoization temporarily when a ``param.Action`` is triggered.

* Just like a DynamicMap will listen to the dependencies of a parameterized method ``hv.util.Dynamic`` will do the same if it is passed a parameterized method as an operation.

- [x] Adds unit tests