### PR TITLE
Fixes for style updates in matplotlib

### DIFF
--- a/holoviews/plotting/mpl/chart.py
+++ b/holoviews/plotting/mpl/chart.py
@@ -15,7 +15,7 @@ from ...core.options import Store, abbreviated_exception
 from ...core.util import (
     OrderedDict, match_spec, unique_iterator, basestring, max_range,
     isfinite, datetime_types, dt_to_int, dt64_to_dt, search_indices,
-    unique_array
+    unique_array, isscalar
 )
 from ...element import Raster, HeatMap
 from ...operation import interpolate_curve
@@ -670,7 +670,10 @@ class PointPlot(ChartPlot, ColorbarPlot):
         (xs, ys), style, _ = self.get_data(element, ranges, style)
         paths.set_offsets(np.column_stack([xs, ys]))
         if 's' in style:
-            paths.set_sizes(style['s'])
+            sizes = style['s']
+            if isscalar(sizes):
+                sizes = [sizes]
+            paths.set_sizes(sizes)
         if 'vmin' in style:
             paths.set_clim((style['vmin'], style['vmax']))
         if 'c' in style:

--- a/holoviews/plotting/mpl/element.py
+++ b/holoviews/plotting/mpl/element.py
@@ -466,6 +466,10 @@ class ElementPlot(GenericElementPlot, MPLPlot):
         ranges = self.compute_ranges(self.hmap, key, ranges)
         ranges = util.match_spec(element, ranges)
 
+        max_cycles = self.style._max_cycles
+        style = self.lookup_options(element, 'style')
+        self.style = style.max_cycles(max_cycles) if max_cycles else style
+
         label = element.label if self.show_legend else ''
         style = dict(label=label, zorder=self.zorder, **self.style[self.cyclic_index])
         axis_kwargs = self.update_handles(key, axis, element, ranges, style)

--- a/holoviews/tests/plotting/matplotlib/testpointplot.py
+++ b/holoviews/tests/plotting/matplotlib/testpointplot.py
@@ -153,6 +153,15 @@ class TestPointPlot(TestMPLPlot):
         self.assertEqual(y_range[0], 0.8)
         self.assertEqual(y_range[1], 3.2)
 
+    def test_points_sizes_scalar_update(self):
+        hmap = HoloMap({i: Points([1, 2, 3]).opts(s=i*10) for i in range(1, 3)})
+        plot = mpl_renderer.get_plot(hmap)
+        artist = plot.handles['artist']
+        plot.update((1,))
+        self.assertEqual(artist.get_sizes(), np.array([10]))
+        plot.update((2,))
+        self.assertEqual(artist.get_sizes(), np.array([20]))
+
     ###########################
     #    Styling mapping      #
     ###########################


### PR DESCRIPTION
This PR ensures that styles are updated generally in the matplotlib backend and also fixes a concrete bug where updating a scalar size on a Point/Scatter plot raised an error.

- [x] Fixes #3439 
- [x] Adds unit test