### PR TITLE
Ensure methods accept both single dimension/spec and list of them

### DIFF
--- a/holoviews/core/data/__init__.py
+++ b/holoviews/core/data/__init__.py
@@ -361,6 +361,8 @@ class Dataset(Element):
             # drop all scalar key dimensions
             key_dims = [d for d in self.kdims if (not vdims or d not in vdims)
                         and not d in scalars]
+        elif not isinstance(kdims, list):
+            key_dims = [self.get_dimension(kdims, strict=True)]
         else:
             key_dims = [self.get_dimension(k, strict=True) for k in kdims]
         dropped = [d for d in self.kdims if not d in key_dims and not d in scalars]

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -691,6 +691,8 @@ class LabelledData(param.Parameterized):
         processed. Otherwise, specs must be a list of
         type.group.label specs, types, and functions.
         """
+        if specs is not None and not isinstance(specs, (list, set, tuple)):
+            specs = [specs]
         accumulator = []
         matches = specs is None
         if not matches:
@@ -715,7 +717,8 @@ class LabelledData(param.Parameterized):
         Recursively replaces elements using a map function when the
         specification applies.
         """
-        if specs and not isinstance(specs, list): specs = [specs]
+        if specs is not None and not isinstance(specs, (list, set, tuple)):
+            specs = [specs]
         applies = specs is None or any(self.matches(spec) for spec in specs)
 
         if self._deep_indexable:

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -270,6 +270,8 @@ class MultiDimensionalMapping(Dimensioned):
         if self.ndims == 1:
             self.warning('Cannot split Map with only one dimension.')
             return self
+        elif not isinstance(dimensions, list):
+            dimensions = [dimensions]
         container_type = container_type if container_type else type(self)
         group_type = group_type if group_type else type(self)
         dimensions = [self.get_dimension(d, strict=True) for d in dimensions]
@@ -361,7 +363,9 @@ class MultiDimensionalMapping(Dimensioned):
         each value uniquely.
         """
         old_kdims = [d.name for d in self.kdims]
-        if not len(kdims):
+        if not isinstance(kdims, list):
+            kdims = [kdims]
+        elif not len(kdims):
             kdims = [d for d in old_kdims
                      if not len(set(self.dimension_values(d))) == 1]
         indices = [self.get_dimension_index(el) for el in kdims]

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1491,6 +1491,8 @@ class DynamicMap(HoloMap):
         usually allows dropping non-constant dimensions is therefore
         ignored and only for API consistency.
         """
+        if not isinstance(kdims, list):
+            kdims = [kdims]
         kdims = [self.get_dimension(kd, strict=True) for kd in kdims]
         dropped = [kd for kd in self.kdims if kd not in kdims]
         if dropped:


### PR DESCRIPTION
In general we have ensured that methods that accept either dimensions or specs will accept both single items and lists of items but this has never been done very consistently.

- [x] Fixes https://github.com/ioam/holoviews/issues/3080