### PR TITLE
Added support for indicating directionality on Graphs

### DIFF
--- a/examples/gallery/demos/bokeh/directed_airline_routes.ipynb
+++ b/examples/gallery/demos/bokeh/directed_airline_routes.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends, this example is also available for:\n",
+    "\n",
+    "* [Matplotlib Directed Airline Routes](../matplotlib/directed_airline_routes.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import networkx as nx\n",
+    "import holoviews as hv\n",
+    "\n",
+    "from holoviews.element.graphs import layout_nodes\n",
+    "from bokeh.sampledata.airport_routes import routes, airports\n",
+    "\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create dataset indexed by AirportID and with additional value dimension\n",
+    "airports = hv.Dataset(airports, ['AirportID'], ['Name', 'IATA', 'City'])\n",
+    "\n",
+    "label = 'Alaska Airline Routes'\n",
+    "\n",
+    "# Select just Alaska Airline routes\n",
+    "as_graph = hv.Graph((routes[routes.Airline=='AS'], airports), ['SourceID', \"DestinationID\"], 'Airline', label=label)\n",
+    "\n",
+    "as_graph = layout_nodes(as_graph, layout=nx.layout.fruchterman_reingold_layout)\n",
+    "labels = hv.Labels(as_graph.nodes, ['x', 'y'], ['IATA', 'City'], label=label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "as_graph.options(\n",
+    "    directed=True, node_size=8, padding=0.1, bgcolor='gray', xaxis=None, yaxis=None,\n",
+    "    edge_line_color='white', edge_line_width=1, width=800, height=800, arrow_length=0.01,\n",
+    "    node_fill_color='white', node_nonselection_fill_color='black'\n",
+    ") *\\\n",
+    "labels.options(\n",
+    "    xoffset=-0.04, yoffset=0.03, text_font_size='10pt'\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/gallery/demos/bokeh/directed_airline_routes.ipynb
+++ b/examples/gallery/demos/bokeh/directed_airline_routes.ipynb
@@ -65,7 +65,7 @@
    "source": [
     "as_graph.options(\n",
     "    directed=True, node_size=8, padding=0.1, bgcolor='gray', xaxis=None, yaxis=None,\n",
-    "    edge_line_color='white', edge_line_width=1, width=800, height=800, arrow_length=0.01,\n",
+    "    edge_line_color='white', edge_line_width=1, width=800, height=800, arrowhead_length=0.01,\n",
     "    node_fill_color='white', node_nonselection_fill_color='black'\n",
     ") *\\\n",
     "labels.options(\n",

--- a/examples/gallery/demos/matplotlib/directed_airline_routes.ipynb
+++ b/examples/gallery/demos/matplotlib/directed_airline_routes.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Most examples work across multiple plotting backends, this example is also available for:\n",
+    "\n",
+    "* [Bokeh Directed Airline Routes](../bokeh/directed_airline_routes.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import networkx as nx\n",
+    "import holoviews as hv\n",
+    "\n",
+    "from holoviews.element.graphs import layout_nodes\n",
+    "from bokeh.sampledata.airport_routes import routes, airports\n",
+    "\n",
+    "hv.extension('matplotlib')\n",
+    "\n",
+    "hv.output(fig='svg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create dataset indexed by AirportID and with additional value dimension\n",
+    "airports = hv.Dataset(airports, ['AirportID'], ['Name', 'IATA', 'City'])\n",
+    "\n",
+    "label = 'Alaska Airline Routes'\n",
+    "\n",
+    "# Select just Alaska Airline routes\n",
+    "as_graph = hv.Graph((routes[routes.Airline=='AS'], airports), ['SourceID', \"DestinationID\"], 'Airline', label=label)\n",
+    "\n",
+    "as_graph = layout_nodes(as_graph, layout=nx.layout.fruchterman_reingold_layout)\n",
+    "labels = hv.Labels(as_graph.nodes, ['x', 'y'], ['IATA', 'City'], label=label)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "as_graph.options(\n",
+    "    directed=True, node_size=8, padding=0.1, bgcolor='gray', xaxis=None, yaxis=None,\n",
+    "    edge_color='white', edge_linewidth=1, arrow_length=0.01,\n",
+    "    node_color='white', fig_size=300\n",
+    ") *\\\n",
+    "labels.options(\n",
+    "    xoffset=-0.04, yoffset=0.03, show_legend=False\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/gallery/demos/matplotlib/directed_airline_routes.ipynb
+++ b/examples/gallery/demos/matplotlib/directed_airline_routes.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "as_graph.options(\n",
     "    directed=True, node_size=8, padding=0.1, bgcolor='gray', xaxis=None, yaxis=None,\n",
-    "    edge_color='white', edge_linewidth=1, arrow_length=0.01,\n",
+    "    edge_color='white', edge_linewidth=1, arrowhead_length=0.01,\n",
     "    node_color='white', fig_size=300\n",
     ") *\\\n",
     "labels.options(\n",

--- a/examples/reference/elements/bokeh/Graph.ipynb
+++ b/examples/reference/elements/bokeh/Graph.ipynb
@@ -24,7 +24,7 @@
     "\n",
     "hv.extension('bokeh')\n",
     "\n",
-    "%opts Graph [width=400 height=400]"
+    "%opts Graph [width=400 height=400 padding=0.1]"
    ]
   },
   {
@@ -62,6 +62,24 @@
     "\n",
     "simple_graph = hv.Graph(((source, target),)).redim.range(**padding)\n",
     "simple_graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Directed graphs\n",
+    "\n",
+    "The Graph element also allows indicating the directionality of graph edges using arrows. To enable the arrows set ``directed=True`` and to optionally control the ``arrowhead_length`` provide a length as a fraction of the total graph extent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simple_graph.options(directed=True, arrowhead_length=0.05)"
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/Graph.ipynb
+++ b/examples/reference/elements/matplotlib/Graph.ipynb
@@ -60,8 +60,26 @@
     "\n",
     "padding = dict(x=(-1.2, 1.2), y=(-1.2, 1.2))\n",
     "\n",
-    "simple_graph = hv.Graph(((source, target),)).redim.range(**padding)\n",
+    "simple_graph = hv.Graph(((source, target),)).options(padding=0.1)\n",
     "simple_graph"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Directed graphs\n",
+    "\n",
+    "The Graph element also allows indicating the directionality of graph edges using arrows. To enable the arrows set ``directed=True`` and to optionally control the ``arrowhead_length`` provide a length as a fraction of the total graph extent:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simple_graph.options(directed=True, arrowhead_length=0.08)"
    ]
   },
   {

--- a/examples/user_guide/Network_Graphs.ipynb
+++ b/examples/user_guide/Network_Graphs.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "hv.extension('bokeh')\n",
     "\n",
-    "%opts Graph [width=400 height=400 padding=0.1]"
+    "%opts Nodes EdgePaths Graph [width=400 height=400 padding=0.1]"
    ]
   },
   {
@@ -68,6 +68,31 @@
    "outputs": [],
    "source": [
     "simple_graph.nodes + simple_graph.edgepaths"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Displaying directed graphs\n",
+    "\n",
+    "When specifying the graph edges the source and target node are listed in order, if the graph is actually a directed graph this may used to indicate the directionality of the graph. By setting ``directed=True`` as a plot option it is possible to indicate the directionality of each edge using an arrow:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "simple_graph.options(directed=True, node_size=5, arrow_length=0.05)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The length of the arrows can be set as an fraction of the overall graph extent using the ``arrow_length`` option."
    ]
   },
   {

--- a/examples/user_guide/Network_Graphs.ipynb
+++ b/examples/user_guide/Network_Graphs.ipynb
@@ -85,14 +85,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simple_graph.options(directed=True, node_size=5, arrow_length=0.05)"
+    "simple_graph.options(directed=True, node_size=5, arrowhead_length=0.05)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The length of the arrows can be set as an fraction of the overall graph extent using the ``arrow_length`` option."
+    "The length of the arrows can be set as an fraction of the overall graph extent using the ``arrowhead_length`` option."
    ]
   },
   {

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -962,6 +962,28 @@ def get_min_distance(element):
         return _get_min_distance_numpy(element)
 
 
+def get_directed_graph_paths(element, arrow_length):
+    """
+    Computes paths for a directed path which include an arrow to
+    indicate the directionality of each edge.
+    """
+    edgepaths = element._split_edgepaths
+    edges = edgepaths.split(datatype='array', dimensions=edgepaths.kdims)
+    arrows = []
+    for e in edges:
+        sx, sy = e[0]
+        ex, ey = e[1]
+        rad = np.arctan2(ey-sy, ex-sx)
+        xa0 = ex - np.cos(rad+np.pi/8)*arrow_length
+        ya0 = ey - np.sin(rad+np.pi/8)*arrow_length
+        xa1 = ex - np.cos(rad-np.pi/8)*arrow_length
+        ya1 = ey - np.sin(rad-np.pi/8)*arrow_length
+        arrow = np.array([(sx, sy), (ex, ey), (np.nan, np.nan),
+                          (xa0, ya0), (ex, ey), (xa1, ya1)])
+        arrows.append(arrow)
+    return arrows
+
+
 def rgb2hex(rgb):
     """
     Convert RGB(A) tuple to hex.


### PR DESCRIPTION
Adds support for arrows on Graph edges to allow indicating directionality of graphs. uses same trick as VectorField to render the arrows.

- [x] Closes https://github.com/ioam/holoviews/issues/2521
- [x] Add gallery example
- [x] Add section to networks user guide

Simple example:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/48239921-acfc9980-e3c8-11e8-87ad-50440fa38ac8.png)

Real data example:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/48239902-96eed900-e3c8-11e8-8682-02670ed95943.png)
