### PR TITLE
Fixed bug in Interface.applies

### DIFF
--- a/holoviews/core/data/interface.py
+++ b/holoviews/core/data/interface.py
@@ -146,7 +146,7 @@ class Interface(param.Parameterized):
         however if the type is expensive to import at load time the
         method may be overridden.
         """
-        return any(isinstance(obj, t) for t in cls.types)
+        return type(obj) in cls.types
 
     @classmethod
     def register(cls, interface):


### PR DESCRIPTION
@jlstevens This was the actual cause of the geopandas issue you encountered today. The types check used a exact match rather than isinstance before my deferred loading PR, which meant pandas would match for a geopandas dataframe when it wasn't meant to.