### PR TITLE
Plotly dynamic map fixes

### DIFF
--- a/holoviews/plotting/plotly/element.py
+++ b/holoviews/plotting/plotly/element.py
@@ -431,6 +431,9 @@ class OverlayPlot(GenericOverlayPlot, ElementPlot):
     def generate_plot(self, key, ranges):
         element = self._get_frame(key)
 
+        # Compute subplot objects
+        self.subplots = self._create_subplots(ranges)
+
         ranges = self.compute_ranges(self.hmap, key, ranges)
         figure = None
         for okey, subplot in self.subplots.items():

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -2,12 +2,14 @@ from __future__ import absolute_import, division, unicode_literals
 
 import param
 
+from holoviews.plotting.util import attach_streams
 from ...core import (OrderedDict, NdLayout, AdjointLayout, Empty,
                      HoloMap, GridSpace, GridMatrix)
 from ...element import Histogram
 from ...core.options import Store
 from ...core.util import wrap_tuple
-from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot
+from ..plot import DimensionedPlot, GenericLayoutPlot, GenericCompositePlot, \
+    GenericElementPlot
 from .util import figure_grid
 
 
@@ -46,6 +48,12 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
     def __init__(self, layout, **params):
         super(LayoutPlot, self).__init__(layout, **params)
         self.layout, self.subplots, self.paths = self._init_layout(layout)
+
+        if self.top_level:
+            self.comm = self.init_comm()
+            self.traverse(lambda x: setattr(x, 'comm', self.comm))
+            self.traverse(lambda x: attach_streams(self, x.hmap, 2),
+                          [GenericElementPlot])
 
     def _get_size(self):
         rows, cols = self.layout.shape

--- a/holoviews/plotting/plotly/plot.py
+++ b/holoviews/plotting/plotly/plot.py
@@ -229,6 +229,10 @@ class LayoutPlot(PlotlyPlot, GenericLayoutPlot):
         self.handles['fig'] = fig
         return self.handles['fig']
 
+    def refresh(self, **kwargs):
+        # Initialize layout plot before executing standard refresh logic
+        self.initialize_plot()
+        super(LayoutPlot, self).refresh(**kwargs)
 
 
 class AdjointLayoutPlot(PlotlyPlot):


### PR DESCRIPTION
In the process of working on `Selection1D` stream support to the plotly backend, I've hit a couple of issues with updating plotly figures inside a DynamicMap.

Setup:
```python
# Imports
import numpy as np
import holoviews as hv
from holoviews.streams import Stream
import param
hv.extension('plotly')

# Data
data = np.random.multivariate_normal((0, 0), [[1, 0.1], [0.1, 1]], (100,))

# Stream
Inds = hv.streams.Stream.define('Inds', index=param.List(default=[]))
inds = Inds(index=[1, 2, 3])

# Points Element
points = hv.Points(data).options(color='gray')

# Dynamic map the generates a single point at mean of indexes provided by the stream
def mean_point(index):
    if index:
        means = data[index, :].mean(axis=0)
        return hv.Points([means]).options(size=12, color='red')
    else:
        return hv.Points([])
mean_sel = hv.DynamicMap(mean_point, kdims=[], streams=[inds])
```

**Case 1)** DynamicMap of single `hv.Points` element

```python
mean_sel
```
![newplot 26](https://user-images.githubusercontent.com/15064365/49827994-baef6280-fd58-11e8-89b0-bc19177d862c.png)

**Case 2)** DynamicMap of overlay of two `hv.Points` elements
```python
points * mean_sel
```
![newplot 27](https://user-images.githubusercontent.com/15064365/49828040-db1f2180-fd58-11e8-84b6-75b85a518525.png)

**Case 3)** DynamicMap of `Layout` of two `hv.Points` elements side-by-side
```python
points + mean_sel
```
![newplot 28](https://user-images.githubusercontent.com/15064365/49828110-0d308380-fd59-11e8-8139-d9a80df02c59.png)

Here the stream was initialized to the list `[1, 2, 3]` and all three cases display properly initially.  Now, update the stream with:

```python
inds.event(index=[4, 5, 6])
```

Prior to this PR, only the output of case 1 would update.  Case 2 and Case 3 remained unchanged. 

**Summary of changes:**
I'm operating at the edge of my understanding of HoloViews' internals here, so I'd appreciate any help on identifying if there are better ways to tackle these issues.

 - Case 2 was fixed by fe95392. Basically the overlay plot layers weren't being regenerated when the overlay plot's `generate_plot` method is called.
 - Case 3 was partially fixed by 19c1320.  A comm was not being created for the plotly LayoutPlot at all, so I pulled a few lines from the constructor of the Bokeh LayoutPlot to do this.  

The other problem with Case 3, and the part I understand the least, is that the subplots were not being regenerated when the LayoutPlot's `refresh` method was called.  I overrode `refresh` and added an explicit call to `initialize_plot` before calling the superclass method in 206b67d.  With this change the plots in case 3 do update when the stream is updated.  But a new problem is that the `mean_point` function ends up being called twice each time the stream is updated.

Thanks for any help on this 🙂  Once we get this worked out, I think I'm pretty close to having `Selection1D` stream support working!