### PR TITLE
Renamed title_format to title throughout

### DIFF
--- a/examples/gallery/apps/bokeh/game_of_life.py
+++ b/examples/gallery/apps/bokeh/game_of_life.py
@@ -68,7 +68,7 @@ def update(pattern, counter, x, y):
 title = 'Game of Life - Tap to place pattern, Doubletap to clear'
 opts =  {
     'style': {'cmap': 'gray', 'toolbar': False, },
-    'plot' : {'height': 400, 'width': 800, 'title_format': '{label}',
+    'plot' : {'height': 400, 'width': 800, 'title': '{label}',
               'xaxis': None, 'yaxis': None}
 }
 img = hv.Image(np.zeros((100, 200), dtype=np.uint8))

--- a/examples/gallery/apps/bokeh/gapminder.py
+++ b/examples/gallery/apps/bokeh/gapminder.py
@@ -42,7 +42,7 @@ text = gapminder_ds.clone({yr: hv.Text(1.2, 25, str(int(yr)), fontsize=30)
 
 # Define options
 opts = {'plot': dict(width=1000, height=600,tools=['hover'], size_index='Population',
-                     color_index='Group', size_fn=np.sqrt, title_format="{label}"),
+                     color_index='Group', size_fn=np.sqrt, title="{label}"),
        'style': dict(cmap='Set1', size=0.3, line_color='black', alpha=0.6)}
 text_opts = {'style': dict(text_font_size='52pt', text_color='lightgray')}
 

--- a/examples/gallery/demos/bokeh/dragon_curve.ipynb
+++ b/examples/gallery/demos/bokeh/dragon_curve.ipynb
@@ -114,7 +114,7 @@
     "\n",
     "hmap.opts(\n",
     "    opts.Path(axiswise=False, color='black', line_width=1, \n",
-    "              padding=0.1, title_format='', xaxis=None, yaxis=None, framewise=True))"
+    "              padding=0.1, title='', xaxis=None, yaxis=None, framewise=True))"
    ]
   }
  ],

--- a/examples/gallery/demos/matplotlib/dragon_curve.ipynb
+++ b/examples/gallery/demos/matplotlib/dragon_curve.ipynb
@@ -113,7 +113,7 @@
     "\n",
     "hmap.opts(\n",
     "    opts.Path(color='black', linewidth=1, fig_size=200, xaxis=None, yaxis=None,\n",
-    "              padding=0.1, title_format='', framewise=True))"
+    "              padding=0.1, title='', framewise=True))"
    ]
   }
  ],

--- a/examples/reference/elements/bokeh/QuadMesh.ipynb
+++ b/examples/reference/elements/bokeh/QuadMesh.ipynb
@@ -72,9 +72,9 @@
    "outputs": [],
    "source": [
     "linearscale = hv.QuadMesh((xs, ys, zs)).opts(\n",
-    "    opts.QuadMesh(title_format='LinearScale', tools=['hover'], xticks=[10, 100, 1000]))\n",
+    "    opts.QuadMesh(title='LinearScale', tools=['hover'], xticks=[10, 100, 1000]))\n",
     "logscale = hv.QuadMesh((xs, ys, zs)).opts(\n",
-    "    opts.QuadMesh(title_format='LogScale', logx=True))\n",
+    "    opts.QuadMesh(title='LogScale', logx=True))\n",
     "linearscale + logscale"
    ]
   },

--- a/examples/reference/elements/bokeh/VectorField.ipynb
+++ b/examples/reference/elements/bokeh/VectorField.ipynb
@@ -63,9 +63,9 @@
    "outputs": [],
    "source": [
     "anglecolor = hv.VectorField(vector_data).opts(\n",
-    "    opts.VectorField(title_format='A', magnitude='Magnitude', color='Angle'))\n",
+    "    opts.VectorField(title='A', magnitude='Magnitude', color='Angle'))\n",
     "magcolor = hv.VectorField(vector_data).opts(\n",
-    "    opts.VectorField(title_format='M', magnitude='Magnitude', color='Magnitude'))\n",
+    "    opts.VectorField(title='M', magnitude='Magnitude', color='Magnitude'))\n",
     "anglecolor + magcolor"
    ]
   },

--- a/holoviews/tests/ipython/testparsers.py
+++ b/holoviews/tests/ipython/testparsers.py
@@ -21,32 +21,32 @@ class OptsSpecPlotOptionsTests(ComparisonTestCase):
     """
 
     def test_plot_opts_simple(self):
-        line = "Layout [fig_inches=(3,3) title_format='foo bar']"
+        line = "Layout [fig_inches=(3,3) title='foo bar']"
         expected= {'Layout':
                    {'plot':
-                    Options(title_format='foo bar', fig_inches=(3, 3))}}
+                    Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_with_space(self):
         "Space in the tuple, see issue #77"
-        line = "Layout [fig_inches=(3, 3) title_format='foo bar']"
+        line = "Layout [fig_inches=(3, 3) title='foo bar']"
         expected= {'Layout':
                    {'plot':
-                    Options(title_format='foo bar', fig_inches=(3, 3))}}
+                    Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_simple_explicit(self):
-        line = "Layout plot[fig_inches=(3,3) title_format='foo bar']"
+        line = "Layout plot[fig_inches=(3,3) title='foo bar']"
         expected= {'Layout':
                    {'plot':
-                    Options(title_format='foo bar', fig_inches=(3, 3))}}
+                    Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_with_space_explicit(self):
-        line = "Layout plot[fig_inches=(3, 3) title_format='foo bar']"
+        line = "Layout plot[fig_inches=(3, 3) title='foo bar']"
         expected= {'Layout':
                    {'plot':
-                    Options(title_format='foo bar', fig_inches=(3, 3))}}
+                    Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_dict_with_space(self):
@@ -60,34 +60,34 @@ class OptsSpecPlotOptionsTests(ComparisonTestCase):
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_nested_brackets(self):
-        line = "Curve [title_format=', '.join(('A', 'B'))]"
-        expected = {'Curve': {'plot': Options(title_format='A, B')}}
+        line = "Curve [title=', '.join(('A', 'B'))]"
+        expected = {'Curve': {'plot': Options(title='A, B')}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_multiple_paths(self):
-        line = "Image Curve [fig_inches=(3, 3) title_format='foo bar']"
+        line = "Image Curve [fig_inches=(3, 3) title='foo bar']"
         expected = {'Image':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))},
+                     Options(title='foo bar', fig_inches=(3, 3))},
                     'Curve':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))}}
+                     Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_plot_opts_multiple_paths_2(self):
-        line = "Image Curve Layout Overlay[fig_inches=(3, 3) title_format='foo bar']"
+        line = "Image Curve Layout Overlay[fig_inches=(3, 3) title='foo bar']"
         expected = {'Image':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))},
+                     Options(title='foo bar', fig_inches=(3, 3))},
                     'Curve':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))},
+                     Options(title='foo bar', fig_inches=(3, 3))},
                     'Layout':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))},
+                     Options(title='foo bar', fig_inches=(3, 3))},
                     'Overlay':
                     {'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3))}}
+                     Options(title='foo bar', fig_inches=(3, 3))}}
         self.assertEqual(OptsSpec.parse(line), expected)
 
 
@@ -245,19 +245,19 @@ class OptsSpecCombinedOptionsTests(ComparisonTestCase):
         self.assertEqual(OptsSpec.parse(line), expected)
 
     def test_combined_multiple_paths(self):
-        line = "Image Curve {+framewise} [fig_inches=(3, 3) title_format='foo bar'] (c='b') Layout [string='foo'] Overlay"
+        line = "Image Curve {+framewise} [fig_inches=(3, 3) title='foo bar'] (c='b') Layout [string='foo'] Overlay"
         expected = {'Image':
                     {'norm':
                      Options(framewise=True, axiswise=False),
                      'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3)),
+                     Options(title='foo bar', fig_inches=(3, 3)),
                      'style':
                      Options(c='b')},
                     'Curve':
                     {'norm':
                      Options(framewise=True, axiswise=False),
                      'plot':
-                     Options(title_format='foo bar', fig_inches=(3, 3)),
+                     Options(title='foo bar', fig_inches=(3, 3)),
                      'style':
                      Options(c='b')},
                     'Layout':

--- a/holoviews/tests/plotting/bokeh/testoverlayplot.py
+++ b/holoviews/tests/plotting/bokeh/testoverlayplot.py
@@ -125,8 +125,8 @@ class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_update_plot_opts(self):
         hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).options(title_format='A'),
-             1: (Curve([]) * Curve([])).options(title_format='B')}
+            {0: (Curve([]) * Curve([])).options(title='A'),
+             1: (Curve([]) * Curve([])).options(title='B')}
         )
         plot = bokeh_renderer.get_plot(hmap)
         self.assertEqual(plot.state.title.text, 'A')
@@ -135,8 +135,8 @@ class TestOverlayPlot(TestBokehPlot):
 
     def test_overlay_update_plot_opts_inherited(self):
         hmap = HoloMap(
-            {0: (Curve([]).options(title_format='A') * Curve([])),
-             1: (Curve([]).options(title_format='B') * Curve([]))}
+            {0: (Curve([]).options(title='A') * Curve([])),
+             1: (Curve([]).options(title='B') * Curve([]))}
         )
         plot = bokeh_renderer.get_plot(hmap)
         self.assertEqual(plot.state.title.text, 'A')

--- a/holoviews/tests/plotting/matplotlib/testoverlayplot.py
+++ b/holoviews/tests/plotting/matplotlib/testoverlayplot.py
@@ -27,8 +27,8 @@ class TestOverlayPlot(TestMPLPlot):
 
     def test_overlay_update_plot_opts(self):
         hmap = HoloMap(
-            {0: (Curve([]) * Curve([])).options(title_format='A'),
-             1: (Curve([]) * Curve([])).options(title_format='B')}
+            {0: (Curve([]) * Curve([])).options(title='A'),
+             1: (Curve([]) * Curve([])).options(title='B')}
         )
         plot = mpl_renderer.get_plot(hmap)
         self.assertEqual(plot.handles['title'].get_text(), 'A')
@@ -37,8 +37,8 @@ class TestOverlayPlot(TestMPLPlot):
 
     def test_overlay_update_plot_opts_inherited(self):
         hmap = HoloMap(
-            {0: (Curve([]).options(title_format='A') * Curve([])),
-             1: (Curve([]).options(title_format='B') * Curve([]))}
+            {0: (Curve([]).options(title='A') * Curve([])),
+             1: (Curve([]).options(title='B') * Curve([]))}
         )
         plot = mpl_renderer.get_plot(hmap)
         self.assertEqual(plot.handles['title'].get_text(), 'A')


### PR DESCRIPTION
Simple PR that renamed `title_format` to `title` in python code and notebooks.