### PR TITLE
Improved linking of axis ranges

### DIFF
--- a/holoviews/operation/element.py
+++ b/holoviews/operation/element.py
@@ -632,7 +632,7 @@ class histogram(Operation):
             params['vdims'] = [Dimension('Frequency', label=label)]
         else:
             label = 'Frequency' if normed else 'Count'
-            params['vdims'] = [Dimension('{0} {1}'.format(dim.name, label),
+            params['vdims'] = [Dimension('{0}_{1}'.format(dim.name, label.lower()),
                                          label=label)]
 
         if element.group != element.__class__.__name__:

--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -78,7 +78,7 @@ class univariate_kde(Operation):
             params['label'] = element.label
             vdim = element.vdims[0]
             vdim_name = '{}_density'.format(selected_dim.name)
-            vdim_label = '{} Density'.format(selected_dim.label)
+            vdim_label = 'Density'.format(selected_dim.label)
             vdims = [vdim(vdim_name, label=vdim_label) if vdim.name == 'Density' else vdim]
         else:
             if self.p.dimension:
@@ -91,7 +91,7 @@ class univariate_kde(Operation):
                                      type(element).__name__)
                 selected_dim = dimensions[0]
             vdim_name = '{}_density'.format(selected_dim.name)
-            vdim_label = '{} Density'.format(selected_dim.label)
+            vdim_label = 'Density'.format(selected_dim.label)
             vdims = [Dimension(vdim_name, label=vdim_label)]
 
         data = element.dimension_values(selected_dim)

--- a/holoviews/operation/stats.py
+++ b/holoviews/operation/stats.py
@@ -78,8 +78,7 @@ class univariate_kde(Operation):
             params['label'] = element.label
             vdim = element.vdims[0]
             vdim_name = '{}_density'.format(selected_dim.name)
-            vdim_label = 'Density'.format(selected_dim.label)
-            vdims = [vdim(vdim_name, label=vdim_label) if vdim.name == 'Density' else vdim]
+            vdims = [vdim(vdim_name, label='Density') if vdim.name == 'Density' else vdim]
         else:
             if self.p.dimension:
                 selected_dim = element.get_dimension(self.p.dimension)
@@ -91,8 +90,7 @@ class univariate_kde(Operation):
                                      type(element).__name__)
                 selected_dim = dimensions[0]
             vdim_name = '{}_density'.format(selected_dim.name)
-            vdim_label = 'Density'.format(selected_dim.label)
-            vdims = [Dimension(vdim_name, label=vdim_label)]
+            vdims = [Dimension(vdim_name, label='Density')]
 
         data = element.dimension_values(selected_dim)
         bin_range = self.p.bin_range or element.range(selected_dim)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -14,7 +14,7 @@ from ...core.util import OrderedDict, max_range, basestring, dimension_sanitizer
 from ...element import Bars
 from ...operation import interpolate_curve
 from ...util.transform import dim
-from ..util import compute_sizes, get_min_distance, dim_axis_label, get_axis_padding
+from ..util import compute_sizes, get_min_distance, get_axis_padding
 from .element import ElementPlot, ColorbarPlot, LegendPlot
 from .styles import (expand_batched_style, line_properties, fill_properties,
                      mpl_to_bokeh, rgb2hex)

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -824,22 +824,13 @@ class BarPlot(ColorbarPlot, LegendPlot):
         return coords
 
 
-    def _get_axis_labels(self, *args, **kwargs):
-        """
-        Override axis mapping by setting the first key and value
-        dimension as the x-axis and y-axis labels.
-        """
-        element = self.current_frame
-        if self.batched:
-            element = element.last
-        xlabel = dim_axis_label(element.kdims[0])
+    def _get_axis_dims(self, element):
         if element.ndims > 1 and not (self.stacked or self.stack_index):
-            gdim = element.get_dimension(1)
+            xdims = element.kdims
         else:
-            gdim = None
-        if gdim and gdim in element.kdims:
-            xlabel = ', '.join([xlabel, dim_axis_label(gdim)])
-        return (xlabel, dim_axis_label(element.vdims[0]), None)
+            xdims = element.kdims[0]
+        return (xdims, element.vdims[0])
+
 
     def get_stack(self, xvals, yvals, baselines, sign='positive'):
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -298,7 +298,6 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 categorical_x = True
             else:
                 if isinstance(el, Graph):
-                    print(xdims)
                     xtype = el.nodes.get_dimension_type(xdims[0])
                 else:
                     xtype = el.get_dimension_type(xdims[0])

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -241,7 +241,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
 
     def _get_axis_dims(self, element):
-        return element.dimensions()
+        """Returns the dimensions corresponding to each axis.
+
+        Should return a list of dimensions or list of lists of
+        dimensions, which will be formatted to label the axis
+        and to link axes.
+        """
+        return element.dimensions()[:2]
 
 
     def _axes_props(self, plots, subplots, element, ranges):

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -40,7 +40,7 @@ from .styles import (
 from .util import (
     bokeh_version, decode_bytes, get_tab_title, glyph_order,
     py2js_tickformatter, recursive_model_update, theme_attr_json,
-    cds_column_replace, hold_policy
+    cds_column_replace, hold_policy, match_dim_specs
 )
 
 
@@ -220,22 +220,22 @@ class ElementPlot(BokehPlot, GenericElementPlot):
     def _merge_ranges(self, plots, xspecs, yspecs):
         """
         Given a list of other plots return axes that are shared
-        with another plot by matching the axes labels
+        with another plot by matching the dimensions specs stored
+        as tags on the dimensions.
         """
         plot_ranges = {}
         for plot in plots:
             if plot is None:
                 continue
-
             if hasattr(plot, 'x_range') and plot.x_range.tags and xspecs is not None:
-                if plot.x_range.tags[0] == xspecs:
+                if match_dim_specs(plot.x_range.tags[0], xspecs):
                     plot_ranges['x_range'] = plot.x_range
-                if plot.x_range.tags[0] == yspecs:
+                if match_dim_specs(plot.x_range.tags[0], yspecs):
                     plot_ranges['y_range'] = plot.x_range
             if hasattr(plot, 'y_range') and plot.y_range.tags and yspecs is not None:
-                if plot.y_range.tags[0] == yspecs:
+                if match_dim_specs(plot.y_range.tags[0], yspecs):
                     plot_ranges['y_range'] = plot.y_range
-                if plot.y_range.tags[0] == xspecs:
+                if match_dim_specs(plot.y_range.tags[0], xspecs):
                     plot_ranges['x_range'] = plot.y_range
         return plot_ranges
 
@@ -265,13 +265,13 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         if xdims:
             if not isinstance(xdims, list):
                 xdims = [xdims]
-            xspecs = tuple((xd.name, xd.label) for xd in xdims)
+            xspecs = tuple((xd.name, xd.label, xd.unit) for xd in xdims)
         else:
             xspecs = None
         if ydims:
             if not isinstance(ydims, list):
                 ydims = [ydims]
-            yspecs = tuple((yd.name, yd.label) for yd in ydims)
+            yspecs = tuple((yd.name, yd.label, yd.unit) for yd in ydims)
         else:
             yspecs = None
 

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -94,8 +94,8 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         return super(GraphPlot, self).get_extents(element.nodes, ranges, range_type)
 
 
-    def _get_axis_dims(self):
-        return el.nodes.dimensions()[:2]
+    def _get_axis_dims(self, element):
+        return element.nodes.dimensions()[:2]
 
 
     def _get_edge_colors(self, element, ranges, edge_data, edge_mapping, style):

--- a/holoviews/plotting/bokeh/graphs.py
+++ b/holoviews/plotting/bokeh/graphs.py
@@ -94,13 +94,8 @@ class GraphPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
         return super(GraphPlot, self).get_extents(element.nodes, ranges, range_type)
 
 
-    def _get_axis_labels(self, *args, **kwargs):
-        """
-        Override axis labels to group all key dimensions together.
-        """
-        element = self.current_frame
-        xlabel, ylabel = [kd.pprint_label for kd in element.nodes.kdims[:2]]
-        return xlabel, ylabel, None
+    def _get_axis_dims(self):
+        return el.nodes.dimensions()[:2]
 
 
     def _get_edge_colors(self, element, ranges, edge_data, edge_mapping, style):

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -90,14 +90,8 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             element, ranges, range_type, 'categorical', element.vdims[0]
         )
 
-    def _get_axis_labels(self, *args, **kwargs):
-        """
-        Override axis labels to group all key dimensions together.
-        """
-        element = self.current_frame
-        xlabel = ', '.join([kd.pprint_label for kd in element.kdims])
-        ylabel = element.vdims[0].pprint_label
-        return xlabel, ylabel, None
+    def _get_axis_dims(self, element):
+        return element.kdims, element.vdims[0]
 
     def _glyph_properties(self, plot, element, source, ranges, style, group=None):
         if element.ndims > 0:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -630,11 +630,10 @@ def match_dim_specs(specs1, specs2):
     The name and label must match exactly while the unit only has to
     match if both specs define one.
     """
-    if len(specs1) != len(specs2):
+    if (specs1 is None or specs2 is None) or (len(specs1) != len(specs2)):
         return False
     for spec1, spec2 in zip(specs1, specs2):
         for s1, s2 in zip(spec1, spec2):
-            print(s1, s2)
             if s1 is None or s2 is None:
                 continue
             if s1 != s2:

--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -620,3 +620,23 @@ def multi_polygons_data(element):
         xsh.append(multi_xs)
         ysh.append(multi_ys)
     return xsh, ysh
+
+
+def match_dim_specs(specs1, specs2):
+    """Matches dimension specs used to link axes.
+
+    Axis dimension specs consists of a list of tuples corresponding
+    to each dimension, each tuple spec has the form (name, label, unit).
+    The name and label must match exactly while the unit only has to
+    match if both specs define one.
+    """
+    if len(specs1) != len(specs2):
+        return False
+    for spec1, spec2 in zip(specs1, specs2):
+        for s1, s2 in zip(spec1, spec2):
+            print(s1, s2)
+            if s1 is None or s2 is None:
+                continue
+            if s1 != s2:
+                return False
+    return True

--- a/holoviews/plotting/mpl/raster.py
+++ b/holoviews/plotting/mpl/raster.py
@@ -330,8 +330,7 @@ class RasterGridPlot(GridPlot, OverlayPlot):
         xticks = (self._xticks, [xdim.pprint_value(l) for l in self._xkeys])
         yticks = (self._yticks, [ydim.pprint_value(l) if ydim else ''
                                  for l in self._ykeys])
-        return dict(xlabel=xdim.pprint_label, ylabel=ydim.pprint_label if ydim else '',
-                    xticks=xticks, yticks=yticks)
+        return dict(dimensions=[xdim, ydim], xticks=xticks, yticks=yticks)
 
 
     def _compute_borders(self):

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1049,7 +1049,7 @@ class GenericElementPlot(DimensionedPlot):
             ylabel = self.ylabel
         elif len(dimensions) >= 2 and ylabel is None:
             ydims = dimensions[1]
-            xlabel = dim_axis_label(ydims) if ydims else ''
+            ylabel = dim_axis_label(ydims) if ydims else ''
 
         if getattr(self, 'zlabel', None) is not None:
             zlabel = self.zlabel

--- a/holoviews/plotting/plot.py
+++ b/holoviews/plotting/plot.py
@@ -1042,11 +1042,15 @@ class GenericElementPlot(DimensionedPlot):
         if self.xlabel is not None:
             xlabel = self.xlabel
         elif dimensions and xlabel is None:
-            xlabel = dim_axis_label(dimensions[0]) if dimensions[0] else ''
+            xdims = dimensions[0]
+            xlabel = dim_axis_label(xdims) if xdims else ''
+
         if self.ylabel is not None:
             ylabel = self.ylabel
         elif len(dimensions) >= 2 and ylabel is None:
-            ylabel = dim_axis_label(dimensions[1]) if dimensions[1] else ''
+            ydims = dimensions[1]
+            xlabel = dim_axis_label(ydims) if ydims else ''
+
         if getattr(self, 'zlabel', None) is not None:
             zlabel = self.zlabel
         elif self.projection == '3d' and len(dimensions) >= 3 and zlabel is None:

--- a/holoviews/tests/element/teststatselements.py
+++ b/holoviews/tests/element/teststatselements.py
@@ -122,7 +122,7 @@ class StatisticalCompositorTest(ComparisonTestCase):
         dist = Distribution(np.array([0, 1, 2]))
         area = Compositor.collapse_element(dist, backend='matplotlib')
         self.assertIsInstance(area, Area)
-        self.assertEqual(area.vdims, [Dimension(('Value_density', 'Value Density'))])
+        self.assertEqual(area.vdims, [Dimension(('Value_density', 'Density'))])
 
     def test_distribution_composite_transfer_opts(self):
         dist = Distribution(np.array([0, 1, 2])).opts(style=dict(color='red'))
@@ -146,13 +146,13 @@ class StatisticalCompositorTest(ComparisonTestCase):
         dist = Distribution(np.array([0, 1, 2]), ).opts(plot=dict(filled=False))
         curve = Compositor.collapse_element(dist, backend='matplotlib')
         self.assertIsInstance(curve, Curve)
-        self.assertEqual(curve.vdims, [Dimension(('Value_density', 'Value Density'))])
+        self.assertEqual(curve.vdims, [Dimension(('Value_density', 'Density'))])
 
     def test_distribution_composite_empty_not_filled(self):
         dist = Distribution([]).opts(plot=dict(filled=False))
         curve = Compositor.collapse_element(dist, backend='matplotlib')
         self.assertIsInstance(curve, Curve)
-        self.assertEqual(curve.vdims, [Dimension(('Value_density', 'Value Density'))])
+        self.assertEqual(curve.vdims, [Dimension(('Value_density', 'Density'))])
 
     def test_bivariate_composite(self):
         dist = Bivariate(np.random.rand(10, 2))

--- a/holoviews/tests/operation/testoperation.py
+++ b/holoviews/tests/operation/testoperation.py
@@ -128,42 +128,24 @@ class OperationTests(ComparisonTestCase):
         points = Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3)
 
-        # Make sure that the name and label are as desired
-        op_freq_dim = op_hist.get_dimension('x_frequency')
-        self.assertEqual(op_freq_dim.label, 'x Frequency')
-
-        # Because the operation labels are now different from the
-        #  default Element label, change back before comparing.
-        op_hist = op_hist.redim(x_frequency='Frequency')
-        hist = Histogram(([0.1, 0.1, 0.133333], [0, 3, 6, 9]))
+        hist = Histogram(([0.1, 0.1, 0.133333], [0, 3, 6, 9]),
+                         vdims=('x_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_bin_range(self):
         points = Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, bin_range=(0, 3))
 
-        # Make sure that the name and label are as desired
-        op_freq_dim = op_hist.get_dimension('x_frequency')
-        self.assertEqual(op_freq_dim.label, 'x Frequency')
-
-        # Because the operation labels are now different from the
-        #  default Element label, change back before comparing.
-        op_hist = op_hist.redim(x_frequency='Frequency')
-        hist = Histogram(([0.25, 0.25, 0.5], [0., 1., 2., 3.]))
+        hist = Histogram(([0.25, 0.25, 0.5], [0., 1., 2., 3.]),
+                         vdims=('x_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_explicit_bins(self):
         points = Points([float(i) for i in range(10)])
         op_hist = histogram(points, bins=[0, 1, 3], normed=False)
 
-        # Make sure that the name and label are as desired
-        op_freq_dim = op_hist.get_dimension('x_frequency')
-        self.assertEqual(op_freq_dim.label, 'x Frequency')
-
-        # Because the operation labels are now different from the
-        #  default Element label, change back before comparing.
-        op_hist = op_hist.redim(x_frequency='Frequency')
-        hist = Histogram(([0, 1, 3], [1, 3]))
+        hist = Histogram(([0, 1, 3], [1, 3]),
+                         vdims=('x_count', 'Count'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_cumulative(self):
@@ -171,28 +153,16 @@ class OperationTests(ComparisonTestCase):
         points = Points(arr)
         op_hist = histogram(points, cumulative=True, num_bins=3, normed=False)
 
-        # Make sure that the name and label are as desired
-        op_freq_dim = op_hist.get_dimension('x_frequency')
-        self.assertEqual(op_freq_dim.label, 'x Frequency')
-
-        # Because the operation labels are now different from the
-        #  default Element label, change back before comparing.
-        op_hist = op_hist.redim(x_frequency='Frequency')
-        hist = Histogram(([0, 1, 2, 3], [1, 2, 4]))
+        hist = Histogram(([0, 1, 2, 3], [1, 2, 4]),
+                         vdims=('x_count', 'Count'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_not_normed(self):
         points = Points([float(i) for i in range(10)])
         op_hist = histogram(points, num_bins=3, normed=False)
 
-        # Make sure that the name and label are as desired
-        op_freq_dim = op_hist.get_dimension('x_frequency')
-        self.assertEqual(op_freq_dim.label, 'x Frequency')
-
-        # Because the operation labels are now different from the
-        #  default Element label, change back before comparing.
-        op_hist = op_hist.redim(x_frequency='Frequency')
-        hist = Histogram(([3, 3, 4], [0, 3, 6, 9]))
+        hist = Histogram(([3, 3, 4], [0, 3, 6, 9]),
+                         vdims=('x_count', 'Count'))
         self.assertEqual(op_hist, hist)
 
     def test_histogram_operation_datetime(self):
@@ -203,7 +173,7 @@ class OperationTests(ComparisonTestCase):
                                        '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
                      'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
                                                    3.85802469e-18])}
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
     def test_histogram_operation_datetime64(self):
@@ -214,7 +184,7 @@ class OperationTests(ComparisonTestCase):
                                        '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
                      'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
                                                    3.85802469e-18])}
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
     @attr(optional=1) # Requires matplotlib
@@ -226,7 +196,7 @@ class OperationTests(ComparisonTestCase):
                                        '2017-01-04T00:00:00.000000'], dtype='datetime64[us]'),
                      'Date_frequency': np.array([  3.85802469e-18,   3.85802469e-18,   3.85802469e-18,
                                                    3.85802469e-18])}
-        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Date Frequency'))
+        hist = Histogram(hist_data, kdims='Date', vdims=('Date_frequency', 'Frequency'))
         self.assertEqual(op_hist, hist)
 
     def test_points_histogram_weighted(self):

--- a/holoviews/tests/operation/teststatsoperations.py
+++ b/holoviews/tests/operation/teststatsoperations.py
@@ -32,20 +32,20 @@ class KDEOperationTests(ComparisonTestCase):
         kde = univariate_kde(self.dist, n_samples=5, bin_range=(0, 4))
         xs = np.arange(5)
         ys = [0.17594505, 0.23548218, 0.23548218, 0.17594505, 0.0740306]
-        area = Area((xs, ys), 'Value', ('Value_density', 'Value Density'))
+        area = Area((xs, ys), 'Value', ('Value_density', 'Density'))
         self.assertEqual(kde, area)
 
     def test_univariate_kde_flat_distribution(self):
         dist = Distribution([1, 1, 1])
         kde = univariate_kde(dist, n_samples=5, bin_range=(0, 4))
-        area = Area([], 'Value', ('Value_density', 'Value Density'))
+        area = Area([], 'Value', ('Value_density', 'Density'))
         self.assertEqual(kde, area)
 
     def test_univariate_kde_nans(self):
         kde = univariate_kde(self.dist_nans, n_samples=5, bin_range=(0, 4))
         xs = np.arange(5)
         ys = [0, 0, 0, 0, 0]
-        area = Area((xs, ys), 'Value', ('Value_density', 'Value Density'))
+        area = Area((xs, ys), 'Value', ('Value_density', 'Density'))
         self.assertEqual(kde, area)
 
     def test_bivariate_kde(self):


### PR DESCRIPTION
This PR makes two improvements:

1) Instead of having custom logic to compute custom axis labels for some plots it consistently computes the axis labels from dimensions. This also fixes various plots that did not implement the xlabel/ylabel options correctly.

2) It improves/fixes the logic which enables shared axes in bokeh, previously it was matching only on the label, which no longer works if a user defines a custom xlabel/ylabel and automatically links dimensions with identical labels but different names (which has forced us to use terrible Histogram/Distribution axis labels).

The new approach uses the bokeh tags property to define a tuple spec on the axis range, which other plots can then match on. Currently the spec consists of the (name, label) of the dimensions the axis range is drawn from. @jlstevens @jbednar Let me know if these semantics for linking axes make sense to you or if for example it should also match on the unit.

- [x] Add some docstrings
- [x] Add unit tests
- [x] Make Histogram/Distribution y-axis labels sane again (and fix https://github.com/ioam/holoviews/issues/3093)