### PR TITLE
Include license in wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE.txt


### PR DESCRIPTION
The BSD license requires all copies of the software include the license text.