### PR TITLE
Minor fixes for comm cleanup

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -74,7 +74,10 @@ class MessageCallback(object):
         self.source = None
         self.streams = []
         if self.comm:
-            self.comm.close()
+            try:
+                self.comm.close()
+            except:
+                pass
         Callback._callbacks = {k: cb for k, cb in Callback._callbacks.items()
                                if cb is not self}
 

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -300,7 +300,7 @@ class BokehPlot(DimensionedPlot):
                     if get_method_owner(subscriber) not in plots
                 ]
 
-        if self.comm:
+        if self.comm and self.root is self.handles.get('plot'):
             self.comm.close()
 
 


### PR DESCRIPTION
When using HoloViews with panel the cleanup of comms usually occurs in panel so to avoid exceptions because a comm has already been closed this PR ensures that this does not error.