### PR TITLE
Disable item checks when getting plot frames

### DIFF
--- a/holoviews/core/ndmapping.py
+++ b/holoviews/core/ndmapping.py
@@ -132,7 +132,9 @@ class MultiDimensionalMapping(Dimensioned):
         they are inserted ensuring that they are of a certain
         type. Subclassed may implement further element restrictions.
         """
-        if self.data_type is not None and not isinstance(data, self.data_type):
+        if not self._check_items:
+            return
+        elif self.data_type is not None and not isinstance(data, self.data_type):
             if isinstance(self.data_type, tuple):
                 data_type = tuple(dt.__name__ for dt in self.data_type)
             else:
@@ -957,7 +959,9 @@ class UniformNdMapping(NdMapping):
 
 
     def _item_check(self, dim_vals, data):
-        if self.type is not None and (type(data) != self.type):
+        if not self._check_items:
+            return
+        elif self.type is not None and (type(data) != self.type):
             raise AssertionError("%s must only contain one type of object, not both %s and %s." %
                                  (self.__class__.__name__, type(data).__name__, self.type.__name__))
         super(UniformNdMapping, self)._item_check(dim_vals, data)

--- a/holoviews/plotting/util.py
+++ b/holoviews/plotting/util.py
@@ -13,6 +13,7 @@ import param
 from ..core import (HoloMap, DynamicMap, CompositeOverlay, Layout,
                     Overlay, GridSpace, NdLayout, Store, NdOverlay)
 from ..core.options import Cycle
+from ..core.ndmapping import item_check
 from ..core.spaces import get_nested_streams
 from ..core.util import (match_spec, wrap_tuple, basestring, get_overlay_spec,
                          unique_iterator, closest_match, is_number, isfinite,
@@ -299,8 +300,9 @@ def get_nested_plot_frame(obj, key_map, cached=False):
         if isinstance(it1, DynamicMap):
             with disable_constant(it2.callback):
                 it2.callback.inputs = it1.callback.inputs
-    return clone.map(lambda x: get_plot_frame(x, key_map, cached=cached),
-                     [DynamicMap, HoloMap], clone=False)
+    with item_check(False):
+        return clone.map(lambda x: get_plot_frame(x, key_map, cached=cached),
+                         [DynamicMap, HoloMap], clone=False)
 
 
 def undisplayable_info(obj, html=False):


### PR DESCRIPTION
This PR fixes a regression on container plots when getting plot frames. The regression was introduced while fixing another bug to do with memoization, and the fix here is simply to disable redundant item checks on an NdMapping. The actual bug is that we are applying a map operation which progressively replaces all HoloMaps and DynamicMaps with the item at a particular key and while it's replacing the items UniformNdMappings may temporarily hold a mixture of HoloMaps/DynamicMaps and ViewableElements, which errors. To fix it we simply suspend these checks using the existing ``item_check`` context manager.

Also had to fix the fact that the ``item_check`` context manager did not fully disable checks.