### PR TITLE
Added a get method to Opts to get an Options object

### DIFF
--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -67,9 +67,15 @@ class Opts(object):
 
 
     def get(self, group=None, backend=None):
-        """
-        Returns an Options object, flattening across option groups if
-        group is None. Uses the current backend if backend is None.
+        """Returns the corresponding Options object.
+
+        Args:
+            group: The options group. Flattens across groups if None.
+            backend: Current backend if None otherwise chosen backend.
+
+        Returns:
+            Options object associated with the object containing the
+            applied option keywords.
         """
         keywords = {}
         groups = Options._option_groups if group is None else [group]

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -66,6 +66,19 @@ class Opts(object):
         self._obj = obj
 
 
+    def get(self, group=None):
+        """
+        Returns an Options object, flattening across option groups if
+        group is None.
+        """
+        keywords = {}
+        groups = Options._option_groups if group is None else [group]
+        for group in groups:
+            optsobj = Store.lookup_options(Store.current_backend, self._obj, group)
+            keywords = dict(keywords, **optsobj.kwargs)
+        return Options(**keywords)
+
+
     def __call__(self, *args, **kwargs):
         """Applies nested options definition.
 

--- a/holoviews/core/options.py
+++ b/holoviews/core/options.py
@@ -66,15 +66,16 @@ class Opts(object):
         self._obj = obj
 
 
-    def get(self, group=None):
+    def get(self, group=None, backend=None):
         """
         Returns an Options object, flattening across option groups if
-        group is None.
+        group is None. Uses the current backend if backend is None.
         """
         keywords = {}
         groups = Options._option_groups if group is None else [group]
+        backend = backend if backend else Store.current_backend
         for group in groups:
-            optsobj = Store.lookup_options(Store.current_backend, self._obj, group)
+            optsobj = Store.lookup_options(backend, self._obj, group)
             keywords = dict(keywords, **optsobj.kwargs)
         return Options(**keywords)
 


### PR DESCRIPTION
Prompted by a stackoverflow question I decide to go ahead and implement the `get` method on `Opts` we have previously discussed. It doesn't do anything fancy for container types but does let you specify the option type if you like e.g with `points.opts.get('style')`.

I haven't put too much thought into the name: `get` was the first thing that came to mind.