### PR TITLE
Add support for literal opts format

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -231,14 +231,18 @@ def deprecated_opts_signature(args, kwargs):
     Returns whether opts.apply_groups should be used (as a bool) and the
     corresponding options.
     """
-    groups = ['plot','style', 'norm']
+    groups = {'plot','style', 'norm'}
     opts = {kw for kw in kwargs if kw not in ('backend', 'clone')}
     apply_groups = False
     options = None
     new_kwargs = {}
     if len(args) > 0 and isinstance(args[0], dict):
         apply_groups = True
-        if set(args[0].keys()) <= set(groups):
+        if (not set(args[0]).issubset(groups) and
+            all(isinstance(v, dict) and not set(v).issubset(groups)
+                for v in args[0].values())):
+            apply_groups = False
+        elif set(args[0].keys()) <= groups:
             new_kwargs = args[0]
         else:
             options = args[0]


### PR DESCRIPTION
Add support for literal opts format to ``.opts`` method, e.g.:

```
(hv.Curve([1, 2, 3]) * hv.Scatter([1, 2, 3])).opts(
    {'Curve': dict(color='red'), 'Scatter': dict(size=10)})
```

If we are going to be recommending ``.opts`` everywhere we should support the same formats as ``.options`` did. Two users already raised their confusion over this. That doesn't mean we should recommend this now that we have the opts builders, but we should make transitioning as straightforward as possible.

- [x] Implements #3300 