### PR TITLE
Ensure toolbar=None does not disable tools

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -105,7 +105,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
     toolbar = param.ObjectSelector(default='right',
                                    objects=["above", "below",
-                                            "left", "right", None],
+                                            "left", "right", "disable", None],
                                    doc="""
         The toolbar location, must be one of 'above', 'below',
         'left', 'right', None.""")
@@ -324,7 +324,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             title = ''
 
-        if self.toolbar:
+        if self.toolbar != 'disable':
             tools = self._init_tools(element)
             properties['tools'] = tools
         properties['toolbar_location'] = self.toolbar


### PR DESCRIPTION
As discussed in https://github.com/ioam/holoviews/issues/3006 setting toolbar=None should not disable all the tools, it should simply hide the toolbar. I've added a toolbar='disable' option instead.

- [x] Closes https://github.com/ioam/holoviews/issues/3006