### PR TITLE
Fix TypeError in string formatting expression

### DIFF
--- a/holoviews/core/util.py
+++ b/holoviews/core/util.py
@@ -714,7 +714,7 @@ class sanitize_identifier_fn(param.ParameterizedFunction):
         name = bytes_to_unicode(name)
         version = self.version if version is None else version
         if not self.allowable(name):
-            raise AttributeError("String %r is in the disallowed list of attribute names: %r" % self.disallowed)
+            raise AttributeError("String %r is in the disallowed list of attribute names: %r" % (name, self.disallowed))
 
         if version == 2:
             name = self.remove_diacritics(name)


### PR DESCRIPTION
`TypeError: not enough arguments for format string` is raised when evaluating the expression.

I changed it the minimum so that it does not crash, although the error raised is not fully informative, since `not self.allowable(name)` excludes more than `self.disallowed`.