### PR TITLE
Options to opts

### DIFF
--- a/examples/reference/elements/bokeh/Graph.ipynb
+++ b/examples/reference/elements/bokeh/Graph.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "simple_graph.options(directed=True, arrowhead_length=0.05)"
+    "simple_graph.opts(directed=True, arrowhead_length=0.05)"
    ]
   },
   {
@@ -148,8 +148,8 @@
     "nodes = hv.Nodes((x, y, node_indices, node_labels), vdims='Type')\n",
     "graph = hv.Graph(((source, target, edge_weights), nodes, paths), vdims='Weight')\n",
     "\n",
-    "graph.redim.range(**padding).options(color_index='Type', edge_color_index='Weight',\n",
-    "                                     cmap=['blue', 'red'], edge_cmap='viridis')"
+    "graph.redim.range(**padding).opts(color_index='Type', edge_color_index='Weight',\n",
+    "                                  cmap=['blue', 'red'], edge_cmap='viridis')"
    ]
   },
   {

--- a/examples/reference/elements/bokeh/Spikes.ipynb
+++ b/examples/reference/elements/bokeh/Spikes.ipynb
@@ -94,8 +94,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay = hv.NdOverlay({i: hv.Spikes(np.random.randint(0, 100, 10), kdims='Time').options(position=0.1*i)\n",
-    "                       for i in range(10)}).options(yticks=[((i+1)*0.1-0.05, i) for i in range(10)])\n",
+    "overlay = hv.NdOverlay({i: hv.Spikes(np.random.randint(0, 100, 10), kdims='Time').opts(position=0.1*i)\n",
+    "                       for i in range(10)}).opts(yticks=[((i+1)*0.1-0.05, i) for i in range(10)])\n",
     "overlay.opts(\n",
     "    opts.Spikes(spike_length=0.1),\n",
     "    opts.NdOverlay(show_legend=False))"

--- a/examples/reference/elements/matplotlib/Bivariate.ipynb
+++ b/examples/reference/elements/matplotlib/Bivariate.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.NdLayout({bw: hv.Bivariate(normal).options(axiswise=True, bandwidth=bw)\n",
+    "hv.NdLayout({bw: hv.Bivariate(normal).opts(axiswise=True, bandwidth=bw)\n",
     "             for bw in [0.05, 0.1, 0.5, 1]}, 'Bandwidth')"
    ]
   },

--- a/examples/reference/elements/matplotlib/Curve.ipynb
+++ b/examples/reference/elements/matplotlib/Curve.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "overlay = hv.NdOverlay({\n",
-    "    interp: hv.Curve(points[::8]).options(interpolation=interp)\n",
+    "    interp: hv.Curve(points[::8]).opts(interpolation=interp)\n",
     "    for interp in ['linear', 'steps-mid', 'steps-pre', 'steps-post']})\n",
     "\n",
     "overlay.opts(legend_position='right')"

--- a/examples/reference/elements/matplotlib/Histogram.ipynb
+++ b/examples/reference/elements/matplotlib/Histogram.ipynb
@@ -78,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.Histogram(curve).options(color=hv.dim('y').bin(bins=[-1, 0, 1], labels=['red', 'blue']))"
+    "hv.Histogram(curve).opts(color=hv.dim('y').bin(bins=[-1, 0, 1], labels=['red', 'blue']))"
    ]
   },
   {

--- a/examples/reference/elements/matplotlib/Spikes.ipynb
+++ b/examples/reference/elements/matplotlib/Spikes.ipynb
@@ -93,7 +93,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay = hv.NdOverlay({i: hv.Spikes(np.random.randint(0, 100, 10), 'Time').options(\n",
+    "overlay = hv.NdOverlay({i: hv.Spikes(np.random.randint(0, 100, 10), 'Time').opts(\n",
     "    position=0.1*i, spike_length=0.1) for i in range(10)})\n",
     "\n",
     "ticks = [((i+1)*0.1-0.05, i) for i in range(10)]\n",

--- a/examples/reference/elements/plotly/Curve.ipynb
+++ b/examples/reference/elements/plotly/Curve.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hv.NdOverlay({interp: hv.Curve(points[::8]).options(interpolation=interp)\n",
+    "hv.NdOverlay({interp: hv.Curve(points[::8]).opts(interpolation=interp)\n",
     "              for interp in ['linear', 'steps-mid', 'steps-pre', 'steps-post']})"
    ]
   },
@@ -89,5 +89,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/examples/reference/streams/bokeh/FreehandDraw.ipynb
+++ b/examples/reference/streams/bokeh/FreehandDraw.ipynb
@@ -38,7 +38,7 @@
     "path = hv.Path([])\n",
     "freehand = streams.FreehandDraw(source=path, num_objects=3)\n",
     "\n",
-    "path.options(\n",
+    "path.opts(\n",
     "    opts.Path(active_tools=['freehand_draw'], height=400, line_width=10, width=400))"
    ]
   },

--- a/examples/reference/streams/bokeh/Selection1D_points.ipynb
+++ b/examples/reference/streams/bokeh/Selection1D_points.ipynb
@@ -48,7 +48,7 @@
     "        label = 'Mean x, y: %.3f, %.3f' % tuple(selected.array().mean(axis=0))\n",
     "    else:\n",
     "        label = 'No selection'\n",
-    "    return selected.relabel(label).options(color='red')\n",
+    "    return selected.relabel(label).opts(color='red')\n",
     "\n",
     "# Combine points and DynamicMap\n",
     "points + hv.DynamicMap(selected_info, streams=[selection])"


### PR DESCRIPTION
I went through the notebooks and modified `.options()` calls to `.opts()`

That leaves only `./examples/reference/features/bokeh/table_hooks_example.ipynb`
When I tried to run it, I got
```
WARNING:root:TablePlot01553: Plotting hook <function apply_format at 0x7fb51fda0d90> could not be applied:

 'plot'
```
which I did not sort out.