### PR TITLE
Removed further uses of %%opts from examples

### DIFF
--- a/examples/reference/elements/bokeh/VectorField.ipynb
+++ b/examples/reference/elements/bokeh/VectorField.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "As you can see above, here the *x* and *y* positions are chosen to make a regular grid and the angles supplied to a ``VectorField`` are expressed in radians. The arrow angles follow a sinsoidal ring pattern, and the arrow lengths fall off exponentially from the center, so this plot has four dimensions of data (direction and length for each *x,y* position).\n",
     "\n",
-    "Using the ``%%opts`` cell-magic, we can also use color as a redundant indicator to the direction or magnitude:"
+    "Using the ``.opts`` method, we can also use color as a redundant indicator to the direction or magnitude:"
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/VectorField.ipynb
+++ b/examples/reference/elements/matplotlib/VectorField.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "As you can see above, here the *x* and *y* positions are chosen to make a regular grid and the angles supplied to a ``VectorField`` are expressed in radians. The arrow angles follow a sinsoidal ring pattern, and the arrow lengths fall off exponentially from the center, so this plot has four dimensions of data (direction and length for each *x,y* position).\n",
     "\n",
-    "Using the ``%%opts`` cell-magic, we can also use color as a redundant indicator to the direction or magnitude:"
+    "Using the ``.opts`` method, we can also use color as a redundant indicator to the direction or magnitude:"
    ]
   },
   {
@@ -62,8 +62,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts VectorField [magnitude='Magnitude'] VectorField.A (color='Angle') VectorField.M (color='Magnitude')\n",
-    "hv.VectorField(vector_data, group='A') + hv.VectorField(vector_data, group='M')"
+    "anglecolor = hv.VectorField(vector_data).opts(\n",
+    "    opts.VectorField(title='A', magnitude='Magnitude', color='Angle'))\n",
+    "magcolor = hv.VectorField(vector_data).opts(\n",
+    "    opts.VectorField(title='M', magnitude='Magnitude', color='Magnitude'))\n",
+    "anglecolor + magcolor"
    ]
   },
   {

--- a/examples/reference/features/bokeh/table_hooks_example.ipynb
+++ b/examples/reference/features/bokeh/table_hooks_example.ipynb
@@ -7,6 +7,7 @@
    "outputs": [],
    "source": [
     "import holoviews as hv\n",
+    "from holoviews import opts\n",
     "from bokeh.models import HTMLTemplateFormatter\n",
     "hv.extension('bokeh')"
    ]
@@ -42,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts Table [width=500]\n",
+    "opts.defaults(opts.Table(width=500))\n",
     "def apply_format(plot, element):\n",
     "    plot.handles['plot'].columns[1].formatter=HTMLTemplateFormatter(template='<a href=\"<%= value %>\"><%= value %></a>')\n",
     "\n",

--- a/examples/user_guide/15-Large_Data.ipynb
+++ b/examples/user_guide/15-Large_Data.ipynb
@@ -23,6 +23,7 @@
    "source": [
     "import numpy as np\n",
     "import holoviews as hv\n",
+    "from holoviews import opts\n",
     "import datashader as ds\n",
     "from holoviews.operation.datashader import datashade, shade, dynspread, rasterize\n",
     "from holoviews.operation import decimate\n",
@@ -328,7 +329,7 @@
     "\n",
     "# Hover info\n",
     "\n",
-    "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. Luckily, you can still provide hover information that reports properties of a subset of the data in a separate layer (as above), or you can provide information for a spatial region of the plot rather than for specific datapoints.  For instance, in some small rectangle you can provide statistics such as the mean, count, standard deviation, etc:"
+    "As you can see in the examples above, converting the data to an image using Datashader makes it feasible to work with even very large datasets interactively.  One unfortunate side effect is that the original datapoints and line segments can no longer be used to support \"tooltips\" or \"hover\" information directly for RGB images generated with `datashade`; that data simply is not present at the browser level, and so the browser cannot unambiguously report information about any specific datapoint. Luckily, you can still provide hover information that reports properties of a subset of the data in a separate layer (as above), or you can provide information for a spatial region of the plot rather than for specific datapoints.  For instance, in some small rectangle you can provide statistics such as the mean, count, standard deviation, etc:"
    ]
   },
   {
@@ -337,23 +338,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%opts QuadMesh [tools=['hover']] (alpha=0 hover_alpha=0.2)\n",
     "from holoviews.streams import RangeXY\n",
     "\n",
-    "fixed_hover = datashade(points, width=400, height=400) * \\\n",
-    "    hv.QuadMesh(rasterize(points, width=10, height=10, dynamic=False))\n",
+    "fixed_hover = (datashade(points, width=400, height=400) *  \n",
+    "               hv.QuadMesh(rasterize(points, width=10, height=10, dynamic=False)))\n",
     "\n",
-    "dynamic_hover = datashade(points, width=400, height=400) * \\\n",
-    "    hv.util.Dynamic(rasterize(points, width=10, height=10, streams=[RangeXY]), operation=hv.QuadMesh)\n",
+    "dynamic_hover = (datashade(points, width=400, height=400) * \n",
+    "                 hv.util.Dynamic(rasterize(points, width=10, height=10, streams=[RangeXY]), operation=hv.QuadMesh))\n",
     "\n",
-    "fixed_hover + dynamic_hover"
+    "(fixed_hover + dynamic_hover).opts(opts.QuadMesh(tools=['hover'], alpha=0, hover_alpha=0.2))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the above examples, the plot on the left provides hover information at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful (but requires a live Python server)."
+    "In the above examples, the plot on the left provides hover information at a fixed spatial scale, while the one on the right reports on an area that scales with the zoom level so that arbitrarily small regions of data space can be examined, which is generally more useful (but requires a live Python server). Note that you can activate the hover tool for `Image` elements output by the `rasterize` operation."
    ]
   },
   {
@@ -407,13 +407,10 @@
    "source": [
     "hv.output(backend='matplotlib')\n",
     "\n",
-    "img_opts = dict(aspect=1, axiswise=True, xaxis='bare', yaxis='bare')\n",
-    "\n",
     "opts.defaults(\n",
-    "    opts.Image(**img_opts),\n",
-    "    opts.Layout(vspace=0.1, hspace=0.1,\n",
-    "                sublabel_format=\"\"),\n",
-    "    opts.RGB(**img_opts))\n",
+    "    opts.Image(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
+    "    opts.RGB(aspect=1, axiswise=True, xaxis='bare', yaxis='bare'),\n",
+    "    opts.Layout(vspace=0.1, hspace=0.1, sublabel_format=\"\"))\n",
     "\n",
     "np.random.seed(12)\n",
     "N=100\n",
@@ -460,7 +457,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Layout([e.relabel(e.__class__.name).opts(**img_opts) for e in shadeable + rasterizable]).cols(6)"
+    "rgb_opts = opts.RGB(aspect=1, axiswise=True, xaxis='bare', yaxis='bare')\n",
+    "hv.Layout([e.relabel(e.__class__.name).opts(rgb_opts) for e in shadeable + rasterizable]).cols(6)"
    ]
   },
   {


### PR DESCRIPTION
Still to do:

* Matplotlib `Scatter` needs a full updated.
* Archiving user guide needs a full rewrite.
* Topics need updating (lower priority as they aren't linked to from the website)