### PR TITLE
Drop gridplot width kwarg

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -877,8 +877,8 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
         else:
             plot_grid = layout_padding(plot_grid, self.renderer)
             plot_grid = filter_toolboxes(plot_grid)
-            plot_grid, width = pad_plots(plot_grid)
-            layout_plot = gridplot(children=plot_grid, width=width,
+            plot_grid = pad_plots(plot_grid)
+            layout_plot = gridplot(children=plot_grid,
                                    toolbar_location=self.toolbar,
                                    merge_tools=self.merge_tools, **kwargs)
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -344,8 +344,7 @@ def pad_plots(plots):
         widths.append(row_widths)
     plots = [[WidgetBox(p, width=w) if isinstance(p, (DataTable, Tabs)) else p
               for p, w in zip(row, ws)] for row, ws in zip(plots, widths)]
-    total_width = np.max([np.sum(row) for row in widths])
-    return plots, total_width
+    return plots
 
 
 def filter_toolboxes(plots):


### PR DESCRIPTION
For some reason we were passing a total width to the bokeh gridplot function, which it simply ignored internally. In bokeh 1.0dev this hole in kwarg validation was fixed and passing in the width now errors, so this PR is required for forward compatibility.