### PR TITLE
Fixes for matplotlib colormapping

### DIFF
--- a/holoviews/plotting/mpl/chart3d.py
+++ b/holoviews/plotting/mpl/chart3d.py
@@ -87,8 +87,9 @@ class Plot3D(ColorbarPlot):
         return super(Plot3D, self)._finalize_axis(key, **kwargs)
 
 
-    def _draw_colorbar(self, dim=None):
-        element = self.hmap.last
+    def _draw_colorbar(self, element=None, dim=None, redraw=True):
+        if element is None:
+            element = self.hmap.last
         artist = self.handles.get('artist', None)
 
         fig = self.handles['fig']

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -679,14 +679,15 @@ class ColorbarPlot(ElementPlot):
 
 
     def _finalize_artist(self, element):
-        artist = self.handles.get('artist', None)
-        if artist and self.colorbar:
-            color_dim = element.get_dimension(getattr(self, 'color_index', None))
-            self._draw_colorbar(color_dim)
+        if self.colorbar:
+            dims = [h for k, h in self.handles.items() if k.endswith('color_dim')]
+            for d in dims:
+                self._draw_colorbar(element, d)
 
 
-    def _draw_colorbar(self, dim=None, redraw=True):
-        element = self.hmap.last
+    def _draw_colorbar(self, element=None, dimension=None, redraw=True):
+        if element is None:
+            element = self.hmap.last
         artist = self.handles.get('artist', None)
         fig = self.handles['fig']
         axis = self.handles['axis']
@@ -703,12 +704,14 @@ class ColorbarPlot(ElementPlot):
             l, b, w, h = position
 
         # Get colorbar label
-        dim = element.get_dimension(dim)
-        if dim:
-            label = dim.pprint_label
+        if isinstance(dimension, dim):
+            dimension = dimension.dimension
+        dimension = element.get_dimension(dimension)
+        if dimension:
+            label = dimension.pprint_label
         elif element.vdims:
             label = element.vdims[0].pprint_label
-        elif dim is None:
+        elif dimension is None:
             label = ''
 
         padding = self.cbar_padding
@@ -719,7 +722,7 @@ class ColorbarPlot(ElementPlot):
             cax = fig.add_axes([l+w+padding+(scaled_w+padding+w*0.15)*offset,
                                 b, scaled_w, h])
             cbar = fig.colorbar(artist, cax=cax, ax=axis, extend=self._cbar_extend)
-            self._adjust_cbar(cbar, label, dim)
+            self._adjust_cbar(cbar, label, dimension)
             self.handles['cax'] = cax
             self.handles['cbar'] = cbar
             ylabel = cax.yaxis.get_label()
@@ -751,6 +754,9 @@ class ColorbarPlot(ElementPlot):
                      element.interface.isscalar(element, vdim.name))
                 )
                 values = np.asarray(element.dimension_values(vdim, expanded=expanded))
+
+        if prefix+'color_dim' not in self.handles:
+            self.handles[prefix+'color_dim'] = vdim
 
         clim = opts.pop(prefix+'clims', None)
         if clim is None:

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -27,10 +27,6 @@ class PathPlot(ColorbarPlot):
 
     style_opts = ['alpha', 'color', 'linestyle', 'linewidth', 'visible', 'cmap']
 
-    def _finalize_artist(self, element):
-        if self.colorbar:
-            self._draw_colorbar(element.get_dimension(self.color_index))
-
     def get_data(self, element, ranges, style):
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
@@ -89,12 +85,6 @@ class ContourPlot(PathPlot):
                                       allow_None=True, doc="""
       Index of the dimension from which the color will the drawn""")
 
-    def _finalize_artist(self, element):
-        if self.colorbar:
-            cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
-            cdim = element.get_dimension(cidx)
-            self._draw_colorbar(cdim)
-
     def init_artists(self, ax, plot_args, plot_kwargs):
         line_segments = LineCollection(*plot_args, **plot_kwargs)
         ax.add_collection(line_segments)
@@ -118,13 +108,17 @@ class ContourPlot(PathPlot):
             style = self._apply_transforms(element, ranges, style)
         if 'c' in style:
             style['array'] = style.pop('c')
+            style['clim'] = style.pop('vmin'), style.pop('vmax')
+
         if isinstance(style.get('color'), np.ndarray):
             style[color_prop] = style.pop('color')
         if None not in [element.level, self.color_index]:
             cdim = element.vdims[0]
-        else:
+        elif 'array' not in style:
             cidx = self.color_index+2 if isinstance(self.color_index, int) else self.color_index
             cdim = element.get_dimension(cidx)
+        else:
+            cdim = None
 
         if cdim is None:
             return (paths,), style, {}

--- a/holoviews/plotting/mpl/path.py
+++ b/holoviews/plotting/mpl/path.py
@@ -104,14 +104,17 @@ class ContourPlot(PathPlot):
             if self.invert_axes:
                 paths = [p[:, ::-1] for p in paths]
 
+        # Process style transform
         with abbreviated_exception():
             style = self._apply_transforms(element, ranges, style)
+
         if 'c' in style:
             style['array'] = style.pop('c')
             style['clim'] = style.pop('vmin'), style.pop('vmax')
-
-        if isinstance(style.get('color'), np.ndarray):
+        elif isinstance(style.get('color'), np.ndarray):
             style[color_prop] = style.pop('color')
+
+        # Process deprecated color_index
         if None not in [element.level, self.color_index]:
             cdim = element.vdims[0]
         elif 'array' not in style:

--- a/holoviews/tests/plotting/matplotlib/testelementplot.py
+++ b/holoviews/tests/plotting/matplotlib/testelementplot.py
@@ -152,3 +152,10 @@ class TestColorbarPlot(TestMPLPlot):
         plot = mpl_renderer.get_plot(scatter)
         cbar_ax = plot.handles['cax']
         self.assertEqual(cbar_ax.get_ylabel(), 'c')
+
+    def test_colorbar_label_style_mapping(self):
+        scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).options(color='color', colorbar=True)
+        plot = mpl_renderer.get_plot(scatter)
+        print(plot.handles)
+        cbar_ax = plot.handles['cax']
+        self.assertEqual(cbar_ax.get_ylabel(), 'color')

--- a/holoviews/tests/plotting/matplotlib/testelementplot.py
+++ b/holoviews/tests/plotting/matplotlib/testelementplot.py
@@ -156,6 +156,5 @@ class TestColorbarPlot(TestMPLPlot):
     def test_colorbar_label_style_mapping(self):
         scatter = Scatter(np.random.rand(100, 3), vdims=["y", "color"]).options(color='color', colorbar=True)
         plot = mpl_renderer.get_plot(scatter)
-        print(plot.handles)
         cbar_ax = plot.handles['cax']
         self.assertEqual(cbar_ax.get_ylabel(), 'color')


### PR DESCRIPTION
Several fixes for matplotlib colormapping:

* Colormapping elements that support fill does not override edgecolor
* Label the colorbar correctly
* Fixed bug colormapping Contours/Polygons