### PR TITLE
New subplot foundation for Plotly backend

### DIFF
--- a/holoviews/plotting/plotly/chart.py
+++ b/holoviews/plotting/plotly/chart.py
@@ -1,5 +1,4 @@
 import param
-import plotly.graph_objs as go
 
 from ...core import util
 from ...operation import interpolate_curve
@@ -14,7 +13,7 @@ class ScatterPlot(ColorbarPlot):
 
     style_opts = ['symbol', 'color', 'cmap', 'fillcolor', 'opacity', 'fill', 'marker', 'size']
 
-    graph_obj = go.Scatter
+    trace_type = 'scatter'
 
     def graph_options(self, element, ranges):
         opts = super(ScatterPlot, self).graph_options(element, ranges)
@@ -47,7 +46,7 @@ class CurvePlot(ElementPlot):
         default is 'linear', other options include 'steps-mid',
         'steps-pre' and 'steps-post'.""")
 
-    graph_obj = go.Scatter
+    trace_type = 'scatter'
 
     style_opts = ['color', 'dash', 'width', 'line_width']
 
@@ -69,7 +68,7 @@ class CurvePlot(ElementPlot):
 
 class ErrorBarsPlot(ElementPlot):
 
-    graph_obj = go.Scatter
+    trace_type = 'scatter'
 
     style_opts = ['color', 'dash', 'width', 'opacity', 'thickness']
 
@@ -98,7 +97,7 @@ class BivariatePlot(ColorbarPlot):
 
     ncontours = param.Integer(default=None)
 
-    graph_obj = go.Histogram2dcontour
+    trace_type = 'histogram2dcontour'
 
     style_opts = ['cmap']
 
@@ -118,7 +117,7 @@ class BivariatePlot(ColorbarPlot):
 
 class DistributionPlot(ElementPlot):
 
-    graph_obj = go.Histogram
+    trace_type = 'histogram'
 
     def get_data(self, element, ranges):
         return (), dict(x=element.dimension_values(0))
@@ -138,7 +137,7 @@ class BarPlot(ElementPlot):
        Index of the dimension in the supplied Bars
        Element, which will stacked.""")
 
-    graph_obj = go.Bar
+    trace_type = 'bar'
 
     def generate_plot(self, key, ranges):
         element = self._get_frame(key)
@@ -154,20 +153,22 @@ class BarPlot(ElementPlot):
                          "on a bar chart at the same time.")
 
         if element.ndims == 1:
-            bars = [go.Bar(x=element.dimension_values(x_dim),
-                          y=element.dimension_values(vdim))]
+            bars = [dict(type='bar',
+                         x=element.dimension_values(x_dim),
+                         y=element.dimension_values(vdim))]
         else:
             group_dim = cat_dim if cat_dim else stack_dim
             els = element.groupby(group_dim)
             bars = []
             for k, el in els.items():
-                bars.append(go.Bar(x=el.dimension_values(x_dim),
-                                   y=el.dimension_values(vdim), name=k))
+                bars.append(dict(type='bar',
+                                 x=el.dimension_values(x_dim),
+                                 y=el.dimension_values(vdim), name=k))
         layout = self.init_layout(key, element, ranges, x_dim, vdim)
         self.handles['layout'] = layout
         layout['barmode'] = 'group' if cat_dim else 'stacked'
 
-        fig = go.Figure(data=bars, layout=layout)
+        fig = dict(data=bars, layout=layout)
         self.handles['fig'] = fig
         return fig
 
@@ -214,10 +215,10 @@ class BoxWhiskerPlot(ElementPlot):
             else:
                 label = key
             data = {axis: group.dimension_values(group.vdims[0])}
-            plots.append(go.Box(name=label, **dict(box_opts, **data)))
+            plots.append(dict(type='box', name=label, **dict(box_opts, **data)))
         layout = self.init_layout(key, element, ranges, element.kdims, element.vdims)
         self.handles['layout'] = layout
-        fig = go.Figure(data=plots, layout=layout)
+        fig = dict(data=plots, layout=layout)
         self.handles['fig'] = fig
         return fig
 

--- a/holoviews/plotting/plotly/chart3d.py
+++ b/holoviews/plotting/plotly/chart3d.py
@@ -1,5 +1,4 @@
 import numpy as np
-import plotly.graph_objs as go
 from matplotlib.cm import get_cmap
 from plotly import colors
 from plotly.tools import FigureFactory as FF
@@ -49,8 +48,8 @@ class Chart3DPlot(ElementPlot):
         else:
             opts['aspectmode'] = 'manual'
             opts['aspectratio'] = self.aspect
-        scene = go.layout.Scene(xaxis=xaxis, yaxis=yaxis,
-                                zaxis=zaxis, **opts)
+        scene = dict(xaxis=xaxis, yaxis=yaxis,
+                     zaxis=zaxis, **opts)
 
         return dict(width=self.width, height=self.height,
                     title=self._format_title(key, separator=' '),
@@ -59,7 +58,7 @@ class Chart3DPlot(ElementPlot):
 
 class SurfacePlot(ColorbarPlot, Chart3DPlot):
 
-    graph_obj = go.Surface
+    trace_type = 'surface'
 
     style_opts = ['opacity', 'lighting', 'lightposition', 'cmap']
 
@@ -78,7 +77,7 @@ class SurfacePlot(ColorbarPlot, Chart3DPlot):
 
 class Scatter3dPlot(ScatterPlot, Chart3DPlot):
 
-    graph_obj = go.Scatter3d
+    trace_type = 'scatter3d'
 
     def get_data(self, element, ranges):
         return (), dict(x=element.dimension_values(0),
@@ -117,4 +116,4 @@ class TriSurfacePlot(ColorbarPlot, Chart3DPlot):
             trisurf = FF._trisurf(*plot_args[:-1], **plot_kwargs)
         else:
             trisurf = trisurface(*plot_args, **plot_kwargs)
-        return trisurf[0]
+        return trisurf[0].to_plotly_json()

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -138,10 +138,6 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
                     legendgroup=element.group,
                     name=legend)
 
-        if self.layout_num:
-            opts['xaxis'] = 'x' + str(self.layout_num)
-            opts['yaxis'] = 'y' + str(self.layout_num)
-
         return opts
 
 

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -1,7 +1,7 @@
 import numpy as np
-import plotly.graph_objs as go
 import param
 
+from holoviews.plotting.plotly.util import merge_figure
 from ...core.util import basestring
 from .plot import PlotlyPlot
 from ..plot import GenericElementPlot, GenericOverlayPlot
@@ -84,7 +84,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         An explicit override of the z-axis label, if set takes precedence
         over the dimension label.""")
 
-    graph_obj = None
+    trace_type = None
 
     def initialize_plot(self, ranges=None):
         """
@@ -116,13 +116,13 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         layout = self.init_layout(key, element, ranges)
         self.handles['layout'] = layout
 
-        if isinstance(graph, go.Figure):
-            graph.update({'layout': layout})
+        if isinstance(graph, dict) and 'data' in graph:
+            merge_figure(graph, {'layout': layout})
             self.handles['fig'] = graph
         else:
             if not isinstance(graph, list):
                 graph = [graph]
-            fig = go.Figure(data=graph, layout=layout)
+            fig = dict(data=graph, layout=layout)
             self.handles['fig'] = fig
             return fig
 
@@ -146,7 +146,8 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
 
 
     def init_graph(self, plot_args, plot_kwargs):
-        return self.graph_obj(*plot_args, **plot_kwargs)
+        plot_kwargs['type'] = self.trace_type
+        return dict(*plot_args, **plot_kwargs)
 
 
     def get_data(self, element, ranges):
@@ -191,11 +192,11 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
             options['yaxis'] = yaxis
 
         l, b, r, t = self.margins
-        margin = go.layout.Margin(l=l, r=r, b=b, t=t, pad=4)
-        return go.Layout(width=self.width, height=self.height,
-                         title=self._format_title(key, separator=' '),
-                         plot_bgcolor=self.bgcolor, margin=margin,
-                         **options)
+        margin = dict(l=l, r=r, b=b, t=t, pad=4)
+        return dict(width=self.width, height=self.height,
+                    title=self._format_title(key, separator=' '),
+                    plot_bgcolor=self.bgcolor, margin=margin,
+                    **options)
 
 
     def update_frame(self, key, ranges=None):
@@ -268,7 +269,7 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
             if figure is None:
                 figure = fig
             else:
-                figure.add_traces(fig.data)
+                merge_figure(figure, fig)
 
         layout = self.init_layout(key, element, ranges)
         figure['layout'].update(layout)

--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -119,6 +119,7 @@ class ElementPlot(PlotlyPlot, GenericElementPlot):
         if isinstance(graph, dict) and 'data' in graph:
             merge_figure(graph, {'layout': layout})
             self.handles['fig'] = graph
+            return self.handles['fig']
         else:
             if not isinstance(graph, list):
                 graph = [graph]

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -209,7 +209,7 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
 
         width, height = self._get_size()
 
-        fig = figure_grid(plots,
+        fig = figure_grid(list(reversed(plots)),
                           column_spacing=self.hspacing,
                           row_spacing=self.vspacing)
 

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -1,5 +1,4 @@
 import param
-from plotly import tools
 
 from ...core import (OrderedDict, NdLayout, AdjointLayout, Empty,
                      HoloMap, GridSpace, GridMatrix)
@@ -7,7 +6,8 @@ from ...element import Histogram
 from ...core.options import Store
 from ...core.util import wrap_tuple
 from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
-from .util import add_figure
+from .util import figure_grid
+
 
 class PlotlyPlot(DimensionedPlot):
 
@@ -207,18 +207,12 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
                 if len(subplots) == 1 and c in insert_cols:
                     plots[r+offset].append(None)
 
-        rows, cols = len(plots), len(plots[0])
-        fig = tools.make_subplots(rows=rows, cols=cols, print_grid=False,
-                                  horizontal_spacing=self.hspacing,
-                                  vertical_spacing=self.vspacing)
-
         width, height = self._get_size()
-        ax_idx = 0
-        for r, row in enumerate(plots):
-            for c, plot in enumerate(row):
-                ax_idx += 1
-                if plot:
-                    add_figure(fig, plot, r, c, ax_idx)
+
+        fig = figure_grid(plots,
+                          column_spacing=self.hspacing,
+                          row_spacing=self.vspacing)
+
         fig['layout'].update(height=height, width=width,
                              title=self._format_title(key))
 
@@ -340,17 +334,12 @@ class GridPlot(PlotlyPlot, GenericCompositePlot):
             else:
                 plots[r].append(None)
 
-        rows, cols = len(plots), len(plots[0])
-        fig = tools.make_subplots(rows=rows, cols=cols, print_grid=False,
-                                  shared_xaxes=True, shared_yaxes=True,
-                                  horizontal_spacing=self.hspacing,
-                                  vertical_spacing=self.vspacing)
-        ax_idx = 0
-        for r, row in enumerate(plots):
-            for c, plot in enumerate(row):
-                ax_idx += 1
-                if plot:
-                    add_figure(fig, plot, r, c, ax_idx)
+        fig = figure_grid(plots,
+                          column_spacing=self.hspacing,
+                          row_spacing=self.vspacing,
+                          share_xaxis=True,
+                          share_yaxis=True)
+
         w, h = self._get_size(subplot.width, subplot.height)
         fig['layout'].update(width=w, height=h,
                              title=self._format_title(key))

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -37,9 +37,9 @@ class PlotlyPlot(DimensionedPlot):
 
 class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
 
-    hspacing = param.Number(default=0.2, bounds=(0, 1))
+    hspacing = param.Number(default=0.15, bounds=(0, 1))
 
-    vspacing = param.Number(default=0.2, bounds=(0, 1))
+    vspacing = param.Number(default=0.15, bounds=(0, 1))
 
     def __init__(self, layout, **params):
         super(LayoutPlot, self).__init__(layout, **params)

--- a/holoviews/plotting/plotly/raster.py
+++ b/holoviews/plotting/plotly/raster.py
@@ -1,5 +1,4 @@
 import numpy as np
-import plotly.graph_objs as go
 
 from ...core.options import SkipRendering
 from ...element import Image, Raster
@@ -10,7 +9,7 @@ class RasterPlot(ColorbarPlot):
 
     style_opts = ['cmap']
 
-    graph_obj = go.Heatmap
+    trace_type = 'heatmap'
 
     def graph_options(self, element, ranges):
         opts = super(RasterPlot, self).graph_options(element, ranges)

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -71,7 +71,7 @@ class PlotlyRenderer(Renderer):
         Returns a json diff required to update an existing plot with
         the latest plot data.
         """
-        diff = plot.state.to_plotly_json()
+        diff = plot.state
         if serialize:
             return json.dumps(diff, cls=utils.PlotlyJSONEncoder)
         else:

--- a/holoviews/plotting/plotly/renderer.py
+++ b/holoviews/plotting/plotly/renderer.py
@@ -3,6 +3,7 @@ import json
 import param
 with param.logging_level('CRITICAL'):
     from plotly.offline.offline import utils, get_plotlyjs, init_notebook_mode
+    import plotly.graph_objs as go
 
 from ..renderer import Renderer, MIME_TYPES
 from ...core.options import Store
@@ -79,7 +80,9 @@ class PlotlyRenderer(Renderer):
 
 
     def _figure_data(self, plot, fmt=None, divuuid=None, comm=True, as_script=False, width=800, height=600):
-        figure = plot.state
+        # Wrapping plot.state in go.Figure here performs validation
+        # and applies any default theme.
+        figure = go.Figure(plot.state)
         if divuuid is None:
             divuuid = plot.id
 

--- a/holoviews/plotting/plotly/tabular.py
+++ b/holoviews/plotting/plotly/tabular.py
@@ -16,7 +16,7 @@ class TablePlot(ElementPlot):
         return (headings+data,), {}
 
     def init_graph(self, plot_args, plot_kwargs):
-        return create_table(*plot_args, **plot_kwargs)
+        return create_table(*plot_args, **plot_kwargs).to_plotly_json()
 
 
     def graph_options(self, element, ranges):

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -1,39 +1,6 @@
 import copy
 import re
 
-
-def add_figure(fig, subfig, r, c, idx):
-    """
-    Combines a figure with an existing figure created with
-    plotly.tools.make_subplots, by adding the data and merging
-    axis layout options.
-    """
-    ref = fig._grid_ref[r][c][0][1:]
-    layout = replace_refs(subfig['layout'].to_plotly_json(), ref)
-
-    fig['layout']['xaxis%s'%ref].update(layout.get('xaxis', {}))
-    fig['layout']['yaxis%s'%ref].update(layout.get('yaxis', {}))
-    fig['layout']['annotations'] += layout.get('annotations', ())
-    for d in subfig['data']:
-        fig.add_trace(d, row=r+1, col=c+1)
-
-
-def replace_refs(obj, ind):
-    """
-    Replaces xref and yref to allow combining multiple plots
-    """
-    if isinstance(obj, tuple):
-        return [replace_refs(o, ind) for o in obj]
-    elif isinstance(obj, dict):
-        new_obj = {}
-        for k, v in obj.items():
-            if k in ['xref', 'yref']:
-                v = '{ax}{ind}'.format(ax=k[0], ind=ind)
-            new_obj[k] = replace_refs(v, ind)
-        return new_obj
-    else:
-        return obj
-
 # Constants
 # ---------
 

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -597,11 +597,7 @@ def figure_grid(figures_grid,
 
     # Compute domain widths/heights for subplots
     column_domains = _compute_subplot_domains(column_widths, column_spacing)
-
-    # Reverse heights/domains so that row 0 corresponds to top and row 1
-    # second from the top, and so on
-    row_domains = _compute_subplot_domains(list(reversed(row_heights)), row_spacing)
-    row_domains = reversed(row_domains)
+    row_domains = _compute_subplot_domains(row_heights, row_spacing)
 
     output_figure = {'data': [], 'layout': {}}
 
@@ -616,7 +612,7 @@ def figure_grid(figures_grid,
 
                 if share_xaxis:
                     subplot_offsets['xaxis'] = c
-                    if r != (rows - 1):
+                    if r != 0:
                         # Only use xaxes from bottom row
                         fig.get('layout', {}).pop('xaxis', None)
 

--- a/holoviews/plotting/plotly/util.py
+++ b/holoviews/plotting/plotly/util.py
@@ -414,20 +414,6 @@ def _scale_translate(fig, scale_x, scale_y, translate_x, translate_y):
             y_domain = yaxis.get('domain', [0, 1])
             yaxis['domain'] = scale_translate_y(y_domain)
 
-    # shapes
-    for obj in layout.get('shapes', []):
-        if obj.get('xref', None) == 'paper':
-            new_x_domain = scale_translate_x(
-                [obj.get('x0', 0.25), obj.get('x1', 0.75)])
-            obj['x0'] = new_x_domain[0]
-            obj['x1'] = new_x_domain[1]
-
-        if obj.get('yref', None) == 'paper':
-            new_y_domain = scale_translate_y(
-                [obj.get('y0', 0.25), obj.get('y1', 0.75)])
-            obj['y0'] = new_y_domain[0]
-            obj['y1'] = new_y_domain[1]
-
     # convert title to annotation
     # This way the annotation will be scaled with the reset of the figure
     annotations = layout.get('annotations', [])

--- a/holoviews/tests/plotting/plotly/testplot.py
+++ b/holoviews/tests/plotting/plotly/testplot.py
@@ -52,7 +52,7 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         curve = Curve([1, 2, 3])
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['y'], np.array([1, 2, 3]))
-        self.assertEqual(state['layout']['yaxis']['range'], (1, 3))
+        self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_scatter3d_state(self):
         scatter = Scatter3D(([0,1], [2,3], [4,5]))
@@ -60,16 +60,16 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         self.assertEqual(state['data'][0]['x'], np.array([0, 1]))
         self.assertEqual(state['data'][0]['y'], np.array([2, 3]))
         self.assertEqual(state['data'][0]['z'], np.array([4, 5]))
-        self.assertEqual(state['layout']['scene']['xaxis']['range'], (0, 1))
-        self.assertEqual(state['layout']['scene']['yaxis']['range'], (2, 3))
-        self.assertEqual(state['layout']['scene']['zaxis']['range'], (4, 5))
+        self.assertEqual(state['layout']['scene']['xaxis']['range'], [0, 1])
+        self.assertEqual(state['layout']['scene']['yaxis']['range'], [2, 3])
+        self.assertEqual(state['layout']['scene']['zaxis']['range'], [4, 5])
 
     def test_overlay_state(self):
         layout = Curve([1, 2, 3]) * Curve([2, 4, 6])
         state = self._get_plot_state(layout)
         self.assertEqual(state['data'][0]['y'], np.array([1, 2, 3]))
         self.assertEqual(state['data'][1]['y'], np.array([2, 4, 6]))
-        self.assertEqual(state['layout']['yaxis']['range'], (1, 6))
+        self.assertEqual(state['layout']['yaxis']['range'], [1, 6])
 
     def test_layout_state(self):
         layout = Curve([1, 2, 3]) + Curve([2, 4, 6])

--- a/holoviews/tests/plotting/plotly/testplot.py
+++ b/holoviews/tests/plotting/plotly/testplot.py
@@ -5,7 +5,7 @@ from nose.plugins.attrib import attr
 import numpy as np
 
 from holoviews.core import Store, DynamicMap, GridSpace
-from holoviews.element import Curve, Scatter3D, Image
+from holoviews.element import Curve, Scatter3D, Image, Scatter
 from holoviews.element.comparison import ComparisonTestCase
 from holoviews.streams import PointerX
 import pyviz_comms as comms
@@ -13,6 +13,8 @@ import pyviz_comms as comms
 try:
     import holoviews.plotting.plotly # noqa (Activate backend)
     plotly_renderer = Store.renderers['plotly']
+    from holoviews.plotting.plotly.util import figure_grid
+    import plotly.graph_objs as go
 except:
     plotly_renderer = None
 
@@ -44,8 +46,6 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         plotly_renderer.comm_manager = self.comm_manager
 
     def _get_plot_state(self, element):
-        import plotly.graph_objs as go
-
         plot = plotly_renderer.get_plot(element)
         plot.initialize_plot()
 
@@ -58,6 +58,14 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         curve = Curve([1, 2, 3])
         state = self._get_plot_state(curve)
         self.assertEqual(state['data'][0]['y'], np.array([1, 2, 3]))
+        self.assertEqual(state['data'][0]['mode'], 'lines')
+        self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
+
+    def test_scatter_state(self):
+        scatter = Scatter([3, 2, 1])
+        state = self._get_plot_state(scatter)
+        self.assertEqual(state['data'][0]['y'], np.array([3, 2, 1]))
+        self.assertEqual(state['data'][0]['mode'], 'markers')
         self.assertEqual(state['layout']['yaxis']['range'], [1, 3])
 
     def test_scatter3d_state(self):
@@ -102,6 +110,62 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         self.assertEqual(state['data'][3]['xaxis'], 'x2')
         self.assertEqual(state['data'][3]['yaxis'], 'y2')
 
+    def test_layout_with_grid(self):
+        # Create GridSpace
+        grid = GridSpace({(i, j): Curve([i, j]) for i in [0, 1]
+                          for j in [0, 1]})
+        grid = grid.options(vspacing=0, hspacing=0)
+
+        # Create Scatter
+        scatter = Scatter([-10, 0])
+
+        # Create Horizontal Layout
+        layout = (scatter + grid).options(vspacing=0, hspacing=0)
+
+        state = self._get_plot_state(layout)
+
+        # Check the scatter plot on the left
+        self.assertEqual(state['data'][0]['y'], np.array([-10, 0]))
+        self.assertEqual(state['data'][0]['mode'], 'markers')
+        self.assertEqual(state['data'][0]['xaxis'], 'x')
+        self.assertEqual(state['data'][0]['yaxis'], 'y')
+        self.assertEqual(state['layout']['xaxis']['range'], [0, 1])
+        self.assertEqual(state['layout']['xaxis']['domain'], [0, 0.5])
+        self.assertEqual(state['layout']['yaxis']['range'], [-10, 0])
+        self.assertEqual(state['layout']['yaxis']['domain'], [0, 1])
+
+        # Check the grid plot on the right
+
+        # (0, 0) - bottom-left
+        self.assertEqual(state['data'][1]['y'], np.array([0, 0]))
+        self.assertEqual(state['data'][1]['mode'], 'lines')
+        self.assertEqual(state['data'][1]['xaxis'], 'x2')
+        self.assertEqual(state['data'][1]['yaxis'], 'y2')
+
+        # (1, 0) - bottom-right
+        self.assertEqual(state['data'][2]['y'], np.array([1, 0]))
+        self.assertEqual(state['data'][2]['mode'], 'lines')
+        self.assertEqual(state['data'][2]['xaxis'], 'x3')
+        self.assertEqual(state['data'][2]['yaxis'], 'y2')
+
+        # (0, 1) - top-left
+        self.assertEqual(state['data'][3]['y'], np.array([0, 1]))
+        self.assertEqual(state['data'][3]['mode'], 'lines')
+        self.assertEqual(state['data'][3]['xaxis'], 'x2')
+        self.assertEqual(state['data'][3]['yaxis'], 'y3')
+
+        # (1, 1) - top-right
+        self.assertEqual(state['data'][4]['y'], np.array([1, 1]))
+        self.assertEqual(state['data'][4]['mode'], 'lines')
+        self.assertEqual(state['data'][4]['xaxis'], 'x3')
+        self.assertEqual(state['data'][4]['yaxis'], 'y3')
+
+        # Axes
+        self.assertEqual(state['layout']['xaxis2']['domain'], [0.5, 0.75])
+        self.assertEqual(state['layout']['xaxis3']['domain'], [0.75, 1.0])
+        self.assertEqual(state['layout']['yaxis2']['domain'], [0, 0.5])
+        self.assertEqual(state['layout']['yaxis3']['domain'], [0.5, 1.0])
+
     def test_stream_callback_single_call(self):
         def history_callback(x, history=deque(maxlen=10)):
             history.append(x)
@@ -129,3 +193,126 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         plot = plotly_renderer.get_plot(layout(plot=dict(transpose=True)))
         positions = [(0, 0), (0, 1), (1, 0), (1, 1), (2, 0), (2, 1), (3, 0), (3, 1)]
         self.assertEqual(sorted(plot.subplots.keys()), positions)
+
+
+@attr(optional=1)
+class TestPlotlyFigureGrid(ComparisonTestCase):
+
+    def test_figure_grid_solo_traces(self):
+
+        fig = figure_grid([[
+            {'data': [{'type': 'table',
+                       'header': {'values': [['One', 'Two']]}}]},
+            {'data': [{'type': 'parcoords',
+                       'dimensions': [{'values': [1, 2]}]}]}
+        ]], column_widths=[0.4, 0.6],
+            column_spacing=0)
+
+        # Validate resulting figure object
+        go.Figure(fig)
+
+        # Check domains
+        self.assertEqual(fig['data'][0]['type'], 'table')
+        self.assertEqual(fig['data'][0]['domain'],
+                         {'x': [0, 0.4], 'y': [0, 1.0]})
+
+        self.assertEqual(fig['data'][1]['type'], 'parcoords')
+        self.assertEqual(fig['data'][1]['domain'],
+                         {'x': [0.4, 1.0], 'y': [0, 1.0]})
+
+    def test_figure_grid_polar_subplots(self):
+        fig = figure_grid([[
+            {'data': [{'type': 'scatterpolar',
+                       'theta': [0, 90], 'r': [0.5, 1.0]}]}
+        ], [
+            {'data': [{'type': 'barpolar',
+                       'theta': [90, 180], 'r': [1.0, 10.0]}],
+             'layout': {'polar': {'radialaxis': {'title': 'radial'}}}}
+        ]], row_spacing=0.1)
+
+        # Validate resulting figure object
+        go.Figure(fig)
+
+        # Check domains
+        self.assertEqual(fig['data'][0]['type'], 'scatterpolar')
+        self.assertEqual(fig['data'][0]['subplot'], 'polar')
+        self.assertEqual(fig['layout']['polar']['domain'],
+                         {'y': [0, 0.45], 'x': [0, 1.0]})
+
+        self.assertEqual(fig['data'][1]['type'], 'barpolar')
+        self.assertEqual(fig['data'][1]['subplot'], 'polar2')
+        self.assertEqual(fig['layout']['polar2']['domain'],
+                         {'y': [0.55, 1.0], 'x': [0, 1.0]})
+
+        # Check that radial axis title stayed with the barpolar trace's polar
+        # subplot
+        self.assertEqual(fig['layout']['polar2']['radialaxis'],
+                         {'title': 'radial'})
+
+    def test_titles_converted_to_annotations(self):
+        fig = figure_grid([[
+            {'data': [{'type': 'scatter',
+                       'y': [1, 3, 2]}],
+             'layout': {'title': 'Scatter!'}}
+        ], [
+            {'data': [{'type': 'bar',
+                       'y': [2, 3, 1]}],
+             'layout': {'title': 'Bar!'}}
+        ]])
+
+        # Validate resulting figure object
+        go.Figure(fig)
+
+        self.assertNotIn('title', fig['layout'])
+        self.assertEqual(len(fig['layout']['annotations']), 2)
+        self.assertEqual(fig['layout']['annotations'][0]['text'], 'Scatter!')
+        self.assertEqual(fig['layout']['annotations'][1]['text'], 'Bar!')
+
+
+    def test_annotations_stick_with_axis(self):
+        fig = figure_grid([[
+            {'data': [{'type': 'scatter',
+                       'y': [1, 3, 2]}],
+             'layout': {
+                 'annotations': [
+                     {'text': 'One',
+                      'xref': 'x', 'yref': 'y',
+                      'x': 0, 'y': 0},
+                     {'text': 'Two',
+                      'xref': 'x', 'yref': 'y',
+                      'x': 1, 'y': 0}
+                 ]}}
+            ,
+            {'data': [{'type': 'bar',
+                       'y': [2, 3, 1]}],
+             'layout': {
+                 'annotations': [
+                     {'text': 'Three',
+                      'xref': 'x', 'yref': 'y',
+                      'x': 2, 'y': 0},
+                     {'text': 'Four',
+                      'xref': 'x', 'yref': 'y',
+                      'x': 3, 'y': 0}
+                 ]}}
+        ]])
+
+        # Validate resulting figure object
+        go.Figure(fig)
+
+        annotations = fig['layout']['annotations']
+        self.assertEqual(len(annotations), 4)
+        self.assertEqual(annotations[0]['text'], 'One')
+        self.assertEqual(annotations[0]['xref'], 'x')
+        self.assertEqual(annotations[0]['yref'], 'y')
+
+        self.assertEqual(annotations[1]['text'], 'Two')
+        self.assertEqual(annotations[1]['xref'], 'x')
+        self.assertEqual(annotations[1]['yref'], 'y')
+
+        self.assertEqual(annotations[2]['text'], 'Three')
+        self.assertEqual(annotations[2]['xref'], 'x2')
+        self.assertEqual(annotations[2]['yref'], 'y2')
+
+        self.assertEqual(annotations[3]['text'], 'Four')
+        self.assertEqual(annotations[3]['xref'], 'x2')
+        self.assertEqual(annotations[3]['yref'], 'y2')

--- a/holoviews/tests/plotting/plotly/testplot.py
+++ b/holoviews/tests/plotting/plotly/testplot.py
@@ -44,8 +44,14 @@ class TestPlotlyPlotInstantiation(ComparisonTestCase):
         plotly_renderer.comm_manager = self.comm_manager
 
     def _get_plot_state(self, element):
+        import plotly.graph_objs as go
+
         plot = plotly_renderer.get_plot(element)
         plot.initialize_plot()
+
+        # Pass to plotly.py for full property validation
+        go.Figure(plot.state)
+
         return plot.state
 
     def test_curve_state(self):


### PR DESCRIPTION
## Overview
This PR introduces a new foundation for combining plotly elements into a figure.

## Background
Currently, the plotly backend makes use of the `plotly.tools.make_subplots` function to support laying out multiple elements in a single plotly figure.  This function is pretty flexible when working with Cartesian trace types, but it has limited support for 3D traces and no support for other trace types. Additionally, it cannot be used recursively so it's not possible to use `make_subplots` to build a `GridSpace` figure and then `make_subplots` again to layout multiple `GridSpace` views in a single figure.

## PR Notes
There is a pretty detailed commit log, but here are the two top-level goals:

### Replace `make_subplots` with `figure_grid`
This PR replaces the use of `make_subplots` with a new `figure_grid` function.  This function inputs a 2D list of figure `dict` instances, along with optional spacing arguments, and returns a new figure that is the combination of all of the input figures.  It handles all plotly trace types along with annotations, shapes, and images that are specified in Cartesian axis coordinates.  It also works fine recursively, so it is now possible to, for example, layout a `GridSpace` next to a `HoloMap`.

I may eventually try to roll this functionality into plotly.py directly, but it would need to be a lot more general, so I'd rather start in Holoviews where we have control over how figures are constructed.

### Replace `graph_objs` with `dicts` at the `Element` level
This PR also changes the elements and layouts to work with `dict` instances rather than `graph_objs` instances. The `graph_objs` in version 3+ perform a lot more validation than in version 2, which is great when a user is directly building their own figure but it does have a performance cost.  For a system like Holoviews that is performing lots of iterative construction, I think it's better to build up the figure using raw `dict` and `list` instances and then convert it to a `graph_objs.Figure` object for validation just before rendering.

I'm not sure if this was the best place for it, but I added the step to convert the figure `dict` to a `Figure` instance to the `_figure_data` method of `PlotlyRenderer`.

## Usage highlights
Here are some examples of layouts that did not work previously

### 3D plots in a layout
```python
import numpy as np
import holoviews as hv
hv.notebook_extension('plotly')

y,x = np.mgrid[-5:5, -5:5] * 0.1
heights = np.sin(x**2+y**2)
scatt3d = hv.Scatter3D(zip(x.flat,y.flat,heights.flat))
scatt3d+scatt3d.options(color_index=2, size=5, cmap='fire')
```
![newplot 11](https://user-images.githubusercontent.com/15064365/49410227-ec9d7380-f731-11e8-97bb-9e7c21725f76.png)

### Tables in a layout
```python
import holoviews as hv
hv.extension('plotly')

gender = ['M','M', 'M','F']
age = [10,16,13,12]
weight = [15,18,16,10]
height = [0.8,0.6,0.7,0.8]

table = hv.Table((gender, age, weight, height), ['Gender', 'Age'], ['Weight', 'Height'])
table.select(Gender='M') + table.select(Gender='M', Age=10)
```
![newplot 12](https://user-images.githubusercontent.com/15064365/49410280-15256d80-f732-11e8-8cdc-4acc07a845c5.png)

Note: I still want to replace this `figure_factory` table with the plotly table trace, but using the figure factory implementation here shows how annotations are merged and maintained successfully.

### GridSpace inside a layout
```python
import numpy as np
import holoviews as hv
hv.extension('plotly')

def sine_curve(phase, freq):
    xvals = [0.1* i for i in range(100)]
    return hv.Curve((xvals, [np.sin(phase+freq*x) for x in xvals]))

phases      = [0, np.pi/2, np.pi, 3*np.pi/2]
frequencies = [0.5, 0.75, 1.0, 1.25]
curve_dict_2D = {(p,f):sine_curve(p,f) for p in phases for f in frequencies}

gridspace = hv.GridSpace(curve_dict_2D, kdims=['phase', 'frequency'])
hmap = hv.HoloMap(gridspace)
hmap + hv.GridSpace(hmap)
```
![gridspace_hmap](https://user-images.githubusercontent.com/15064365/49410146-903a5400-f731-11e8-89f5-f71c1a1ba019.gif)

Note that the `GridSpace`s shared x-axes and y-axes are maintained when placed inside a larger layout.

## Performance
The plotly backend had felt a bit sluggish to me compared to bokeh and matplotlib, but with these changes it's much faster that it was, and faster than the other backends in some cases.  I'm not sure how to time this exactly, but here's a GIF of the display time for a layout of two 4x4 `GridSpace`s using each backend

![gridspace_performance](https://user-images.githubusercontent.com/15064365/49410948-fecce100-f734-11e8-8b8c-8f6d8784e8fb.gif)

Thanks for taking a look, and please let me know if you have any questions!

