### PR TITLE
Removed duplicated output in Custom Interactivity

### DIFF
--- a/examples/user_guide/13-Custom_Interactivity.ipynb
+++ b/examples/user_guide/13-Custom_Interactivity.ipynb
@@ -92,15 +92,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
-    "None\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Before continuing, we can check the stream parameters that are made available to user callbacks from a given stream instance by looking at its contents:"
    ]
   },
@@ -111,15 +102,6 @@
    "outputs": [],
    "source": [
     "print('The %s stream has contents %r' % (pointer, pointer.contents))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "The PointerXY(x=None,y=None) stream has contents {'y': None, 'x': None}\n",
-    "```"
    ]
   },
   {
@@ -150,15 +132,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
-    "True\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "The ``DynamicMap`` we defined above simply defines returns a ``Points`` object composed of a single point that marks the current ``x`` and ``y`` position supplied by our ``PointerXY`` stream. The stream is linked whenever this ``DynamicMap`` object is displayed as it is the stream source:"
    ]
   },
@@ -175,13 +148,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/point_hover.gif\" width=300></center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "If you hover over the plot canvas above you can see that the point tracks the current mouse position. We can also inspect the last cursor position by examining the stream contents:"
    ]
   },
@@ -192,15 +158,6 @@
    "outputs": [],
    "source": [
     "pointer.contents"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "{'x': 0.40575409375411886, 'y': 0.6441381051588625}\n",
-    "```"
    ]
   },
   {
@@ -239,13 +196,6 @@
     "    opts.Area(color='#fff8dc', line_width=2),\n",
     "    opts.Curve(color='black'),\n",
     "    opts.VLine(color='red'))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/area_hover.gif\" width=300></center>"
    ]
   },
   {
@@ -299,13 +249,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/raster_hover.gif\" width=600></center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "This will even work across different cells. If we use this particular stream instance in another ``DynamicMap`` and display it, this new visualization will also be supplied with the cursor position when hovering over the image. \n",
     "\n",
     "To illustrate this, we will now use the pointer ``x`` and ``y`` position to generate cross-sections of the image at the cursor position on the ``Image``, making use of the ``Image.sample`` method. Note the use of ``np.clip`` to make sure the cross-section is well defined when the cusor goes out of bounds:"
@@ -321,13 +264,6 @@
     "y_sample = hv.DynamicMap(lambda x, y: img.sample(y=np.clip(y,-.49,.49)), streams=[pointer])\n",
     "\n",
     "(x_sample + y_sample).opts(opts.Curve(framewise=True))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/cross_section_hover.gif\" width=600></center>"
    ]
   },
   {
@@ -377,13 +313,6 @@
    "outputs": [],
    "source": [
     "cross_dmap + cross_dmap.clone(link_inputs=False)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/unlink.gif\" width=600></center>"
    ]
   },
   {
@@ -471,13 +400,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<center><img src=\"https://assets.holoviews.org/gifs/guides/user_guide/Custom_Interactivity/tap_record.gif\" width=300></center>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Now try single- and double-tapping within the plot area, each time you tap a new point is appended to the list and displayed. Single taps show up in red and double taps show up in grey.  We can also inspect the list of taps directly:"
    ]
   },
@@ -488,20 +410,6 @@
    "outputs": [],
    "source": [
     "taps"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "```\n",
-    "[(0.4395821339578692, 0.6807756323806448, 1),\n",
-    " (0.3583948374688684, 0.6073731430597871, 2),\n",
-    " (0.7327584823903722, 0.48095774478497655, 1),\n",
-    " (0.20053064985136673, 0.17103612320802172, 1),\n",
-    " (0.8590498324843735, 0.7337885413345976, 1),\n",
-    " (0.3358428106663682, 0.358620262583547, 2)]\n",
-    "```"
    ]
   }
  ],


### PR DESCRIPTION
This user guide is currently the only one that has static versions of the expected output. For users running the user guides, this is quite confusing.

Although this PR removes the output, it does serve an important purpose for doc building so that the website is more useful. We haven't found a general solution to this yet but for now I think we should be consistent with what we have. The last commit good for doc building (including this output) is 409900f.

I hope we find a good solution to this issue that we can apply throughout.