### PR TITLE
Fixes for opts method

### DIFF
--- a/holoviews/core/spaces.py
+++ b/holoviews/core/spaces.py
@@ -1181,9 +1181,8 @@ class DynamicMap(HoloMap):
                        streams=self.streams, link_inputs=True)
         if not clone:
             with util.disable_constant(self):
+                obj.callback = self.callback
                 self.callback = dmap.callback
-            self.callback.inputs[:] = [obj]
-            obj.callback.inputs[:] = []
             dmap = self
             dmap.data = OrderedDict([(k, v.opts(*args, **kwargs))
                                      for k, v in self.data.items()])
@@ -1225,21 +1224,9 @@ class DynamicMap(HoloMap):
         Returns:
             Returns the cloned object with the options applied
         """
-        from ..util import Dynamic
-        clone = kwargs.get('clone', True)
-
-        obj = self if clone else self.clone()
-        dmap = Dynamic(obj, operation=lambda obj, **dynkwargs: obj.options(*args, **kwargs),
-                       streams=self.streams, link_inputs=True)
-        if not clone:
-            with util.disable_constant(self):
-                self.callback = dmap.callback
-            self.callback.inputs[:] = [obj]
-            obj.callback.inputs[:] = []
-            dmap = self
-        dmap.data = OrderedDict([(k, v.options(*args, **kwargs))
-                                 for k, v in self.data.items()])
-        return dmap
+        if 'clone' not in kwargs:
+            kwargs['clone'] = True
+        return self.opts(*args, **kwargs)
 
 
     def clone(self, data=None, shared_data=True, new_type=None, link=True,

--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -232,7 +232,7 @@ def deprecated_opts_signature(args, kwargs):
     corresponding options.
     """
     groups = ['plot','style', 'norm']
-    signature = groups + ['clone', 'backend']
+    opts = {kw for kw in kwargs if kw not in ('backend', 'clone')}
     apply_groups = False
     options = None
     new_kwargs = {}
@@ -242,7 +242,7 @@ def deprecated_opts_signature(args, kwargs):
             new_kwargs = args[0]
         else:
             options = args[0]
-    elif kwargs and set(kwargs.keys()).issubset(set(signature)):
+    elif opts and opts.issubset(set(groups)):
         apply_groups = True
     elif kwargs.get('options', None) is not None:
         apply_groups = True


### PR DESCRIPTION
Fixes two bugs:

* ``img.opts(opts.Image(cmap='viridis'), clone=False)`` was incorrectly recognized as the old signature
* ``DynamicMap.opts`` did not correctly copy stream sources. 