### PR TITLE
Added hook to clean up custom option trees

### DIFF
--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -658,17 +658,17 @@ class LabelledData(param.Parameterized):
         return self._id
 
     @id.setter
-    def id(self, id):
+    def id(self, opts_id):
         """Handles tracking and cleanup of custom ids."""
         old_id = self._id
-        self._id = id
+        self._id = opts_id
         if old_id is not None:
             cleanup_custom_options(old_id)
-        if id is not None:
-            if id not in Store._weakrefs:
-                Store._weakrefs[id] = []
-            ref = weakref.ref(self, partial(cleanup_custom_options, id))
-            Store._weakrefs[id].append(ref)
+        if opts_id is not None and opts_id != old_id:
+            if opts_id not in Store._weakrefs:
+                Store._weakrefs[opts_id] = []
+            ref = weakref.ref(self, partial(cleanup_custom_options, opts_id))
+            Store._weakrefs[opts_id].append(ref)
 
 
     def clone(self, data=None, shared_data=True, new_type=None, link=True,

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -852,14 +852,14 @@ class LabelledData(param.Parameterized):
         "Ensures pickles save options applied to this objects."
         obj_dict = self.__dict__.copy()
         try:
-            if Store.save_option_state and (obj_dict.get('id', None) is not None):
-                custom_key = '_custom_option_%d' % obj_dict['id']
+            if Store.save_option_state and (obj_dict.get('_id', None) is not None):
+                custom_key = '_custom_option_%d' % obj_dict['_id']
                 if custom_key not in obj_dict:
-                    obj_dict[custom_key] = {backend:s[obj_dict['id']]
+                    obj_dict[custom_key] = {backend:s[obj_dict['_id']]
                                             for backend,s in Store._custom_options.items()
-                                            if obj_dict['id'] in s}
+                                            if obj_dict['_id'] in s}
             else:
-                obj_dict['id'] = None
+                obj_dict['_id'] = None
         except:
             self.param.warning("Could not pickle custom style information.")
         return obj_dict
@@ -868,6 +868,9 @@ class LabelledData(param.Parameterized):
     def __setstate__(self, d):
         "Restores options applied to this object."
         d = param_aliases(d)
+
+        # Backwards compatibility for objects before id was made a property
+        id_key = '_id' if '_id' in d else 'id'
         try:
             load_options = Store.load_counter_offset is not None
             if load_options:
@@ -886,13 +889,15 @@ class LabelledData(param.Parameterized):
 
                     d.pop(match)
 
-                if d['id'] is not None:
-                    d['id'] += Store.load_counter_offset
+                if d[id_key] is not None:
+                    d[id_key] += Store.load_counter_offset
                 else:
-                    d['id'] = None
+                    d[id_key] = None
         except:
             self.param.warning("Could not unpickle custom style information.")
         self.__dict__.update(d)
+        if d.get(id_key) is not None:
+            self.id = d[id_key]
 
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -895,9 +895,9 @@ class LabelledData(param.Parameterized):
                     d[id_key] = None
         except:
             self.param.warning("Could not unpickle custom style information.")
+        obj_id = d.pop(id_key, None)
         self.__dict__.update(d)
-        if d.get(id_key) is not None:
-            self.id = d[id_key]
+        self.id = obj_id
 
 
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -632,7 +632,8 @@ class LabelledData(param.Parameterized):
         may be set to associate some custom options with the object.
         """
         self.data = data
-        self._id = id
+        self._id = None
+        self.id = id
         self._plot_id = plot_id or util.builtins.id(self)
         if isinstance(params.get('label',None), tuple):
             (alias, long_name) = params['label']
@@ -660,11 +661,14 @@ class LabelledData(param.Parameterized):
     def id(self, id):
         old_id = self._id
         self._id = id
+        if old_id is not None:
+            cleanup_custom_options(old_id)
+        if id is None:
+            return
         if id not in Store._weakrefs:
             Store._weakrefs[id] = []
         Store._weakrefs[id].append(weakref.ref(self, partial(cleanup_custom_options, id)))
-        if old_id is not None:
-            cleanup_custom_options(old_id)
+
 
     def clone(self, data=None, shared_data=True, new_type=None, link=True,
               *args, **overrides):

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -659,15 +659,16 @@ class LabelledData(param.Parameterized):
 
     @id.setter
     def id(self, id):
+        """Handles tracking and cleanup of custom ids."""
         old_id = self._id
         self._id = id
         if old_id is not None:
             cleanup_custom_options(old_id)
-        if id is None:
-            return
-        if id not in Store._weakrefs:
-            Store._weakrefs[id] = []
-        Store._weakrefs[id].append(weakref.ref(self, partial(cleanup_custom_options, id)))
+        if id is not None:
+            if id not in Store._weakrefs:
+                Store._weakrefs[id] = []
+            ref = weakref.ref(self, partial(cleanup_custom_options, id))
+            Store._weakrefs[id].append(ref)
 
 
     def clone(self, data=None, shared_data=True, new_type=None, link=True,
@@ -896,6 +897,7 @@ class LabelledData(param.Parameterized):
         except:
             self.param.warning("Could not unpickle custom style information.")
         obj_id = d.pop(id_key, None)
+        d['_id'] = None
         self.__dict__.update(d)
         self.id = obj_id
 

--- a/holoviews/core/dimension.py
+++ b/holoviews/core/dimension.py
@@ -887,20 +887,20 @@ class LabelledData(param.Parameterized):
                         if backend not in Store._custom_options:
                             Store._custom_options[backend] = {}
                         Store._custom_options[backend][Store.load_counter_offset + custom_id] = info
-
                     d.pop(match)
 
                 if d[id_key] is not None:
                     d[id_key] += Store.load_counter_offset
+                    if backend_info:
+                        if opts_id not in Store._weakrefs:
+                            Store._weakrefs[opts_id] = []
+                        ref = weakref.ref(self, partial(cleanup_custom_options, d[id_key]))
+                        Store._weakrefs[d[id_key]].append(ref)
                 else:
                     d[id_key] = None
         except:
             self.param.warning("Could not unpickle custom style information.")
-        obj_id = d.pop(id_key, None)
-        d['_id'] = None
         self.__dict__.update(d)
-        self.id = obj_id
-
 
 
 class Dimensioned(LabelledData):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -50,24 +50,25 @@ from .pprint import InfoPrinter, PrettyPrinter
 
 def cleanup_custom_options(id, weakref=None):
     """
-    Cleans up unused custom trees if no object matching the custom
-    options id exists anymore.
+    Cleans up unused custom trees if all objects referencing the
+    custom id have been garbage collected.
     """
-    weakrefs = Store._weakrefs[id]
+    weakrefs = Store._weakrefs.get(id, [])
+    if weakref is not None and weakref in weakrefs:
+        weakrefs.remove(weakref)
     refs = []
     for wr in weakrefs:
         r = wr()
-        if r is None:
-            continue
-        elif r.id != id:
+        if r is None or r.id != id:
             weakrefs.remove(wr)
         else:
             refs.append(r)
     if not refs:
         for bk in Store.loaded_backends():
-            Store._custom_options[bk].pop(id)
-    if weakref is not None:
-        weakrefs.remove(weakref)
+            if id in Store._custom_options[bk]:
+                Store._custom_options[bk].pop(id)
+    if not weakrefs:
+        Store._weakrefs.pop(id, None)
 
 
 class SkipRendering(Exception):
@@ -1570,6 +1571,7 @@ class StoreOptions(object):
         matching the applied_keys. This method can only be called if
         there is a tree with a matching id in Store.custom_options
         """
+        applied = False
         if not new_id in Store.custom_options(backend=backend):
             raise AssertionError("The set_ids method requires "
                                  "Store.custom_options to contain"
@@ -1577,7 +1579,12 @@ class StoreOptions(object):
         def propagate(o):
             if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
                 setattr(o, 'id', new_id)
+                applied = True
         obj.traverse(propagate, specs=set(applied_keys) | {'DynamicMap'})
+
+        # Clean up the custom tree if it was not applied
+        if not applied:
+            cleanup_custom_options(new_id)
 
     @classmethod
     def capture_ids(cls, obj):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1577,6 +1577,7 @@ class StoreOptions(object):
                                  "Store.custom_options to contain"
                                  " a tree with id %d" % new_id)
         def propagate(o):
+            global applied
             if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
                 setattr(o, 'id', new_id)
                 applied = True

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -51,24 +51,31 @@ from .pprint import InfoPrinter, PrettyPrinter
 def cleanup_custom_options(id, weakref=None):
     """
     Cleans up unused custom trees if all objects referencing the
-    custom id have been garbage collected.
+    custom id have been garbage collected or tree is otherwise
+    unreferenced.
     """
-    weakrefs = Store._weakrefs.get(id, [])
-    if weakref is not None and weakref in weakrefs:
-        weakrefs.remove(weakref)
-    refs = []
-    for wr in weakrefs:
-        r = wr()
-        if r is None or r.id != id:
-            weakrefs.remove(wr)
-        else:
-            refs.append(r)
-    if not refs:
-        for bk in Store.loaded_backends():
-            if id in Store._custom_options[bk]:
-                Store._custom_options[bk].pop(id)
-    if not weakrefs:
-        Store._weakrefs.pop(id, None)
+    try:
+        weakrefs = Store._weakrefs.get(id, [])
+        if weakref in weakrefs:
+            weakrefs.remove(weakref)
+        refs = []
+        for wr in list(weakrefs):
+            r = wr()
+            if r is None or r.id != id:
+                weakrefs.remove(wr)
+            else:
+                refs.append(r)
+        if not refs:
+            for bk in Store.loaded_backends():
+                if id in Store._custom_options[bk]:
+                    Store._custom_options[bk].pop(id)
+        if not weakrefs:
+            Store._weakrefs.pop(id, None)
+    except Exception as e:
+        raise Exception('Cleanup of custom options tree with id %s '
+                        'failed with the following exception: %s, '
+                        'an unreferenced orphan tree may persist in '
+                        'memory' % (e, id))
 
 
 class SkipRendering(Exception):
@@ -1571,16 +1578,15 @@ class StoreOptions(object):
         matching the applied_keys. This method can only be called if
         there is a tree with a matching id in Store.custom_options
         """
-        applied = False
+        applied = []
         if not new_id in Store.custom_options(backend=backend):
             raise AssertionError("The set_ids method requires "
                                  "Store.custom_options to contain"
                                  " a tree with id %d" % new_id)
         def propagate(o):
-            global applied
             if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
                 setattr(o, 'id', new_id)
-                applied = True
+                applied.append(o)
         obj.traverse(propagate, specs=set(applied_keys) | {'DynamicMap'})
 
         # Clean up the custom tree if it was not applied

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -1579,10 +1579,6 @@ class StoreOptions(object):
         there is a tree with a matching id in Store.custom_options
         """
         applied = []
-        if not new_id in Store.custom_options(backend=backend):
-            raise AssertionError("The set_ids method requires "
-                                 "Store.custom_options to contain"
-                                 " a tree with id %d" % new_id)
         def propagate(o):
             if o.id == match_id or (o.__class__.__name__ == 'DynamicMap'):
                 setattr(o, 'id', new_id)
@@ -1592,6 +1588,10 @@ class StoreOptions(object):
         # Clean up the custom tree if it was not applied
         if not applied:
             cleanup_custom_options(new_id)
+        elif not new_id in Store.custom_options(backend=backend):
+            raise AssertionError("New option id %d does not match any "
+                                 "option trees in Store.custom_options."
+                                 % new_id)
 
     @classmethod
     def capture_ids(cls, obj):

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -55,6 +55,8 @@ def cleanup_custom_options(id, weakref=None):
     unreferenced.
     """
     try:
+        if Store._options_context:
+            return
         weakrefs = Store._weakrefs.get(id, [])
         if weakref in weakrefs:
             weakrefs.remove(weakref)
@@ -1227,6 +1229,7 @@ class Store(object):
 
     # Weakrefs to record objects per id
     _weakrefs = {}
+    _options_context = False
 
     # A list of hooks to call after registering the plot and style options
     option_setters = []
@@ -1812,12 +1815,14 @@ class StoreOptions(object):
         """
         if (options is None) and kwargs == {}: yield
         else:
+            Store._options_context = True
             optstate = cls.state(obj)
             groups = Store.options().groups.keys()
             options = cls.merge_options(groups, options, **kwargs)
             cls.set_options(obj, options)
             yield
         if options is not None:
+            Store._options_context = True
             cls.state(obj, state=optstate)
 
 

--- a/holoviews/tests/core/testdimensioned.py
+++ b/holoviews/tests/core/testdimensioned.py
@@ -235,6 +235,6 @@ class TestOptionsCleanup(CustomBackendTestCase):
         self.assertEqual(len(custom_options), 0)
 
     def test_opts_clear_cleans_unused_tree(self):
-        obj = TestObj([]).opts(style_opt1='A').opts.clear()
+        TestObj([]).opts(style_opt1='A').opts.clear()
         custom_options = Store._custom_options['backend_1']
         self.assertEqual(len(custom_options), 0)


### PR DESCRIPTION
This PR adds a dictionary of weakrefs to the Store which tracks all HoloViews objects which have had custom options applied to them. Whenever the ``id`` of an object changes or an object is garbage collected a callback then checks whether there are any remaining objects referencing the custom tree and deletes both the weakref and the custom options tree if it is no longer referenced.

- [x] Fixes https://github.com/ioam/holoviews/issues/3421
- [x] Add unit tests