### PR TITLE
Fixed bug in HLine/VLine datetime handling

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -14,13 +14,13 @@ except:
     arrow_end = {'->': NormalHead, '-[': OpenHead, '-|>': NormalHead,
                  '-': None}
 
-from ...core.util import datetime_types, dimension_sanitizer, basestring
+from ...core.util import dimension_sanitizer, basestring
 from ...element import HLine
 from ..plot import GenericElementPlot
 from .element import (ElementPlot, CompositeElementPlot, ColorbarPlot,
                       text_properties, line_properties)
 from .plot import BokehPlot
-from .util import date_to_integer
+
 
 
 class TextPlot(ElementPlot):
@@ -126,8 +126,6 @@ class LineAnnotationPlot(ElementPlot):
             dim = 'width' if dim == 'height' else 'height'
         mapping['dimension'] = dim
         loc = element.data
-        if isinstance(loc, datetime_types):
-            loc = date_to_integer(loc)
         mapping['location'] = loc
         return (data, mapping, style)
 


### PR DESCRIPTION
Apparently there is no need to transform datetime types in the HLine/VLine plotting code and getting rid of this processing also fixes timezone issues.

- [x] Closes https://github.com/ioam/holoviews/issues/2857