### PR TITLE
Tutorial typo fix (due to renaming?)

### DIFF
--- a/examples/user_guide/11-Responding_to_Events.ipynb
+++ b/examples/user_guide/11-Responding_to_Events.ipynb
@@ -310,7 +310,7 @@
     "```python\n",
     "X = Stream.define('X',x=0.0)\n",
     "Y = Stream.define('Y',y=0.0)\n",
-    "hv.DynamicMap(crosshairs, streams=[X(),Y()])\n",
+    "hv.DynamicMap(marker, streams=[X(),Y()])\n",
     "```\n",
     "\n",
     "The reason why you might want to list multiple streams instead of always defining a single stream containing all the required stream parameters will be made clear in the [Custom Interactivity](./12-Custom_Interactivity.ipynb) guide."


### PR DESCRIPTION
I've been going through this tutorial and spotted this.
I think this fixes a small typo in the "responding to events" tutorial: `crosshairs` must have been renamed to `markers` earlier, because at that point in the tutorial, no object with this name has been introduced.