### PR TITLE
Improved RGB clipping logic

### DIFF
--- a/holoviews/plotting/bokeh/raster.py
+++ b/holoviews/plotting/bokeh/raster.py
@@ -103,11 +103,12 @@ class RGBPlot(ElementPlot):
         if img.ndim == 3:
             if img.dtype.kind == 'f':
                 img = img*255
-            if img.size and img.max() > 255:
+            if img.size and img.min() < 0 or img.max() > 255:
                 self.param.warning('Clipping input data to the valid '
                                    'range for RGB data ([0..1] for '
                                    'floats or [0..255] for integers).')
-                img[img>255] = 255
+                img = np.clip(img, 0, 255)
+
             if img.dtype.name != 'uint8':
                 img = img.astype(np.uint8)
             if img.shape[2] == 3: # alpha channel not included


### PR DESCRIPTION
As suggested in https://github.com/ioam/holoviews/pull/3305 this fixes the clipping logic in bokeh's RGBPlot. It is now identical to the logic used by matplotlib's imshow internally.