### PR TITLE
Sync axis and grid tickers

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -610,6 +610,10 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                      for k, v in dict(both, **xgrid).items()}
             yopts = {k.replace('grid_', '') if any(r in k for r in replace) else k: v
                      for k, v in dict(both, **ygrid).items()}
+            if plot.xaxis:
+                xopts['ticker'] = plot.xaxis[0].ticker
+            if plot.yaxis:
+                yopts['ticker'] = plot.yaxis[0].ticker
             plot.xgrid[0].update(**xopts)
             plot.ygrid[0].update(**yopts)
 

--- a/holoviews/tests/plotting/bokeh/testelementplot.py
+++ b/holoviews/tests/plotting/bokeh/testelementplot.py
@@ -253,6 +253,16 @@ class TestElementPlot(LoggingComparisonTestCase, TestBokehPlot):
         plot = bokeh_renderer.get_plot(curve).state
         self.assertIsInstance(plot.yaxis[0].formatter, FuncTickFormatter)
 
+    def test_element_grid_custom_xticker(self):
+        curve = Curve([1, 2, 3]).opts(xticks=[0.5, 1.5], show_grid=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertIs(plot.state.xgrid[0].ticker, plot.state.xaxis[0].ticker)
+
+    def test_element_grid_custom_yticker(self):
+        curve = Curve([1, 2, 3]).opts(yticks=[0.5, 2.5], show_grid=True)
+        plot = bokeh_renderer.get_plot(curve)
+        self.assertIs(plot.state.ygrid[0].ticker, plot.state.yaxis[0].ticker)
+
     def test_element_grid_options(self):
         grid_style = {'grid_line_color': 'blue', 'grid_line_width': 1.5, 'ygrid_bounds': (0.3, 0.7),
                       'minor_xgrid_line_color': 'lightgray', 'xgrid_line_dash': [4, 4]}


### PR DESCRIPTION
By default axis and grid tickers are independent which is not usually desirable. This PR ensures that at least by default the axis and grid tickers match. Take this simple example:

```python
hv.Curve([1, 2, 3]).opts(
    xticks=[0.25, 0.75, 1.25, 1.75], show_grid=True)
```

Before the PR this produced:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/51111918-ab4eb800-17f5-11e9-8b94-e4dac13bf192.png)

With this PR applied:

![bokeh_plot](https://user-images.githubusercontent.com/1550771/51111886-85291800-17f5-11e9-90d2-8bf1cd84c084.png)
