### PR TITLE
Updated pinning of bokeh and IPython

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,10 +25,10 @@ requirements:
     - pyviz_comms >=0.7.0
     - numpy
     - matplotlib>=2.1
-    - bokeh >=1.0.0,<1.1.0
+    - bokeh >=1.0.4,<1.1.0
     - jupyter
     - notebook
-    - ipython >=5.4.0
+    - ipython <=7.1.1
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,7 @@ dependencies:
   - conda-forge::ffmpeg
   - conda-forge::flexx=0.4.1
   - conda-forge::plotly=3.4
-  - bokeh::bokeh=1.0.0
+  - bokeh::bokeh=1.0.4
   - bokeh::selenium
   # Testing requirements
   - flake8

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ install_requires = ['param>=1.8.0,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.0']
 extras_require = {}
 
 # Notebook dependencies of IPython 3
-extras_require['notebook-dependencies'] = ['ipython', 'pyzmq', 'jinja2', 'tornado',
+extras_require['notebook-dependencies'] = ['ipython<=7.1.1', 'pyzmq', 'jinja2', 'tornado',
                                            'jsonschema', 'notebook', 'pygments']
 # IPython Notebook + matplotlib
-extras_require['recommended'] = extras_require['notebook-dependencies'] + ['matplotlib>=2.1', 'bokeh>=1.0.0']
+extras_require['recommended'] = extras_require['notebook-dependencies'] + ['matplotlib>=2.1', 'bokeh>=1.0.4']
 # Additional, useful third-party packages
 extras_require['extras'] = (['pandas', 'seaborn']
                             + extras_require['recommended'])


### PR DESCRIPTION
Pins bokeh as 1.0.3 had an issue with broken hover (seems to be fixed in 1.0.4) and IPython due to the broken tab completion described in https://github.com/ipython/ipython/issues/11561.