### PR TITLE
Removed charwidth setting and added output.info method

### DIFF
--- a/examples/getting_started/2-Customization.ipynb
+++ b/examples/getting_started/2-Customization.ipynb
@@ -224,7 +224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dashed.opts.show()"
+    "dashed.opts.info()"
    ]
   },
   {

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -116,7 +116,7 @@ class Opts(object):
     def clear(self, clone=False):
         return self.obj.opts(clone=clone)
 
-    def show(self):
+    def info(self):
         pprinter = PrettyPrinter(show_options=True)
         print(pprinter.pprint(self.obj))
 

--- a/holoviews/ipython/magics.py
+++ b/holoviews/ipython/magics.py
@@ -47,13 +47,12 @@ class OutputMagic(Magics):
     @classmethod
     def pprint(cls):
         """
-        Pretty print the current element options with a maximum width of
-        cls.pprint_width.
+        Pretty print the current element options
         """
         current, count = '', 0
         for k,v in Store.output_settings.options.items():
             keyword = '%s=%r' % (k,v)
-            if len(current) + len(keyword) > Store.output_settings.options['charwidth']:
+            if len(current) + len(keyword) > 80:
                 print(('%output' if count==0 else '      ')  + current)
                 count += 1
                 current = keyword

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -494,7 +494,7 @@ class output(param.ParameterizedFunction):
     """
 
     @classmethod
-    def show(cls):
+    def info(cls):
         deprecate = ['filename', 'info', 'mode']
         options = Store.output_settings.options
         defaults = Store.output_settings.defaults

--- a/holoviews/util/__init__.py
+++ b/holoviews/util/__init__.py
@@ -469,7 +469,7 @@ class output(param.ParameterizedFunction):
     output(options)
 
     Where options may be an options specification string (as accepted by
-    the %opts magic) or an options specifications dictionary.
+    the IPython opts magic) or an options specifications dictionary.
 
     For instance:
 
@@ -489,11 +489,25 @@ class output(param.ParameterizedFunction):
     curve = hv.Curve([1,2,3])
     output("filename='curve.png'", curve)
 
-    These two modes are equivalent to the %output line magic and the
-    %%output cell magic respectively. Note that only the filename
-    argument is supported when supplying an object and all other options
-    are ignored.
+    These two modes are equivalent to the IPython output line magic and
+    the cell magic respectively.
     """
+
+    @classmethod
+    def show(cls):
+        deprecate = ['filename', 'info', 'mode']
+        options = Store.output_settings.options
+        defaults = Store.output_settings.defaults
+        keys = [k for k,v in options.items() if k not in deprecate and v != defaults[k]]
+        pairs = {k:options[k] for k in sorted(keys)}
+        if 'backend' not in keys:
+            pairs['backend'] = Store.current_backend
+        if ':' in pairs['backend']:
+            pairs['backend'] = pairs['backend'].split(':')[0]
+
+        keywords = ', '.join('%s=%r' % (k,pairs[k]) for k in sorted(pairs.keys()))
+        print('output({kws})'.format(kws=keywords))
+
 
     def __call__(self, *args, **options):
         help_prompt = 'For help with hv.util.output call help(hv.util.output)'

--- a/holoviews/util/settings.py
+++ b/holoviews/util/settings.py
@@ -10,8 +10,8 @@ class KeywordSettings(object):
     keyword options.
     """
     # Dictionary from keywords to allowed bounds/values
-    allowed = {'charwidth'   : (0, float('inf'))}
-    defaults = OrderedDict([('charwidth'   , 80)])  # Default keyword values.
+    allowed = {}
+    defaults = OrderedDict([])  # Default keyword values.
     options =  OrderedDict(defaults.items()) # Current options
 
     # Callables accepting (value, keyword, allowed) for custom exceptions
@@ -149,7 +149,6 @@ class OutputSettings(KeywordSettings):
                'max_branches': {None},            # Deprecated
                'size'        : (0, float('inf')),
                'dpi'         : (1, float('inf')),
-               'charwidth'   : (0, float('inf')),
                'filename'    : {None},
                'info'        : [True, False],
                'css'         : {k: basestring
@@ -165,14 +164,13 @@ class OutputSettings(KeywordSettings):
                             ('max_frames'  , 500),
                             ('size'        , None),
                             ('dpi'         , None),
-                            ('charwidth'   , 80),
                             ('filename'    , None),
                             ('info'        , False),
                             ('css'         , None)])
 
     # Defines the options the OutputSettings remembers. All other options
     # are held by the backend specific Renderer.
-    remembered = ['max_frames', 'charwidth', 'info', 'filename']
+    remembered = ['max_frames', 'info', 'filename']
 
     # Remaining backend specific options renderer options
     render_params = ['fig', 'holomap', 'size', 'fps', 'dpi', 'css', 'widget_mode', 'mode']
@@ -218,8 +216,6 @@ class OutputSettings(KeywordSettings):
                       % cls.defaults['max_frames'])
         size =   "size         : The percentage size of displayed output"
         dpi =    "dpi          : The rendered dpi of the figure"
-        charwidth =  ("charwidth    : The max character width for displaying helper (default %r)"
-                  % cls.defaults['charwidth'])
         filename =  ("filename    : The filename of the saved output, if any (default %r)"
                      % cls.defaults['filename'])
         info = ("info    : The information to page about the displayed objects (default %r)"
@@ -227,9 +223,9 @@ class OutputSettings(KeywordSettings):
         css =   ("css     : Optional css style attributes to apply to the figure image tag")
 
         descriptions = [backend, fig, holomap, widgets, fps, max_frames, size,
-                        dpi, charwidth, filename, info, css]
+                        dpi, filename, info, css]
         keywords = ['backend', 'fig', 'holomap', 'widgets', 'fps', 'max_frames',
-                    'size', 'dpi', 'charwidth', 'filename', 'info', 'css']
+                    'size', 'dpi', 'filename', 'info', 'css']
         signature = '\noutput(%s)\n' % ', '.join('%s=None' % kw for kw in keywords)
         return '\n'.join([signature] + intro + descriptions)
 


### PR DESCRIPTION
This screenshot illustrates the `output.show` method which is the replacement for using the `%output` magic without any arguments:

![image](https://user-images.githubusercontent.com/890576/50309513-b74c9180-0464-11e9-9ead-971052fff39e.png)

The charwidth setting is now removed as it was just confusing and unused cruft.