### PR TITLE
Improve dim transform repr and add further operators

### DIFF
--- a/holoviews/tests/util/testtransform.py
+++ b/holoviews/tests/util/testtransform.py
@@ -133,8 +133,8 @@ class TestDimTransforms(ComparisonTestCase):
         self.assertEqual(dim('categories').categorize({'A': 'circle', 'B': 'square', 'C': 'triangle'}).apply(self.dataset),
                          np.array((['circle', 'square', 'triangle']*3)+['circle']))
 
-    def test_categorize_transform_dict_with_empty(self):
-        self.assertEqual(dim('categories').categorize({'A': 'circle', 'B': 'square'}, empty='triangle').apply(self.dataset),
+    def test_categorize_transform_dict_with_default(self):
+        self.assertEqual(dim('categories').categorize({'A': 'circle', 'B': 'square'}, default='triangle').apply(self.dataset),
                          np.array((['circle', 'square', 'triangle']*3)+['circle']))
 
     # Complex expressions

--- a/holoviews/tests/util/testtransform.py
+++ b/holoviews/tests/util/testtransform.py
@@ -152,9 +152,24 @@ class TestDimTransforms(ComparisonTestCase):
     def test_dim_repr(self):
         self.assertEqual(repr(dim('float')), "'float'")
 
+    def test_unary_op_repr(self):
+        self.assertEqual(repr(-dim('float')), "-dim('float')")
+
+    def test_binary_op_repr(self):
+        self.assertEqual(repr(dim('float')*2), "dim('float')*2")
+
+    def test_reverse_binary_op_repr(self):
+        self.assertEqual(repr(1+dim('float')), "1+dim('float')")
+
+    def test_ufunc_expression_repr(self):
+        self.assertEqual(repr(np.log(dim('float'))), "np.log(dim('float'))")
+
+    def test_custom_func_repr(self):
+        self.assertEqual(repr(dim('float').norm()), "dim('float').norm()")
+
     def test_multi_operator_expression_repr(self):
         self.assertEqual(repr(((dim('float')-2)*3)**2),
-                         "pow(mul(sub('float', 2), 3), 2)")
+                         "((dim('float')-2)*3)**2")
 
     # Applies method
 

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -113,10 +113,9 @@ class dim(object):
         operator.add: '+', operator.and_: '&', operator.eq: '=',
         operator.floordiv: '//', operator.ge: '>=', operator.gt: '>',
         operator.le: '<=', operator.lshift: '<<', operator.lt: '<',
-        operator.matmul: '@', operator.mod: '%', operator.mul: '*',
-        operator.ne: '!=', operator.or_: '|', operator.pow: '**',
-        operator.rshift: '>>', operator.sub: '-',
-        operator.truediv: '/'}
+        operator.mod: '%', operator.mul: '*', operator.ne: '!=',
+        operator.or_: '|', operator.pow: '**', operator.rshift: '>>',
+        operator.sub: '-', operator.truediv: '/'}
 
     _builtin_funcs = {abs: 'abs', len: 'len'}
 
@@ -183,7 +182,6 @@ class dim(object):
     def __le__(self, other):        return dim(self, operator.le, other)
     def __lt__(self, other):        return dim(self, operator.lt, other)
     def __lshift__(self, other):    return dim(self, operator.lshift, other)
-    def __matmul__(self, other):    return dim(self, operator.matmul, other)
     def __mod__(self, other):       return dim(self, operator.mod, other)
     def __mul__(self, other):       return dim(self, operator.mul, other)
     def __ne__(self, other):        return dim(self, operator.ne, other)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -110,12 +110,12 @@ class dim(object):
     """
 
     _binary_funcs = {
-        operator.add: '+', operator.and_: '&', operator.div: '/',
-        operator.eq: '=', operator.floordiv: '//', operator.ge: '>=',
-        operator.gt: '>', operator.le: '<=', operator.lshift: '<<',
-        operator.lt: '<', operator.matmul: '@', operator.mod: '%',
-        operator.mul: '*', operator.ne: '!=', operator.or_: '|',
-        operator.pow: '**', operator.rshift: '>>', operator.sub: '-',
+        operator.add: '+', operator.and_: '&', operator.eq: '=',
+        operator.floordiv: '//', operator.ge: '>=', operator.gt: '>',
+        operator.le: '<=', operator.lshift: '<<', operator.lt: '<',
+        operator.matmul: '@', operator.mod: '%', operator.mul: '*',
+        operator.ne: '!=', operator.or_: '|', operator.pow: '**',
+        operator.rshift: '>>', operator.sub: '-',
         operator.truediv: '/'}
 
     _builtin_funcs = {abs: 'abs', len: 'len'}
@@ -128,7 +128,7 @@ class dim(object):
         np.mean: 'mean', np.min: 'min', np.round: 'round',
         np.sum: 'sum', np.std: 'std', np.var: 'var'}
 
-    _unary_funcs = {operator.pos: '+', operator.neg: '-', operator.not: '~'}
+    _unary_funcs = {operator.pos: '+', operator.neg: '-', operator.not_: '~'}
 
     _all_funcs = [_binary_funcs, _builtin_funcs, _custom_funcs,
                   _numpy_funcs, _unary_funcs]
@@ -375,7 +375,10 @@ class dim(object):
                 format_string = '{fn}' + prev
             else:
                 fn_name = fn.__name__
-                if fn in self._numpy_funcs:
+                if fn in self._builtin_funcs:
+                    fn_name = self._builtin_funcs[fn]
+                    format_string = {fn}+prev
+                elif fn in self._numpy_funcs:
                     fn_name = self._numpy_funcs[fn]
                     format_string = prev+'.{fn}('
                 elif fn in self._custom_funcs:
@@ -390,8 +393,10 @@ class dim(object):
                     format_string = prev+', {fn}'
                 if args:
                     format_string += ', {args}'
-                if kwargs:
-                    format_string += ', {kwargs}'
+                    if kwargs:
+                        format_string += ', {kwargs}'
+                elif kwargs:
+                    format_string += '{kwargs}'
                 format_string += ')'
             op_repr = format_string.format(fn=fn_name, repr=op_repr,
                                            args=args, kwargs=kwargs)

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -154,6 +154,10 @@ class dim(object):
                           'reverse': kwargs.pop('reverse', False)}]
         self.ops = ops
 
+    def __bool__(self):
+        "Ensure dim is truthy"
+        return True
+
     @classmethod
     def register(cls, key, function):
         """

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -386,7 +386,10 @@ class dim(object):
                     format_string = prev+'.{fn}('
                 elif ufunc:
                     fn_name = str(fn)[8:-2]
-                    format_string = '{fn}' + prev
+                    if not (prev.startswith('dim') or prev.endswith(')')):
+                        format_string = '{fn}' + prev
+                    else:
+                        format_string = '{fn}(' + prev
                     if fn_name in dir(np):
                         format_string = 'np.'+format_string
                 else:

--- a/holoviews/util/transform.py
+++ b/holoviews/util/transform.py
@@ -103,10 +103,10 @@ def categorize(values, categories, empty=None):
 
 class dim(object):
     """
-    dim transform objects are a way to express deferred transformations
-    on HoloViews Datasets. Dims support all mathematical operations
-    and NumPy ufuncs, and provide a number of useful methods for normalizing,
-    binning and categorizing data.
+    dim transform objects are a way to express deferred transforms on
+    Datasets. dim transforms support all mathematical and bitwise
+    operators, NumPy ufuncs and methods, and provide a number of
+    useful methods for normalizing, binning and categorizing data.
     """
 
     _binary_funcs = {
@@ -117,7 +117,7 @@ class dim(object):
         operator.or_: '|', operator.pow: '**', operator.rshift: '>>',
         operator.sub: '-', operator.truediv: '/'}
 
-    _builtin_funcs = {abs: 'abs', len: 'len'}
+    _builtin_funcs = {abs: 'abs', round: 'round'}
 
     _custom_funcs = {norm: 'norm', bin: 'bin', categorize: 'categorize'}
 
@@ -131,6 +131,8 @@ class dim(object):
 
     _all_funcs = [_binary_funcs, _builtin_funcs, _custom_funcs,
                   _numpy_funcs, _unary_funcs]
+
+    _namespaces = {'numpy': 'np'}
 
     def __init__(self, obj, *args, **kwargs):
         ops = []
@@ -154,10 +156,6 @@ class dim(object):
                           'reverse': kwargs.pop('reverse', False)}]
         self.ops = ops
 
-    def __bool__(self):
-        "Ensure dim is truthy"
-        return True
-
     @classmethod
     def register(cls, key, function):
         """
@@ -167,8 +165,10 @@ class dim(object):
         cls._custom_funcs[key] = function
 
     # Builtin functions
-    def __abs__(self): return dim(self, abs)
-    def __len__(self): return dim(self, len)
+    def __abs__(self):            return dim(self, abs)
+    def __round__(self, ndigits=None):
+        args = () if ndigits is None else (ndigits,)
+        return dim(self, round, *args)
 
     # Unary operators
     def __neg__(self): return dim(self, operator.neg)
@@ -393,7 +393,7 @@ class dim(object):
                     else:
                         format_string = '{fn}(' + prev
                     if fn_name in dir(np):
-                        format_string = 'np.'+format_string
+                        format_string = self._namespaces['numpy']+format_string
                 else:
                     format_string = prev+', {fn}'
                 if args:


### PR DESCRIPTION
This PR improves the repr of ``dim`` transform to ensure it is in most cases fully usable. It also adds support for further operators and numpy functions.

Here's a mixture of unary operators (``-``), binary operators (``*`` and ``+``), numpy ufuncs (``np.log``), and ndarray methods (``min``): 

```python
> np.log(-dim('A')*3+3).min()

np.log((-dim('A')*3)+3)).min()
```

And here's an example using one of some of the custom functions (``norm`` and ``categorize``):

```python
> (dim('y').norm()>0.5).categorize({False: 'red', True: 'blue'})

(dim('y').norm()>0.5).categorize(categories={False: 'red', True: 'blue'}, empty=None)
```