### PR TITLE
Implement MultiInterface groupby

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -50,7 +50,8 @@ except ImportError:
 
 if 'array' not in datatypes:
     datatypes.append('array')
-
+if 'multitabular' not in datatypes:
+    datatypes.append('multitabular')
 
 
 def concat(datasets, datatype=None):

--- a/holoviews/core/data/dictionary.py
+++ b/holoviews/core/data/dictionary.py
@@ -43,7 +43,10 @@ class DictInterface(Interface):
             vdims = eltype.vdims
 
         dimensions = [dimension_name(d) for d in kdims + vdims]
-        if isinstance(data, tuple):
+        if (isinstance(data, list) and all(isinstance(d, dict) for d in data) and
+            not all(c in d for d in data for c in dimensions)):
+            raise ValueError('DictInterface could not find specified dimensions in the data.')
+        elif isinstance(data, tuple):
             data = {d: v for d, v in zip(dimensions, data)}
         elif util.is_dataframe(data) and all(d in data for d in dimensions):
             data = {d: data[d] for d in dimensions}

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -1,8 +1,8 @@
 import numpy as np
 
+from .. import util
 from ..element import Element
 from ..ndmapping import NdMapping, item_check, sorted_context
-from ..util import max_range, get_param_values, unique_iterator, isscalar
 from .dictionary import DictInterface
 from .interface import Interface, DataError
 
@@ -112,7 +112,7 @@ class MultiInterface(Interface):
         for d in dataset.data:
             ds.data = d
             ranges.append(ds.interface.range(ds, dim))
-        return max_range(ranges)
+        return util.max_range(ranges)
 
 
     @classmethod
@@ -188,7 +188,7 @@ class MultiInterface(Interface):
         group_kwargs = {}
         group_type = list if group_type == 'raw' else group_type
         if issubclass(group_type, Element):
-            group_kwargs.update(get_param_values(dataset))
+            group_kwargs.update(util.get_param_values(dataset))
             group_kwargs['kdims'] = kdims
         group_kwargs.update(kwargs)
 
@@ -208,7 +208,7 @@ class MultiInterface(Interface):
         ds = Dataset(values, dimensions)
         keys = (tuple(vals[i] for vals in values) for i in range(len(vals)))
         grouped_data = []
-        for unique_key in unique_iterator(keys):
+        for unique_key in util.unique_iterator(keys):
             mask = ds.interface.select_mask(ds, dict(zip(dimensions, unique_key)))
             selection = [data for data, m in zip(dataset.data, mask) if m]
             group_data = group_type(selection, **group_kwargs)
@@ -334,7 +334,7 @@ class MultiInterface(Interface):
     def add_dimension(cls, dataset, dimension, dim_pos, values, vdim):
         if not len(dataset.data):
             return dataset.data
-        elif values is None or np.isscalar(values):
+        elif values is None or util.isscalar(values):
             values = [values]*len(dataset.data)
         elif not len(values) == len(dataset.data):
             raise ValueError('Added dimension values must be scalar or '

--- a/holoviews/core/data/multipath.py
+++ b/holoviews/core/data/multipath.py
@@ -182,7 +182,6 @@ class MultiInterface(Interface):
         # Get dimensions information
         dimensions = [dataset.get_dimension(d) for d in dimensions]
         kdims = [kdim for kdim in dataset.kdims if kdim not in dimensions]
-        vdims = dataset.vdims
 
         # Update the kwargs appropriately for Element group types
         group_kwargs = {}

--- a/holoviews/core/data/pandas.py
+++ b/holoviews/core/data/pandas.py
@@ -126,7 +126,8 @@ class PandasInterface(Interface):
                 if not cls.expanded(data):
                     raise ValueError('PandasInterface expects data to be of uniform shape.')
                 data = pd.DataFrame(dict(zip(columns, data)), columns=columns)
-            elif isinstance(data, dict) and any(c not in data for c in columns):
+            elif ((isinstance(data, dict) and any(c not in data for c in columns)) or
+                  (isinstance(data, list) and any(isinstance(d, dict) and c not in d for d in data for c in columns))):
                 raise ValueError('PandasInterface could not find specified dimensions in the data.')
             else:
                 data = pd.DataFrame(data, columns=columns)

--- a/holoviews/tests/core/data/testmultiinterface.py
+++ b/holoviews/tests/core/data/testmultiinterface.py
@@ -5,6 +5,7 @@ Tests for the Dataset Element types.
 from unittest import SkipTest
 
 import numpy as np
+from holoviews.core.data import Dataset
 from holoviews.core.data.interface import DataError
 from holoviews.element import Path
 from holoviews.element.comparison import ComparisonTestCase
@@ -155,3 +156,30 @@ class MultiInterfaceTest(ComparisonTestCase):
     def test_multi_values_empty(self):
         mds = Path([], kdims=['x', 'y'], datatype=['multitabular'])
         self.assertEqual(mds.dimension_values(0), np.array([]))
+
+    def test_multi_dict_groupby(self):
+        arrays = [{'x': np.arange(i, i+2), 'y': i} for i in range(2)]
+        mds = Dataset(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+        for i, (k, ds) in enumerate(mds.groupby('y').items()):
+            self.assertEqual(k, arrays[i]['y'])
+            self.assertEqual(ds, Dataset([arrays[i]], kdims=['x']))
+
+    def test_multi_dict_groupby_non_scalar(self):
+        arrays = [{'x': np.arange(i, i+2), 'y': i} for i in range(2)]
+        mds = Dataset(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+        with self.assertRaises(ValueError):
+            mds.groupby('x')
+
+    def test_multi_array_groupby(self):
+        arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
+        mds = Dataset(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+        for i, (k, ds) in enumerate(mds.groupby('y').items()):
+            self.assertEqual(k, arrays[i][0, 1])
+            self.assertEqual(ds, Dataset([arrays[i]], kdims=['x']))
+
+    def test_multi_array_groupby_non_scalar(self):
+        arrays = [np.array([(1+i, i), (2+i, i), (3+i, i)]) for i in range(2)]
+        mds = Dataset(arrays, kdims=['x', 'y'], datatype=['multitabular'])
+        with self.assertRaises(ValueError):
+            mds.groupby('x')
+


### PR DESCRIPTION
This PR implements groupby operations for the MultiInterface. A groupby on a MultiInterface can only be applied if the dimension being grouped on is a scalar value in each item of the data. This allows polygon type data indexed by a variable to be grouped by one of those index values. For example you might have a Dataset containing geometries for all countries indexed by continent. Using groupby you can group the polygons by continent:

```python
> ds
:Dataset   [lon,lat,continent] (country)

> ds.groupby('continent')
:HoloMap   [continent]
   :Dataset   [lon,lat]   (country)
```

- [x] Add unit tests
