### PR TITLE
Update dimensioned stream layout title

### DIFF
--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -982,7 +982,6 @@ class LayoutPlot(CompositePlot, GenericLayoutPlot):
             subplot = self.subplots.get((r, c), None)
             if subplot is not None:
                 subplot.update_frame(key, ranges)
-        print(key)
         title = self._get_title(key)
         if title:
             self.handles['title'] = title

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1353,7 +1353,13 @@ class GenericCompositePlot(DimensionedPlot):
         nested_streams = layout.traverse(lambda x: get_nested_streams(x),
                                          [DynamicMap])
         self.streams = list(set([s for streams in nested_streams for s in streams]))
+        self._link_dimensioned_streams()
 
+    def _link_dimensioned_streams(self):
+        """
+        Should perform any linking required to update titles when dimensioned
+        streams change.
+        """
 
     def _get_frame(self, key):
         """

--- a/holoviews/tests/plotting/bokeh/testgridplot.py
+++ b/holoviews/tests/plotting/bokeh/testgridplot.py
@@ -1,8 +1,10 @@
 import numpy as np
 
-from holoviews.core import HoloMap, GridSpace, NdOverlay, Dataset
+from holoviews.core import (HoloMap, GridSpace, NdOverlay, Dataset,
+                            DynamicMap, GridMatrix)
 from holoviews.element import Curve, Image, Points
 from holoviews.operation import gridmatrix
+from holoviews.streams import Stream
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -113,3 +115,14 @@ class TestGridPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(grid)
         self.assertIsInstance(plot.state, Column)
         self.assertEqual([p for p in plot.state.children if isinstance(p, ToolbarBox)], [])
+
+    def test_grid_dimensioned_stream_title_update(self):
+        stream = Stream.define('Test', test=0)()
+        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
+        grid = GridMatrix({0: dmap, 1: Curve([])}, 'X')
+        plot = bokeh_renderer.get_plot(grid)
+        self.assertIn('test: 0', plot.handles['title'].text)
+        stream.event(test=1)
+        self.assertIn('test: 1', plot.handles['title'].text)
+        plot.cleanup()
+        self.assertEqual(stream._subscribers, [])

--- a/holoviews/tests/plotting/bokeh/testlayoutplot.py
+++ b/holoviews/tests/plotting/bokeh/testlayoutplot.py
@@ -1,7 +1,9 @@
 import numpy as np
 
-from holoviews.core import HoloMap, GridSpace, Layout, Empty, Dataset, NdOverlay
+from holoviews.core import (HoloMap, GridSpace, Layout, Empty, Dataset,
+                            NdOverlay, DynamicMap)
 from holoviews.element import Curve, Image, Points
+from holoviews.streams import Stream
 
 from .testplot import TestBokehPlot, bokeh_renderer
 
@@ -247,3 +249,13 @@ class TestLayoutPlot(TestBokehPlot):
         self.assertEqual(subplot.handles['y_range'].start, 1)
         self.assertEqual(subplot.handles['y_range'].end, 0)
 
+    def test_layout_dimensioned_stream_title_update(self):
+        stream = Stream.define('Test', test=0)()
+        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
+        layout = dmap + Curve([])
+        plot = bokeh_renderer.get_plot(layout)
+        self.assertIn('test: 0', plot.handles['title'].text)
+        stream.event(test=1)
+        self.assertIn('test: 1', plot.handles['title'].text)
+        plot.cleanup()
+        self.assertEqual(stream._subscribers, [])

--- a/holoviews/tests/plotting/matplotlib/testlayoutplot.py
+++ b/holoviews/tests/plotting/matplotlib/testlayoutplot.py
@@ -1,7 +1,8 @@
 import numpy as np
 
-from holoviews.core import HoloMap, NdOverlay
+from holoviews.core import HoloMap, NdOverlay, DynamicMap
 from holoviews.element import Image, Curve
+from holoviews.streams import Stream
 
 from .testplot import TestMPLPlot, mpl_renderer
 
@@ -35,3 +36,14 @@ class TestLayoutPlot(TestMPLPlot):
             adjoint = plot.subplots[pos]
             if 'main' in adjoint.subplots:
                 self.assertEqual(adjoint.subplots['main'].layout_num, num)
+
+    def test_layout_dimensioned_stream_title_update(self):
+        stream = Stream.define('Test', test=0)()
+        dmap = DynamicMap(lambda test: Curve([]), kdims=['test'], streams=[stream])
+        layout = dmap + Curve([])
+        plot = mpl_renderer.get_plot(layout)
+        self.assertIn('test: 0', plot.handles['title'].get_text())
+        stream.event(test=1)
+        self.assertIn('test: 1', plot.handles['title'].get_text())
+        plot.cleanup()
+        self.assertEqual(stream._subscribers, [])


### PR DESCRIPTION
When plotting a layout or grid containing dimensioned streams the layout or grid title does not currently update because it is not notified about changes in the stream values. This ensures that the plots subscribe to changes in any dimensioned streams.