### PR TITLE
Ensure changing CDS columns do not trigger errors

### DIFF
--- a/holoviews/plotting/bokeh/bokehwidgets.js
+++ b/holoviews/plotting/bokeh/bokehwidgets.js
@@ -15,10 +15,7 @@ BokehScrubberWidget.prototype = Object.create(ScrubberWidget.prototype);
 var BokehMethods = {
   update_cache : function(){
     for (var index in this.frames) {
-      var data = this.frames[index];
-      for (var i=0; i<data.content.length; i++) {
-        data.content[i] = JSON.parse(data.content[i]);
-      }
+      this.frames[index] = JSON.parse(this.frames[index]);
     }
   },
   update : function(current){
@@ -32,11 +29,7 @@ var BokehMethods = {
       } else {
         var doc = Bokeh.index[data.root].model.document;
       }
-      for (var i=0; i<data.content.length; i++) {
-        try {
-          doc.apply_json_patch(data.content[i]);
-        } catch(err) { }
-      }
+      doc.apply_json_patch(data.content);
     }
   },
   init_comms: function() {

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -6,6 +6,7 @@ import numpy as np
 import bokeh
 import bokeh.plotting
 from bokeh.core.properties import value
+from bokeh.document.events import ModelChangedEvent
 from bokeh.models import (HoverTool, Renderer, Range1d, DataRange1d, Title,
                           FactorRange, FuncTickFormatter, Tool, Legend,
                           TickFormatter, PrintfTickFormatter)
@@ -727,12 +728,11 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         elif self.document:
             server = self.renderer.mode == 'server'
             with hold_policy(self.document, 'collect', server=server):
-                source.data = {c: [] for c in columns}
-                event = self.document._held_events[-1]
-                event.hint = None
-                event.setter = 'override'
-                event.new = source.data
-                event.serializable_new = source.data
+                empty_data = {c: [] for c in columns}
+                event = ModelChangedEvent(self.document, source, 'data',
+                                          source.data, empty_data, empty_data,
+                                          setter='empty')
+                self.document._held_events.append(event)
 
         if legend is not None:
             for leg in self.state.legend:

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -30,7 +30,8 @@ from ..util import dynamic_update, process_cmap, color_intervals
 from .plot import BokehPlot, TOOLS
 from .util import (mpl_to_bokeh, get_tab_title,  py2js_tickformatter,
                    rgba_tuple, recursive_model_update, glyph_order,
-                   decode_bytes, bokeh_version, theme_attr_json)
+                   decode_bytes, bokeh_version, theme_attr_json,
+                   cds_column_replace, hold_policy)
 
 property_prefixes = ['selection', 'nonselection', 'muted', 'hover']
 
@@ -690,24 +691,53 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return {k: v for k, v in glyph_props.items() if k in allowed}
 
 
-    def _update_glyph(self, renderer, properties, mapping, glyph):
+    def _update_glyph(self, renderer, properties, mapping, glyph, source, data):
         allowed_properties = glyph.properties()
         properties = mpl_to_bokeh(properties)
         merged = dict(properties, **mapping)
         legend = merged.pop('legend', None)
+        columns = list(source.data.keys())
+        glyph_updates = []
         for glyph_type in ('', 'selection_', 'nonselection_', 'hover_', 'muted_'):
             if renderer:
                 glyph = getattr(renderer, glyph_type+'glyph', None)
             if not glyph or (not renderer and glyph_type):
                 continue
             filtered = self._filter_properties(merged, glyph_type, allowed_properties)
-            glyph.update(**filtered)
+
+            # Ensure that data is populated before updating glyph
+            dataspecs = glyph.dataspecs()
+            for spec in dataspecs:
+                new_spec = filtered.get(spec)
+                old_spec = getattr(glyph, spec)
+                new_field = new_spec.get('field') if isinstance(new_spec, dict) else new_spec
+                old_field = old_spec.get('field') if isinstance(old_spec, dict) else old_spec
+                if new_field not in data or new_field in source.data or new_field == old_field:
+                    continue
+                columns.append(new_field)
+            glyph_updates.append((glyph, filtered))
+
+        # If a dataspec has changed and the CDS.data will be replaced
+        # the GlyphRenderer will not find the column, therefore we
+        # craft an event which will make the column available.
+        if self.document and cds_column_replace(source, data):
+            server = self.renderer.mode == 'server'
+            with hold_policy(self.document, 'collect', server=server):
+                source.data = {c: [] for c in columns}
+                event = self.document._held_events[-1]
+                event.hint = None
+                event.setter = 'override'
+                event.new = source.data
+                event.serializable_new = source.data
 
         if legend is not None:
             for leg in self.state.legend:
                 for item in leg.items:
                     if renderer in item.renderers:
                         item.label = legend
+
+        for glyph, update in glyph_updates:
+            glyph.update(**update)
 
 
     def _postprocess_hover(self, renderer, source):
@@ -761,7 +791,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         # Update plot, source and glyph
         with abbreviated_exception():
-            self._update_glyph(renderer, properties, mapping, glyph)
+            self._update_glyph(renderer, properties, mapping, glyph, source, source.data)
 
 
     def initialize_plot(self, ranges=None, plot=None, plots=None, source=None):
@@ -828,14 +858,14 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         else:
             data, mapping, style = self.get_data(element, ranges, style)
 
-        if not self.static_source:
-            self._update_datasource(source, data)
-
         if glyph:
             properties = self._glyph_properties(plot, element, source, ranges, style)
             renderer = self.handles.get('glyph_renderer')
             with abbreviated_exception():
-                self._update_glyph(renderer, properties, mapping, glyph)
+                self._update_glyph(renderer, properties, mapping, glyph, source, data)
+
+        if not self.static_source:
+            self._update_datasource(source, data)
 
 
     def update_frame(self, key, ranges=None, plot=None, element=None):
@@ -958,7 +988,8 @@ class CompositeElementPlot(ElementPlot):
 
             # Update plot, source and glyph
             with abbreviated_exception():
-                self._update_glyph(renderer, properties, mapping.get(key, {}), glyph)
+                self._update_glyph(renderer, properties, mapping.get(key, {}), glyph,
+                                   source, source.data)
 
 
     def _process_properties(self, key, properties, mapping):
@@ -1005,7 +1036,8 @@ class CompositeElementPlot(ElementPlot):
                 properties = self._process_properties(key, properties, mapping[key])
                 renderer = self.handles.get(key+'_glyph_renderer')
                 with abbreviated_exception():
-                    self._update_glyph(renderer, properties, mapping[key], glyph)
+                    self._update_glyph(renderer, properties, mapping[key],
+                                       glyph, source, data)
 
 
     def _init_glyph(self, plot, mapping, properties, key):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -5,8 +5,10 @@ from collections import defaultdict
 import numpy as np
 import param
 
+from bokeh.layouts import gridplot
 from bokeh.models import (ColumnDataSource, Column, Row, Div)
 from bokeh.models.widgets import Panel, Tabs
+from bokeh.plotting.helpers import _known_tools as known_tools
 
 from ...core import (OrderedDict, Store, AdjointLayout, NdLayout, Layout,
                      Empty, GridSpace, HoloMap, Element, DynamicMap)
@@ -20,10 +22,8 @@ from ..plot import (DimensionedPlot, GenericCompositePlot, GenericLayoutPlot,
 from ..util import attach_streams, displayable, collate
 from .callbacks import LinkCallback
 from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
-                   update_shared_sources, empty_plot, decode_bytes, theme_attr_json)
-
-from bokeh.layouts import gridplot
-from bokeh.plotting.helpers import _known_tools as known_tools
+                   update_shared_sources, empty_plot, decode_bytes,
+                   theme_attr_json, cds_column_replace, hold_policy)
 
 TOOLS = {name: tool if isinstance(tool, basestring) else type(tool())
          for name, tool in known_tools.items()}
@@ -223,6 +223,9 @@ class BokehPlot(DimensionedPlot):
         """
         Update datasource with data for a new frame.
         """
+        if not self.document:
+            return
+
         data = {k: decode_bytes(vs) for k, vs in data.items()}
         empty = all(len(v) == 0 for v in data.values())
         if (self.streaming and self.streaming[0].data is self.current_frame.data
@@ -233,13 +236,7 @@ class BokehPlot(DimensionedPlot):
                 source.stream(data, stream.length)
             return
 
-        # Determine if the CDS.data requires a full replacement or simply needs
-        # to be updated. A replacement is required if untouched columns
-        # are not the same length as the columns being updated.
-        current_length = [len(v) for v in source.data.values() if isinstance(v, (list, np.ndarray))]
-        new_length = [len(v) for v in data.values() if isinstance(v, (list, np.ndarray))]
-        untouched = [k for k in source.data if k not in data]
-        if (untouched and current_length and new_length and current_length[0] != new_length[0]):
+        if cds_column_replace(source, data):
             source.data = data
         else:
             source.data.update(data)

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -190,16 +190,15 @@ class BokehPlot(DimensionedPlot):
         if self.comm is None:
             raise Exception('Renderer does not have a comm.')
 
-        msgs = self.renderer.diff(self, binary=True, individual=True)
-        if not msgs:
+        msg = self.renderer.diff(self, binary=True)
+        if msg is None:
             return
-        for msg in msgs:
-            self.comm.send(msg.header_json)
-            self.comm.send(msg.metadata_json)
-            self.comm.send(msg.content_json)
-            for header, payload in msg.buffers:
-                self.comm.send(json.dumps(header))
-                self.comm.send(buffers=[payload])
+        self.comm.send(msg.header_json)
+        self.comm.send(msg.metadata_json)
+        self.comm.send(msg.content_json)
+        for header, payload in msg.buffers:
+            self.comm.send(json.dumps(header))
+            self.comm.send(buffers=[payload])
 
 
     def set_root(self, root):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -23,7 +23,7 @@ from ..util import attach_streams, displayable, collate
 from .callbacks import LinkCallback
 from .util import (layout_padding, pad_plots, filter_toolboxes, make_axis,
                    update_shared_sources, empty_plot, decode_bytes,
-                   theme_attr_json, cds_column_replace, hold_policy)
+                   theme_attr_json, cds_column_replace)
 
 TOOLS = {name: tool if isinstance(tool, basestring) else type(tool())
          for name, tool in known_tools.items()}

--- a/holoviews/plotting/bokeh/renderer.py
+++ b/holoviews/plotting/bokeh/renderer.py
@@ -330,7 +330,7 @@ class BokehRenderer(Renderer):
         return data
 
 
-    def diff(self, plot, binary=True, individual=False):
+    def diff(self, plot, binary=True):
         """
         Returns a json diff required to update an existing plot with
         the latest plot data.
@@ -338,16 +338,9 @@ class BokehRenderer(Renderer):
         events = list(plot.document._held_events)
         if not events:
             return None
-
-        if individual:
-            msgs = []
-            for event in events:
-                msg = Protocol("1.0").create("PATCH-DOC", [event], use_buffers=binary)
-                msgs.append(msg)
-        else:
-            msgs = Protocol("1.0").create("PATCH-DOC", events, use_buffers=binary)
+        msg = Protocol("1.0").create("PATCH-DOC", events, use_buffers=binary)
         plot.document._held_events = []
-        return msgs
+        return msg
 
 
     @classmethod

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -500,11 +500,13 @@ def hold_policy(document, policy, server=False):
     """
     old_policy = document._hold
     document._hold = policy
-    yield
-    if server and not old_policy:
-        document.unhold()
-    else:
-        document._hold = old_policy
+    try:
+        yield
+    finally:
+        if server and not old_policy:
+            document.unhold()
+        else:
+            document._hold = old_policy
 
 
 def recursive_model_update(model, props):

--- a/holoviews/plotting/bokeh/widgets.py
+++ b/holoviews/plotting/bokeh/widgets.py
@@ -306,9 +306,10 @@ class BokehWidget(NdWidget):
         """
         self.plot.update(idx)
         if self.embed:
-            patch = self.renderer.diff(self.plot, binary=False, individual=True)
-            patches = [serialize_json(p.content) for p in patch]
-            return {'content': patches, 'root': self.plot.state._id}
+            patch = self.renderer.diff(self.plot, binary=False)
+            msg = serialize_json(dict(content=patch.content,
+                                      root=self.plot.state._id))
+            return msg
 
 
 class BokehSelectionWidget(BokehWidget, SelectionWidget):


### PR DESCRIPTION
In https://github.com/ioam/holoviews/pull/3158 I made a change to the way bokeh events are handled, which sent each bokeh model change as a separate event and thereby avoided an error triggered by one event breaking a plot irreparably because subsequent errors would be ignored. Unfortunately that change introduced a noticeable delay between a CDS data and color mapper ranges being updated, resulting in undesirable flicker on updates. It was also a bit of a hack around the actual issue because the underlying issue would still trigger errors. This PR reverts that change and fixes the underlying problem.

It does this through a fairly involved change, so I'll step through it slowly:

1. It detects whether a glyph dataspec references a CDS.data column which does not yet exist
2. If this is the case it triggers a new ModelChangedEvent which replaces the data with empty columns which do contain the new column(s) and the old column(s)
3. Once the glyph has been updated to reference the new column(s), it sends another event containing the actual data 