### PR TITLE
Fixed Selection1D stream

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -787,9 +787,9 @@ class Selection1DCallback(Callback):
     Returns the current selection on a ColumnDataSource.
     """
 
-    attributes = {'index': 'cb_obj.selected.indices'}
-    models = ['source']
-    on_changes = ['selected']
+    attributes = {'index': 'cb_obj.indices'}
+    models = ['selected']
+    on_changes = ['indices']
 
     def _process_msg(self, msg):
         if 'index' in msg:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -746,6 +746,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             source = self._init_datasource(data)
         self.handles['previous_id'] = current_id
         self.handles['source'] = self.handles['cds'] = source
+        self.handles['selected'] = source.selected
 
         properties = self._glyph_properties(plot, style_element, source, ranges, style)
         with abbreviated_exception():

--- a/holoviews/tests/plotting/bokeh/testcallbacks.py
+++ b/holoviews/tests/plotting/bokeh/testcallbacks.py
@@ -311,12 +311,11 @@ class TestServerCallbacks(CallbackTestCase):
         points = Points([1, 2, 3])
         Selection1D(source=points)
         plot = bokeh_server_renderer.get_plot(points)
-        cds = plot.handles['cds']
-        cds.selected = Selection(indices=[0, 2])
+        selected = Selection(indices=[0, 2])
         callback = plot.callbacks[0]
         spec = callback.attributes['index']
-        resolved = callback.resolve_attr_spec(spec, cds, model=cds)
-        self.assertEqual(resolved, {'id': cds.ref['id'], 'value': [0, 2]})
+        resolved = callback.resolve_attr_spec(spec, selected, model=selected)
+        self.assertEqual(resolved, {'id': selected.ref['id'], 'value': [0, 2]})
 
     def test_rangexy_resolves(self):
         points = Points([1, 2, 3])


### PR DESCRIPTION
In the most recent release of bokeh it is now no longer possible to listen to the selected attribute on a ColumnDataSource, instead one has to listen to the indices on the selected object.