### PR TITLE
Implemented continuous style mapping for Paths

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -27,7 +27,7 @@ from bokeh.plotting.helpers import _known_tools as known_tools
 from ...core import DynamicMap, CompositeOverlay, Element, Dimension
 from ...core.options import abbreviated_exception, SkipRendering
 from ...core import util
-from ...element import Graph, VectorField
+from ...element import Graph, VectorField, Path, Contours
 from ...streams import Buffer
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
@@ -680,6 +680,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
             if len(v.ops) == 0 and v.dimension in self.overlay_dims:
                 val = self.overlay_dims[v.dimension]
+            elif isinstance(element, Path) and not isinstance(element, Contours):
+                val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]
+                                      for el in element.split()])
             else:
                 val = v.apply(element, ranges=ranges, flat=True)
 
@@ -697,9 +700,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                                      'to the {style} use a groupby operation '
                                      'to overlay your data along the dimension.'.format(
                                          style=k, dim=v.dimension, element=element,
-                                         backend=self.renderer.backend
-                                 )
-                    )
+                                         backend=self.renderer.backend))
                 elif source.data and len(val) != len(list(source.data.values())[0]):
                     if isinstance(element, VectorField):
                         val = np.tile(val, 3)

--- a/holoviews/plotting/bokeh/path.py
+++ b/holoviews/plotting/bokeh/path.py
@@ -75,14 +75,17 @@ class PathPlot(ColorbarPlot):
                 data = dict(xs=xs, ys=ys)
             return data, mapping, style
 
-        vals = {util.dimension_sanitizer(vd.name): [] for vd in element.vdims}
+        vals = {}
+        hover = 'hover' in self.handles
+        if hover:
+            vals = {util.dimension_sanitizer(vd.name): [] for vd in element.vdims}
         if cdim:
             dim_name = util.dimension_sanitizer(cdim.name)
             cmapper = self._get_colormapper(cdim, element, ranges, style)
             mapping['line_color'] = {'field': dim_name, 'transform': cmapper}
+            vals[dim_name] = []
 
         paths = []
-        hover = 'hover' in self.handles
         for path in element.split():
             if cdim:
                 cvals = path.dimension_values(cdim)
@@ -100,7 +103,8 @@ class PathPlot(ColorbarPlot):
                     vals[vd_name+'_dt_strings'] = [vd.pprint_value(v) for v in values]
 
         xs, ys = ([path[:, idx] for path in paths] for idx in inds)
-        data = dict(xs=xs, ys=ys, **{d: np.asarray(vs) for d, vs in vals.items() if vs != []})
+        data = dict(xs=xs, ys=ys, **{d: np.asarray(vs) for d, vs in vals.items()})
+        self._get_hover_data(data, element)
         return data, mapping, style
 
 

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -15,7 +15,7 @@ from ...core import util
 from ...core import (OrderedDict, NdOverlay, DynamicMap, Dataset,
                      CompositeOverlay, Element3D, Element)
 from ...core.options import abbreviated_exception
-from ...element import Graph
+from ...element import Graph, Path, Contours
 from ...util.transform import dim
 from ..plot import GenericElementPlot, GenericOverlayPlot
 from ..util import dynamic_update, process_cmap, color_intervals, dim_range_key
@@ -538,6 +538,9 @@ class ElementPlot(GenericElementPlot, MPLPlot):
 
             if len(v.ops) == 0 and v.dimension in self.overlay_dims:
                 val = self.overlay_dims[v.dimension]
+            elif isinstance(element, Path) and not isinstance(element, Contours):
+                val = np.concatenate([v.apply(el, ranges=ranges, flat=True)[:-1]
+                                      for el in element.split()])
             else:
                 val = v.apply(element, ranges)
 
@@ -554,9 +557,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
                                  'to the {style} use a groupby operation '
                                  'to overlay your data along the dimension.'.format(
                                      style=k, dim=v.dimension, element=element,
-                                     backend=self.renderer.backend
-                                 )
-                )
+                                     backend=self.renderer.backend))
 
             style_groups = getattr(self, '_style_groups', [])
             groups = [sg for sg in style_groups if k.startswith(sg)]

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -77,7 +77,7 @@ class ElementPlot(GenericElementPlot, MPLPlot):
     style_opts = []
 
     # Declare which styles cannot be mapped to a non-scalar dimension
-    _nonvectorized_styles = ['marker', 'alpha', 'cmap', 'angle']
+    _nonvectorized_styles = ['marker', 'alpha', 'cmap', 'angle', 'visible']
 
     # Whether plot has axes, disables setting axis limits, labels and ticks
     _has_axes = True

--- a/holoviews/tests/plotting/matplotlib/testpathplot.py
+++ b/holoviews/tests/plotting/matplotlib/testpathplot.py
@@ -2,9 +2,58 @@ import numpy as np
 
 from holoviews.core import NdOverlay
 from holoviews.core.spaces import HoloMap
-from holoviews.element import Polygons, Contours
+from holoviews.element import Polygons, Contours, Path
 
 from .testplot import TestMPLPlot, mpl_renderer
+
+
+class TestPathPlot(TestMPLPlot):
+
+    def test_path_continuously_varying_color_op(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        color = [998, 999, 998, 994]
+        data = {'x': xs, 'y': ys, 'color': color}
+        levels = [0, 38, 73, 95, 110, 130, 156, 999]
+        colors = ['#5ebaff', '#00faf4', '#ffffcc', '#ffe775', '#ffc140', '#ff8f20', '#ff6060']
+        path = Path([data], vdims='color').options(
+            color='color', color_levels=levels, cmap=colors)
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_array(), np.array([998, 999, 998]))
+        self.assertEqual(artist.get_clim(), (994, 999))
+
+    def test_path_continuously_varying_alpha_op(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        alpha = [0.1, 0.7, 0.3, 0.2]
+        data = {'x': xs, 'y': ys, 'alpha': alpha}
+        path = Path([data], vdims='alpha').options(alpha='alpha')
+        with self.assertRaises(Exception):
+            mpl_renderer.get_plot(path)
+
+    def test_path_continuously_varying_line_width_op(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        line_width = [1, 7, 3, 2]
+        data = {'x': xs, 'y': ys, 'line_width': line_width}
+        path = Path([data], vdims='line_width').options(linewidth='line_width')
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_linewidths(), [1, 7, 3])
+
+    def test_path_continuously_varying_line_width_op_update(self):
+        xs = [1, 2, 3, 4]
+        ys = xs[::-1]
+        path = HoloMap({
+            0: Path([{'x': xs, 'y': ys, 'line_width': [1, 7, 3, 2]}], vdims='line_width'),
+            1: Path([{'x': xs, 'y': ys, 'line_width': [3, 8, 2, 3]}], vdims='line_width')
+        }).options(linewidth='line_width')
+        plot = mpl_renderer.get_plot(path)
+        artist = plot.handles['artist']
+        self.assertEqual(artist.get_linewidths(), [1, 7, 3])
+        plot.update((1,))
+        self.assertEqual(artist.get_linewidths(), [3, 8, 2])
 
 
 class TestPolygonPlot(TestMPLPlot):

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -288,7 +288,8 @@ class dim(object):
                     arg = arg.apply(dataset, flat, expanded, ranges, all_values)
                 fn_args.append(arg)
             args = tuple(fn_args[::-1] if o['reverse'] else fn_args)
-            drange = ranges.get(str(self), {})
+            eldim = dataset.get_dimension(dimension)
+            drange = ranges.get(eldim.name, {})
             drange = drange.get('combined', drange)
             if o['fn'] is _norm and drange != {}:
                 data = o['fn'](data, *drange)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -9,7 +9,7 @@ from ..core.util import basestring, unique_iterator
 from ..element import Graph
 
 
-def _norm(values, min=None, max=None):
+def norm(values, min=None, max=None):
     """
     min-max normalizes to scale data into 0-1 range.
 
@@ -32,7 +32,7 @@ def _norm(values, min=None, max=None):
     return (values - min) / (max-min)
 
 
-def _bin(values, bins, labels=None):
+def bin(values, bins, labels=None):
     """
     Bins data into declared bins. By default each bin is labelled
     with bin center values but an explicit list of bin labels may be
@@ -65,7 +65,7 @@ def _bin(values, bins, labels=None):
     return binned
 
 
-def _categorize(values, categories, empty=None):
+def categorize(values, categories, empty=None):
     """
     Replaces discrete values in input array into a fixed set of
     categories defined either as a list or dictionary.
@@ -108,7 +108,7 @@ class dim(object):
     binning and categorizing data.
     """
 
-    _op_registry = {'norm': _norm, 'bin': _bin, 'categorize': _categorize}
+    _op_registry = {'norm': norm, 'bin': bin, 'categorize': categorize}
 
     def __init__(self, obj, *args, **kwargs):
         ops = []
@@ -194,7 +194,7 @@ class dim(object):
         empty: any (optional)
            Value assigned to input values no category could be assigned to
         """
-        return dim(self, _bin, bins, labels=labels)
+        return dim(self, bin, bins, labels=labels)
 
     def categorize(self, categories, empty=None):
         """
@@ -209,13 +209,16 @@ class dim(object):
         labels: np.ndarray or list (optional)
            Labels for bins should have length N-1 compared to bins
         """
-        return dim(self, _categorize, categories=categories, empty=empty)
+        return dim(self, categorize, categories=categories, empty=empty)
 
-    def norm(self):
+    def norm(self, limits=None):
         """
         min-max normalizes to scale data into 0-1 range.
         """
-        return dim(self, _norm)
+        kwargs = {}
+        if limits is not None:
+            kwargs = {'min': limits[0], 'max': limits[1]}
+        return dim(self, norm, **kwargs)
 
     def str(self):
         """
@@ -291,10 +294,11 @@ class dim(object):
             eldim = dataset.get_dimension(dimension)
             drange = ranges.get(eldim.name, {})
             drange = drange.get('combined', drange)
-            if o['fn'] is _norm and drange != {}:
+            kwargs = o['kwargs']
+            if o['fn'] is norm and drange != {} and not ('min' in kwargs and 'max' in kwargs):
                 data = o['fn'](data, *drange)
             else:
-                data = o['fn'](*args, **o['kwargs'])
+                data = o['fn'](*args, **kwargs)
         return data
 
     def __repr__(self):
@@ -302,7 +306,13 @@ class dim(object):
         for o in self.ops:
             args = ', '.join([repr(r) for r in o['args']]) if o['args'] else ''
             kwargs = sorted(o['kwargs'].items(), key=operator.itemgetter(0))
-            kwargs = ', %s' % ', '.join(['%s=%s' % item for item in kwargs]) if kwargs else ''
-            op_repr = '{fn}({repr}, {args}{kwargs})'.format(fn=o['fn'].__name__, repr=op_repr,
-                                                            args=args, kwargs=kwargs)
+            kwargs = '%s' % ', '.join(['%s=%s' % item for item in kwargs]) if kwargs else ''
+            format_string = '{fn}({repr}'
+            if args:
+                format_string += ', {args}'
+            if kwargs:
+                format_string += ', {kwargs}'
+            format_string += ')'
+            op_repr = format_string.format(fn=o['fn'].__name__, repr=op_repr,
+                                           args=args, kwargs=kwargs)
         return op_repr


### PR DESCRIPTION
Followup on the recent PR to support mapping styles. In that PR I had not yet implemented style mappings for continuously varying paths.

Here is an example of a continuously colormapped, alpha-mapped, and linewidth-mapped path:

![screen shot 2018-11-23 at 3 01 30 am](https://user-images.githubusercontent.com/1550771/48927233-29fd3800-eecc-11e8-9738-845ba1cb09ee.png)

- [x] Add unit tests
- [x] Update existing continuous colormapping example