### PR TITLE
Allow using explicit colormapping on non-categorical data

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1137,7 +1137,7 @@ class ColorbarPlot(ElementPlot):
 
         cmap = colors or style.pop('cmap', 'viridis')
         nan_colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
-        if isinstance(cmap, dict) or factors:
+        if isinstance(cmap, dict):
             if not factors:
                 factors = list(cmap)
             palette = [cmap.get(f, nan_colors.get('NaN', self._default_nan)) for f in factors]

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1137,8 +1137,11 @@ class ColorbarPlot(ElementPlot):
 
         cmap = colors or style.pop('cmap', 'viridis')
         nan_colors = {k: rgba_tuple(v) for k, v in self.clipping_colors.items()}
-        if isinstance(cmap, dict) and factors:
+        if isinstance(cmap, dict) or factors:
+            if not factors:
+                factors = list(cmap)
             palette = [cmap.get(f, nan_colors.get('NaN', self._default_nan)) for f in factors]
+            factors = [dim.pprint_value(f) for f in factors]
         else:
             categorical = ncolors is not None
             if isinstance(self.color_levels, int):
@@ -1189,6 +1192,11 @@ class ColorbarPlot(ElementPlot):
 
         mapper = self._get_colormapper(cdim, element, ranges, style,
                                        factors, colors)
+        if not factors and isinstance(mapper, CategoricalColorMapper):
+            field += '_str'
+            cdata = [cdim.pprint_value(c) for c in cdata]
+            factors = mapper.factors
+
         data[field] = cdata
         if factors is not None and self.show_legend:
             mapping['legend'] = {'field': field}

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1186,14 +1186,14 @@ class ColorbarPlot(ElementPlot):
         if factors is None and (isinstance(cdata, list) or cdata.dtype.kind in dtypes):
             factors = list(util.unique_array(cdata))
         if factors and int_categories and cdata.dtype.kind == 'i':
-            field += '_str'
+            field += '_str__'
             cdata = [str(f) for f in cdata]
             factors = [str(f) for f in factors]
 
         mapper = self._get_colormapper(cdim, element, ranges, style,
                                        factors, colors)
         if not factors and isinstance(mapper, CategoricalColorMapper):
-            field += '_str'
+            field += '_str__'
             cdata = [cdim.pprint_value(c) for c in cdata]
             factors = mapper.factors
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -111,7 +111,7 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
                 cvals = cvals.astype(np.int32)
                 factors = factors.astype(np.int32)
             if factors.dtype.kind not in 'SU':
-                field += '_str'
+                field += '_str__'
                 cvals = [str(f) for f in cvals]
                 factors = (str(f) for f in factors)
             factors = list(factors)

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -241,7 +241,7 @@ class TestColorbarPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(points)
         cmapper = plot.handles['color_mapper']
         cds = plot.handles['cds']
-        self.assertEqual(cds.data['Category_str'], ['0', '1', '2', '3'])
+        self.assertEqual(cds.data['Category_str__'], ['0', '1', '2', '3'])
         self.assertEqual(cmapper.factors, ['0', '1', '2', '3'])
         self.assertEqual(cmapper.palette, ['blue', 'red', 'green', 'purple'])
 

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from nose.plugins.attrib import attr
 
 import numpy as np
@@ -231,6 +232,18 @@ class TestColorbarPlot(TestBokehPlot):
         cmapper = plot.handles['color_mapper']
         self.assertEqual(cmapper.low_color, 'red')
         self.assertEqual(cmapper.high_color, 'blue')
+
+    def test_explicit_categorical_cmap_on_integer_data(self):
+        explicit_mapping = OrderedDict([(0, 'blue'), (1, 'red'), (2, 'green'), (3, 'purple')])
+        points = Scatter(([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3]), vdims=['y', 'Category']).options(
+            color_index='Category', cmap=explicit_mapping
+        )
+        plot = bokeh_renderer.get_plot(points)
+        cmapper = plot.handles['color_mapper']
+        cds = plot.handles['cds']
+        self.assertEqual(cds.data['Category_str'], ['0', '1', '2', '3'])
+        self.assertEqual(cmapper.factors, ['0', '1', '2', '3'])
+        self.assertEqual(cmapper.palette, ['blue', 'red', 'green', 'purple'])
 
 
 class TestOverlayPlot(TestBokehPlot):

--- a/holoviews/tests/plotting/bokeh/testgraphplot.py
+++ b/holoviews/tests/plotting/bokeh/testgraphplot.py
@@ -142,8 +142,8 @@ class TestBokehGraphPlot(TestBokehPlot):
         self.assertIsInstance(cmapper, CategoricalColorMapper)
         factors = ['0', '1', '2', '3', '4', '5', '6', '7']
         self.assertEqual(cmapper.factors, factors)
-        self.assertEqual(edge_source.data['start_str'], factors)
-        self.assertEqual(glyph.line_color, {'field': 'start_str', 'transform': cmapper})
+        self.assertEqual(edge_source.data['start_str__'], factors)
+        self.assertEqual(glyph.line_color, {'field': 'start_str__', 'transform': cmapper})
 
     def test_graph_edges_numerically_colormapped(self):
         g = self.graph4.opts(plot=dict(edge_color_index='Weight'),
@@ -202,8 +202,8 @@ class TestBokehTriMeshPlot(TestBokehPlot):
         self.assertIsInstance(cmapper, CategoricalColorMapper)
         factors = ['0', '1', '2', '3']
         self.assertEqual(cmapper.factors, factors)
-        self.assertEqual(edge_source.data['node1_str'], ['0', '1'])
-        self.assertEqual(glyph.line_color, {'field': 'node1_str', 'transform': cmapper})
+        self.assertEqual(edge_source.data['node1_str__'], ['0', '1'])
+        self.assertEqual(glyph.line_color, {'field': 'node1_str__', 'transform': cmapper})
 
     def test_graph_nodes_numerically_colormapped(self):
         g = self.trimesh_weighted.opts(plot=dict(edge_color_index='weight'),
@@ -258,6 +258,6 @@ class TestBokehChordPlot(TestBokehPlot):
         self.assertIsInstance(cmapper, CategoricalColorMapper)
         self.assertEqual(cmapper.palette, ['#FFFFFF', '#000000', '#FFFFFF'])
         self.assertEqual(cmapper.factors, ['0', '1', '2'])
-        self.assertEqual(edge_source.data['start_str'], ['0', '0', '1'])
-        self.assertEqual(glyph.line_color, {'field': 'start_str', 'transform': cmapper})
+        self.assertEqual(edge_source.data['start_str__'], ['0', '0', '1'])
+        self.assertEqual(glyph.line_color, {'field': 'start_str__', 'transform': cmapper})
 


### PR DESCRIPTION
This PR allows providing an explicit colormapping for non-categorical data.

- [x] Closes https://github.com/ioam/holoviews/issues/3033
- [x] Adds unit test