### PR TITLE
Add explicit xlabel/ylabel(/zlabel) plot options

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -1321,7 +1321,7 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                           'border', 'invert_xaxis', 'invert_yaxis', 'sizing_mode',
                           'title_format', 'legend_position', 'legend_offset',
                           'legend_cols', 'gridstyle', 'legend_muted', 'padding',
-                          'xlim', 'ylim', 'zlim']
+                          'xlabel', 'ylabel', 'xlim', 'ylim', 'zlim']
 
     def __init__(self, overlay, **params):
         super(OverlayPlot, self).__init__(overlay, **params)

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -56,6 +56,10 @@ class ElementPlot(GenericElementPlot, MPLPlot):
     zaxis = param.Boolean(default=True, doc="""
         Whether to display the z-axis.""")
 
+    zlabel = param.String(default=None, doc="""
+        An explicit override of the z-axis label, if set takes precedence
+        over the dimension label.""")
+
     zrotation = param.Integer(default=0, bounds=(0, 360), doc="""
         Rotation angle of the zticks.""")
 
@@ -780,7 +784,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                           'xticks', 'yticks', 'zticks', 'xrotation', 'yrotation',
                           'zrotation', 'invert_xaxis', 'invert_yaxis',
                           'invert_zaxis', 'title_format', 'padding',
-                          'xlim', 'ylim', 'zlim']
+                          'xlabel', 'ylabel', 'xlim', 'ylim', 'zlim']
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -784,7 +784,7 @@ class OverlayPlot(LegendPlot, GenericOverlayPlot):
                           'xticks', 'yticks', 'zticks', 'xrotation', 'yrotation',
                           'zrotation', 'invert_xaxis', 'invert_yaxis',
                           'invert_zaxis', 'title_format', 'padding',
-                          'xlabel', 'ylabel', 'xlim', 'ylim', 'zlim']
+                          'xlabel', 'ylabel', 'zlabel', 'xlim', 'ylim', 'zlim']
 
     def __init__(self, overlay, ranges=None, **params):
         if 'projection' not in params:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -132,6 +132,13 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                 # Set axis labels
                 if dimensions:
                     self._set_labels(axis, dimensions, xlabel, ylabel, zlabel)
+                else:
+                    if self.xlabel is not None:
+                        axis.set_xlabel(self.xlabel)
+                    if self.ylabel is not None:
+                        axis.set_ylabel(self.ylabel)
+                    if self.zlabel is not None and hasattr(axis, 'set_zlabel'):
+                        axis.set_zlabel(self.zlabel)
 
                 if not subplots:
                     legend = axis.get_legend()

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -209,6 +209,9 @@ class RasterGridPlot(GridPlot, OverlayPlot):
     zaxis = param.Parameter(precedence=-1)
     zrotation = param.Parameter(precedence=-1)
     zformatter = param.Parameter(precedence=-1)
+    xlabel = param.Parameter(precedence=-1)
+    ylabel = param.Parameter(precedence=-1)
+    zlabel = param.Parameter(precedence=-1)
 
 
     def __init__(self, layout, keys=None, dimensions=None, create_axes=False, ranges=None,

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -673,6 +673,14 @@ class GenericElementPlot(DimensionedPlot):
         The "bare" options allow suppressing all axis labels, including ticks and ylabel.
         Valid options are 'left', 'right', 'bare', 'left-bare' and 'right-bare'.""")
 
+    xlabel = param.String(default=None, doc="""
+        An explicit override of the x-axis label, if set takes precedence
+        over the dimension label.""")
+
+    ylabel = param.String(default=None, doc="""
+        An explicit override of the y-axis label, if set takes precedence
+        over the dimension label.""")
+
     xlim = param.NumericTuple(default=(np.nan, np.nan), length=2, doc="""
        User-specified x-axis range limits for the plot, as a tuple (low,high).
        If specified, takes precedence over data and dimension ranges.""")
@@ -967,11 +975,17 @@ class GenericElementPlot(DimensionedPlot):
 
 
     def _get_axis_labels(self, dimensions, xlabel=None, ylabel=None, zlabel=None):
-        if dimensions and xlabel is None:
+        if self.xlabel is not None:
+            xlabel = self.xlabel
+        elif dimensions and xlabel is None:
             xlabel = dim_axis_label(dimensions[0]) if dimensions[0] else ''
-        if len(dimensions) >= 2 and ylabel is None:
+        if self.ylabel is not None:
+            ylabel = self.ylabel
+        elif len(dimensions) >= 2 and ylabel is None:
             ylabel = dim_axis_label(dimensions[1]) if dimensions[1] else ''
-        if self.projection == '3d' and len(dimensions) >= 3 and zlabel is None:
+        if getattr(self, 'zlabel', None) is not None:
+            zlabel = self.zlabel
+        elif self.projection == '3d' and len(dimensions) >= 3 and zlabel is None:
             zlabel = dim_axis_label(dimensions[2]) if dimensions[2] else ''
         return xlabel, ylabel, zlabel
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -80,6 +80,10 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         labels or a matplotlib tick locator object. If set to None
         default matplotlib ticking behavior is applied.""")
 
+    zlabel = param.String(default=None, doc="""
+        An explicit override of the z-axis label, if set takes precedence
+        over the dimension label.""")
+
     graph_obj = None
 
     def initialize_plot(self, ranges=None):

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -26,7 +26,7 @@ class TestElementPlot(TestBokehPlot):
         self.assertEqual(plot.outline_line_alpha, 0)
 
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).options(xlabel='custom x-label')
+        curve = Curve(range(10)).options(xformatter='%d')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertIsInstance(xaxis.formatter, PrintfTickFormatter)
@@ -120,12 +120,6 @@ class TestElementPlot(TestBokehPlot):
         curve = Curve(range(10)).options(labelled=[])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, '')
-        self.assertEqual(plot.yaxis[0].axis_label, '')
-
-    def test_element_labelled_y_disabled(self):
-        curve = Curve(range(10)).options(labelled=['x'])
-        plot = bokeh_renderer.get_plot(curve).state
-        self.assertEqual(plot.xaxis[0].axis_label, 'x')
         self.assertEqual(plot.yaxis[0].axis_label, '')
 
     def test_static_source_optimization(self):

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -26,7 +26,7 @@ class TestElementPlot(TestBokehPlot):
         self.assertEqual(plot.outline_line_alpha, 0)
 
     def test_element_xformatter_string(self):
-        curve = Curve(range(10)).options(xformatter='%d')
+        curve = Curve(range(10)).options(xlabel='custom x-label')
         plot = bokeh_renderer.get_plot(curve)
         xaxis = plot.handles['xaxis']
         self.assertIsInstance(xaxis.formatter, PrintfTickFormatter)
@@ -94,6 +94,16 @@ class TestElementPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.yaxis[0].major_label_orientation, np.pi/2)
 
+    def test_element_xlabel_override(self):
+        curve = Curve(range(10)).options(xlabel='custom x-label')
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
+
+    def test_element_ylabel_override(self):
+        curve = Curve(range(10)).options(ylabel='custom y-label')
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
+
     def test_element_labelled_x_disabled(self):
         curve = Curve(range(10)).options(labelled=['y'])
         plot = bokeh_renderer.get_plot(curve).state
@@ -110,6 +120,12 @@ class TestElementPlot(TestBokehPlot):
         curve = Curve(range(10)).options(labelled=[])
         plot = bokeh_renderer.get_plot(curve).state
         self.assertEqual(plot.xaxis[0].axis_label, '')
+        self.assertEqual(plot.yaxis[0].axis_label, '')
+
+    def test_element_labelled_y_disabled(self):
+        curve = Curve(range(10)).options(labelled=['x'])
+        plot = bokeh_renderer.get_plot(curve).state
+        self.assertEqual(plot.xaxis[0].axis_label, 'x')
         self.assertEqual(plot.yaxis[0].axis_label, '')
 
     def test_static_source_optimization(self):

--- a/holoviews/tests/plotting/bokeh/testoverlayplot.py
+++ b/holoviews/tests/plotting/bokeh/testoverlayplot.py
@@ -81,6 +81,26 @@ class TestOverlayPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertFalse(plot.yaxis[0].visible)
 
+    def test_overlay_xlabel_override(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options(xlabel='custom x-label')
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
+
+    def test_overlay_ylabel_override(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options(ylabel='custom y-label')
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
+
+    def test_overlay_xlabel_override_propagated(self):
+        overlay = (Curve(range(10)).options(xlabel='custom x-label') * Curve(range(10)))
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
+
+    def test_overlay_ylabel_override(self):
+        overlay = (Curve(range(10)).options(ylabel='custom y-label') * Curve(range(10)))
+        plot = bokeh_renderer.get_plot(overlay).state
+        self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')
+
     def test_overlay_xrotation(self):
         overlay = (Curve(range(10)) * Curve(range(10))).opts(plot=dict(xrotation=90))
         plot = bokeh_renderer.get_plot(overlay).state

--- a/holoviews/tests/plotting/bokeh/testoverlayplot.py
+++ b/holoviews/tests/plotting/bokeh/testoverlayplot.py
@@ -96,7 +96,7 @@ class TestOverlayPlot(TestBokehPlot):
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.xaxis[0].axis_label, 'custom x-label')
 
-    def test_overlay_ylabel_override(self):
+    def test_overlay_ylabel_override_propagated(self):
         overlay = (Curve(range(10)).options(ylabel='custom y-label') * Curve(range(10)))
         plot = bokeh_renderer.get_plot(overlay).state
         self.assertEqual(plot.yaxis[0].axis_label, 'custom y-label')

--- a/holoviews/tests/plotting/matplotlib/testelementplot.py
+++ b/holoviews/tests/plotting/matplotlib/testelementplot.py
@@ -21,6 +21,16 @@ class TestElementPlot(TestMPLPlot):
         plot.cleanup()
         self.assertFalse(bool(stream._subscribers))
 
+    def test_element_xlabel(self):
+        element = Curve(range(10)).options(xlabel='custom x-label')
+        axes = mpl_renderer.get_plot(element).handles['axis']
+        self.assertEqual(axes.get_xlabel(), 'custom x-label')
+
+    def test_element_ylabel(self):
+        element = Curve(range(10)).options(ylabel='custom y-label')
+        axes = mpl_renderer.get_plot(element).handles['axis']
+        self.assertEqual(axes.get_ylabel(), 'custom y-label')
+
     def test_element_xformatter_string(self):
         curve = Curve(range(10)).options(xformatter='%d')
         plot = mpl_renderer.get_plot(curve)

--- a/holoviews/tests/plotting/matplotlib/testoverlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/testoverlayplot.py
@@ -77,3 +77,23 @@ class TestOverlayPlot(TestMPLPlot):
         self.assertEqual(len(plot.subplots), 3)
         for i, subplot in enumerate(plot.subplots.values()):
             self.assertEqual(subplot.cyclic_index, i)
+
+    def test_overlay_xlabel(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options(xlabel='custom x-label')
+        axes = mpl_renderer.get_plot(overlay).handles['axis']
+        self.assertEqual(axes.get_xlabel(), 'custom x-label')
+
+    def test_overlay_ylabel(self):
+        overlay = (Curve(range(10)) * Curve(range(10))).options(ylabel='custom y-label')
+        axes = mpl_renderer.get_plot(overlay).handles['axis']
+        self.assertEqual(axes.get_ylabel(), 'custom y-label')
+
+    def test_overlay_xlabel_override_propagated(self):
+        overlay = (Curve(range(10)).options(xlabel='custom x-label') * Curve(range(10)))
+        axes = mpl_renderer.get_plot(overlay).handles['axis']
+        self.assertEqual(axes.get_xlabel(), 'custom x-label')
+
+    def test_overlay_ylabel_override(self):
+        overlay = (Curve(range(10)).options(ylabel='custom y-label') * Curve(range(10)))
+        axes = mpl_renderer.get_plot(overlay).handles['axis']
+        self.assertEqual(axes.get_ylabel(), 'custom y-label')


### PR DESCRIPTION
Overriding the axis labels is currently a fairly complex procedure because you have to redimension a bunch of elements. Particularly when you are working with a DynamicMap where you can't necessarily inspect the dimensions of returned elements it is, in some cases, not feasible at all. It also would add huge complexity to perform operations like this in ``hvplot``. Various users have therefore requested explicit ``xlabel``/``ylabel``(``/zlabel``) plot options, which are easy to add and much easier to control.

- [x] Closes https://github.com/ioam/holoviews/issues/2833