### PR TITLE
Change trimesh_rasterize value dimension handling

### DIFF
--- a/tests/operation/testdatashader.py
+++ b/tests/operation/testdatashader.py
@@ -330,6 +330,24 @@ class DatashaderRasterizeTests(ComparisonTestCase):
                       bounds=(0, 0, 1, 1))
         self.assertEqual(img, image)
 
+    def test_rasterize_trimesh_node_vdim_precedence(self):
+        simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
+        vertices = [(0., 0., 1), (0., 1., 2), (1., 0, 3), (1, 1, 4)]
+        trimesh = TriMesh((simplices, Points(vertices, vdims=['node_z'])), vdims=['z'])
+        img = rasterize(trimesh, width=3, height=3, dynamic=False)
+        image = Image(np.array([[2., 3., np.NaN], [1.5, 2.5, np.NaN], [np.NaN, np.NaN, np.NaN]]),
+                      bounds=(0, 0, 1, 1), vdims='node_z')
+        self.assertEqual(img, image)
+
+    def test_rasterize_trimesh_node_explicit_vdim(self):
+        simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
+        vertices = [(0., 0., 1), (0., 1., 2), (1., 0, 3), (1, 1, 4)]
+        trimesh = TriMesh((simplices, Points(vertices, vdims=['node_z'])), vdims=['z'])
+        img = rasterize(trimesh, width=3, height=3, dynamic=False, aggregator=ds.mean('z'))
+        image = Image(np.array([[1.5, 1.5, np.NaN], [0.5, 1.5, np.NaN], [np.NaN, np.NaN, np.NaN]]),
+                      bounds=(0, 0, 1, 1))
+        self.assertEqual(img, image)
+
     def test_rasterize_trimesh_zero_range(self):
         simplices = [(0, 1, 2, 0.5), (3, 2, 1, 1.5)]
         vertices = [(0., 0.), (0., 1.), (1., 0), (1, 1)]


### PR DESCRIPTION
Makes a number of changes and fixes to trimesh rasterization:

* A value dimension defined on the nodes takes precedence over one defined on the tris
* If an explicit aggregator is defined that column is actually respected
