### PR TITLE
Pinned pandas temporarily

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
   - notebook
   - matplotlib=2.1.2
   - pillow=5.2.0
-  - pandas
+  - pandas=0.23.4
   - scipy
   - xarray=0.10.9
   - networkx


### PR DESCRIPTION
pandas 0.24.0rc1 was pushed to conda-forge for some reason and it's breaking our tests.