### PR TITLE
Skip empty stream callbacks

### DIFF
--- a/holoviews/plotting/bokeh/callbacks.py
+++ b/holoviews/plotting/bokeh/callbacks.py
@@ -119,7 +119,7 @@ class MessageCallback(object):
             ids = list(handle_ids.values())
             filtered_msg = self._filter_msg(msg, ids)
             processed_msg = self._process_msg(filtered_msg)
-            if not processed_msg and not stream.transient:
+            if not processed_msg:
                 continue
             stream.update(**processed_msg)
             stream._metadata = {h: {'id': hid, 'events': self.on_events}


### PR DESCRIPTION
This fix seems correct to me, i.e. I see no reason why an empty message received by a callback should trigger a stream event even if that stream is declared transient, but maybe I'm just missing something. The skipping and the exception for transient streams was made here https://github.com/ioam/holoviews/pull/1350 but I can't see any reference to the reasoning behind making an exception for transient streams.