### PR TITLE
Handled (deprecated) empty __call__ case

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -1315,6 +1315,9 @@ class Dimensioned(LabelledData):
                 'in future. Use the equivalent opts method or use '
                 'the recommended .options method instead.')
 
+        if not kwargs and options is None:
+            return self.opts.clear()
+
         return self.opts(options, **kwargs)
 
 


### PR DESCRIPTION
Although ``__call__`` on dimensioned objects is deprecated, the old behavior should be preserved for now.