### PR TITLE
Fix of timestamp selections in streams

### DIFF
--- a/holoviews/plotting/bokeh/util.py
+++ b/holoviews/plotting/bokeh/util.py
@@ -86,7 +86,7 @@ def convert_timestamp(timestamp):
     """
     Converts bokehJS timestamp to datetime64.
     """
-    datetime = dt.datetime.fromtimestamp(timestamp/1000., dt.timezone.utc)
+    datetime = dt.datetime.utcfromtimestamp(timestamp/1000.)
     return np.datetime64(datetime.replace(tzinfo=None))
 
 


### PR DESCRIPTION
Changed from fromtimestamp to utcfromtimestamp for support of 2.7.15 and 3.6+

Closes #3412 