### PR TITLE
Fixed no memoization bug if stream provides no kwargs

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -542,7 +542,7 @@ class Callable(param.Parameterized):
         # Nothing to do for callbacks that accept no arguments
         kwarg_hash = kwargs.pop('memoization_hash', ())
         (self.args, self.kwargs) = (args, kwargs)
-        if not args and not kwargs: return self.callable()
+        if not args and not kwarg_hash: return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []
         for stream in [s for i in inputs for s in get_nested_streams(i)]:

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -540,7 +540,7 @@ class Callable(param.Parameterized):
 
     def __call__(self, *args, **kwargs):
         # Nothing to do for callbacks that accept no arguments
-        kwarg_hash = kwargs.pop('memoization_hash', ())
+        kwarg_hash = kwargs.pop('_memoization_hash_', ())
         (self.args, self.kwargs) = (args, kwargs)
         if not args and not kwargs and not any(kwarg_hash): return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
@@ -912,7 +912,7 @@ class DynamicMap(HoloMap):
         else:
             kwargs = dict(flattened)
         if not isinstance(self.callback, Generator):
-            kwargs['memoization_hash'] = hash_items
+            kwargs['_memoization_hash_'] = hash_items
 
         with dynamicmap_memoization(self.callback, self.streams):
             retval = self.callback(*args, **kwargs)

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -542,7 +542,7 @@ class Callable(param.Parameterized):
         # Nothing to do for callbacks that accept no arguments
         kwarg_hash = kwargs.pop('memoization_hash', ())
         (self.args, self.kwargs) = (args, kwargs)
-        if not args and not kwarg_hash: return self.callable()
+        if not args and not kwargs and not any(kwarg_hash): return self.callable()
         inputs = [i for i in self.inputs if isinstance(i, DynamicMap)]
         streams = []
         for stream in [s for i in inputs for s in get_nested_streams(i)]:


### PR DESCRIPTION
Our recent work on supporting ``param.depends`` allows defining DynamicMaps which do not have any args or kwargs, since the parameters are available on the ``self`` in the parameterized method callback. However there is a small bug in ``Callable`` which skips memoization if both args and kwargs are empty rather than checking the ``kwarg_hash`` which is what is actually memoized on.