### PR TITLE
Install plotly from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - conda-forge::netcdf4=1.3.1
   - conda-forge::ffmpeg
   - conda-forge::flexx=0.4.1
-  - plotly::plotly=3.4
+  - conda-forge::plotly=3.4
   - bokeh::bokeh=1.0.0
   - bokeh::selenium
   # Testing requirements


### PR DESCRIPTION
The more channels are used to specify an environment the longer it takes to resolve the dependencies so this switches plotly back to the conda-forge channel.