### PR TITLE
 Handle updating of bokeh legends

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -17,13 +17,13 @@ except:
 from ...core.util import dimension_sanitizer, basestring
 from ...element import HLine
 from ..plot import GenericElementPlot
-from .element import (ElementPlot, CompositeElementPlot, ColorbarPlot,
-                      text_properties, line_properties)
+from .element import (AnnotationPlot, CompositeElementPlot, ColorbarPlot,
+                      ElementPlot, text_properties, line_properties)
 from .plot import BokehPlot
 
 
 
-class TextPlot(ElementPlot):
+class TextPlot(ElementPlot, AnnotationPlot):
 
     style_opts = text_properties+['color', 'angle']
     _plot_methods = dict(single='text', batched='text')
@@ -66,7 +66,7 @@ class TextPlot(ElementPlot):
 
 
 
-class LabelsPlot(ColorbarPlot):
+class LabelsPlot(ColorbarPlot, AnnotationPlot):
 
     color_index = param.ClassSelector(default=None, class_=(basestring, int),
                                       allow_None=True, doc="""
@@ -118,7 +118,7 @@ class LabelsPlot(ColorbarPlot):
 
 
 
-class LineAnnotationPlot(ElementPlot):
+class LineAnnotationPlot(ElementPlot, AnnotationPlot):
 
     style_opts = line_properties + ['level']
 
@@ -147,7 +147,7 @@ class LineAnnotationPlot(ElementPlot):
 
 
 
-class SplinePlot(ElementPlot):
+class SplinePlot(ElementPlot, AnnotationPlot):
     """
     Draw the supplied Spline annotation (see Spline docstring).
     Does not support matplotlib Path codes.
@@ -180,7 +180,7 @@ class SplinePlot(ElementPlot):
 
 
 
-class ArrowPlot(CompositeElementPlot):
+class ArrowPlot(CompositeElementPlot, AnnotationPlot):
 
     style_opts = (['arrow_%s' % p for p in line_properties+['size']] + text_properties)
 
@@ -249,7 +249,7 @@ class ArrowPlot(CompositeElementPlot):
 
 
 
-class DivPlot(BokehPlot, GenericElementPlot):
+class DivPlot(BokehPlot, GenericElementPlot, AnnotationPlot):
 
     height = param.Number(default=300)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1297,6 +1297,12 @@ class LegendPlot(ElementPlot):
 
 
 
+class AnnotationPlot(object):
+    """
+    Mix-in plotting subclass for AnnotationPlots which do not have a legend.
+    """
+
+
 class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     tabs = param.Boolean(default=False, doc="""

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1381,18 +1381,24 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
             label = tuple(sorted(item.label.items())) if isinstance(item.label, dict) else item.label
             if not label or (isinstance(item.label, dict) and not item.label.get('value', True)):
                 continue
-            if item not in legend_items:
-                for oitem in legend_items:
-                    oitem.renderers[:] = [r for r in oitem.renderers if r not in item.renderers]
             if label in legend_labels:
                 prev_item = legend_labels[label]
                 prev_item.renderers[:] = list(util.unique_iterator(prev_item.renderers+item.renderers))
             else:
                 legend_labels[label] = item
                 legend_items.append(item)
-                self.handles['legend_items'].append(item)
-        legend_items = [item for item in legend_items if any(r.visible for r in item.renderers)]
-        legend.items[:] = list(util.unique_iterator(legend_items))
+                if item not in self.handles['legend_items']:
+                    self.handles['legend_items'].append(item)
+
+        filtered = []
+        renderers = []
+        for item in legend_items:
+            item.renderers[:] = [r for r in item.renderers if r not in renderers]
+            if item in filtered or not item.renderers or not any(r.visible for r in item.renderers):
+                continue
+            renderers += item.renderers
+            filtered.append(item)
+        legend.items[:] = list(util.unique_iterator(filtered))
 
         if self.multiple_legends:
             plot.legend.pop(plot.legend.index(legend))

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1600,7 +1600,8 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
                 # Skip updates to subplots when its streams is not one of
                 # the streams that initiated the update
-                if triggering and all(s not in triggering for s in subplot.streams):
+                if (triggering and all(s not in triggering for s in subplot.streams) and
+                    not subplot in self.dynamic_subplots):
                     continue
             subplot.update_frame(key, ranges, element=el)
 

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1375,10 +1375,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
         if 'legend_items' not in self.handles:
             self.handles['legend_items'] = []
         legend_items = self.handles['legend_items']
-        legend_labels = {tuple(i.label.items()) if isinstance(i.label, dict) else i.label: i
+        legend_labels = {tuple(sorted(i.label.items())) if isinstance(i.label, dict) else i.label: i
                          for i in legend_items}
         for item in legend.items:
-            label = tuple(item.label.items()) if isinstance(item.label, dict) else item.label
+            label = tuple(sorted(item.label.items())) if isinstance(item.label, dict) else item.label
             if not label or (isinstance(item.label, dict) and not item.label.get('value', True)):
                 continue
             if item not in legend_items:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1390,6 +1390,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 if item not in self.handles['legend_items']:
                     self.handles['legend_items'].append(item)
 
+        # Ensure that each renderer is only singly referenced by a legend item
         filtered = []
         renderers = []
         for item in legend_items:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1497,10 +1497,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
 
     def initialize_plot(self, ranges=None, plot=None, plots=None):
         key = util.wrap_tuple(self.hmap.last_key)
-        nonempty = [el for el in self.hmap.data.values() if el]
+        nonempty = [(k, el) for k, el in self.hmap.data.items() if el]
         if not nonempty:
             raise SkipRendering('All Overlays empty, cannot initialize plot.')
-        element = nonempty[-1]
+        dkey, element = nonempty[-1]
         ranges = self.compute_ranges(self.hmap, key, ranges)
         if plot is None and not self.tabs and not self.batched:
             plot = self._init_plot(key, element, ranges=ranges, plots=plots)
@@ -1518,8 +1518,10 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 subplot.overlaid = False
             child = subplot.initialize_plot(ranges, plot, plots)
             if isinstance(element, CompositeOverlay):
+                # Ensure that all subplots are in the same state
                 frame = element.get(key, None)
                 subplot.current_frame = frame
+                subplot.current_key = dkey
             if self.batched:
                 self.handles['plot'] = child
             if self.tabs:

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1144,6 +1144,8 @@ class GenericOverlayPlot(GenericElementPlot):
             oidx = 0
         else:
             vtype = type(obj.last)
+            if style_key not in ordering:
+                ordering.append(style_key)
             oidx = ordering.index(style_key)
 
         plottype = registry.get(vtype, None)

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1050,6 +1050,7 @@ class GenericOverlayPlot(GenericElementPlot):
         self.subplots = self._create_subplots(ranges)
         self.traverse(lambda x: setattr(x, 'comm', self.comm))
         self.top_level = keys is None
+        self.dynamic_subplots = []
         if self.top_level:
             self.comm = self.init_comm()
             self.traverse(lambda x: setattr(x, 'comm', self.comm))
@@ -1202,17 +1203,16 @@ class GenericOverlayPlot(GenericElementPlot):
         """
         length = self.style_grouping
         group_fn = lambda x: (x.type.__name__, x.last.group, x.last.label)
-        keys, vmaps = self.hmap.split_overlays()
-        for k, m in items:
-            self.map_lengths[group_fn(vmaps[keys.index(k)])[:length]] += 1
-
-        for k, obj in items:
-            subplot = self._create_subplot(k, vmaps[keys.index(k)], [], ranges)
+        for i, (k, obj) in enumerate(items):
+            vmap = self.hmap.clone([(key, obj)])
+            self.map_lengths[group_fn(vmap)[:length]] += 1
+            subplot = self._create_subplot(k, vmap, [], ranges)
             if subplot is None:
                 continue
             self.subplots[k] = subplot
             subplot.initialize_plot(ranges, **init_kwargs)
             subplot.update_frame(key, ranges, element=obj)
+            self.dynamic_subplots.append(subplot)
 
 
     def _update_subplot(self, subplot, spec):


### PR DESCRIPTION
Previous legends were completely static in the bokeh backend, i.e. in a HoloMap it would display all legend items for all frames at once and in a DynamicMap they would simply not update. Additionally this PR fixes a bug where the addition of an annotation on a plot would cause a legend to appear.

Also includes various fixes for dynamically creating and reassigning plot instances to ensure that a) the cyclic index is consistent and that b) dynamically created plot instances are updated appropriately despite not being assigned the correct stream mappings.

- [x] Closes https://github.com/ioam/holoviews/issues/2611
- [x] Closes https://github.com/ioam/holoviews/issues/2927
- [x] Add unit tests