### PR TITLE
Add options to PrettyPrinter

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -244,7 +244,7 @@ class Cycle(param.Parameterized):
     attribute.
     """
 
-    key = param.String(default='default_colors', doc="""
+    key = param.String(default='default_colors', allow_None=True, doc="""
        The key in the default_cycles dictionary used to specify the
        color cycle if values is not supplied. """)
 
@@ -259,6 +259,7 @@ class Cycle(param.Parameterized):
                 params['key'] = cycle
             else:
                 params['values'] = cycle
+                params['key'] = None
         super(Cycle, self).__init__(**params)
         self.values = self._get_values()
 
@@ -285,8 +286,13 @@ class Cycle(param.Parameterized):
 
 
     def __repr__(self):
-        return "%s(values=%s)" % (type(self).__name__,
-                                  [str(el) for el in self.values])
+        if self.key == self.param.params('key').default:
+            vrepr = ''
+        elif self.key:
+            vrepr = repr(self.key)
+        else:
+            vrepr = [str(el) for el in self.values]
+        return "%s(%s)" % (type(self).__name__, vrepr)
 
 
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -708,7 +708,6 @@ class OptionTree(AttrTree):
         if self.groups.get(group, None) is None:
             return None
         if self.parent is None and target and (self is not Store.options()) and defaults:
-            print(group)
             root_name = self.__class__.__name__
             replacement = root_name + ('' if len(target) == len(root_name) else '.')
             option_key = target.replace(replacement,'')

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1181,8 +1181,10 @@ class Store(object):
         # Current custom_options dict may not have entry for obj.id
         if obj.id in cls._custom_options[backend]:
             return cls._custom_options[backend][obj.id].closest(obj, group, defaults)
-        else:
+        elif defaults:
             return cls._options[backend].closest(obj, group, defaults)
+        else:
+            return OptionTree(groups=cls._options[backend].groups)
 
     @classmethod
     def lookup(cls, backend, obj):

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -337,7 +337,7 @@ class PrettyPrinter(object):
         else:
             fst_lvl = level
 
-        if opts:
+        if opts and opts.kwargs:
             lines.append((fst_lvl, ' * ' + str(opts)))
         return (lvl, lines)
 
@@ -347,7 +347,7 @@ class PrettyPrinter(object):
         Return the information summary for an Element. This consists
         of the dotted name followed by an value dimension names.
         """
-        info =  cls.component_type(node)
+        info = cls.component_type(node)
         if len(node.kdims) >= 1:
             info += cls.tab + '[%s]' % ','.join(d.name for d in node.kdims)
         if value_dims and len(node.vdims) >= 1:

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -338,7 +338,7 @@ class PrettyPrinter(object):
             fst_lvl = level
 
         if opts and opts.kwargs:
-            lines.append((fst_lvl, ' * ' + str(opts)))
+            lines.append((fst_lvl, ' ' + str(opts)))
         return (lvl, lines)
 
     @classmethod

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -365,6 +365,8 @@ class PrettyPrinter(param.Parameterized):
 
     @bothmethod
     def option_info(cls_or_slf, node):
+        if not cls_or_slf.show_options:
+            return None
         from .options import Store, Options
         options = {}
         for g in ['plot', 'style', 'norm']:

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -405,12 +405,11 @@ class PrettyPrinter(param.Parameterized):
         if cls_or_slf.show_options and opts and opts.kwargs:
             lines += [(level, l) for l in cls_or_slf.format_options(opts)]
 
-        additional_lines = []
         if len(node.data) == 0:
             return level, lines
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
-        if last is not None and getattr(last, '_deep_indexable'):
+        if last is not None and getattr(last, '_deep_indexable') and not hasattr(last, 'children'):
             level, additional_lines = cls_or_slf.ndmapping_info(last, [], level, value_dims)
         else:
             additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -390,7 +390,10 @@ class PrettyPrinter(param.Parameterized):
         key_dim_info = '[%s]' % ','.join(d.name for d in node.kdims)
         first_line = cls_or_slf.component_type(node) + cls_or_slf.tab + key_dim_info
         lines = [(level, first_line)]
+
         opts = cls_or_slf.option_info(node)
+        if cls_or_slf.show_options and opts and opts.kwargs:
+            lines.append((fst_lvl, ' ' + str(opts)))
 
         additional_lines = []
         if len(node.data) == 0:

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -411,7 +411,7 @@ class PrettyPrinter(param.Parameterized):
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
         if last is not None and getattr(last, '_deep_indexable'):
-            level, additional_lines = cls.ndmapping_info(last, [], level, value_dims)
+            level, additional_lines = cls_or_slf.ndmapping_info(last, [], level, value_dims)
         else:
             additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)
         lines += cls_or_slf.shift(additional_lines, 1)

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -263,7 +263,8 @@ class PrettyPrinter(param.Parameterized):
     """
 
     show_defaults = param.Boolean(default=False, doc="""
-        Whether to show default options as part of the repr.""")
+        Whether to show default options as part of the repr.
+        If show_options=False this has no effect.""")
 
     show_options = param.Boolean(default=False, doc="""
         Whether to show options as part of the repr.""")

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -17,6 +17,7 @@ import sys, re
 import param
 # IPython not required to import ParamPager
 from param.ipython import ParamPager
+from param.parameterized import bothmethod
 from holoviews.core.util import group_sanitizer, label_sanitizer
 
 
@@ -255,142 +256,148 @@ class InfoPrinter(object):
         return '\n'.join(lines)
 
 
-class PrettyPrinter(object):
+class PrettyPrinter(param.Parameterized):
     """
     The PrettyPrinter used to print all HoloView objects via the
-    pprint classmethod.
+    pprint method.
     """
+
+    show_defaults = param.Boolean(default=False, doc="""
+        Whether to show default options as part of the repr.""")
+
+    show_options = param.Boolean(default=False, doc="""
+        Whether to show options as part of the repr.""")
 
     tab = '   '
 
     type_formatter= ':{type}'
 
-    @classmethod
-    def pprint(cls, node):
-        reprval = cls.serialize(cls.recurse(node))
+    @bothmethod
+    def pprint(cls_or_slf, node):
+        reprval = cls_or_slf.serialize(cls_or_slf.recurse(node))
         if sys.version_info.major == 2:
             return str(reprval.encode("utf8"))
         else:
             return str(reprval)
 
 
-    @classmethod
-    def serialize(cls, lines):
+    @bothmethod
+    def serialize(cls_or_slf, lines):
         accumulator = []
         for level, line in lines:
-            accumulator.append((level *cls.tab) + line)
+            accumulator.append((level *cls_or_slf.tab) + line)
         return "\n".join(accumulator)
 
-    @classmethod
-    def shift(cls, lines, shift=0):
+    @bothmethod
+    def shift(cls_or_slf, lines, shift=0):
         return [(lvl+shift, line) for (lvl, line) in lines]
 
-    @classmethod
-    def padding(cls, items):
+    @bothmethod
+    def padding(cls_or_slf, items):
         return max(len(p) for p in items) if len(items) > 1 else len(items[0])
 
-    @classmethod
-    def component_type(cls, node):
+    @bothmethod
+    def component_type(cls_or_slf, node):
         "Return the type.group.label dotted information"
         if node is None: return ''
-        return cls.type_formatter.format(type=str(type(node).__name__))
+        return cls_or_slf.type_formatter.format(type=str(type(node).__name__))
 
-    @classmethod
-    def recurse(cls, node, attrpath=None, attrpaths=[], siblings=[], level=0, value_dims=True):
+    @bothmethod
+    def recurse(cls_or_slf, node, attrpath=None, attrpaths=[], siblings=[], level=0, value_dims=True):
         """
         Recursive function that builds up an ASCII tree given an
         AttrTree node.
         """
-        level, lines = cls.node_info(node, attrpath, attrpaths, siblings, level, value_dims)
+        level, lines = cls_or_slf.node_info(node, attrpath, attrpaths, siblings, level, value_dims)
         attrpaths = ['.'.join(k) for k in node.keys()] if  hasattr(node, 'children') else []
         siblings = [node.get(child) for child in attrpaths]
         for attrpath in attrpaths:
-            lines += cls.recurse(node.get(attrpath), attrpath, attrpaths=attrpaths,
+            lines += cls_or_slf.recurse(node.get(attrpath), attrpath, attrpaths=attrpaths,
                                  siblings=siblings, level=level+1, value_dims=value_dims)
         return lines
 
-    @classmethod
-    def node_info(cls, node, attrpath, attrpaths, siblings, level, value_dims):
+    @bothmethod
+    def node_info(cls_or_slf, node, attrpath, attrpaths, siblings, level, value_dims):
         """
         Given a node, return relevant information.
         """
         opts = None
         if hasattr(node, 'children'):
-            (lvl, lines) = (level, [(level, cls.component_type(node))])
-            opts = cls.option_info(node)
+            (lvl, lines) = (level, [(level, cls_or_slf.component_type(node))])
+            opts = cls_or_slf.option_info(node)
         elif hasattr(node, 'main'):
-            (lvl, lines) = cls.adjointlayout_info(node, siblings, level, value_dims)
+            (lvl, lines) = cls_or_slf.adjointlayout_info(node, siblings, level, value_dims)
         elif getattr(node, '_deep_indexable', False):
-            (lvl, lines) = cls.ndmapping_info(node, siblings, level, value_dims)
+            (lvl, lines) = cls_or_slf.ndmapping_info(node, siblings, level, value_dims)
         elif hasattr(node, 'unit_format'):
             (lvl, lines) = level, [(level, repr(node))]
         else:
-            (lvl, lines) = cls.element_info(node, siblings, level, value_dims)
-            opts = cls.option_info(node)
+            (lvl, lines) = cls_or_slf.element_info(node, siblings, level, value_dims)
+            opts = cls_or_slf.option_info(node)
 
         # The attribute indexing path acts as a prefix (if applicable)
         if attrpath is not None:
-            padding = cls.padding(attrpaths)
+            padding = cls_or_slf.padding(attrpaths)
             (fst_lvl, fst_line) = lines[0]
             line = '.'+attrpath.ljust(padding) +' ' + fst_line
             lines[0] = (fst_lvl, line)
         else:
             fst_lvl = level
 
-        if opts and opts.kwargs:
+        if cls_or_slf.show_options and opts and opts.kwargs:
             lines.append((fst_lvl, ' ' + str(opts)))
         return (lvl, lines)
 
-    @classmethod
-    def element_info(cls, node, siblings, level, value_dims):
+    @bothmethod
+    def element_info(cls_or_slf, node, siblings, level, value_dims):
         """
         Return the information summary for an Element. This consists
         of the dotted name followed by an value dimension names.
         """
-        info = cls.component_type(node)
+        info = cls_or_slf.component_type(node)
         if len(node.kdims) >= 1:
-            info += cls.tab + '[%s]' % ','.join(d.name for d in node.kdims)
+            info += cls_or_slf.tab + '[%s]' % ','.join(d.name for d in node.kdims)
         if value_dims and len(node.vdims) >= 1:
-            info += cls.tab + '(%s)' % ','.join(d.name for d in node.vdims)
+            info += cls_or_slf.tab + '(%s)' % ','.join(d.name for d in node.vdims)
         return level, [(level, info)]
 
-    @classmethod
-    def option_info(cls, node):
+    @bothmethod
+    def option_info(cls_or_slf, node):
         from .options import Store, Options
         options = {}
         for g in ['plot', 'style', 'norm']:
             gopts = Store.lookup_options(Store.current_backend, node, g,
-                                         defaults=False)
+                                         defaults=cls_or_slf.show_defaults)
             if gopts:
                 options.update(gopts.kwargs)
         opts = Options(**options)
         return opts
 
-    @classmethod
-    def adjointlayout_info(cls, node, siblings, level, value_dims):
-        first_line = cls.component_type(node)
+    @bothmethod
+    def adjointlayout_info(cls_or_slf, node, siblings, level, value_dims):
+        first_line = cls_or_slf.component_type(node)
         lines = [(level, first_line)]
         additional_lines = []
         for component in list(node.data.values()):
-            additional_lines += cls.recurse(component, level=level)
-        lines += cls.shift(additional_lines, 1)
+            additional_lines += cls_or_slf.recurse(component, level=level)
+        lines += cls_or_slf.shift(additional_lines, 1)
         return level, lines
 
 
-    @classmethod
-    def ndmapping_info(cls, node, siblings, level, value_dims):
+    @bothmethod
+    def ndmapping_info(cls_or_slf, node, siblings, level, value_dims):
         key_dim_info = '[%s]' % ','.join(d.name for d in node.kdims)
-        first_line = cls.component_type(node) + cls.tab + key_dim_info
+        first_line = cls_or_slf.component_type(node) + cls_or_slf.tab + key_dim_info
         lines = [(level, first_line)]
-        opts = cls.option_info(node)
+        opts = cls_or_slf.option_info(node)
 
         additional_lines = []
         if len(node.data) == 0:
             return level, lines
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
-        additional_lines = cls.recurse(last, level=level, value_dims=value_dims)
-        lines += cls.shift(additional_lines, 1)
+        additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)
+        lines += cls_or_slf.shift(additional_lines, 1)
         return level, lines
 
 

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -396,7 +396,10 @@ class PrettyPrinter(param.Parameterized):
             return level, lines
         # .last has different semantics for GridSpace
         last = list(node.data.values())[-1]
-        additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)
+        if last is not None and getattr(last, '_deep_indexable'):
+            level, additional_lines = cls.ndmapping_info(last, [], level, value_dims)
+        else:
+            additional_lines = cls_or_slf.recurse(last, level=level, value_dims=value_dims)
         lines += cls_or_slf.shift(additional_lines, 1)
         return level, lines
 

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -14,6 +14,7 @@ In addition, there are several different ways of
 """
 
 import sys, re
+import textwrap
 import param
 # IPython not required to import ParamPager
 from param.ipython import ParamPager
@@ -346,7 +347,7 @@ class PrettyPrinter(param.Parameterized):
             fst_lvl = level
 
         if cls_or_slf.show_options and opts and opts.kwargs:
-            lines.append((fst_lvl, ' ' + str(opts)))
+            lines += [(fst_lvl, l) for l in cls_or_slf.format_options(opts)]
         return (lvl, lines)
 
     @bothmethod
@@ -375,6 +376,14 @@ class PrettyPrinter(param.Parameterized):
         return opts
 
     @bothmethod
+    def format_options(cls_or_slf, opts, wrap_count=80):
+        opt_repr = str(opts)
+        cls_name = type(opts).__name__
+        indent = ' '*(len(cls_name)+1)
+        wrapper = textwrap.TextWrapper(width=wrap_count, subsequent_indent=indent)
+        return [' '+l for l in wrapper.wrap(opt_repr)]
+
+    @bothmethod
     def adjointlayout_info(cls_or_slf, node, siblings, level, value_dims):
         first_line = cls_or_slf.component_type(node)
         lines = [(level, first_line)]
@@ -384,7 +393,6 @@ class PrettyPrinter(param.Parameterized):
         lines += cls_or_slf.shift(additional_lines, 1)
         return level, lines
 
-
     @bothmethod
     def ndmapping_info(cls_or_slf, node, siblings, level, value_dims):
         key_dim_info = '[%s]' % ','.join(d.name for d in node.kdims)
@@ -393,7 +401,7 @@ class PrettyPrinter(param.Parameterized):
 
         opts = cls_or_slf.option_info(node)
         if cls_or_slf.show_options and opts and opts.kwargs:
-            lines.append((fst_lvl, ' ' + str(opts)))
+            lines += [(level, l) for l in cls_or_slf.format_options(opts)]
 
         additional_lines = []
         if len(node.data) == 0:

--- a/holoviews/tests/core/testdimensioned.py
+++ b/holoviews/tests/core/testdimensioned.py
@@ -1,8 +1,8 @@
-from holoviews.core.element import ViewableElement
+from holoviews.core.element import Element
 from holoviews.core.options import Store, Keywords, Options, OptionTree
 from ..utils import LoggingComparisonTestCase
 
-class TestObj(ViewableElement):
+class TestObj(Element):
     pass
 
 

--- a/holoviews/tests/core/testprettyprint.py
+++ b/holoviews/tests/core/testprettyprint.py
@@ -32,12 +32,6 @@ class PrettyPrintTest(ComparisonTestCase):
         r = PrettyPrinter.pprint(Curve([1,2,3]))
         self.assertEqual(repr(r), expected)
 
-    def test_curve_pprint_repr(self):
-        # Ensure it isn't a bytes object with the 'b' prefix
-        expected = "':Curve   [x]   (y)'"
-        r = PrettyPrinter.pprint(Curve([1,2,3]))
-        self.assertEqual(repr(r), expected)
-
 
 class PrettyPrintOptionsTest(CustomBackendTestCase):
 

--- a/holoviews/tests/core/testprettyprint.py
+++ b/holoviews/tests/core/testprettyprint.py
@@ -4,8 +4,10 @@ Test cases for the pretty printing system.
 
 
 from holoviews.element.comparison import ComparisonTestCase
-from holoviews import Element, Curve
+from holoviews import Store, Element, Curve, Overlay, Layout
 from holoviews.core.pprint import PrettyPrinter
+
+from .testdimensioned import CustomBackendTestCase, TestObj
 
 
 class PrettyPrintTest(ComparisonTestCase):
@@ -29,3 +31,51 @@ class PrettyPrintTest(ComparisonTestCase):
         expected = "':Curve   [x]   (y)'"
         r = PrettyPrinter.pprint(Curve([1,2,3]))
         self.assertEqual(repr(r), expected)
+
+    def test_curve_pprint_repr(self):
+        # Ensure it isn't a bytes object with the 'b' prefix
+        expected = "':Curve   [x]   (y)'"
+        r = PrettyPrinter.pprint(Curve([1,2,3]))
+        self.assertEqual(repr(r), expected)
+
+
+class PrettyPrintOptionsTest(CustomBackendTestCase):
+
+    def setUp(self):
+        self.current_backend = Store.current_backend
+        self.pprinter = PrettyPrinter(show_options=True)
+        self.register_custom(TestObj, 'backend_1', ['plot_custom1'], ['style_custom1'])
+        self.register_custom(Overlay, 'backend_1', ['plot_custom1'])
+        self.register_custom(Layout, 'backend_1', ['plot_custom1'])
+        self.register_custom(TestObj, 'backend_2', ['plot_custom2'])
+        Store.current_backend = 'backend_1'
+
+    def test_element_options(self):
+        element = TestObj(None).opts(style_opt1='A', backend='backend_1')
+        r = self.pprinter.pprint(element)
+        self.assertEqual(r, ":TestObj\n Options(style_opt1='A')")
+
+    def test_element_options_wrapping(self):
+        element = TestObj(None).opts(plot_opt1='A'*40, style_opt1='B'*40, backend='backend_1')
+        r = self.pprinter.pprint(element)
+        self.assertEqual(r, ":TestObj\n Options(plot_opt1='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',\n         style_opt1='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')")
+
+    def test_overlay_options(self):
+        overlay = (TestObj(None) * TestObj(None)).opts(plot_opt1='A')
+        r = self.pprinter.pprint(overlay)
+        self.assertEqual(r, ":Overlay\n Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
+
+    def test_overlay_nested_options(self):
+        overlay = (TestObj(None) * TestObj(None)).opts('TestObj', plot_opt1='A', style_opt1='A')
+        r = self.pprinter.pprint(overlay)
+        self.assertEqual(r, ":Overlay\n   .Element.I  :TestObj\n    Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    Options(plot_opt1='A', style_opt1='A')")
+
+    def test_layout_options(self):
+        overlay = (TestObj(None) + TestObj(None)).opts(plot_opt1='A')
+        r = self.pprinter.pprint(overlay)
+        self.assertEqual(r, ":Layout\n Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
+
+    def test_layout_nested_options(self):
+        overlay = (TestObj(None) + TestObj(None)).opts('TestObj', plot_opt1='A', style_opt1='A')
+        r = self.pprinter.pprint(overlay)
+        self.assertEqual(r, ":Layout\n   .Element.I  :TestObj\n    Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    Options(plot_opt1='A', style_opt1='A')")


### PR DESCRIPTION
Adds options to the ``PrettyPrinter``, very much a work in progress but the basics work. 

```
> p1 = hv.Points([1, 2, 3]).opts(color='red')
> c1 = hv.Curve([]).opts(alpha=0.3, xticks=[1, 2, 3])
> print(p1)

:Points   [x,y]
 Options(color='red')

> print(hv.HoloMap({0: c1*p1}))

:HoloMap   [Default]
   :Overlay
      .Curve.I  :Curve   [x]   (y)
       Options(alpha=0.3, xticks=[1, 2, 3])
      .Points.I :Points   [x,y]
       Options(color='red')

> print(p1 + (c1 * p1).opts(xaxis=None))

:Layout
   .Points.I  :Points   [x,y]
    Options(color='red')
   .Overlay.I :Overlay
    Options(xaxis=None)
      .Curve.I  :Curve   [x]   (y)
       Options(alpha=0.3, xticks=[1, 2, 3])
      .Points.I :Points   [x,y]
       Options(color='red')
```

To do:

- [x] Decide on nice formatting
- [x] Parameterize PrettyPrinter to allow toggling between showing options at all and whether to show default options
- [x] Add tests