### PR TITLE
Refactored GraphPlot and fixed renderer ordering

### DIFF
--- a/holoviews/plotting/bokeh/sankey.py
+++ b/holoviews/plotting/bokeh/sankey.py
@@ -48,7 +48,7 @@ class SankeyPlot(GraphPlot):
 
     _style_groups = dict(GraphPlot._style_groups, quad='node', text='label')
 
-    _draw_order = ['patches', 'quad', 'scatter', 'text']
+    _draw_order = ['graph', 'quad_1', 'text_1']
 
     style_opts = GraphPlot.style_opts + ['edge_fill_alpha', 'nodes_line_color',
                                          'label_text_font_size']
@@ -56,7 +56,7 @@ class SankeyPlot(GraphPlot):
     filled = True
 
     def _init_glyphs(self, plot, element, ranges, source):
-        ret = super(SankeyPlot, self)._init_glyphs(plot, element, ranges, source)
+        super(SankeyPlot, self)._init_glyphs(plot, element, ranges, source)
         renderer = plot.renderers.pop(plot.renderers.index(self.handles['glyph_renderer']))
         plot.renderers = [renderer] + plot.renderers
         arc_renderer = self.handles['quad_1_glyph_renderer']
@@ -66,7 +66,6 @@ class SankeyPlot(GraphPlot):
         self.handles['quad_1_source'] = scatter_renderer.data_source
         self._sync_nodes()
 
-        return ret
 
     def get_data(self, element, ranges, style):
         data, mapping, style = super(SankeyPlot, self).get_data(element, ranges, style)

--- a/holoviews/tests/plotting/bokeh/testgraphplot.py
+++ b/holoviews/tests/plotting/bokeh/testgraphplot.py
@@ -500,6 +500,21 @@ class TestBokehChordPlot(TestBokehPlot):
         self.nodes = Dataset([(0, 'A'), (1, 'B'), (2, 'C')], 'index', 'Label')
         self.chord = Chord((self.edges, self.nodes))
 
+    def test_chord_draw_order(self):
+        plot = bokeh_renderer.get_plot(self.chord)
+        renderers = plot.state.renderers
+        graph_renderer = plot.handles['glyph_renderer']
+        arc_renderer = plot.handles['multi_line_2_glyph_renderer']
+        self.assertTrue(renderers.index(arc_renderer)<renderers.index(graph_renderer))
+
+    def test_chord_label_draw_order(self):
+        g = self.chord.options(labels='Label')
+        plot = bokeh_renderer.get_plot(g)
+        renderers = plot.state.renderers
+        graph_renderer = plot.handles['glyph_renderer']
+        label_renderer = plot.handles['text_1_glyph_renderer']
+        self.assertTrue(renderers.index(graph_renderer)<renderers.index(label_renderer))
+
     def test_chord_nodes_label_text(self):
         g = self.chord.opts(plot=dict(label_index='Label'))
         plot = bokeh_renderer.get_plot(g)

--- a/holoviews/tests/plotting/bokeh/testsankey.py
+++ b/holoviews/tests/plotting/bokeh/testsankey.py
@@ -43,6 +43,13 @@ class TestSankeyPlot(TestBokehPlot):
 
         self.assertEqual(patch_source.data['Value'], np.array([5, 7, 6, 2, 9, 4]))
 
+        renderers = plot.state.renderers
+        quad_renderer = plot.handles['quad_1_glyph_renderer']
+        text_renderer = plot.handles['text_1_glyph_renderer']
+        graph_renderer = plot.handles['glyph_renderer']
+        self.assertTrue(renderers.index(graph_renderer)<renderers.index(quad_renderer))
+        self.assertTrue(renderers.index(quad_renderer)<renderers.index(text_renderer))
+
 
     def test_sankey_label_index(self):
         sankey = Sankey(([
@@ -71,4 +78,11 @@ class TestSankeyPlot(TestBokehPlot):
                       'Value': np.array([5, 7, 6, 2, 9, 4])}
         for k in patch_data:
             self.assertEqual(patch_source.data[k], patch_data[k])
+
+        renderers = plot.state.renderers
+        quad_renderer = plot.handles['quad_1_glyph_renderer']
+        text_renderer = plot.handles['text_1_glyph_renderer']
+        graph_renderer = plot.handles['glyph_renderer']
+        self.assertTrue(renderers.index(graph_renderer)<renderers.index(quad_renderer))
+        self.assertTrue(renderers.index(quad_renderer)<renderers.index(text_renderer))
 


### PR DESCRIPTION
This PR refactors the ``GraphPlot._init_glyphs`` method so it is a bit less unwieldy and then adds a method which reorders the renderers on the plot depending on the defined ``draw_order``.

- [x] Adds unit tests

Before:

![image 1](https://user-images.githubusercontent.com/1550771/49741312-0e48ae80-fc8e-11e8-84d6-c62192d81a31.png)

After:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/49741339-1e608e00-fc8e-11e8-849b-10362d13bda6.png)
