### PR TITLE
Do not expand scalar style options

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -742,7 +742,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         # Process color/alpha styles and expand to fill/line style
         for style, val in list(new_style.items()):
             for s in ('alpha', 'color'):
-                if prefix+s != style or style not in source.data:
+                if prefix+s != style or style not in source.data or validate(s, val, True):
                     continue
                 supports_fill = any(
                     o.startswith(prefix+'fill') and (prefix != 'edge_' or getattr(self, 'filled', True))


### PR DESCRIPTION
As part of the style mapping PR I added some code that expands the ``color`` and ``alpha`` options to ``fill_color``/``fill_alpha`` and ``line_color``/``line_alpha``. This should however only apply for actual style mapping while currently it also applies to scalar options, which in some cases overrides the desired styling.

Before the fix:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/49154777-3db3fe80-f311-11e8-9687-333fd15fd5dd.png)

With the fix:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/49154738-29700180-f311-11e8-8f0e-c7b5cbfd935e.png)
