### PR TITLE
Removing redundant call to `gaussian_kde`

### DIFF
--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -108,7 +108,6 @@ class univariate_kde(Operation):
                 kde = stats.gaussian_kde(data)
             except LinAlgError:
                 return element_type([], selected_dim, vdims, **params)
-            kde = stats.gaussian_kde(data)
             if self.p.bandwidth:
                 kde.set_bandwidth(self.p.bandwidth)
             bw = kde.scotts_factor() * data.std(ddof=1)


### PR DESCRIPTION
There are only two ways the procoess can go forth. Either `kde` is set correctly to the return value of `stats.gaussian_kde` or there's an exception and the function `return`s. The second call to `stats.gaussian_kde` seems redundant