### PR TITLE
Skip Tap callbacks if outside axis bounds

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -608,6 +608,30 @@ class TapCallback(PointerXYCallback):
     individual tap events within a doubletap event.
     """
 
+    # Skip if tap is outside axis range
+    code = """
+    if (x_range.type.endsWith('Range1d')) {
+      xstart = x_range.start;
+      xend = x_range.end;
+      if (xstart > xend) {
+        [xstart, xend] = [xend, xstart]
+      }
+      if ((cb_obj.x < xstart) || (cb_obj.x > xend)) {
+        return
+      }
+    }
+    if (y_range.type.endsWith('Range1d')) {
+      ystart = y_range.start;
+      yend = y_range.end;
+      if (ystart > yend) {
+        [ystart, yend] = [yend, ystart]
+      }
+      if ((cb_obj.y < ystart) || (cb_obj.y > yend) {
+        return
+      }
+    }
+    """
+
     on_events = ['tap', 'doubletap']
 
 
@@ -616,6 +640,8 @@ class SingleTapCallback(PointerXYCallback):
     Returns the mouse x/y-position on tap event.
     """
 
+    code = TapCallback.code
+
     on_events = ['tap']
 
 
@@ -623,6 +649,8 @@ class DoubleTapCallback(PointerXYCallback):
     """
     Returns the mouse x/y-position on doubletap event.
     """
+
+    code = TapCallback.code
 
     on_events = ['doubletap']
 


### PR DESCRIPTION
Unlike the PointerXY stream where we clip the pointer location if it goes outside the bounds to ensure that fast mouse movements are captured the tap callback should simply be skipped if the tap occurs outside the plot bounds.

- [x] Closes https://github.com/ioam/holoviews/issues/3135