### PR TITLE
Allow more customizations of bokeh gridlines

### DIFF
--- a/holoviews/plotting/bokeh/element.py
+++ b/holoviews/plotting/bokeh/element.py
@@ -601,7 +601,7 @@ class ElementPlot(BokehPlot, GenericElementPlot):
             plot.xgrid.grid_line_color = None
             plot.ygrid.grid_line_color = None
         else:
-            replace = ['bounds', 'bands', 'visible']
+            replace = ['bounds', 'bands', 'visible', 'level', 'ticker', 'visible']
             style_items = list(self.gridstyle.items())
             both = {k: v for k, v in style_items if k.startswith('grid_') or k.startswith('minor_grid')}
             xgrid = {k.replace('xgrid', 'grid'): v for k, v in style_items if 'xgrid' in k}
@@ -610,9 +610,9 @@ class ElementPlot(BokehPlot, GenericElementPlot):
                      for k, v in dict(both, **xgrid).items()}
             yopts = {k.replace('grid_', '') if any(r in k for r in replace) else k: v
                      for k, v in dict(both, **ygrid).items()}
-            if plot.xaxis:
+            if plot.xaxis and 'ticker' not in xopts:
                 xopts['ticker'] = plot.xaxis[0].ticker
-            if plot.yaxis:
+            if plot.yaxis and 'ticker' not in yopts:
                 yopts['ticker'] = plot.yaxis[0].ticker
             plot.xgrid[0].update(**xopts)
             plot.ygrid[0].update(**yopts)


### PR DESCRIPTION
Allows control over grid ticker, level and visible properties, e.g.:

```
xxx = np.random.rand(100, 100)
hv.QuadMesh((range(100), range(100), xxx)).opts(show_grid=True, gridstyle={'grid_level': 'annotation', 'xgrid_visible': False})
```

![bokeh_plot](https://user-images.githubusercontent.com/1550771/51184278-afe5a000-18cb-11e9-88c1-159c0684ea1e.png)
