### PR TITLE
Fix style mapping with explicit colormap

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -822,7 +822,16 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                 cmapper = self._get_colormapper(v, element, ranges,
                                                 dict(style), name=k+'_color_mapper',
                                                 group=group, **kwargs)
-                key = {'field': k, 'transform': cmapper}
+                if isinstance(cmapper, CategoricalColorMapper) and val.dtype.kind in 'ifMu':
+                    if v.dimension in element:
+                        formatter = element.get_dimension(v.dimension).pprint_value
+                    else:
+                        formatter = str
+                    field = k + '_str__'
+                    data[k+'_str__'] = [formatter(d) for d in val]
+                else:
+                    field = k
+                key = {'field': field, 'transform': cmapper}
             new_style[k] = key
 
         # Process color/alpha styles and expand to fill/line style

--- a/holoviews/tests/plotting/bokeh/testpointplot.py
+++ b/holoviews/tests/plotting/bokeh/testpointplot.py
@@ -363,6 +363,20 @@ class TestPointPlot(TestBokehPlot):
         self.assertEqual(glyph.fill_color, {'field': 'color', 'transform': cmapper})
         self.assertEqual(glyph.line_color, {'field': 'color', 'transform': cmapper})
 
+    def test_point_explicit_cmap_color_op(self):
+        points = Points([(0, 0), (0, 1), (0, 2)]).options(
+            color='y', cmap={0: 'red', 1: 'green', 2: 'blue'})
+        plot = bokeh_renderer.get_plot(points)
+        cds = plot.handles['cds']
+        glyph = plot.handles['glyph']
+        cmapper = plot.handles['color_color_mapper']
+        self.assertTrue(cmapper, CategoricalColorMapper)
+        self.assertEqual(cmapper.factors, ['0', '1', '2'])
+        self.assertEqual(cmapper.palette, ['red', 'green', 'blue'])
+        self.assertEqual(cds.data['color_str__'], ['0', '1', '2'])
+        self.assertEqual(glyph.fill_color, {'field': 'color_str__', 'transform': cmapper})
+        self.assertEqual(glyph.line_color, {'field': 'color_str__', 'transform': cmapper})
+
     def test_point_line_color_op(self):
         points = Points([(0, 0, '#000'), (0, 1, '#F00'), (0, 2, '#0F0')],
                         vdims='color').options(line_color='color')


### PR DESCRIPTION
Fixes style mapping when the ``cmap`` is an explicit mapping such as ``{1: 'red', 2: 'green'}``