### PR TITLE
Fixed conversion of Pandas Timestamp to integer for Bokeh

### DIFF
--- a/holoviews/plotting/bokeh/annotation.py
+++ b/holoviews/plotting/bokeh/annotation.py
@@ -14,13 +14,13 @@ except:
     arrow_end = {'->': NormalHead, '-[': OpenHead, '-|>': NormalHead,
                  '-': None}
 
-from ...core.util import dimension_sanitizer, basestring
+from ...core.util import datetime_types, dimension_sanitizer, basestring
 from ...element import HLine
 from ..plot import GenericElementPlot
 from .element import (AnnotationPlot, CompositeElementPlot, ColorbarPlot,
                       ElementPlot, text_properties, line_properties)
 from .plot import BokehPlot
-
+from .util import date_to_integer
 
 
 class TextPlot(ElementPlot, AnnotationPlot):
@@ -131,6 +131,8 @@ class LineAnnotationPlot(ElementPlot, AnnotationPlot):
             dim = 'width' if dim == 'height' else 'height'
         mapping['dimension'] = dim
         loc = element.data
+        if isinstance(loc, datetime_types):
+            loc = date_to_integer(loc)
         mapping['location'] = loc
         return (data, mapping, style)
 

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -649,9 +649,9 @@ def date_to_integer(date):
     """
     if isinstance(date, np.datetime64):
         date = dt64_to_dt(date)
-    elif pd and isinstance(date, pd.Timestamp):
-        date = date.to_pydatetime()
-    if isinstance(date, (dt.datetime, dt.date)):
+    if pd and isinstance(date, pd.Timestamp):
+        dt_int = date.timestamp()*1000
+    elif isinstance(date, (dt.datetime, dt.date)):
         dt_int = time.mktime(date.timetuple())*1000
     else:
         raise ValueError('Datetime type not recognized')


### PR DESCRIPTION
- Reverts #3075 which effectively drops support for datetime types entirely
- Use [`pandas.Timestamp.timestamp`](https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.Timestamp.timestamp.html#pandas.Timestamp.timestamp) to convert to a POSIX timestamp, which will handle timezone conversions to fix #2857 and also support millisecond precision in Timestamps

Closes #3167 