### PR TITLE
Output cell magic replacement and minor tweaks

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -539,7 +539,7 @@ class Options(param.Parameterized):
             self.warning("Invalid options %s, valid options are: %s"
                          % (repr(invalid_kws), str(allowed_keywords)))
 
-        self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
+        self.kwargs = OrderedDict([(k,kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
         self._options = []
         self._max_cycles = max_cycles
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -37,13 +37,13 @@ import traceback
 import difflib
 import inspect
 from contextlib import contextmanager
-from collections import OrderedDict, defaultdict
+from collections import defaultdict
 
 import numpy as np
 
 import param
 from .tree import AttrTree
-from .util import sanitize_identifier, group_sanitizer,label_sanitizer, basestring
+from .util import sanitize_identifier, group_sanitizer,label_sanitizer, basestring, OrderedDict
 from .util import deprecated_opts_signature, disable_constant, config
 from .pprint import InfoPrinter, PrettyPrinter
 
@@ -539,7 +539,7 @@ class Options(param.Parameterized):
             self.warning("Invalid options %s, valid options are: %s"
                          % (repr(invalid_kws), str(allowed_keywords)))
 
-        self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
+        self.kwargs = OrderedDict([(k,kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
         self._options = []
         self._max_cycles = max_cycles
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -539,7 +539,7 @@ class Options(param.Parameterized):
             self.warning("Invalid options %s, valid options are: %s"
                          % (repr(invalid_kws), str(allowed_keywords)))
 
-        self.kwargs = OrderedDict([(k,kwargs[k]) for k in sorted(kwargs.keys()) if k not in invalid_kws])
+        self.kwargs = {k:v for k,v in kwargs.items() if k not in invalid_kws}
         self._options = []
         self._max_cycles = max_cycles
 

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -383,7 +383,7 @@ class PrettyPrinter(param.Parameterized):
         cls_name = type(opts).__name__
         indent = ' '*(len(cls_name)+1)
         wrapper = textwrap.TextWrapper(width=wrap_count, subsequent_indent=indent)
-        return [' '+l for l in wrapper.wrap(opt_repr)]
+        return [' | '+l for l in wrapper.wrap(opt_repr)]
 
     @bothmethod
     def adjointlayout_info(cls_or_slf, node, siblings, level, value_dims):

--- a/holoviews/core/pprint.py
+++ b/holoviews/core/pprint.py
@@ -378,7 +378,7 @@ class PrettyPrinter(param.Parameterized):
         return opts
 
     @bothmethod
-    def format_options(cls_or_slf, opts, wrap_count=80):
+    def format_options(cls_or_slf, opts, wrap_count=100):
         opt_repr = str(opts)
         cls_name = type(opts).__name__
         indent = ' '*(len(cls_name)+1)

--- a/holoviews/tests/core/testprettyprint.py
+++ b/holoviews/tests/core/testprettyprint.py
@@ -52,7 +52,7 @@ class PrettyPrintOptionsTest(CustomBackendTestCase):
     def test_element_options_wrapping(self):
         element = TestObj(None).opts(plot_opt1='A'*40, style_opt1='B'*40, backend='backend_1')
         r = self.pprinter.pprint(element)
-        self.assertEqual(r, ":TestObj\n | Options(plot_opt1='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',\n         style_opt1='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')")
+        self.assertEqual(r, ":TestObj\n | Options(plot_opt1='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',\n |         style_opt1='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')")
 
     def test_overlay_options(self):
         overlay = (TestObj(None) * TestObj(None)).opts(plot_opt1='A')

--- a/holoviews/tests/core/testprettyprint.py
+++ b/holoviews/tests/core/testprettyprint.py
@@ -47,29 +47,29 @@ class PrettyPrintOptionsTest(CustomBackendTestCase):
     def test_element_options(self):
         element = TestObj(None).opts(style_opt1='A', backend='backend_1')
         r = self.pprinter.pprint(element)
-        self.assertEqual(r, ":TestObj\n Options(style_opt1='A')")
+        self.assertEqual(r, ":TestObj\n | Options(style_opt1='A')")
 
     def test_element_options_wrapping(self):
         element = TestObj(None).opts(plot_opt1='A'*40, style_opt1='B'*40, backend='backend_1')
         r = self.pprinter.pprint(element)
-        self.assertEqual(r, ":TestObj\n Options(plot_opt1='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',\n         style_opt1='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')")
+        self.assertEqual(r, ":TestObj\n | Options(plot_opt1='AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',\n         style_opt1='BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB')")
 
     def test_overlay_options(self):
         overlay = (TestObj(None) * TestObj(None)).opts(plot_opt1='A')
         r = self.pprinter.pprint(overlay)
-        self.assertEqual(r, ":Overlay\n Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
+        self.assertEqual(r, ":Overlay\n | Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
 
     def test_overlay_nested_options(self):
         overlay = (TestObj(None) * TestObj(None)).opts('TestObj', plot_opt1='A', style_opt1='A')
         r = self.pprinter.pprint(overlay)
-        self.assertEqual(r, ":Overlay\n   .Element.I  :TestObj\n    Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    Options(plot_opt1='A', style_opt1='A')")
+        self.assertEqual(r, ":Overlay\n   .Element.I  :TestObj\n    | Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    | Options(plot_opt1='A', style_opt1='A')")
 
     def test_layout_options(self):
         overlay = (TestObj(None) + TestObj(None)).opts(plot_opt1='A')
         r = self.pprinter.pprint(overlay)
-        self.assertEqual(r, ":Layout\n Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
+        self.assertEqual(r, ":Layout\n | Options(plot_opt1='A')\n   .Element.I  :TestObj\n   .Element.II :TestObj")
 
     def test_layout_nested_options(self):
         overlay = (TestObj(None) + TestObj(None)).opts('TestObj', plot_opt1='A', style_opt1='A')
         r = self.pprinter.pprint(overlay)
-        self.assertEqual(r, ":Layout\n   .Element.I  :TestObj\n    Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    Options(plot_opt1='A', style_opt1='A')")
+        self.assertEqual(r, ":Layout\n   .Element.I  :TestObj\n    | Options(plot_opt1='A', style_opt1='A')\n   .Element.II :TestObj\n    | Options(plot_opt1='A', style_opt1='A')")

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -509,6 +509,8 @@ class output(param.ParameterizedFunction):
 
             Store.output_settings.output(line=line, cell=obj, cell_runner=display_fn,
                                          help_prompt=help_prompt, **options)
+        elif obj is not None:
+            return obj
         else:
             Store.output_settings.output(line=line, help_prompt=help_prompt, **options)
 

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -505,10 +505,7 @@ class output(param.ParameterizedFunction):
                     from IPython.display import display
                 except:
                     return
-
-                # Small hack to avoid printing in IPython terminal
-                if get_ipython().__class__.__name__ != 'TerminalInteractiveShell': # noqa
-                    display(obj)
+                display(obj)
 
             Store.output_settings.output(line=line, cell=obj, cell_runner=display_fn,
                                          help_prompt=help_prompt, **options)

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -477,13 +477,7 @@ class output(param.ParameterizedFunction):
     are ignored.
     """
 
-    filename_warning = param.Boolean(default=True, doc="""
-       Whether to warn if the output utility is called on an object and
-       a filename is not given (in which case the utility has no
-       effect)""" )
-
     def __call__(self, *args, **options):
-        warn = options.pop('filename_warning', self.filename_warning)
         help_prompt = 'For help with hv.util.output call help(hv.util.output)'
         line, obj = None,None
         if len(args) > 2:
@@ -513,7 +507,7 @@ class output(param.ParameterizedFunction):
                     return
 
                 # Small hack to avoid printing in IPython terminal
-                if get_ipython().__class__.__name__ != 'TerminalInteractiveShell':
+                if get_ipython().__class__.__name__ != 'TerminalInteractiveShell': # noqa
                     display(obj)
 
             Store.output_settings.output(line=line, cell=obj, cell_runner=display_fn,


### PR DESCRIPTION
Here is an example of the output cell magic replacement:

![image](https://user-images.githubusercontent.com/890576/50233780-c9053a80-0379-11e9-8360-b40957e0b568.png)

Here is an example of the updated options repr:

![image](https://user-images.githubusercontent.com/890576/50233739-ae32c600-0379-11e9-8adb-7bb6cf66795f.png)

My main worry here is that the return value of `hv.output` has changed from returning the `obj` to returning `None` (needed to avoid double display). This means this change isn't backwards compatible but I don't think anyone was using this other than our automated conversion of magics to python syntax (e.g for bokeh server) behind the scenes.

It is also worth mentioning that anyone using `_` to get the value of the previously executed cell will now change if using this utility.

Finally, I should mention the small hack I added to avoid printing reprs in the IPython terminal. It isn't a big deal if we remove it as in most contexts, `IPython.display` won't be available.