### PR TITLE
Stream and Link are inherited on clone

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -648,13 +648,17 @@ class LabelledData(param.Parameterized):
             raise ValueError("Supplied label %r contains invalid characters." %
                              self.label)
 
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
         """Clones the object, overriding data and parameters.
 
         Args:
             data: New data replacing the existing data
             shared_data (bool, optional): Whether to use existing data
             new_type (optional): Type to cast object to
+            link (bool, optional): Whether clone should be linked
+                Determines whether Streams and Links attached to
+                original object will be inherited.
             *args: Additional arguments to pass to constructor
             **overrides: New keyword arguments to pass to constructor
 
@@ -677,7 +681,8 @@ class LabelledData(param.Parameterized):
 
         if data is None and shared_data:
             data = self.data
-            settings['plot_id'] = self._plot_id
+            if link:
+                settings['plot_id'] = self._plot_id
         # Apply name mangling for __ attribute
         pos_args = getattr(self, '_' + type(self).__name__ + '__pos_params', [])
         return clone_type(data, *args, **{k:v for k,v in settings.items()

--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -256,6 +256,9 @@ class MultiDimensionalMapping(Dimensioned):
             data: New data replacing the existing data
             shared_data (bool, optional): Whether to use existing data
             new_type (optional): Type to cast object to
+            link (bool, optional): Whether clone should be linked
+                Determines whether Streams and Links attached to
+                original object will be inherited.
             *args: Additional arguments to pass to constructor
             **overrides: New keyword arguments to pass to constructor
 
@@ -808,13 +811,17 @@ class UniformNdMapping(NdMapping):
         super(UniformNdMapping, self).__init__(initial_items, kdims=kdims, **params)
 
 
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
         """Clones the object, overriding data and parameters.
 
         Args:
             data: New data replacing the existing data
             shared_data (bool, optional): Whether to use existing data
             new_type (optional): Type to cast object to
+            link (bool, optional): Whether clone should be linked
+                Determines whether Streams and Links attached to
+                original object will be inherited.
             *args: Additional arguments to pass to constructor
             **overrides: New keyword arguments to pass to constructor
 
@@ -839,7 +846,8 @@ class UniformNdMapping(NdMapping):
 
         if data is None and shared_data:
             data = self.data
-            settings['plot_id'] = self._plot_id
+            if link:
+                settings['plot_id'] = self._plot_id
         # Apply name mangling for __ attribute
         pos_args = getattr(self, '_' + type(self).__name__ + '__pos_params', [])
         with item_check(not shared_data and self._check_items):

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1210,7 +1210,7 @@ class DynamicMap(HoloMap):
         Returns:
             Cloned object
         """
-        if 'link_inputs' in overrides and config.future_deprecations:
+        if 'link_inputs' in overrides and util.config.future_deprecations:
             self.warning('link_inputs argument to the clone method is '
                          'deprecated, use the more general link '
                          'argument instead.')

--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1193,7 +1193,7 @@ class DynamicMap(HoloMap):
         return dmap
 
 
-    def clone(self, data=None, shared_data=True, new_type=None, link_inputs=True,
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
               *args, **overrides):
         """Clones the object, overriding data and parameters.
 
@@ -1201,25 +1201,35 @@ class DynamicMap(HoloMap):
             data: New data replacing the existing data
             shared_data (bool, optional): Whether to use existing data
             new_type (optional): Type to cast object to
+            link (bool, optional): Whether clone should be linked
+                Determines whether Streams and Links attached to
+                original object will be inherited.
             *args: Additional arguments to pass to constructor
             **overrides: New keyword arguments to pass to constructor
 
         Returns:
             Cloned object
         """
+        if 'link_inputs' in overrides and config.future_deprecations:
+            self.warning('link_inputs argument to the clone method is '
+                         'deprecated, use the more general link '
+                         'argument instead.')
+        link = link and overrides.pop('link_inputs', True)
+        callback = overrides.pop('callback', self.callback)
         if data is None and shared_data:
             data = self.data
-            overrides['plot_id'] = self._plot_id
-        clone = super(UniformNdMapping, self).clone(overrides.pop('callback', self.callback),
-                                                    shared_data, new_type,
-                                                    *(data,) + args, **overrides)
+            if link and callback is self.callback:
+                overrides['plot_id'] = self._plot_id
+        clone = super(UniformNdMapping, self).clone(
+            callback, shared_data, new_type, link,
+            *(data,) + args, **overrides)
 
         # Ensure the clone references this object to ensure
         # stream sources are inherited
         if clone.callback is self.callback:
             with util.disable_constant(clone):
                 clone.callback = clone.callback.clone(inputs=[self],
-                                                      link_inputs=link_inputs)
+                                                      link_inputs=link)
         return clone
 
 

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -234,7 +234,8 @@ class Graph(Dataset, Element2D):
                                  'edgepaths (%d)' % (nedges, npaths))
 
 
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
         if data is None:
             data = (self.data, self.nodes)
             if self._edgepaths is not None:
@@ -244,7 +245,8 @@ class Graph(Dataset, Element2D):
             data = (data, self.nodes)
             if self._edgepaths:
                 data = data + (self.edgepaths,)
-        return super(Graph, self).clone(data, shared_data, new_type, *args, **overrides)
+        return super(Graph, self).clone(data, shared_data, new_type, link,
+                                        *args, **overrides)
 
 
     def select(self, selection_specs=None, selection_mode='edges', **selection):

--- a/holoviews/element/path.py
+++ b/holoviews/element/path.py
@@ -292,10 +292,11 @@ class BaseShape(Path):
         Returns a clone of the object with matching parameter values
         containing the specified args and kwargs.
         """
+        link = overrides.pop('link', True)
         settings = dict(self.get_param_values(), **overrides)
         if 'id' not in settings:
             settings['id'] = self.id
-        if not args:
+        if not args and link:
             settings['plot_id'] = self._plot_id
 
         pos_args = getattr(self, '_' + type(self).__name__ + '__pos_params', [])

--- a/holoviews/element/raster.py
+++ b/holoviews/element/raster.py
@@ -388,7 +388,8 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
         super(Dataset, self).__setstate__(state)
 
 
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
         """
         Returns a clone of the object with matching parameter values
         containing the specified args and kwargs.
@@ -401,7 +402,8 @@ class Image(Dataset, Raster, SheetCoordinateSystem):
             sheet_params = dict(bounds=self.bounds, xdensity=self.xdensity,
                                 ydensity=self.ydensity)
             overrides = dict(sheet_params, **overrides)
-        return super(Image, self).clone(data, shared_data, new_type, *args, **overrides)
+        return super(Image, self).clone(data, shared_data, new_type, link,
+                                        *args, **overrides)
 
 
     def aggregate(self, dimensions=None, function=None, spreadfn=None, **kwargs):

--- a/holoviews/element/sankey.py
+++ b/holoviews/element/sankey.py
@@ -350,7 +350,9 @@ class Sankey(Graph):
         self._validate()
         self.redim = redim_graph(self, mode='dataset')
 
-    def clone(self, data=None, shared_data=True, new_type=None, *args, **overrides):
+    def clone(self, data=None, shared_data=True, new_type=None, link=True,
+              *args, **overrides):
         if data is None:
             overrides['sankey'] = self._sankey
-        return super(Sankey, self).clone(data, shared_data, new_type, *args, **overrides)
+        return super(Sankey, self).clone(data, shared_data, new_type, link,
+                                         *args, **overrides)

--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -1175,12 +1175,19 @@ class LinkCallback(param.Parameterized):
         Searches a GenericElementPlot for a Link.
         """
         sources = plot.hmap.traverse(lambda x: x, [ViewableElement])
-        for src in sources:
+        registry = Link.registry.items()
+        for source in sources:
             if link is None:
-                if src in Link.registry:
-                    return (plot, Link.registry[src])
+                links = [
+                    l for src, links in registry for l in links
+                    if src is source or (src._plot_id is not None and
+                                         src._plot_id == source._plot_id)]
+                if links:
+                    return (plot, links)
             else:
-                if link.target is src:
+                if ((link.target is source) or
+                    (link.target._plot_id is not None and
+                     link.target._plot_id == source._plot_id)):
                     return (plot, [link])
 
     def validate(self):

--- a/holoviews/plotting/bokeh/plot.py
+++ b/holoviews/plotting/bokeh/plot.py
@@ -169,11 +169,15 @@ class BokehPlot(DimensionedPlot):
             sources = [(self.zorder, self.hmap.last)]
 
         cb_classes = set()
+        registry = list(Stream.registry.items())
+        callbacks = Stream._callbacks['bokeh']
         for _, source in sources:
-            streams = Stream.registry.get(source, [])
-            registry = Stream._callbacks['bokeh']
-            cb_classes |= {(registry[type(stream)], stream) for stream in streams
-                           if type(stream) in registry and stream.linked
+            streams = [
+                s for src, streams in registry for s in streams
+                if src is source or (src._plot_id is not None and
+                                     src._plot_id == source._plot_id)]
+            cb_classes |= {(callbacks[type(stream)], stream) for stream in streams
+                           if type(stream) in callbacks and stream.linked
                            and stream.source is not None}
         cbs = []
         sorted_cbs = sorted(cb_classes, key=lambda x: id(x[0]))

--- a/holoviews/tests/plotting/bokeh/testcallbacks.py
+++ b/holoviews/tests/plotting/bokeh/testcallbacks.py
@@ -53,6 +53,22 @@ class TestCallbacks(CallbackTestCase):
         self.assertEqual(data['x'], np.array([10]))
         self.assertEqual(data['y'], np.array([-10]))
 
+    def test_stream_callback_on_clone(self):
+        points = Points([])
+        stream = PointerXY(source=points)
+        plot = bokeh_server_renderer.get_plot(points.clone())
+        bokeh_server_renderer(plot)
+        plot.callbacks[0].on_msg({"x": 10, "y": -10})
+        self.assertEqual(stream.x, 10)
+        self.assertEqual(stream.y, -10)
+
+    def test_stream_callback_on_unlinked_clone(self):
+        points = Points([])
+        PointerXY(source=points)
+        plot = bokeh_server_renderer.get_plot(points.clone(link=False))
+        bokeh_server_renderer(plot)
+        self.assertTrue(len(plot.callbacks) == 0)
+
     def test_stream_callback_with_ids(self):
         dmap = DynamicMap(lambda x, y: Points([(x, y)]), kdims=[], streams=[PointerXY()])
         plot = bokeh_server_renderer.get_plot(dmap)

--- a/holoviews/tests/plotting/bokeh/testlinks.py
+++ b/holoviews/tests/plotting/bokeh/testlinks.py
@@ -65,7 +65,29 @@ class TestLinkCallbacks(ComparisonTestCase):
                        'A': np.array(['A', 'B']), 'B': np.array([1, 2])}
         for k, v in cds[0].data.items():
             self.assertEqual(v, merged_data[k])
-    
+
+    def test_data_link_poly_table_on_clone(self):
+        arr1 = np.random.rand(10, 2)
+        arr2 = np.random.rand(10, 2)
+        polys = Polygons([arr1, arr2])
+        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        DataLink(polys, table)
+        layout = polys.clone() + table.clone()
+        plot = bokeh_renderer.get_plot(layout)
+        cds = list(plot.state.select({'type': ColumnDataSource}))
+        self.assertEqual(len(cds), 1)
+
+    def test_data_link_poly_table_on_unlinked_clone(self):
+        arr1 = np.random.rand(10, 2)
+        arr2 = np.random.rand(10, 2)
+        polys = Polygons([arr1, arr2])
+        table = Table([('A', 1), ('B', 2)], 'A', 'B')
+        DataLink(polys, table)
+        layout = polys.clone() + table.clone(link=False)
+        plot = bokeh_renderer.get_plot(layout)
+        cds = list(plot.state.select({'type': ColumnDataSource}))
+        self.assertEqual(len(cds), 2)
+
     def test_data_link_mismatch(self):
         polys = Polygons([np.random.rand(10, 2)])
         table = Table([('A', 1), ('B', 2)], 'A', 'B')


### PR DESCRIPTION
A highly confusing issue has meant that whenever you attach a Stream or Link to an element and subsequently apply some method to it, e.g. ``.relabel``, ``.redim``, ``.options`` etc., it becomes unlinked. This behavior is extremely confusing and routinely catches even me out even though I'm fully aware of the issue.

In the  case of linking a DynamicMap we had already solved this issue via the ``link_inputs`` parameter on the ``Callable``. This solution is complementary to what is being proposed here, but this PR standardizes linking behavior by adding a ``link`` argument to all ``clone`` methods. This controls both the ``link_inputs`` behavior of a DynamicMap and controls whether an element remains linked. I haven't touched the way links on Stream and Link classes are actually stored as the current arrangement allows garbage collection to occur properly, therefore I've only changed how a linked Stream or a Link is looked up. The required changes are therefore fairly minimal, but I believe this will provide a huge improvement to usability.

There is some risk that a user might accidentally end up with multiple links in their plots, but I'm quite certain this would only occur if they use cloned elements in unorthodox ways and they always have the option to unlink. The benefit therefore hugely outweighs the risk because currently you have to structure your code in very awkward ways or know about things like ``.options(..., clone=False)`` if you want to ensure your element stays linked.