### PR TITLE
Pin numpy to <1.16.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,7 @@
 name: holoviews
 
 dependencies:
-  - numpy
+  - numpy<1.16.0
   - notebook
   - matplotlib=2.1.2
   - pillow=5.2.0


### PR DESCRIPTION
Travis currently failing due to a NumPy version bump, pinning it should fix it for now. Hopefully xarray will push out a compatible release soon.