### PR TITLE
Make matplotlib's BarPlot consistent with other backends

### DIFF
--- a/examples/gallery/demos/matplotlib/bars_economic.ipynb
+++ b/examples/gallery/demos/matplotlib/bars_economic.ipynb
@@ -17,6 +17,8 @@
    "source": [
     "import pandas as pd\n",
     "import holoviews as hv\n",
+    "from holoviews import opts\n",
+    "\n",
     "hv.extension('matplotlib')"
    ]
   },
@@ -53,9 +55,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Bars [category_index=2 stack_index=1 group_index=0 xrotation=90 color_by=['stack']] (color=Cycle('tab20'))\n",
-    "%%opts Bars [legend_position='right' legend_cols=2]\n",
-    "macro.to.bars([ 'Year', 'Country'], 'Trade', [])"
+    "macro.to.bars(['Year', 'Country'], 'Trade', []).opts(\n",
+    "    opts.Bars(aspect=3, color=hv.Cycle('tab20'), legend_position='right', fig_size=300, legend_cols=2, stacked=True, xrotation=90))"
    ]
   }
  ],

--- a/examples/reference/elements/matplotlib/Bars.ipynb
+++ b/examples/reference/elements/matplotlib/Bars.ipynb
@@ -64,7 +64,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "``Bars`` support stacking just like the ``Area`` element as well as grouping by a second key dimension. To activate grouping and stacking set the ``group_index`` or ``stack_index`` to the dimension name or dimension index:"
+    "``Bars`` support stacking just like the ``Area`` element as well as grouping by a second key dimension. When declaring a second key dimension ``Bars`` will break down a secondary category (i.e.``kdims`` as a separate group, to activate stacking set the ``stacked=True`` option, "
    ]
   },
   {
@@ -80,10 +80,10 @@
     "bars = hv.Bars([k+(np.random.rand()*100.,) for k in keys],\n",
     "               ['Index', 'Group'], 'Count')\n",
     "\n",
-    "grouped = bars.relabel('Grouped').opts(category_index=5, color_by=['stack'], stack_index=1)\n",
-    "stacked = bars.relabel('Stacked').opts(stack_index=5)\n",
+    "grouped = bars.relabel('Grouped')\n",
+    "stacked = bars.relabel('Stacked')\n",
     "\n",
-    "grouped + stacked"
+    "grouped + stacked.opts(stacked=True)"
    ]
   },
   {

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -929,7 +929,7 @@ class BarPlot(LegendPlot):
     def get_extents(self, element, ranges, range_type='combined'):
         ngroups = len(self.values['group'])
         vdim = element.vdims[0].name
-        if self.stacked:
+        if self.stacked or self.stack_index == 1:
             return 0, 0, ngroups, np.NaN
         else:
             vrange = ranges[vdim]['combined']
@@ -970,7 +970,10 @@ class BarPlot(LegendPlot):
         if element.ndims < 2:
             gdim, cdim, sdim = element.kdims[0], None, None
             gi, ci, si = 0, ndims+1, ndims+1
-        elif self.stacked:
+        elif element.ndims == 3:
+            gdim, cdim, sdim = element.kdims
+            gi, ci, si = 0, 1, 2
+        elif self.stacked or self.stack_index == 1:
             gdim, cdim, sdim = element.kdims[0], None, element.kdims[1]
             gi, ci, si = 0, ndims+1, 1
         else:
@@ -981,7 +984,7 @@ class BarPlot(LegendPlot):
 
     def _create_bars(self, axis, element):
         # Get style and dimension information
-        values = self.values
+        values = self.values    
         if self.group_index != 0:
             self.warning('Bars group_index plot option is deprecated '
                          'and will be ignored, set stacked=True/False '
@@ -990,7 +993,7 @@ class BarPlot(LegendPlot):
             self.warning('Bars category_index plot option is deprecated '
                          'and will be ignored, set stacked=True/False '
                          'instead.')
-        if self.stack_index != 2:
+        if self.stack_index != 2 and not (self.stack_index == 1 and not self.stacked):
             self.warning('Bars stack_index plot option is deprecated '
                          'and will be ignored, set stacked=True/False '
                          'instead.')

--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -1026,7 +1026,7 @@ class BarPlot(LegendPlot):
                                  **dict(zip(sopts, color_groups[tuple(style_key)])))
                     with abbreviated_exception():
                         style = self._apply_transforms(element, {}, style)
-                    bar = axis.bar([xpos], [val], width=width, bottom=prev,
+                    bar = axis.bar([xpos+width/2.], [val], width=width, bottom=prev,
                                    **style)
 
                     # Update variables


### PR DESCRIPTION
Fixes bug in matplotlib BarPlot where Bars are not correctly aligned with ticks.

Broken:

![download 21](https://user-images.githubusercontent.com/1550771/49804485-8a083100-fd4a-11e8-887d-19879eb04d6d.png)

Fixed:

![download 20](https://user-images.githubusercontent.com/1550771/49804482-883e6d80-fd4a-11e8-9312-9db6ddb456bd.png)
