### PR TITLE
Improved attribute handling in Graph.from_networkx

### DIFF
--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -442,10 +442,13 @@ class Graph(Dataset, Element2D):
 
         # Unpack node positions
         for idx, pos in sorted(positions.items()):
+            node = G.nodes.get(idx)
+            if node is None:
+                continue
             x, y = pos
             node_columns[xdim.name].append(x)
             node_columns[ydim.name].append(y)
-            for attr, value in G.nodes[idx].items():
+            for attr, value in node.items():
                 if isinstance(value, (list, dict)):
                     continue
                 node_columns[attr].append(value)

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -407,6 +407,8 @@ class Graph(Dataset, Element2D):
         """
         if not isinstance(positions, dict):
             positions = positions(G, **kwargs)
+
+        # Unpack edges
         edges = defaultdict(list)
         for start, end in G.edges():
             for attr, value in sorted(G.adj[start][end].items()):
@@ -426,6 +428,7 @@ class Graph(Dataset, Element2D):
         edge_vdims = [str(col) if isinstance(col, int) else col for col in edge_cols]
         edge_data = tuple(edges[col] for col in ['start', 'end']+edge_cols)
 
+        # Unpack user node info
         xdim, ydim, idim = cls.node_type.kdims[:3]
         if nodes:
             node_columns = nodes.columns()
@@ -436,6 +439,8 @@ class Graph(Dataset, Element2D):
             info_cols = []
             node_info = None
         node_columns = defaultdict(list)
+
+        # Unpack node positions
         for idx, pos in sorted(positions.items()):
             x, y = pos
             node_columns[xdim.name].append(x)
@@ -451,6 +456,10 @@ class Graph(Dataset, Element2D):
             node_columns[idim.name].append(idx)
         node_cols = sorted([k for k in node_columns if k not in cls.node_type.kdims
                             and len(node_columns[k]) == len(node_columns[xdim.name])])
+        columns = [xdim.name, ydim.name, idim.name]+node_cols+list(info_cols)
+        node_data = tuple(node_columns[col] for col in columns)
+
+        # Construct nodes
         vdims = []
         for col in node_cols:
             if isinstance(col, int):
@@ -460,9 +469,9 @@ class Graph(Dataset, Element2D):
             else:
                 dim = col
             vdims.append(dim)
-        columns = [xdim.name, ydim.name, idim.name]+node_cols+list(info_cols)
-        node_data = tuple(node_columns[col] for col in columns)
         nodes = cls.node_type(node_data, vdims=vdims)
+
+        # Construct graph
         return cls((edge_data, nodes), vdims=edge_vdims)
 
 

--- a/holoviews/element/graphs.py
+++ b/holoviews/element/graphs.py
@@ -384,20 +384,34 @@ class Graph(Dataset, Element2D):
 
 
     @classmethod
-    def from_networkx(cls, G, layout_function, nodes=None, **kwargs):
+    def from_networkx(cls, G, positions, nodes=None, **kwargs):
         """
         Generate a HoloViews Graph from a networkx.Graph object and
-        networkx layout function. Any keyword arguments will be passed
-        to the layout function. By default it will extract all node
-        and edge attributes from the networkx.Graph but explicit node
-        information may also be supplied.
+        networkx layout function or dictionary of node positions.
+        Any keyword arguments will be passed to the layout
+        function. By default it will extract all node and edge
+        attributes from the networkx.Graph but explicit node
+        information may also be supplied. Any non-scalar attributes,
+        such as lists or dictionaries will be ignored.
+
+        Args:
+            G (networkx.Graph): Graph to convert to Graph element
+            positions (dict or callable): Node positions
+                Node positions defined as a dictionary mapping from
+                node id to (x, y) tuple or networkx layout function
+                which computes a positions dictionary
+            kwargs (dict): Keyword arguments for layout function
+
+        Returns:
+            Graph element
         """
-        positions = layout_function(G, **kwargs)
+        if isinstance(positions, dict):
+            positions = positions(G, **kwargs)
         edges = defaultdict(list)
         for start, end in G.edges():
             for attr, value in sorted(G.adj[start][end].items()):
                 if isinstance(value, (list, dict)):
-                    continue # Cannot handle lists
+                    continue # Cannot handle list or dict attrs
                 edges[attr].append(value)
 
             # Handle tuple node indexes (used in 2D grid Graphs)

--- a/holoviews/tests/element/testgraphelement.py
+++ b/holoviews/tests/element/testgraphelement.py
@@ -129,12 +129,16 @@ class GraphTests(ComparisonTestCase):
         self.assertEqual(redimmed.nodes, graph.nodes.redim(x='x2', y='y2'))
         self.assertEqual(redimmed.edgepaths, graph.edgepaths.redim(x='x2', y='y2'))
 
-    @attr(optional=1)
-    def test_from_networkx_with_node_attrs(self):
+class FromNetworkXTests(ComparisonTestCase):
+
+    def setUp(self):
         try:
             import networkx as nx
         except:
             raise SkipTest('Test requires networkx to be installed')
+
+    def test_from_networkx_with_node_attrs(self):
+        import networkx as nx
         G = nx.karate_club_graph()
         graph = Graph.from_networkx(G, nx.circular_layout)
         clubs = np.array([
@@ -146,41 +150,56 @@ class GraphTests(ComparisonTestCase):
             'Officer', 'Officer', 'Officer', 'Officer'])
         self.assertEqual(graph.nodes.dimension_values('club'), clubs)
 
-    @attr(optional=1)
+    def test_from_networkx_with_invalid_node_attrs(self):
+        import networkx as nx
+        FG = nx.Graph()
+        FG.add_node(1, test=[])
+        FG.add_node(2, test=[])
+        FG.add_edge(1, 2)
+        graph = Graph.from_networkx(FG, nx.circular_layout)
+        self.assertEqual(graph.nodes.vdims, [])
+        self.assertEqual(graph.nodes.dimension_values(2), np.array([1, 2]))
+        self.assertEqual(graph.array(), np.array([(1, 2)]))
+
     def test_from_networkx_with_edge_attrs(self):
-        try:
-            import networkx as nx
-        except:
-            raise SkipTest('Test requires networkx to be installed')
+        import networkx as nx
         FG = nx.Graph()
         FG.add_weighted_edges_from([(1,2,0.125), (1,3,0.75), (2,4,1.2), (3,4,0.375)])
         graph = Graph.from_networkx(FG, nx.circular_layout)
         self.assertEqual(graph.dimension_values('weight'), np.array([0.125, 0.75, 1.2, 0.375]))
 
-    @attr(optional=1)
+    def test_from_networkx_with_invalid_edge_attrs(self):
+        import networkx as nx
+        FG = nx.Graph()
+        FG.add_weighted_edges_from([(1,2,[]), (1,3,[]), (2,4,[]), (3,4,[])])
+        graph = Graph.from_networkx(FG, nx.circular_layout)
+        self.assertEqual(graph.vdims, [])
+
     def test_from_networkx_only_nodes(self):
-        try:
-            import networkx as nx
-        except:
-            raise SkipTest('Test requires networkx to be installed')
+        import networkx as nx
         G = nx.Graph()
         G.add_nodes_from([1, 2, 3])
         graph = Graph.from_networkx(G, nx.circular_layout)
         self.assertEqual(graph.nodes.dimension_values(2), np.array([1, 2, 3]))
 
-    @attr(optional=1)
     def test_from_networkx_custom_nodes(self):
-        try:
-            import networkx as nx
-        except:
-            raise SkipTest('Test requires networkx to be installed')
+        import networkx as nx
         FG = nx.Graph()
         FG.add_weighted_edges_from([(1,2,0.125), (1,3,0.75), (2,4,1.2), (3,4,0.375)])
         nodes = Dataset([(1, 'A'), (2, 'B'), (3, 'A'), (4, 'B')], 'index', 'some_attribute')
         graph = Graph.from_networkx(FG, nx.circular_layout, nodes=nodes)
         self.assertEqual(graph.nodes.dimension_values('some_attribute'), np.array(['A', 'B', 'A', 'B']))
 
+    def test_from_networkx_dictionary_positions(self):
+        import networkx as nx
+        G = nx.Graph()
+        G.add_nodes_from([1, 2, 3])
+        positions = nx.circular_layout(G)
+        graph = Graph.from_networkx(G, positions)
+        self.assertEqual(graph.nodes.dimension_values(2), np.array([1, 2, 3]))
+
         
+
 class ChordTests(ComparisonTestCase):
 
     def setUp(self):

--- a/holoviews/tests/element/testgraphelement.py
+++ b/holoviews/tests/element/testgraphelement.py
@@ -2,7 +2,6 @@
 Unit tests of Graph Element.
 """
 from unittest import SkipTest
-from nose.plugins.attrib import attr
 
 import numpy as np
 from holoviews.core.data import Dataset
@@ -133,7 +132,7 @@ class FromNetworkXTests(ComparisonTestCase):
 
     def setUp(self):
         try:
-            import networkx as nx
+            import networkx as nx # noqa
         except:
             raise SkipTest('Test requires networkx to be installed')
 


### PR DESCRIPTION
This PR improves Graph.from_networkx in a number of ways. First of all it makes sure that non-scalar attributes and indexes (e.g. lists, tuples or dictionaries) do not break the Graph. Secondly this PR will allow passing in a dictionary of node positions which is the canonical way to specify node positions in networkx. 

- [x] Handle non-scalar attributes
- [x] Handle dictionary node positions