### PR TITLE
Add support for multi-level categorical axes for all Charts 

### DIFF
--- a/holoviews/element/chart.py
+++ b/holoviews/element/chart.py
@@ -240,7 +240,7 @@ class Spikes(Chart):
 
     group = param.String(default='Spikes', constant=True)
 
-    kdims = param.List(default=[Dimension('x')], bounds=(1, 1))
+    kdims = param.List(default=[Dimension('x')], bounds=(1, 3))
 
     vdims = param.List(default=[])
 

--- a/holoviews/plotting/bokeh/__init__.py
+++ b/holoviews/plotting/bokeh/__init__.py
@@ -31,9 +31,10 @@ from .annotation import (TextPlot, LineAnnotationPlot, SplinePlot,
 from ..plot import PlotSelector
 from .callbacks import Callback # noqa (API import)
 from .element import OverlayPlot, ElementPlot
-from .chart import (PointPlot, CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
+from .chart import (CurvePlot, SpreadPlot, ErrorPlot, HistogramPlot,
                     SideHistogramPlot, BarPlot, SpikesPlot, SideSpikesPlot,
-                    AreaPlot, VectorFieldPlot)
+                    AreaPlot, ScatterPlot)
+from .geom import PointPlot, VectorFieldPlot
 from .graphs import GraphPlot, NodePlot, TriMeshPlot, ChordPlot
 from .heatmap import HeatMapPlot, RadialHeatMapPlot
 from .hex_tiles import HexTilesPlot
@@ -64,7 +65,7 @@ associations = {Overlay: OverlayPlot,
                 Curve: CurvePlot,
                 Bars: BarPlot,
                 Points: PointPlot,
-                Scatter: PointPlot,
+                Scatter: ScatterPlot,
                 ErrorBars: ErrorPlot,
                 Spread: SpreadPlot,
                 Spikes: SpikesPlot,

--- a/holoviews/plotting/bokeh/chart.py
+++ b/holoviews/plotting/bokeh/chart.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, unicode_literals
 
 from collections import defaultdict
+from itertools import product
 
 import numpy as np
 import param
@@ -9,94 +10,75 @@ from bokeh.models.tools import BoxSelectTool
 from bokeh.transform import jitter
 
 from ...core.data import Dataset
-from ...core.dimension import dimension_name
 from ...core.util import OrderedDict, max_range, basestring, dimension_sanitizer, isfinite, range_pad
 from ...element import Bars
 from ...operation import interpolate_curve
 from ...util.transform import dim
-from ..util import compute_sizes, get_min_distance, get_axis_padding
+from ..util import get_axis_padding
 from .element import ElementPlot, ColorbarPlot, LegendPlot
+from .geom import PointPlot
 from .styles import (expand_batched_style, line_properties, fill_properties,
                      mpl_to_bokeh, rgb2hex)
 from .util import categorize_array
 
 
-class PointPlot(LegendPlot, ColorbarPlot):
+class ChartPlot(object):
 
-    jitter = param.Number(default=None, bounds=(0, None), doc="""
-      The amount of jitter to apply to offset the points along the x-axis.""")
-
-    # Deprecated parameters
-
-    color_index = param.ClassSelector(default=None, class_=(basestring, int),
-                                      allow_None=True, doc="""
-        Deprecated in favor of color style mapping, e.g. `color=dim('color')`""")
-
-    size_index = param.ClassSelector(default=None, class_=(basestring, int),
-                                     allow_None=True, doc="""
-        Deprecated in favor of size style mapping, e.g. `size=dim('size')`""")
-
-    scaling_method = param.ObjectSelector(default="area",
-                                          objects=["width", "area"],
-                                          doc="""
-        Deprecated in favor of size style mapping, e.g.
-        size=dim('size')**2.""")
-
-    scaling_factor = param.Number(default=1, bounds=(0, None), doc="""
-      Scaling factor which is applied to either the width or area
-      of each point, depending on the value of `scaling_method`.""")
-
-    size_fn = param.Callable(default=np.abs, doc="""
-      Function applied to size values before applying scaling,
-      to remove values lower than zero.""")
-
-    style_opts = (['cmap', 'palette', 'marker', 'size', 'angle'] +
-                  line_properties + fill_properties)
-
-    _plot_methods = dict(single='scatter', batched='scatter')
-    _batched_style_opts = line_properties + fill_properties + ['size']
-
-    def _get_size_data(self, element, ranges, style):
-        data, mapping = {}, {}
-        sdim = element.get_dimension(self.size_index)
-        ms = style.get('size', np.sqrt(6))
-        if sdim and ((isinstance(ms, basestring) and ms in element) or isinstance(ms, dim)):
-            self.param.warning(
-                "Cannot declare style mapping for 'size' option and "
-                "declare a size_index; ignoring the size_index.")
-            sdim = None
-        if not sdim or self.static_source:
-            return data, mapping
-
-        map_key = 'size_' + sdim.name
-        ms = ms**2
-        sizes = element.dimension_values(self.size_index)
-        sizes = compute_sizes(sizes, self.size_fn,
-                              self.scaling_factor,
-                              self.scaling_method, ms)
-        if sizes is None:
-            eltype = type(element).__name__
-            self.param.warning(
-                '%s dimension is not numeric, cannot use to scale %s size.'
-                % (sdim.pprint_label, eltype))
+    def _get_axis_dims(self, element):
+        if element.ndims > 1:
+            xdims = element.kdims
         else:
-            data[map_key] = np.sqrt(sizes)
-            mapping['size'] = map_key
-        return data, mapping
+            xdims = element.kdims[0]
+        return (xdims, element.vdims[0])
 
+    def _get_factors(self, element, ranges):
+        """
+        Get factors for categorical axes.
+        """
+        factors = []
+        for kd in element.kdims:
+            dfactors = ranges[kd.name].get('factors')
+            if dfactors is None:
+                dfactors = element.dimension_values(kd, expanded=False)
+            if dfactors.dtype.kind != 'SU':
+                dfactors = [kd.pprint_value(f) for f in dfactors]
+            factors.append(dfactors)
+        if len(factors) == 1:
+            xfactors = factors[0]
+        else:
+            xfactors = sorted(product(*factors))
+        return ([], xfactors) if self.invert_axes else (xfactors, [])
+
+    def _get_position_data(self, element):
+        xvalues = []
+        for kd in element.kdims:
+            xs = element.dimension_values(kd)
+            if xs.dtype.kind != 'SU':
+                xs = [kd.pprint_value(x) for x in xs]
+            xvalues.append(xs)
+
+        yvalues = element.dimension_values(element.vdims[0])
+        if len(xvalues) == 1:
+            xvals, yvals = xvalues[0], yvalues
+        else:
+            xvals, yvals = list(zip(*xvalues)), yvalues
+        return (yvals, xvals) if self.invert_axes else (xvals, yvals)
+
+
+
+class ScatterPlot(ChartPlot, PointPlot):
 
     def get_data(self, element, ranges, style):
         dims = element.dimensions(label=True)
 
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
+        xvals, yvals = self._get_position_data(element)
         mapping = dict(x=dims[xidx], y=dims[yidx])
         data = {}
 
         if not self.static_source or self.batched:
-            xdim, ydim = dims[xidx], dims[yidx]
-            data[xdim] = element.dimension_values(xidx)
-            data[ydim] = element.dimension_values(yidx)
-            self._categorize_data(data, (xdim, ydim), element.dimensions())
+            data[dims[xidx]] = xvals
+            data[dims[yidx]] = yvals
 
         cdata, cmapping = self._get_color_data(element, ranges, style)
         data.update(cdata)
@@ -121,184 +103,8 @@ class PointPlot(LegendPlot, ColorbarPlot):
         return data, mapping, style
 
 
-    def get_batched_data(self, element, ranges):
-        data = defaultdict(list)
-        zorders = self._updated_zorders(element)
-        for (key, el), zorder in zip(element.data.items(), zorders):
-            self.param.set_param(**self.lookup_options(el, 'plot').options)
-            style = self.lookup_options(element.last, 'style')
-            style = style.max_cycles(len(self.ordering))[zorder]
-            eldata, elmapping, style = self.get_data(el, ranges, style)
-            for k, eld in eldata.items():
-                data[k].append(eld)
 
-            # Skip if data is empty
-            if not eldata:
-                continue
-
-            # Apply static styles
-            nvals = len(list(eldata.values())[0])
-            sdata, smapping = expand_batched_style(style, self._batched_style_opts,
-                                                   elmapping, nvals)
-            elmapping.update(smapping)
-            for k, v in sdata.items():
-                data[k].append(v)
-
-            if 'hover' in self.handles:
-                for d, k in zip(element.dimensions(), key):
-                    sanitized = dimension_sanitizer(d.name)
-                    data[sanitized].append([k]*nvals)
-
-        data = {k: np.concatenate(v) for k, v in data.items()}
-        return data, elmapping, style
-
-
-
-class VectorFieldPlot(ColorbarPlot):
-
-    arrow_heads = param.Boolean(default=True, doc="""
-        Whether or not to draw arrow heads.""")
-
-    magnitude = param.ClassSelector(class_=(basestring, dim), doc="""
-        Dimension or dimension value transform that declares the magnitude
-        of each vector. Magnitude is expected to be scaled between 0-1,
-        by default the magnitudes are rescaled relative to the minimum
-        distance between vectors, this can be disabled with the
-        rescale_lengths option.""")
-
-    pivot = param.ObjectSelector(default='mid', objects=['mid', 'tip', 'tail'],
-                                 doc="""
-        The point around which the arrows should pivot valid options
-        include 'mid', 'tip' and 'tail'.""")
-
-    rescale_lengths = param.Boolean(default=True, doc="""
-        Whether the lengths will be rescaled to take into account the
-        smallest non-zero distance between two vectors.""")
-
-    # Deprecated parameters
-
-    color_index = param.ClassSelector(default=None, class_=(basestring, int),
-                                      allow_None=True, doc="""
-        Deprecated in favor of dimension value transform on color option,
-        e.g. `color=dim('Magnitude')`.
-        """)
-
-    size_index = param.ClassSelector(default=None, class_=(basestring, int),
-                                     allow_None=True, doc="""
-        Deprecated in favor of the magnitude option, e.g.
-        `magnitude=dim('Magnitude')`.
-        """)
-
-    normalize_lengths = param.Boolean(default=True, doc="""
-        Deprecated in favor of rescaling length using dimension value
-        transforms using the magnitude option, e.g.
-        `dim('Magnitude').norm()`.""")
-
-    style_opts = line_properties + ['scale', 'cmap']
-
-    _nonvectorized_styles = ['scale', 'cmap']
-
-    _plot_methods = dict(single='segment')
-
-    def _get_lengths(self, element, ranges):
-        size_dim = element.get_dimension(self.size_index)
-        mag_dim = self.magnitude
-        if size_dim and mag_dim:
-            self.param.warning(
-                "Cannot declare style mapping for 'magnitude' option "
-                "and declare a size_index; ignoring the size_index.")
-        elif size_dim:
-            mag_dim = size_dim
-        elif isinstance(mag_dim, basestring):
-            mag_dim = element.get_dimension(mag_dim)
-
-        (x0, x1), (y0, y1) = (element.range(i) for i in range(2))
-        if mag_dim:
-            if isinstance(mag_dim, dim):
-                magnitudes = mag_dim.apply(element, flat=True)
-            else:
-                magnitudes = element.dimension_values(mag_dim)
-                _, max_magnitude = ranges[dimension_name(mag_dim)]['combined']
-                if self.normalize_lengths and max_magnitude != 0:
-                    magnitudes = magnitudes / max_magnitude
-            if self.rescale_lengths:
-                base_dist = get_min_distance(element)
-                magnitudes *= base_dist
-        else:
-            magnitudes = np.ones(len(element))
-            if self.rescale_lengths:
-                base_dist = get_min_distance(element)
-                magnitudes *= base_dist
-
-        return magnitudes
-
-    def _glyph_properties(self, *args):
-        properties = super(VectorFieldPlot, self)._glyph_properties(*args)
-        properties.pop('scale', None)
-        return properties
-
-
-    def get_data(self, element, ranges, style):
-        input_scale = style.pop('scale', 1.0)
-
-        # Get x, y, angle, magnitude and color data
-        rads = element.dimension_values(2)
-        if self.invert_axes:
-            xidx, yidx = (1, 0)
-            rads = rads+1.5*np.pi
-        else:
-            xidx, yidx = (0, 1)
-        lens = self._get_lengths(element, ranges)/input_scale
-        cdim = element.get_dimension(self.color_index)
-        cdata, cmapping = self._get_color_data(element, ranges, style,
-                                               name='line_color')
-
-        # Compute segments and arrowheads
-        xs = element.dimension_values(xidx)
-        ys = element.dimension_values(yidx)
-
-        # Compute offset depending on pivot option
-        xoffsets = np.cos(rads)*lens/2.
-        yoffsets = np.sin(rads)*lens/2.
-        if self.pivot == 'mid':
-            nxoff, pxoff = xoffsets, xoffsets
-            nyoff, pyoff = yoffsets, yoffsets
-        elif self.pivot == 'tip':
-            nxoff, pxoff = 0, xoffsets*2
-            nyoff, pyoff = 0, yoffsets*2
-        elif self.pivot == 'tail':
-            nxoff, pxoff = xoffsets*2, 0
-            nyoff, pyoff = yoffsets*2, 0
-        x0s, x1s = (xs + nxoff, xs - pxoff)
-        y0s, y1s = (ys + nyoff, ys - pyoff)
-
-        color = None
-        if self.arrow_heads:
-            arrow_len = (lens/4.)
-            xa1s = x0s - np.cos(rads+np.pi/4)*arrow_len
-            ya1s = y0s - np.sin(rads+np.pi/4)*arrow_len
-            xa2s = x0s - np.cos(rads-np.pi/4)*arrow_len
-            ya2s = y0s - np.sin(rads-np.pi/4)*arrow_len
-            x0s = np.tile(x0s, 3)
-            x1s = np.concatenate([x1s, xa1s, xa2s])
-            y0s = np.tile(y0s, 3)
-            y1s = np.concatenate([y1s, ya1s, ya2s])
-            if cdim and cdim.name in cdata:
-                color = np.tile(cdata[cdim.name], 3)
-        elif cdim:
-            color = cdata.get(cdim.name)
-
-        data = {'x0': x0s, 'x1': x1s, 'y0': y0s, 'y1': y1s}
-        mapping = dict(x0='x0', x1='x1', y0='y0', y1='y1')
-        if cdim and color is not None:
-            data[cdim.name] = color
-            mapping.update(cmapping)
-
-        return (data, mapping, style)
-
-
-
-class CurvePlot(ElementPlot):
+class CurvePlot(ChartPlot, ElementPlot):
 
     interpolation = param.ObjectSelector(objects=['linear', 'steps-mid',
                                                   'steps-pre', 'steps-post'],
@@ -315,17 +121,17 @@ class CurvePlot(ElementPlot):
 
     def get_data(self, element, ranges, style):
         xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
-        x = element.get_dimension(xidx).name
-        y = element.get_dimension(yidx).name
+        x = dimension_sanitizer(element.get_dimension(xidx).name)
+        y = dimension_sanitizer(element.get_dimension(yidx).name)
         if self.static_source and not self.batched:
             return {}, dict(x=x, y=y), style
 
         if 'steps' in self.interpolation:
             element = interpolate_curve(element, interpolation=self.interpolation)
-        data = {x: element.dimension_values(xidx),
-                y: element.dimension_values(yidx)}
+
+        xvals, yvals = self._get_position_data(element)
+        data = {x: xvals, y: yvals}
         self._get_hover_data(data, element)
-        self._categorize_data(data, (x, y), element.dimensions())
         return (data, dict(x=x, y=y), style)
 
     def _hover_opts(self, element):
@@ -478,7 +284,7 @@ class SideHistogramPlot(HistogramPlot):
 
 
 
-class ErrorPlot(ColorbarPlot):
+class ErrorPlot(ChartPlot, ColorbarPlot):
 
     style_opts = line_properties + ['lower_head', 'upper_head']
 
@@ -493,13 +299,12 @@ class ErrorPlot(ColorbarPlot):
         if self.static_source:
             return {}, mapping, style
 
-        base = element.dimension_values(0)
-        ys = element.dimension_values(1)
+        base, ys = self._get_position_data(element)
         if len(element.vdims) > 2:
             neg, pos = (element.dimension_values(vd) for vd in element.vdims[1:3])
             lower, upper = ys-neg, ys+pos
         else:
-            err = element.dimension_values(2)
+            err = element.dimension_values(element.ndims+1)
             lower, upper = ys-err, ys+err
         data = dict(base=base, lower=lower, upper=upper)
 
@@ -507,9 +312,8 @@ class ErrorPlot(ColorbarPlot):
             mapping['dimension'] = 'width'
         else:
             mapping['dimension'] = 'height'
-        self._categorize_data(data, ('base',), element.dimensions())
+        style['level'] = 'glyph'
         return (data, mapping, style)
-
 
     def _init_glyph(self, plot, mapping, properties):
         """
@@ -625,7 +429,7 @@ class AreaPlot(SpreadPlot):
 
 
 
-class SpikesPlot(ColorbarPlot):
+class SpikesPlot(ChartPlot, ColorbarPlot):
 
     spike_length = param.Number(default=0.5, doc="""
       The length of each spike if Spikes object is one dimensional.""")
@@ -674,15 +478,16 @@ class SpikesPlot(ColorbarPlot):
     def get_data(self, element, ranges, style):
         dims = element.dimensions()
 
+        xvals, yvals = self._get_position_data(element)
         data = {}
         pos = self.position
         if len(element) == 0 or self.static_source:
             data = {'x': [], 'y0': [], 'y1': []}
         else:
-            data['x'] = element.dimension_values(0)
+            data['x'] = xvals
             data['y0'] = np.full(len(element), pos)
             if len(dims) > 1:
-                data['y1'] = element.dimension_values(1)+pos
+                data['y1'] = yvals+pos
             else:
                 data['y1'] = data['y0']+self.spike_length
 
@@ -803,7 +608,7 @@ class BarPlot(ColorbarPlot, LegendPlot):
         return (x0, y0, x1, y1)
 
 
-    def _get_factors(self, element):
+    def _get_factors(self, element, ranges):
         """
         Get factors for categorical axes.
         """

--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -626,7 +626,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
 
         xfactors, yfactors = None, None
         if any(isinstance(ax_range, FactorRange) for ax_range in [x_range, y_range]):
-            xfactors, yfactors = self._get_factors(element)
+            xfactors, yfactors = self._get_factors(element, ranges)
         framewise = self.framewise
         streaming = (self.streaming and any(stream._triggering for stream in self.streaming))
         xupdate = ((not self.model_changed(x_range) and (framewise or streaming))
@@ -712,7 +712,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
         return self.width/self.height
 
 
-    def _get_factors(self, element):
+    def _get_factors(self, element, ranges):
         """
         Get factors for categorical axes.
         """
@@ -1789,19 +1789,16 @@ class OverlayPlot(GenericOverlayPlot, LegendPlot):
                 self.handles['hover'] = tool
 
 
-    def _get_factors(self, overlay):
+    def _get_factors(self, overlay, ranges):
         xfactors, yfactors = [], []
         for k, sp in self.subplots.items():
             el = overlay.data.get(k)
             if el is not None:
-                xfs, yfs = sp._get_factors(el)
-                xfactors.append(xfs)
-                yfactors.append(yfs)
-        if xfactors:
-            xfactors = np.concatenate(xfactors)
-        if yfactors:
-            yfactors = np.concatenate(yfactors)
-        return util.unique_array(xfactors), util.unique_array(yfactors)
+                elranges = util.match_spec(el, ranges)
+                xfs, yfs = sp._get_factors(el, elranges)
+                xfactors += list(xfs)
+                yfactors += list(yfs)
+        return list(util.unique_iterator(xfactors)), list(util.unique_iterator(yfactors))
 
 
     def _get_axis_dims(self, element):

--- a/holoviews/plotting/bokeh/geom.py
+++ b/holoviews/plotting/bokeh/geom.py
@@ -1,0 +1,286 @@
+from __future__ import absolute_import, division, unicode_literals
+
+from collections import defaultdict
+
+import numpy as np
+import param
+from bokeh.transform import jitter
+
+from ...core.dimension import dimension_name
+from ...core.util import basestring, dimension_sanitizer
+from ...util.transform import dim
+from ..util import compute_sizes, get_min_distance
+from .element import ColorbarPlot, LegendPlot
+from .styles import expand_batched_style, line_properties, fill_properties
+
+
+class PointPlot(LegendPlot, ColorbarPlot):
+
+    jitter = param.Number(default=None, bounds=(0, None), doc="""
+      The amount of jitter to apply to offset the points along the x-axis.""")
+
+    # Deprecated parameters
+
+    color_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                      allow_None=True, doc="""
+        Deprecated in favor of color style mapping, e.g. `color=dim('color')`""")
+
+    size_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                     allow_None=True, doc="""
+        Deprecated in favor of size style mapping, e.g. `size=dim('size')`""")
+
+    scaling_method = param.ObjectSelector(default="area",
+                                          objects=["width", "area"],
+                                          doc="""
+        Deprecated in favor of size style mapping, e.g.
+        size=dim('size')**2.""")
+
+    scaling_factor = param.Number(default=1, bounds=(0, None), doc="""
+      Scaling factor which is applied to either the width or area
+      of each point, depending on the value of `scaling_method`.""")
+
+    size_fn = param.Callable(default=np.abs, doc="""
+      Function applied to size values before applying scaling,
+      to remove values lower than zero.""")
+
+    style_opts = (['cmap', 'palette', 'marker', 'size', 'angle'] +
+                  line_properties + fill_properties)
+
+    _plot_methods = dict(single='scatter', batched='scatter')
+    _batched_style_opts = line_properties + fill_properties + ['size']
+
+    def _get_size_data(self, element, ranges, style):
+        data, mapping = {}, {}
+        sdim = element.get_dimension(self.size_index)
+        ms = style.get('size', np.sqrt(6))
+        if sdim and ((isinstance(ms, basestring) and ms in element) or isinstance(ms, dim)):
+            self.param.warning(
+                "Cannot declare style mapping for 'size' option and "
+                "declare a size_index; ignoring the size_index.")
+            sdim = None
+        if not sdim or self.static_source:
+            return data, mapping
+
+        map_key = 'size_' + sdim.name
+        ms = ms**2
+        sizes = element.dimension_values(self.size_index)
+        sizes = compute_sizes(sizes, self.size_fn,
+                              self.scaling_factor,
+                              self.scaling_method, ms)
+        if sizes is None:
+            eltype = type(element).__name__
+            self.param.warning(
+                '%s dimension is not numeric, cannot use to scale %s size.'
+                % (sdim.pprint_label, eltype))
+        else:
+            data[map_key] = np.sqrt(sizes)
+            mapping['size'] = map_key
+        return data, mapping
+
+
+    def get_data(self, element, ranges, style):
+        dims = (dimension_sanitizer(d) for d in element.dimensions(label=True))
+
+        xidx, yidx = (1, 0) if self.invert_axes else (0, 1)
+        mapping = dict(x=dims[xidx], y=dims[yidx])
+        data = {}
+
+        if not self.static_source or self.batched:
+            xdim, ydim = dims[xidx], dims[yidx]
+            data[xdim] = element.dimension_values(xidx)
+            data[ydim] = element.dimension_values(yidx)
+            self._categorize_data(data, (xdim, ydim), element.dimensions())
+
+        cdata, cmapping = self._get_color_data(element, ranges, style)
+        data.update(cdata)
+        mapping.update(cmapping)
+
+        sdata, smapping = self._get_size_data(element, ranges, style)
+        data.update(sdata)
+        mapping.update(smapping)
+
+        if 'angle' in style and isinstance(style['angle'], (int, float)):
+            style['angle'] = np.deg2rad(style['angle'])
+
+        if self.jitter:
+            axrange = 'y_range' if self.invert_axes else 'x_range'
+            mapping['x'] = jitter(dims[xidx], self.jitter,
+                                  range=self.handles[axrange])
+
+        self._get_hover_data(data, element)
+        return data, mapping, style
+
+
+    def get_batched_data(self, element, ranges):
+        data = defaultdict(list)
+        zorders = self._updated_zorders(element)
+        for (key, el), zorder in zip(element.data.items(), zorders):
+            self.param.set_param(**self.lookup_options(el, 'plot').options)
+            style = self.lookup_options(element.last, 'style')
+            style = style.max_cycles(len(self.ordering))[zorder]
+            eldata, elmapping, style = self.get_data(el, ranges, style)
+            for k, eld in eldata.items():
+                data[k].append(eld)
+
+            # Skip if data is empty
+            if not eldata:
+                continue
+
+            # Apply static styles
+            nvals = len(list(eldata.values())[0])
+            sdata, smapping = expand_batched_style(style, self._batched_style_opts,
+                                                   elmapping, nvals)
+            elmapping.update(smapping)
+            for k, v in sdata.items():
+                data[k].append(v)
+
+            if 'hover' in self.handles:
+                for d, k in zip(element.dimensions(), key):
+                    sanitized = dimension_sanitizer(d.name)
+                    data[sanitized].append([k]*nvals)
+
+        data = {k: np.concatenate(v) for k, v in data.items()}
+        return data, elmapping, style
+
+
+class VectorFieldPlot(ColorbarPlot):
+
+    arrow_heads = param.Boolean(default=True, doc="""
+        Whether or not to draw arrow heads.""")
+
+    magnitude = param.ClassSelector(class_=(basestring, dim), doc="""
+        Dimension or dimension value transform that declares the magnitude
+        of each vector. Magnitude is expected to be scaled between 0-1,
+        by default the magnitudes are rescaled relative to the minimum
+        distance between vectors, this can be disabled with the
+        rescale_lengths option.""")
+
+    pivot = param.ObjectSelector(default='mid', objects=['mid', 'tip', 'tail'],
+                                 doc="""
+        The point around which the arrows should pivot valid options
+        include 'mid', 'tip' and 'tail'.""")
+
+    rescale_lengths = param.Boolean(default=True, doc="""
+        Whether the lengths will be rescaled to take into account the
+        smallest non-zero distance between two vectors.""")
+
+    # Deprecated parameters
+
+    color_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                      allow_None=True, doc="""
+        Deprecated in favor of dimension value transform on color option,
+        e.g. `color=dim('Magnitude')`.
+        """)
+
+    size_index = param.ClassSelector(default=None, class_=(basestring, int),
+                                     allow_None=True, doc="""
+        Deprecated in favor of the magnitude option, e.g.
+        `magnitude=dim('Magnitude')`.
+        """)
+
+    normalize_lengths = param.Boolean(default=True, doc="""
+        Deprecated in favor of rescaling length using dimension value
+        transforms using the magnitude option, e.g.
+        `dim('Magnitude').norm()`.""")
+
+    style_opts = line_properties + ['scale', 'cmap']
+
+    _nonvectorized_styles = ['scale', 'cmap']
+
+    _plot_methods = dict(single='segment')
+
+    def _get_lengths(self, element, ranges):
+        size_dim = element.get_dimension(self.size_index)
+        mag_dim = self.magnitude
+        if size_dim and mag_dim:
+            self.param.warning(
+                "Cannot declare style mapping for 'magnitude' option "
+                "and declare a size_index; ignoring the size_index.")
+        elif size_dim:
+            mag_dim = size_dim
+        elif isinstance(mag_dim, basestring):
+            mag_dim = element.get_dimension(mag_dim)
+
+        (x0, x1), (y0, y1) = (element.range(i) for i in range(2))
+        if mag_dim:
+            if isinstance(mag_dim, dim):
+                magnitudes = mag_dim.apply(element, flat=True)
+            else:
+                magnitudes = element.dimension_values(mag_dim)
+                _, max_magnitude = ranges[dimension_name(mag_dim)]['combined']
+                if self.normalize_lengths and max_magnitude != 0:
+                    magnitudes = magnitudes / max_magnitude
+            if self.rescale_lengths:
+                base_dist = get_min_distance(element)
+                magnitudes *= base_dist
+        else:
+            magnitudes = np.ones(len(element))
+            if self.rescale_lengths:
+                base_dist = get_min_distance(element)
+                magnitudes *= base_dist
+
+        return magnitudes
+
+    def _glyph_properties(self, *args):
+        properties = super(VectorFieldPlot, self)._glyph_properties(*args)
+        properties.pop('scale', None)
+        return properties
+
+
+    def get_data(self, element, ranges, style):
+        input_scale = style.pop('scale', 1.0)
+
+        # Get x, y, angle, magnitude and color data
+        rads = element.dimension_values(2)
+        if self.invert_axes:
+            xidx, yidx = (1, 0)
+            rads = rads+1.5*np.pi
+        else:
+            xidx, yidx = (0, 1)
+        lens = self._get_lengths(element, ranges)/input_scale
+        cdim = element.get_dimension(self.color_index)
+        cdata, cmapping = self._get_color_data(element, ranges, style,
+                                               name='line_color')
+
+        # Compute segments and arrowheads
+        xs = element.dimension_values(xidx)
+        ys = element.dimension_values(yidx)
+
+        # Compute offset depending on pivot option
+        xoffsets = np.cos(rads)*lens/2.
+        yoffsets = np.sin(rads)*lens/2.
+        if self.pivot == 'mid':
+            nxoff, pxoff = xoffsets, xoffsets
+            nyoff, pyoff = yoffsets, yoffsets
+        elif self.pivot == 'tip':
+            nxoff, pxoff = 0, xoffsets*2
+            nyoff, pyoff = 0, yoffsets*2
+        elif self.pivot == 'tail':
+            nxoff, pxoff = xoffsets*2, 0
+            nyoff, pyoff = yoffsets*2, 0
+        x0s, x1s = (xs + nxoff, xs - pxoff)
+        y0s, y1s = (ys + nyoff, ys - pyoff)
+
+        color = None
+        if self.arrow_heads:
+            arrow_len = (lens/4.)
+            xa1s = x0s - np.cos(rads+np.pi/4)*arrow_len
+            ya1s = y0s - np.sin(rads+np.pi/4)*arrow_len
+            xa2s = x0s - np.cos(rads-np.pi/4)*arrow_len
+            ya2s = y0s - np.sin(rads-np.pi/4)*arrow_len
+            x0s = np.tile(x0s, 3)
+            x1s = np.concatenate([x1s, xa1s, xa2s])
+            y0s = np.tile(y0s, 3)
+            y1s = np.concatenate([y1s, ya1s, ya2s])
+            if cdim and cdim.name in cdata:
+                color = np.tile(cdata[cdim.name], 3)
+        elif cdim:
+            color = cdata.get(cdim.name)
+
+        data = {'x0': x0s, 'x1': x1s, 'y0': y0s, 'y1': y1s}
+        mapping = dict(x0='x0', x1='x1', y0='y0', y1='y1')
+        if cdim and color is not None:
+            data[cdim.name] = color
+            mapping.update(cmapping)
+
+        return (data, mapping, style)

--- a/holoviews/plotting/bokeh/heatmap.py
+++ b/holoviews/plotting/bokeh/heatmap.py
@@ -63,8 +63,8 @@ class HeatMapPlot(ColorbarPlot):
         return ((any(o in opts for o in ('start_angle', 'radius_inner', 'radius_outer'))
                  and not (opts.get('radial') == False)) or opts.get('radial', False))
 
-    def _get_factors(self, element):
-        return super(HeatMapPlot, self)._get_factors(element.gridded)
+    def _get_factors(self, element, ranges):
+        return super(HeatMapPlot, self)._get_factors(element.gridded, ranges)
 
     def get_data(self, element, ranges, style):
         x, y, z = [dimension_sanitizer(d) for d in element.dimensions(label=True)[:3]]

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -105,7 +105,7 @@ class BoxWhiskerPlot(CompositeElementPlot, ColorbarPlot, LegendPlot):
             element = element.clone([(element.aggregate(function=np.mean),)])
         return super(BoxWhiskerPlot, self)._apply_transforms(element, data, ranges, style, group)
 
-    def _get_factors(self, element):
+    def _get_factors(self, element, ranges):
         """
         Get factors for categorical axes.
         """


### PR DESCRIPTION
This PR is meant to overhaul handling of categorical axes for all Chart elements. This is a backward incompatible change and the plan is to be able to toggle the new behavior on in the next release and eventually defaulting to the new behavior in the next release.

This PR implements the suggestion in https://github.com/ioam/holoviews/issues/1668, which allows all chart elements to support multi-level categorical axes. This means that a Chart element with more than one key dimension will always be interpreted as a multi-level categorical axis, which will make it possible to overlay existing charts on top of elements which already support this mechanism for multi-level categorical axes, e.g. as a straightforward example let's take a multi-level Bars plot:

```python
data = [
    ('A', 1, 2, 0.2), ('A', 2, 3, 0.3),
    ('B', 1, 4, 0.7), ('B', 2, 1, 0.5)]
hv.Bars(data, kdims=['a', 'b'], vdims=['c'])
```

![bokeh_plot](https://user-images.githubusercontent.com/1550771/51074934-ff825c80-167c-11e9-8395-88a43bf78f6b.png)

Currently if we want to overlay points, errorbars, curves, etc. on top of this plot there would be no way of doing so. Once this PR is merged it will be possible to do this:

```python
data = [
    ('A', 1, 2, 0.2), ('A', 2, 3, 0.3),
    ('B', 1, 4, 0.7), ('B', 2, 1, 0.5)]
hv.Bars(data, kdims=['a', 'b'], vdims=['c']) * hv.ErrorBars(data, kdims=['a', 'b'], vdims=['c', 'error']) 
```

![bokeh_plot](https://user-images.githubusercontent.com/1550771/51074976-5851f500-167d-11e9-9d77-92f533ce21bf.png)

