### PR TITLE
Active tool fix

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -428,9 +428,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 matching = [t for t in plot.toolbar.tools
                             if isinstance(t, tool_type)]
                 if not matching:
-                    raise ValueError('Tool of type %r could not be found '
-                                     'and could not be activated by default.'
-                                     % tool)
+                    self.param.warning('Tool of type %r could not be found '
+                                       'and could not be activated by default.'
+                                       % tool)
+                    continue
                 tool = matching[0]
             if isinstance(tool, tools.Drag):
                 plot.toolbar.active_drag = tool

--- a/holoviews/streams.py
+++ b/holoviews/streams.py
@@ -928,8 +928,8 @@ class PointDraw(CDSStream):
         if isinstance(source, UniformNdMapping):
             source = source.last
         if not self.data:
-            return source.clone([])
-        return source.clone(self.data)
+            return source.clone([], id=None)
+        return source.clone(self.data, id=None)
 
     @property
     def dynamic(self):
@@ -977,13 +977,13 @@ class PolyDraw(CDSStream):
             source = source.last
         data = self.data
         if not data:
-            return source.clone([])
+            return source.clone([], id=None)
         cols = list(self.data)
         x, y = source.kdims
         lookup = {'xs': x.name, 'ys': y.name}
         data = [{lookup.get(c, c): data[c][i] for c in self.data}
                 for i in range(len(data[cols[0]]))]
-        return source.clone(data)
+        return source.clone(data, id=None)
 
     @property
     def dynamic(self):
@@ -1015,13 +1015,13 @@ class FreehandDraw(CDSStream):
             source = source.last
         data = self.data
         if not data:
-            return source.clone([])
+            return source.clone([], id=None)
         cols = list(self.data)
         x, y = source.kdims
         lookup = {'xs': x.name, 'ys': y.name}
         data = [{lookup.get(c, c): data[c][i] for c in self.data}
                 for i in range(len(data[cols[0]]))]
-        return source.clone(data)
+        return source.clone(data, id=None)
 
     @property
     def dynamic(self):


### PR DESCRIPTION
This is a two-fold fix for an issue with the ``active_tools`` option. First of all it changes the error when a tool listed in `active_tools` is not found to a warning and secondly it drops the styling applied to the stream source on streams which have a element property.