### PR TITLE
Fix violin 'box'

### DIFF
--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -347,26 +347,22 @@ class ViolinPlot(BoxWhiskerPlot):
         if not len(values):
             pass
         elif self.inner == 'quartiles':
-            for stat_fn in self._stat_fns:
-                stat = stat_fn(values)
-                if len(xs):
+            if len(xs):
+                for stat_fn in self._stat_fns:
+                    stat = stat_fn(values)
                     sidx = np.argmin(np.abs(xs-stat))
                     sx, sy = xs[sidx], ys[sidx]
-                else:
-                    continue
-                segments['x'].append(sx)
-                segments['y0'].append(key+(-sy[-1],))
-                segments['y1'].append(sy)
+                    segments['x'].append(sx)
+                    segments['y0'].append(key+(-sy[-1],))
+                    segments['y1'].append(sy)
         elif self.inner == 'stick':
-            for value in values:
-                if len(xs):
+            if len(xs):
+                for value in values:
                     sidx = np.argmin(np.abs(xs-value))
-                else:
-                    continue
-                sx, sy = xs[sidx], ys[sidx]
-                segments['x'].append(sx)
-                segments['y0'].append(key+(-sy[-1],))
-                segments['y1'].append(sy)
+                    sx, sy = xs[sidx], ys[sidx]
+                    segments['x'].append(sx)
+                    segments['y0'].append(key+(-sy[-1],))
+                    segments['y1'].append(sy)
         elif self.inner == 'box':
             xpos = key+(0,)
             q1, q2, q3 = (np.percentile(values, q=q)

--- a/holoviews/plotting/bokeh/stats.py
+++ b/holoviews/plotting/bokeh/stats.py
@@ -359,7 +359,10 @@ class ViolinPlot(BoxWhiskerPlot):
                 segments['y1'].append(sy)
         elif self.inner == 'stick':
             for value in values:
-                sidx = np.argmin(np.abs(xs-value))
+                if len(xs):
+                    sidx = np.argmin(np.abs(xs-value))
+                else:
+                    continue
                 sx, sy = xs[sidx], ys[sidx]
                 segments['x'].append(sx)
                 segments['y0'].append(key+(-sy[-1],))

--- a/holoviews/tests/plotting/bokeh/testviolinplot.py
+++ b/holoviews/tests/plotting/bokeh/testviolinplot.py
@@ -91,6 +91,13 @@ class TestBokehViolinPlot(TestBokehPlot):
         self.assertEqual(patch_source.data['xs'], [[]])
         self.assertEqual(patch_source.data['ys'], [np.array([])])
 
+    def test_violin_single_point(self):
+        data = {'x': [1], 'y': [1]}
+        violin = Violin(data=data, kdims='x', vdims='y').opts(plot=dict(inner='box'))
+
+        plot = bokeh_renderer.get_plot(violin)
+        self.assertEqual(plot.handles['x_range'].factors, ['1'])
+
     ###########################
     #    Styling mapping      #
     ###########################


### PR DESCRIPTION
Fix 'box' `inner` option for violin plots with singular data and add a test.