### PR TITLE
Fix jitter when axes inverted

### DIFF
--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -110,9 +110,12 @@ class PointPlot(LegendPlot, ColorbarPlot):
             style['angle'] = np.deg2rad(style['angle'])
 
         if self.jitter:
-            axrange = 'y_range' if self.invert_axes else 'x_range'
-            mapping['x'] = jitter(dims[xidx], self.jitter,
-                                  range=self.handles[axrange])
+            if self.invert_axes:
+                mapping['y'] = jitter(dims[yidx], self.jitter,
+                                      range=self.handles['y_range'])
+            else:
+                mapping['x'] = jitter(dims[xidx], self.jitter,
+                                      range=self.handles['x_range'])
 
         self._get_hover_data(data, element)
         return data, mapping, style
@@ -306,7 +309,7 @@ class CurvePlot(ElementPlot):
 
     style_opts = line_properties
     _nonvectorized_styles = line_properties
-    
+
     _plot_methods = dict(single='line', batched='multi_line')
     _batched_style_opts = line_properties
 


### PR DESCRIPTION
When testing https://github.com/ioam/holoviews/issues/3379, I realized if I turned off jitter, it showed but misaligned.
![image](https://user-images.githubusercontent.com/15331990/51069116-a7484d80-15dd-11e9-9d40-1e0e4fc0985f.png)

Then I tried just plotting scatter inverted with jitter, and noticed that jitter on inverted didn't work.
![image](https://user-images.githubusercontent.com/15331990/51069121-baf3b400-15dd-11e9-8853-a7436f5c5f4e.png)

This PR fixes that for both scatter and points.
![image](https://user-images.githubusercontent.com/15331990/51069129-eb3b5280-15dd-11e9-99a3-80ab9535cb67.png)

```
import holoviews as hv
from holoviews import dim
hv.extension('bokeh')

from bokeh.sampledata.autompg import autompg as df

title = "MPG by Cylinders and Data Source, Colored by Cylinders"
hv.BoxWhisker(df, 'cyl', 'mpg', label=title).opts(invert_axes=True) * \
hv.Scatter(df, ['cyl', 'mpg']).opts(invert_axes=True, jitter=0.5)

hv.Scatter(df, ['cyl', 'mpg']).opts(jitter=0.5) + \
hv.Scatter(df, ['cyl', 'mpg']).opts(invert_axes=True, jitter=0.5)

hv.Points(df, ['cyl', 'mpg']).opts(jitter=0.5) + \
hv.Points(df, ['cyl', 'mpg']).opts(invert_axes=True, jitter=0.5)
```