### PR TITLE
Pinning IPython to avoid broken tab-completion behavior

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - bokeh >=1.0.0,<1.1.0
     - jupyter
     - notebook
-    - ipython >=5.4.0
+    - ipython <=7.1.1
 
 test:
   imports:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - bokeh >=1.0.0,<1.1.0
     - jupyter
     - notebook
-    - ipython <=7.1.1
+    - ipython >=5.4.0,<=7.1.1  # <=7.1.1 due to tab completion regression
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scipy
   - xarray=0.10.9
   - networkx
-  - ipython=5.4.1
+  - ipython=7.1.1
   - jsonschema=2.6.0
   - cyordereddict
   - nbconvert=5.3.1

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - scipy
   - xarray=0.10.9
   - networkx
-  - ipython=7.1.1
+  - ipython=5.4.1
   - jsonschema=2.6.0
   - cyordereddict
   - nbconvert=5.3.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,8 @@ install_requires = ['param>=1.8.0,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.0']
 extras_require = {}
 
 # Notebook dependencies of IPython 3
-extras_require['notebook-dependencies'] = ['ipython<=7.1.1', 'pyzmq', 'jinja2', 'tornado',
+extras_require['notebook-dependencies'] = ['ipython<=7.1.1,>=5.4.0',
+                                           'pyzmq', 'jinja2', 'tornado',
                                            'jsonschema', 'notebook', 'pygments']
 # IPython Notebook + matplotlib
 extras_require['recommended'] = extras_require['notebook-dependencies'] + ['matplotlib>=2.1', 'bokeh>=1.0.0']

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = ['param>=1.8.0,<2.0', 'numpy>=1.0', 'pyviz_comms>=0.7.0']
 extras_require = {}
 
 # Notebook dependencies of IPython 3
-extras_require['notebook-dependencies'] = ['ipython', 'pyzmq', 'jinja2', 'tornado',
+extras_require['notebook-dependencies'] = ['ipython<=7.1.1', 'pyzmq', 'jinja2', 'tornado',
                                            'jsonschema', 'notebook', 'pygments']
 # IPython Notebook + matplotlib
 extras_require['recommended'] = extras_require['notebook-dependencies'] + ['matplotlib>=2.1', 'bokeh>=1.0.0']


### PR DESCRIPTION
This PR drops the bokeh pinning and test data update of #3411, only pinning IPython.