### PR TITLE
Fix missing import to get example to work

### DIFF
--- a/examples/user_guide/Deploying_Bokeh_Apps.ipynb
+++ b/examples/user_guide/Deploying_Bokeh_Apps.ipynb
@@ -547,7 +547,7 @@
     "import numpy as np\n",
     "import holoviews as hv\n",
     "\n",
-    "from bokeh.io import show\n",
+    "from bokeh.io import show, curdoc\n",
     "from bokeh.layouts import layout\n",
     "from bokeh.models import Slider, Button\n",
     "\n",


### PR DESCRIPTION
Hi,
I just went through the deploying with Bokeh tutorial and found that the above import was missing if you wanted to do standalone execution outside the notebook with `bokeh serve`.
This little fix allowed me to finally run the example.

Hope this helps others.
Best regards,
Florian