### PR TITLE
Fixed handling of Link targets

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1165,7 +1165,7 @@ class LinkCallback(param.Parameterized):
         found = []
         for plot, links in source_links:
             for link in links:
-                if link.target is None:
+                if not link._requires_target:
                     # If link has no target don't look further
                     found.append((link, plot, None))
                     continue

--- a/holoviews/plotting/links.py
+++ b/holoviews/plotting/links.py
@@ -28,9 +28,14 @@ class Link(param.Parameterized):
     # e.g. Link._callbacks['bokeh'][Stream] = Callback
     _callbacks = defaultdict(dict)
 
+    # Whether the link requires a target
+    _requires_target = False
+
     def __init__(self, source, target=None, **params):
         if source is None:
             raise ValueError('%s must define a source' % type(self).__name__)
+        if self._requires_target and target is None:
+            raise ValueError('%s must define a target.' % type(self).__name__)
 
         # Source is stored as a weakref to allow it to be garbage collected
         self._source = None if source is None else weakref.ref(source)
@@ -84,6 +89,8 @@ class RangeToolLink(Link):
     axes = param.ListSelector(default=['x'], objects=['x', 'y'], doc="""
         Which axes to link the tool to.""")
 
+    _requires_target = True
+
 
 class DataLink(Link):
     """
@@ -91,8 +98,5 @@ class DataLink(Link):
     them to be selected together. In order for a DataLink to be
     established the source and target data must be of the same length.
     """
- 
-    def __init__(self, source, target, **params):
-        if source is None or target is None:
-            raise ValueError('%s must define a source and a target.')
-        super(DataLink, self).__init__(source=source, target=target, **params)
+
+    _requires_target = True


### PR DESCRIPTION
Since Links now use a weakrefdict to store handles on the source and target objects it is possible for the reference to be deleted before the plot is instantiated. In cases like that the plots should not attempt to instantiate the link callback.