### PR TITLE
Further replacement of .options with .opts

### DIFF
--- a/examples/gallery/demos/bokeh/image_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/image_range_tool.ipynb
@@ -89,7 +89,7 @@
     "RangeToolLink(src, tgt, axes=['x', 'y'])\n",
     "\n",
     "(tgt + src).opts(\n",
-    "    opts.Image(default_tools=[]),\n",
+    "    opts.Image(default_tools=['wheel_zoom']),\n",
     "    opts.Layout(shared_axes=False))"
    ]
   }

--- a/examples/gallery/demos/bokeh/image_range_tool.ipynb
+++ b/examples/gallery/demos/bokeh/image_range_tool.ipynb
@@ -83,13 +83,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "src = mbset_image.options(width=300, height=300)\n",
-    "tgt = mbset_image.options(width=500, height=500, xaxis=None, yaxis=None)\n",
+    "src = mbset_image.clone(link=False).opts(width=300, height=300, padding=0.1)\n",
+    "tgt = mbset_image.opts(width=500, height=500, xaxis=None, yaxis=None, clone=True)\n",
     "# Declare a RangeToolLink between the x- and y-axes of the two plots\n",
     "RangeToolLink(src, tgt, axes=['x', 'y'])\n",
     "\n",
     "(tgt + src).opts(\n",
-    "    opts.Image(default_tools=['wheel_zoom']),\n",
+    "    opts.Image(default_tools=[]),\n",
     "    opts.Layout(shared_axes=False))"
    ]
   }

--- a/examples/gallery/demos/bokeh/lesmis_example.ipynb
+++ b/examples/gallery/demos/bokeh/lesmis_example.ipynb
@@ -76,7 +76,7 @@
     "cmaps = ['Greys', 'Reds', 'Greys', 'Greens', 'Blues',\n",
     "         'Purples', 'Oranges', 'Greys', 'Greys', 'PuRd', 'Reds', 'Greys']\n",
     "\n",
-    "combined = hv.Overlay([o.options(cmap=cm).sort() for o, cm in zip(overlaid, cmaps)], label='LesMis Occurences')\n",
+    "combined = hv.Overlay([o.opts(cmap=cm).sort() for o, cm in zip(overlaid, cmaps)], label='LesMis Occurences')\n",
     "styled = combined.opts(\n",
     "    opts.HeatMap(logz=True, clipping_colors={'NaN':(1,1,1,0.)},\n",
     "                xaxis='top', xrotation=90,\n",

--- a/examples/gallery/demos/matplotlib/autompg_violins.ipynb
+++ b/examples/gallery/demos/matplotlib/autompg_violins.ipynb
@@ -51,7 +51,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "violin.options(aspect=1.5)"
+    "violin.opts(aspect=1.5)"
    ]
   }
  ],

--- a/examples/gallery/demos/matplotlib/hextile_movie_ratings.ipynb
+++ b/examples/gallery/demos/matplotlib/hextile_movie_ratings.ipynb
@@ -49,7 +49,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "hextiles.options(min_count=0) * hv.Bivariate(hextiles)"
+    "hextiles.opts(min_count=0) * hv.Bivariate(hextiles)"
    ]
   }
  ],

--- a/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
+++ b/examples/gallery/demos/matplotlib/texas_choropleth_example.ipynb
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "choropleth.options(\n",
+    "choropleth.opts(\n",
     "    color='Unemployment', edgecolor='white',\n",
     "    xaxis=None, yaxis=None, show_grid=False,\n",
     "    show_frame=False, colorbar=True, fig_size=200)"

--- a/examples/gallery/demos/matplotlib/us_unemployment.ipynb
+++ b/examples/gallery/demos/matplotlib/us_unemployment.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heatmap.options(fig_size=450, aspect=3, xrotation=45, show_values=False, labelled=[],\n",
+    "heatmap.opts(fig_size=450, aspect=3, xrotation=45, show_values=False, labelled=[],\n",
     "                cmap=colors)"
    ]
   }

--- a/examples/gallery/demos/matplotlib/us_unemployment.ipynb
+++ b/examples/gallery/demos/matplotlib/us_unemployment.ipynb
@@ -57,8 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "heatmap.opts(fig_size=450, aspect=3, xrotation=45, show_values=False, labelled=[],\n",
-    "                cmap=colors)"
+    "heatmap.opts(fig_size=450, aspect=3, xrotation=45, show_values=False, labelled=[], cmap=colors)"
    ]
   }
  ],


### PR DESCRIPTION
Continues on from #3362. The remaining uses of `.options` are either necessary or in topics which still needs updating.