### PR TITLE
Ensure QuadMesh with xarray handles datetime range

### DIFF
--- a/holoviews/core/data/grid.py
+++ b/holoviews/core/data/grid.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import sys
+import datetime as dt
 from collections import OrderedDict, defaultdict, Iterable
 
 try:
@@ -188,6 +190,9 @@ class GridInterface(DictInterface):
                [ 2.5,  3.5,  4.5]])
         """
         coord = np.asarray(coord)
+        if sys.version_info.major == 2 and len(coord) and isinstance(coord[0], (dt.datetime, dt.date)):
+            # np.diff does not work on datetimes in python 2
+            coord = coord.astype('datetime64')
         deltas = 0.5 * np.diff(coord, axis=axis)
         first = np.take(coord, [0], axis=axis) - np.take(deltas, [0], axis=axis)
         last = np.take(coord, [-1], axis=axis) + np.take(deltas, [-1], axis=axis)

--- a/holoviews/core/data/xarray.py
+++ b/holoviews/core/data/xarray.py
@@ -200,7 +200,10 @@ class XArrayInterface(GridInterface):
         dim = dataset.get_dimension(dimension, strict=True).name
         if dataset._binned and dimension in dataset.kdims:
             data = cls.coords(dataset, dim, edges=True)
-            dmin, dmax = np.nanmin(data), np.nanmax(data)
+            if data.dtype.kind == 'M':
+                dmin, dmax = data.min(), data.max()
+            else:
+                dmin, dmax = np.nanmin(data), np.nanmax(data)
         else:
             data = dataset.data[dim]
             if len(data):
@@ -211,8 +214,8 @@ class XArrayInterface(GridInterface):
         da = dask_array_module()
         if da and isinstance(dmin, da.Array):
             dmin, dmax = da.compute(dmin, dmax)
-        dmin = dmin if np.isscalar(dmin) else dmin.item()
-        dmax = dmax if np.isscalar(dmax) else dmax.item()
+        dmin = dmin if np.isscalar(dmin) or isinstance(dmin, util.datetime_types) else dmin.item()
+        dmax = dmax if np.isscalar(dmax) or isinstance(dmax, util.datetime_types) else dmax.item()
         return dmin, dmax
 
 

--- a/holoviews/tests/core/data/testxarrayinterface.py
+++ b/holoviews/tests/core/data/testxarrayinterface.py
@@ -1,3 +1,4 @@
+import datetime as dt
 from collections import OrderedDict
 from nose.plugins.attrib import attr
 from unittest import SkipTest
@@ -12,7 +13,7 @@ except:
 from holoviews.core.data import Dataset, concat
 from holoviews.core.dimension import Dimension
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Image, RGB, HSV
+from holoviews.element import Image, RGB, HSV, QuadMesh
 
 from .testimageinterface import (
     Image_ImageInterfaceTests, RGB_ImageInterfaceTests, HSV_ImageInterfaceTests
@@ -181,6 +182,25 @@ class XArrayInterfaceTests(GridInterfaceTests):
         self.assertTrue(np.isnan(z0))
         self.assertTrue(np.isnan(z1))
 
+    def test_datetime_bins_range(self):
+        xs = [dt.datetime(2018, 1, i) for i in range(1, 11)]
+        ys = np.arange(10)
+        array = np.random.rand(10, 10)
+        ds = QuadMesh((xs, ys, array))
+        self.assertEqual(ds.interface.datatype, 'xarray')
+        expected = (dt.datetime(2017, 12, 31, 12, 0), dt.datetime(2018, 1, 10, 12, 0))
+        self.assertEqual(ds.range('x'), expected)
+
+    def test_datetime64_bins_range(self):
+        xs = [np.datetime64(dt.datetime(2018, 1, i)) for i in range(1, 11)]
+        ys = np.arange(10)
+        array = np.random.rand(10, 10)
+        ds = QuadMesh((xs, ys, array))
+        self.assertEqual(ds.interface.datatype, 'xarray')
+        expected = (np.datetime64(dt.datetime(2017, 12, 31, 12, 0)),
+                    np.datetime64(dt.datetime(2018, 1, 10, 12, 0)))
+        self.assertEqual(ds.range('x'), expected)
+        
     def test_dataset_array_init_hm(self):
         "Tests support for arrays (homogeneous)"
         raise SkipTest("Not supported")


### PR DESCRIPTION
When using the xarray interface with a QuadMesh the range method would break on the datetimes.

- [x] Adds unit tests