### PR TITLE
Improved bokeh RGBPlot dtype handling

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -101,13 +101,18 @@ class RGBPlot(ElementPlot):
         img = np.dstack([element.dimension_values(d, flat=False)
                          for d in element.vdims])
         if img.ndim == 3:
-            if img.shape[2] == 3: # alpha channel not included
-                alpha = np.ones(img.shape[:2])
-                if img.dtype.name == 'uint8':
-                    alpha = (alpha*255).astype('uint8')
-                img = np.dstack([img, alpha])
+            if img.dtype.kind == 'f':
+                img = img*255
+            if img.max() > 255:
+                self.param.warning('Clipping input data to the valid '
+                                   'range for RGB data ([0..1] for '
+                                   'floats or [0..255] for integers).')
+                img[img>255] = 255
             if img.dtype.name != 'uint8':
-                img = (img*255).astype(np.uint8)
+                img = img.astype(np.uint8)
+            if img.shape[2] == 3: # alpha channel not included
+                alpha = np.full(img.shape[:2], 255, dtype='uint8')
+                img = np.dstack([img, alpha])
             N, M, _ = img.shape
             #convert image NxM dtype=uint32
             img = img.view(dtype=np.uint32).reshape((N, M))


### PR DESCRIPTION
This makes the RGB handling in the bokeh backend consistent with matplotlib. There has been some discussion that we should use the value dimension ranges to define the RGB range but a) I would find this very awkward to use and b) it'd be a large backward incompatible change. This PR instead fixes the ``int`` but not ``uint8`` case which was being handled like it was integers. Instead the plot now does what matplotlib does, which is to interpret floats in a 0-1 range and integers in a 0-255 range, anything outside these ranges is clipped.

- [x] Fixes https://github.com/ioam/holoviews/issues/3291