### PR TITLE
Subclass pyviz_comms extension and add delete hook

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -21,11 +21,11 @@ requirements:
     - setuptools
   run:
     - python
-    - param >=1.6.1,<2.0
-    - pyviz_comms >=0.6.0
+    - param >=1.8.0,<2.0
+    - pyviz_comms >=0.7.0
     - numpy
     - matplotlib>=2.1
-    - bokeh >=0.12.15,<1.1.0
+    - bokeh >=1.0.0,<1.1.0
     - jupyter
     - notebook
     - ipython >=5.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - jsonschema=2.6.0
   - cyordereddict
   - nbconvert=5.3.1
-  - pyviz/label/dev::param=1.8.0a10
-  - pyviz::pyviz_comms=0.6.0
+  - pyviz::param=1.8.0
+  - pyviz::pyviz_comms=0.7.0
   - pyviz::datashader
   - conda-forge::netcdf4=1.3.1
   - conda-forge::ffmpeg

--- a/holoviews/ipython/__init__.py
+++ b/holoviews/ipython/__init__.py
@@ -264,15 +264,6 @@ class notebook_extension(extension):
                 mimebundle = {'text/html': mimebundle_to_html(mimebundle)}
             publish_display_data(data=mimebundle)
 
-    @classmethod
-    def _process_comm_msg(cls, msg):
-        """
-        Processes comm messages to handle global actions such as
-        cleaning up plots.
-        """
-        if msg['event_type'] == 'delete':
-            Renderer._delete_plot(msg['id'])
-
 
     @param.parameterized.bothmethod
     def tab_completion_docstring(self_or_cls):
@@ -289,6 +280,8 @@ class notebook_extension(extension):
 
 
 notebook_extension.__doc__ = notebook_extension.tab_completion_docstring()
+notebook_extension.add_delete_action(Renderer._delete_plot)
+
 
 def load_ipython_extension(ip):
     notebook_extension(ip=ip)

--- a/holoviews/tests/plotting/testcomms.py
+++ b/holoviews/tests/plotting/testcomms.py
@@ -1,4 +1,3 @@
-import json
 from nose.plugins.attrib import attr
 from holoviews.element.comparison import ComparisonTestCase
 from pyviz_comms import Comm, JupyterComm

--- a/holoviews/tests/plotting/testcomms.py
+++ b/holoviews/tests/plotting/testcomms.py
@@ -18,28 +18,26 @@ class TestComm(ComparisonTestCase):
         self.assertEqual(Comm.decode(msg), msg)
 
     def test_handle_message_error_reply(self):
-        def raise_error(msg):
+        def raise_error(msg=None, metadata=None):
             raise Exception('Test')
-        def assert_error(msg):
-            decoded = json.loads(msg)
-            self.assertEqual(decoded['msg_type'], "Error")
-            self.assertTrue(decoded['traceback'].endswith('Exception: Test'))
+        def assert_error(msg=None, metadata=None):
+            self.assertEqual(metadata['msg_type'], "Error")
+            self.assertTrue(metadata['traceback'].endswith('Exception: Test'))
         comm = Comm(id='Test', on_msg=raise_error)
         comm.send = assert_error
         comm._handle_msg({})
 
     def test_handle_message_ready_reply(self):
-        def assert_ready(msg):
-            self.assertEqual(json.loads(msg), {'msg_type': "Ready", 'content': ''})
+        def assert_ready(msg=None, metadata=None):
+            self.assertEqual(metadata, {'msg_type': "Ready", 'content': ''})
         comm = Comm(id='Test')
         comm.send = assert_ready
         comm._handle_msg({})
 
     def test_handle_message_ready_reply_with_comm_id(self):
-        def assert_ready(msg):
-            decoded = json.loads(msg)
-            self.assertEqual(decoded, {'msg_type': "Ready", 'content': '',
-                                       'comm_id': 'Testing id'})
+        def assert_ready(msg=None, metadata=None):
+            self.assertEqual(metadata, {'msg_type': "Ready", 'content': '',
+                                        'comm_id': 'Testing id'})
         comm = Comm(id='Test')
         comm.send = assert_ready
         comm._handle_msg({'comm_id': 'Testing id'})

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -1,6 +1,7 @@
 import os, sys, inspect, shutil
 
 import param
+from pyviz_comms import extension as _pyviz_extension
 
 from ..core import DynamicMap, HoloMap, Dimensioned, ViewableElement, StoreOptions, Store
 from ..core.options import options_policy, Keywords, Options
@@ -563,7 +564,7 @@ def renderer(name):
         raise ImportError(msg.format(name=name, available=available))
 
 
-class extension(param.ParameterizedFunction):
+class extension(_pyviz_extension):
     """
     Helper utility used to load holoviews extensions. These can be
     plotting extensions, element extensions or anything else that can be


### PR DESCRIPTION
This PR subclasses the extension from pyviz_comms ensuring that independently of which extension you load all plots are cleaned up correctly when a cell is deleted, re-executed or cleared.

Should not be merged until pyviz_comms 0.7 containing the extension has been released.

- Depends on https://github.com/pyviz/pyviz_comms/pull/21