### PR TITLE
Fixed bug in combining data range and soft_range

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -852,6 +852,7 @@ def range_pad(lower, upper, padding=None, log=False):
             start, end = lower-lpad, upper+upad
     else:
         start, end = lower, upper
+
     return start, end
 
 
@@ -861,7 +862,8 @@ def dimension_range(lower, upper, hard_range, soft_range, padding=None, log=Fals
     with the Dimension soft_range and range.
     """
     lower, upper = range_pad(lower, upper, padding, log)
-    lower, upper = max_range([(lower, upper), soft_range])
+    lower = max_range([(lower, None), (soft_range[0], None)])[0]
+    upper = max_range([(None, upper), (None, soft_range[1])])[1]
     dmin, dmax = hard_range
     lower = lower if dmin is None or not isfinite(dmin) else dmin
     upper = upper if dmax is None or not isfinite(dmax) else dmax

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -345,7 +345,7 @@ class HistogramPlot(ElementPlot):
         ydim = element.get_dimension(1)
         s0, s1 = ranges[ydim.name]['soft']
         s0 = min(s0, 0) if isfinite(s0) else 0
-        s0 = max(s1, 0) if isfinite(s1) else 0
+        s1 = max(s1, 0) if isfinite(s1) else 0
         ranges[ydim.name]['soft'] = (s0, s1)
         return super(HistogramPlot, self).get_extents(element, ranges, range_type)
 
@@ -592,7 +592,7 @@ class SpikesPlot(ColorbarPlot):
             ydim = element.get_dimension(1)
             s0, s1 = ranges[ydim.name]['soft']
             s0 = min(s0, 0) if isfinite(s0) else 0
-            s0 = max(s1, 0) if isfinite(s1) else 0
+            s1 = max(s1, 0) if isfinite(s1) else 0
             ranges[ydim.name]['soft'] = (s0, s1)
         l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type)
         if len(element.dimensions()) == 1 and range_type != 'hard':

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -366,7 +366,7 @@ class HistogramPlot(ChartPlot):
         ydim = element.get_dimension(1)
         s0, s1 = ranges[ydim.name]['soft']
         s0 = min(s0, 0) if isfinite(s0) else 0
-        s0 = max(s1, 0) if isfinite(s1) else 0
+        s1 = max(s1, 0) if isfinite(s1) else 0
         ranges[ydim.name]['soft'] = (s0, s1)
         return super(HistogramPlot, self).get_extents(element, ranges, range_type)
 
@@ -973,7 +973,7 @@ class SpikesPlot(PathPlot, ColorbarPlot):
             ydim = element.get_dimension(1)
             s0, s1 = ranges[ydim.name]['soft']
             s0 = min(s0, 0) if isfinite(s0) else 0
-            s0 = max(s1, 0) if isfinite(s1) else 0
+            s1 = max(s1, 0) if isfinite(s1) else 0
             ranges[ydim.name]['soft'] = (s0, s1)
         l, b, r, t = super(SpikesPlot, self).get_extents(element, ranges, range_type)
         if len(element.dimensions()) == 1 and range_type != 'hard':

--- a/holoviews/tests/plotting/bokeh/testoverlayplot.py
+++ b/holoviews/tests/plotting/bokeh/testoverlayplot.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from holoviews.core import NdOverlay, HoloMap, DynamicMap
 from holoviews.core.options import Cycle
-from holoviews.element import Curve, Points, ErrorBars, Text
+from holoviews.element import Curve, Points, ErrorBars, Text, VLine
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -169,3 +169,15 @@ class TestOverlayPlot(TestBokehPlot):
         self.assertEqual(len(plot.subplots), 3)
         for i, subplot in enumerate(plot.subplots.values()):
             self.assertEqual(subplot.cyclic_index, i)
+
+    def test_complex_range_example(self):
+        errors = [(0.1*i, np.sin(0.1*i), (i+1)/3., (i+1)/5.) for i in np.linspace(0, 100, 11)]
+        errors = ErrorBars(errors, vdims=['y', 'yerrneg', 'yerrpos']).redim.range(y=(0, None))
+        overlay = Curve(errors) * errors * VLine(4)
+        plot = bokeh_renderer.get_plot(overlay)
+        x_range = plot.handles['x_range']
+        y_range = plot.handles['y_range']
+        self.assertEqual(x_range.start, 0)
+        self.assertEqual(x_range.end, 10.0)
+        self.assertEqual(y_range.start, 0)
+        self.assertEqual(y_range.end, 19.655978889110628)


### PR DESCRIPTION
The ``dimension_range`` utility which is responsible for combining different types of ranges did not correctly handle soft ranges if one of the limits is not defined.

- [x] Fixes https://github.com/pyviz/pyviz/issues/117
- [x] Fixes https://github.com/ioam/holoviews/issues/3021
- [x] Added unit test