### PR TITLE
Ensure that contours operation is robust to curvilinear coord edges

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -429,9 +429,21 @@ class contours(Operation):
             raise ImportError("contours operation requires matplotlib.")
         extent = element.range(0) + element.range(1)[::-1]
 
-        data = (element.dimension_values(0, False, flat=False),
-                element.dimension_values(1, False, flat=False),
-                element.dimension_values(2, flat=False))
+        xs = element.dimension_values(0, True, flat=False)
+        ys = element.dimension_values(1, True, flat=False)
+        zs = element.dimension_values(2, flat=False)
+
+        # Ensure that coordinate arrays specify bin centers
+        if xs.shape[0] != zs.shape[0]:
+            xs = xs[:-1] + np.diff(xs, axis=0)/2.
+        if xs.shape[1] != zs.shape[1]:
+            xs = xs[:, :-1] + (np.diff(xs, axis=1)/2.)
+        if ys.shape[0] != zs.shape[0]:
+            ys = ys[:-1] + np.diff(ys, axis=0)/2.
+        if ys.shape[1] != zs.shape[1]:
+            ys = ys[:, :-1] + (np.diff(ys, axis=1)/2.)
+        data = (xs, ys, zs)
+
         xdim, ydim = element.dimensions('key', label=True)
         if self.p.filled:
             contour_type = Polygons

--- a/holoviews/tests/operation/testoperation.py
+++ b/holoviews/tests/operation/testoperation.py
@@ -6,6 +6,7 @@ from nose.plugins.attrib import attr
 from holoviews import (HoloMap, NdOverlay, NdLayout, GridSpace, Image,
                        Contours, Polygons, Points, Histogram, Curve, Area,
                        QuadMesh, Dataset)
+from holoviews.core.data.grid import GridInterface
 from holoviews.core.util import pd
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.operation.element import (operation, transform, threshold,
@@ -88,6 +89,23 @@ class OperationTests(ComparisonTestCase):
     def test_qmesh_curvilinear_contours(self):
         x = y = np.arange(3)
         xs, ys = np.meshgrid(x, y)
+        zs = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
+        qmesh = QuadMesh((xs, ys+0.1, zs))
+        op_contours = contours(qmesh, levels=[0.5])
+        contour = Contours([[(0,  0.266667, 0.5), (0.5, 0.1, 0.5),
+                             (np.NaN, np.NaN, 0.5), (1.5, 0.1, 0.5),
+                             (2, 0.2, 0.5)]],
+                            vdims=qmesh.vdims)
+        self.assertEqual(op_contours, contour)
+
+    @attr(optional=1) # Requires matplotlib
+    def test_qmesh_curvilinear_edges_contours(self):
+        x = y = np.arange(3)
+        xs, ys = np.meshgrid(x, y)
+        xs = GridInterface._infer_interval_breaks(xs)
+        xs = GridInterface._infer_interval_breaks(xs, 1)
+        ys = GridInterface._infer_interval_breaks(ys)
+        ys = GridInterface._infer_interval_breaks(ys, 1)
         zs = np.array([[0, 1, 0], [3, 4, 5.], [6, 7, 8]])
         qmesh = QuadMesh((xs, ys+0.1, zs))
         op_contours = contours(qmesh, levels=[0.5])


### PR DESCRIPTION
Due to recent changes the contours operation did not robustly deal with curvilinear quadmesh coordinate edges.

- [x] Add unit test