### PR TITLE
Add size_index to graphs

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -82,7 +82,7 @@ class Nodes(Points):
     """
 
     kdims = param.List(default=[Dimension('x'), Dimension('y'),
-                                Dimension('index')], bounds=(3, 3))
+                                Dimension('index')], bounds=(3, None))
 
     group = param.String(default='Nodes', constant=True)
 
@@ -114,7 +114,7 @@ class Graph(Dataset, Element2D):
     group = param.String(default='Graph', constant=True)
 
     kdims = param.List(default=[Dimension('start'), Dimension('end')],
-                       bounds=(2, 2))
+                       bounds=(2, None))
 
     node_type = Nodes
 
@@ -133,7 +133,7 @@ class Graph(Dataset, Element2D):
             node_info = None
             if isinstance(nodes, self.node_type):
                 pass
-            elif not isinstance(nodes, Dataset) or nodes.ndims == 3:
+            elif not isinstance(nodes, Dataset) or nodes.ndims >= 3:
                 nodes = self.node_type(nodes)
             else:
                 node_info = nodes


### PR DESCRIPTION
Try to address https://github.com/ioam/holoviews/issues/3097, but I'm not really sure what I'm doing; just copying a bunch of code from the other scripts.

Still useless too because I can't seem to figure out where it only takes the first three(?) columns and converts it to `['index', 'x', 'y']`(?) instead of `['index', 'x', 'y', 'test']` so size_index/color_index only works on either `'index'`, `'x'` or `'y'`... (I think if the three column restriction is removed, it'll help complement the fix to the image hover_col limit too(?) https://github.com/pyviz/geoviews/issues/242 besides changing `bounds=(1, None))`)

![image](https://user-images.githubusercontent.com/15331990/47406329-90930880-d70a-11e8-84d6-a626b94d940b.png)


