### PR TITLE
Ensure garbage collection is able to clean up after bokeh server sessions are destroyed

### DIFF
--- a/holoviews/__init__.py
+++ b/holoviews/__init__.py
@@ -38,7 +38,7 @@ try:
     import IPython                 # noqa (API import)
     from .ipython import notebook_extension
     extension = notebook_extension # noqa (name remapping)
-except ImportError as e:
+except ImportError:
     class notebook_extension(param.ParameterizedFunction):
         def __call__(self, *args, **opts): # noqa (dummy signature)
             raise Exception("IPython notebook not available: use hv.extension instead.")

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1150,10 +1150,10 @@ class LinkCallback(param.Parameterized):
         sources = plot.hmap.traverse(lambda x: x, [ViewableElement])
         for src in sources:
             if link is None:
-                if id(src) in Link.registry:
-                    return (plot, Link.registry[id(src)])
+                if src in Link.registry:
+                    return (plot, Link.registry[src])
             else:
-                if id(link.target) == id(src):
+                if link.target is src:
                     return (plot, [link])
 
     def validate(self):

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -68,8 +68,15 @@ class MessageCallback(object):
 
 
     def cleanup(self):
+        self.reset()
+        self.handle_ids = None
+        self.plot = None
+        self.source = None
+        self.streams = []
         if self.comm:
             self.comm.close()
+        Callback._callbacks = {k: cb for k, cb in Callback._callbacks.items()
+                               if cb is not self}
 
 
     def reset(self):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -17,7 +17,7 @@ from ..links import Link
 from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
                     GenericElementPlot, GenericOverlayPlot)
 from ..util import attach_streams, displayable, collate
-from .callbacks import Callback, LinkCallback
+from .callbacks import LinkCallback
 from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
                    update_shared_sources, empty_plot, decode_bytes)
 
@@ -281,6 +281,7 @@ class BokehPlot(DimensionedPlot):
                 continue
             streams = list(plot.streams)
             plot.streams = []
+            plot._document = None
             if isinstance(plot, GenericElementPlot):
                 for callback in plot.callbacks:
                     streams += callback.streams

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -103,7 +103,8 @@ class BokehPlot(DimensionedPlot):
 
     @document.setter
     def document(self, doc):
-        if hasattr(doc, 'on_session_destroyed') and self.root is self.handles.get('plot'):
+        if (doc and hasattr(doc, 'on_session_destroyed') and
+            self.root is self.handles.get('plot') and not isinstance(self, AdjointLayoutPlot)):
             doc.on_session_destroyed(self._session_destroy)
             if self._document:
                 self._document._session_destroyed_callbacks.pop(self._session_destroy, None)
@@ -116,8 +117,6 @@ class BokehPlot(DimensionedPlot):
 
     def _session_destroy(self, session_context):
         self.cleanup()
-        self._document = None
-
 
     def __init__(self, *args, **params):
         root = params.pop('root', None)
@@ -158,7 +157,7 @@ class BokehPlot(DimensionedPlot):
 
         cb_classes = set()
         for _, source in sources:
-            streams = Stream.registry.get(id(source), [])
+            streams = Stream.registry.get(source, [])
             registry = Stream._callbacks['bokeh']
             cb_classes |= {(registry[type(stream)], stream) for stream in streams
                            if type(stream) in registry and stream.linked}
@@ -281,19 +280,21 @@ class BokehPlot(DimensionedPlot):
             if not isinstance(plot, (GenericCompositePlot, GenericElementPlot, GenericOverlayPlot)):
                 continue
             streams = list(plot.streams)
+            plot.streams = []
+            if isinstance(plot, GenericElementPlot):
+                for callback in plot.callbacks:
+                    streams += callback.streams
+                    callback.cleanup()
+
             for stream in set(streams):
                 stream._subscribers = [
                     (p, subscriber) for p, subscriber in stream._subscribers
                     if get_method_owner(subscriber) not in plots
                 ]
-            if not isinstance(plot, GenericElementPlot):
-                continue
-            for callback in plot.callbacks:
-                streams += callback.streams
-                callbacks = {k: cb for k, cb in callback._callbacks.items()
-                            if cb is not callback}
-                Callback._callbacks = callbacks
-                callback.cleanup()
+
+        self.subplots.clear()
+        if self.comm:
+            self.comm.close()
 
 
     def _fontsize(self, key, label='fontsize', common=True):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -103,11 +103,20 @@ class BokehPlot(DimensionedPlot):
 
     @document.setter
     def document(self, doc):
+        if hasattr(doc, 'on_session_destroyed') and self.root is self.handles.get('plot'):
+            doc.on_session_destroyed(self._session_destroy)
+            if self._document:
+                self._document._session_destroyed_callbacks.pop(self._session_destroy, None)
+
         self._document = doc
         if self.subplots:
             for plot in self.subplots.values():
                 if plot is not None:
                     plot.document = doc
+
+    def _session_destroy(self, session_context):
+        self.cleanup()
+        self._document = None
 
 
     def __init__(self, *args, **params):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -282,6 +282,10 @@ class BokehPlot(DimensionedPlot):
             streams = list(plot.streams)
             plot.streams = []
             plot._document = None
+
+            if plot.subplots:
+                plot.subplots.clear()
+
             if isinstance(plot, GenericElementPlot):
                 for callback in plot.callbacks:
                     streams += callback.streams
@@ -293,7 +297,6 @@ class BokehPlot(DimensionedPlot):
                     if get_method_owner(subscriber) not in plots
                 ]
 
-        self.subplots.clear()
         if self.comm:
             self.comm.close()
 

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -78,6 +78,9 @@ class BokehServerWidgets(param.Parameterized):
         self._queue = []
         self._active = False
 
+        if hasattr(self.plot.document, 'on_session_destroyed'):
+            self.plot.document.on_session_destroyed(self.plot._session_destroy)
+
 
     @classmethod
     def create_widget(self, dim, holomap=None, editable=False):

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -1,8 +1,7 @@
+import weakref
 from collections import defaultdict
 
 import param
-
-from ..core import ViewableElement
 
 
 class Link(param.Parameterized):
@@ -22,14 +21,8 @@ class Link(param.Parameterized):
     directional links between the source and target object.
     """
 
-    source = param.ClassSelector(class_=ViewableElement, doc="""
-        The source object of the link (required).""")
-
-    target = param.ClassSelector(class_=ViewableElement, doc="""
-        The target object of the link (optional).""")
-
     # Mapping from a source id to a Link instance
-    registry = defaultdict(list)
+    registry = weakref.WeakKeyDictionary()
 
     # Mapping to define callbacks by backend and Link type.
     # e.g. Link._callbacks['bokeh'][Stream] = Callback
@@ -38,7 +31,11 @@ class Link(param.Parameterized):
     def __init__(self, source, target=None, **params):
         if source is None:
             raise ValueError('%s must define a source' % type(self).__name__)
-        super(Link, self).__init__(source=source, target=target, **params)
+
+        # Source is stored as a weakref to allow it to be garbage collected
+        self._source = weakref.ref(source) if source else None
+        self._target = weakref.ref(target) if target else None
+        super(Link, self).__init__(**params)
         self.link()
 
     @classmethod
@@ -49,17 +46,28 @@ class Link(param.Parameterized):
         """
         cls._callbacks[backend][cls] = callback
 
+    @property
+    def source(self):
+        return self._source() if self._source else None
+
+    @property
+    def target(self):
+        return self._target() if self._target else None
+
     def link(self):
         """
         Registers the Link
         """
-        self.registry[id(self.source)].append(self)
+        if self.source in self.registry:
+            self.registry[self.source].append(self)
+        else:
+            self.registry[self.source] = [self]
 
     def unlink(self):
         """
         Unregisters the Link
         """
-        links = self.registry.get(id(self.source))
+        links = self.registry.get(self.source)
         if self in links:
             links.pop(links.index(self))
 

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -72,7 +72,9 @@ class Stream(param.Parameterized):
     respectively.
     """
 
-    # Mapping from a source id to a list of streams
+    # Mapping from a source to a list of streams
+    # WeakKeyDictionary to allow garbage collection
+    # of unreferenced sources
     registry = weakref.WeakKeyDictionary()
 
     # Mapping to define callbacks by backend and Stream type.
@@ -200,7 +202,10 @@ class Stream(param.Parameterized):
         Some streams are configured to automatically link to the source
         plot, to disable this set linked=False
         """
+
+        # Source is stored as a weakref to allow it to be garbage collected
         self._source = weakref.ref(source) if source else None
+
         self._subscribers = []
         for subscriber in subscribers:
             self.add_subscriber(subscriber)

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -224,7 +224,7 @@ class Stream(param.Parameterized):
         super(Stream, self).__init__(**params)
         self._rename = self._validate_rename(rename)
         if source is not None:
-            if sid in self.registry:
+            if source in self.registry:
                 self.registry[source].append(self)
             else:
                 self.registry[source] = [self]

--- a/holoviews/tests/teststreams.py
+++ b/holoviews/tests/teststreams.py
@@ -484,12 +484,12 @@ class TestStreamSource(ComparisonTestCase):
     def test_source_registry(self):
         points = Points([(0, 0)])
         PointerX(source=points)
-        self.assertIn(id(points), Stream.registry)
+        self.assertIn(points, Stream.registry)
 
     def test_source_registry_empty_element(self):
         points = Points([])
         PointerX(source=points)
-        self.assertIn(id(points), Stream.registry)
+        self.assertIn(points, Stream.registry)
 
 
 class TestParameterRenaming(ComparisonTestCase):


### PR DESCRIPTION
Cleans up plots when a bokeh server session is destroyed allowing the plots and objects to be garbage collected.

Here's a screenshot of the output of ``memprof`` of a bokeh server session where I open consecutive sessions and then close them. As you can see after all the sessions are cleaned up memory usage returns to the 200 MB baseline, which is used to keep all the sys.modules in memory and run a bokeh server.

Before:

![screen shot 2018-10-26 at 10 21 41 pm](https://user-images.githubusercontent.com/1550771/47592988-8d4b8700-d96d-11e8-9af1-667cf806cce2.png)

After:

![screen shot 2018-10-26 at 10 13 00 pm](https://user-images.githubusercontent.com/1550771/47592730-6c366680-d96c-11e8-89ce-04869e3cb9ac.png)

Without https://github.com/bokeh/bokeh/pull/8368 the garbage collection will not happen immediately and things may stick around for a while. So we won't quite see the behavior shown above until bokeh 1.0.1 is released with that fix.

- [x] Closes https://github.com/ioam/holoviews/issues/2111