### PR TITLE
Fixed Overlay constructor bug

### DIFF
--- a/holoviews/core/overlay.py
+++ b/holoviews/core/overlay.py
@@ -137,15 +137,10 @@ class Overlay(ViewableTree, CompositeOverlay):
     """
 
     def __init__(self, items=None, group=None, label=None, **params):
-        view_params = ViewableElement.params().keys()
         self.__dict__['_fixed'] = False
         self.__dict__['_group'] = group
         self.__dict__['_label'] = label
-        ViewableTree.__init__(self, items,
-                              **{k:v for k,v in params.items() if k not in view_params})
-        ViewableElement.__init__(self, self.data,
-                                 **{k:v for k,v in params.items() if k in view_params})
-
+        super(Overlay, self).__init__(items, **params)
 
     def __getitem__(self, key):
         """

--- a/holoviews/tests/core/testcomposites.py
+++ b/holoviews/tests/core/testcomposites.py
@@ -342,6 +342,12 @@ class OverlayTestCase(ElementTestCase):
         composite = overlay * HoloMap({0: Element(None, group='HoloMap')})
         self.assertEqual(composite.last.keys(), [('Custom', 'LabelA'), ('HoloMap', 'I')])
 
+    def test_overlay_id_inheritance(self):
+        overlay = Overlay([], id=1)
+        self.assertEqual(overlay.clone().id, 1)
+        self.assertEqual(overlay.clone()._plot_id, overlay._plot_id)
+        self.assertNotEqual(overlay.clone([])._plot_id, overlay._plot_id)
+
 
 class CompositeTestCase(ElementTestCase):
     """


### PR DESCRIPTION
The Overlay constructor was not rewritten when it was changed to inherit from ViewableTree. This meant that the constructor was called twice and the ``id`` used to associate options with an element was always set to None.

- [x] Fixes https://github.com/ioam/holoviews/issues/3434
- [ ] Adds unit tests