### PR TITLE
Fixed bug setting integer number of contour levels

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -439,13 +439,14 @@ class contours(Operation):
             contour_type = Contours
         vdims = element.vdims[:1]
 
+        kwargs = {}
         levels = self.p.levels
         zmin, zmax = element.range(2)
         if isinstance(self.p.levels, int):
             if zmin == zmax:
                 contours = contour_type([], [xdim, ydim], vdims)
                 return (element * contours) if self.p.overlaid else contours
-            kwargs = {'N': self.p.levels}
+            data += (levels,)
         else:
             kwargs = {'levels': levels}
 

--- a/holoviews/tests/operation/teststatsoperations.py
+++ b/holoviews/tests/operation/teststatsoperations.py
@@ -61,7 +61,7 @@ class KDEOperationTests(ComparisonTestCase):
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, levels=10)
         self.assertIsInstance(kde, Contours)
-        self.assertEqual(len(kde.data), 6)
+        self.assertEqual(len(kde.data), 9)
 
     def test_bivariate_kde_contours_filled(self):
         np.random.seed(1)
@@ -69,7 +69,7 @@ class KDEOperationTests(ComparisonTestCase):
         kde = bivariate_kde(bivariate, n_samples=100, x_range=(0, 1),
                             y_range=(0, 1), contours=True, filled=True, levels=10)
         self.assertIsInstance(kde, Polygons)
-        self.assertEqual(len(kde.data), 7)
+        self.assertEqual(len(kde.data), 10)
 
     def test_bivariate_kde_nans(self):
         kde = bivariate_kde(self.bivariate_nans, n_samples=2, x_range=(0, 4),


### PR DESCRIPTION
Small bug I introduced in the recent geometry handling PR, for older versions of matplotlib an integer number of contours needs to be passed in as a positional argument.